### PR TITLE
Lightning settings: native iOS row pattern for address

### DIFF
--- a/CashuWallet/Views/Components/LiquidGlassModifiers.swift
+++ b/CashuWallet/Views/Components/LiquidGlassModifiers.swift
@@ -49,6 +49,64 @@ struct CanvasDivider: View {
     }
 }
 
+// MARK: - Settings Canvas Components
+
+/// Section grouping on a single-canvas Settings screen. Renders an
+/// uppercase tracking-spaced title above its content; matches the
+/// shape used by the root `SettingsView` so detail screens read as
+/// the same family.
+struct SettingsSectionGroup<Content: View>: View {
+    let title: String?
+    let content: () -> Content
+
+    init(_ title: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let title {
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                    .tracking(1.2)
+                    .padding(.horizontal, 4)
+                    .padding(.top, 16)
+                    .padding(.bottom, 8)
+            } else {
+                Color.clear.frame(height: 8)
+            }
+
+            VStack(spacing: 0) {
+                content()
+            }
+            .padding(.horizontal, 4)
+        }
+    }
+}
+
+/// Section footer text on a single-canvas Settings screen. Visual
+/// weight matches an iOS Form section footer without nesting cards.
+struct SettingsSectionFooter<Content: View>: View {
+    let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        content()
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 6)
+            .padding(.top, 8)
+            .padding(.bottom, 12)
+    }
+}
+
 // MARK: - Full Width Capsule Button Style
 
 /// Full-width capsule rendered as subtly-frosted Liquid Glass on iOS 26+,

--- a/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
+++ b/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
@@ -8,115 +8,53 @@ struct LightningAddressSettingsSection: View {
     @Binding var isCheckingPayments: Bool
     @Binding var showMintPicker: Bool
 
-    var body: some View {
-        Group {
-            Text("Receive Lightning payments to your wallet using a Lightning address.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+    @State private var showAddressQR = false
 
-            Toggle(isOn: $npcService.isEnabled) {
-                Text("Enable Lightning Address")
+    var body: some View {
+        LazyVStack(spacing: 0) {
+            SettingsSectionGroup("Lightning Address") {
+                Toggle("Enable Lightning Address", isOn: $npcService.isEnabled)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 14)
+
+                if npcService.isEnabled && npcService.isInitialized {
+                    CanvasDivider()
+                    addressRow
+                }
             }
 
-            if npcService.isEnabled {
-                if npcService.isInitialized {
-                    // Lightning Address Display
-                    Button(action: copyLightningAddress) {
-                        HStack {
-                            Text(npcService.lightningAddress)
-                                .font(.system(.subheadline, design: .monospaced))
-                                .foregroundStyle(Color.accentColor)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+            statusFooter
 
-                            Spacer()
+            if npcService.isEnabled && npcService.isInitialized {
+                SettingsSectionGroup("Preferences") {
+                    Toggle("Auto-claim payments", isOn: $npcService.automaticClaim)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 14)
 
-                            Image(systemName: copiedLightningAddress ? "checkmark" : "doc.on.doc")
-                                .foregroundStyle(copiedLightningAddress ? .green : Color.accentColor)
-                        }
-                    }
-
-                    // Auto-claim toggle
-                    Toggle(isOn: $npcService.automaticClaim) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Auto-claim payments")
-                            Text("Automatically mint received payments")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    // Mint selection
                     if !walletManager.mints.isEmpty {
-                        Button(action: { showMintPicker = true }) {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 2) {
-                                    Text("Receiving Mint")
-                                        .font(.subheadline)
-                                    Text(npcService.selectedMintUrl ?? "Select a mint")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                        .truncationMode(.middle)
-                                }
-
-                                Spacer()
-
-                                Image(systemName: "chevron.right")
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
+                        CanvasDivider()
+                        receivingMintRow
                     }
+                }
 
-                    // Manual check button
-                    Button(action: checkForPayments) {
-                        HStack {
-                            if isCheckingPayments {
-                                ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: Color.accentColor))
-                                    .scaleEffect(0.8)
-                            } else {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                            Text("Check for Payments")
+                SettingsSectionFooter {
+                    Text("Incoming payments are minted as ecash at your chosen mint.")
+                }
 
-                            Spacer()
-
-                            if let lastCheck = npcService.lastCheck {
-                                Text("Last: \(formatRelativeTime(lastCheck))")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                    .disabled(isCheckingPayments)
-
-                    // Connection status
-                    HStack {
-                        Circle()
-                            .fill(npcService.isConnected ? Color.green : Color.orange)
-                            .frame(width: 8, height: 8)
-
-                        Text(npcService.isConnected ? "Connected to npubx.cash" : "Connecting...")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    // Error message
-                    if let error = npcService.errorMessage {
-                        Text(error)
-                            .font(.caption)
-                            .foregroundStyle(.red)
-                    }
-                } else {
-                    // Nostr not initialized
-                    HStack {
-                        Image(systemName: "exclamationmark.triangle")
+                SettingsSectionGroup(nil) {
+                    checkForPaymentsRow
+                }
+            } else if npcService.isEnabled && !npcService.isInitialized {
+                SettingsSectionGroup(nil) {
+                    HStack(spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                         Text("Wallet not fully initialized. Please restart the app.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 14)
                 }
             }
         }
@@ -131,21 +69,181 @@ struct LightningAddressSettingsSection: View {
                 }
             )
         }
+        .sheet(isPresented: $showAddressQR) {
+            QRCodeDetailSheet(
+                title: "Lightning Address",
+                content: npcService.lightningAddress
+            )
+            .presentationDetents([.medium, .large])
+        }
     }
 
-    // MARK: - Helpers
+    // MARK: - Status footer + helpers
+
+    @ViewBuilder
+    private var statusFooter: some View {
+        if !npcService.isEnabled {
+            SettingsSectionFooter {
+                Text("Receive Lightning payments to your wallet using a Lightning address.")
+            }
+        } else if let error = npcService.errorMessage {
+            SettingsSectionFooter {
+                Text(error)
+                    .foregroundStyle(.red)
+            }
+        } else if !npcService.isInitialized {
+            SettingsSectionFooter {
+                Text("Setting up Lightning address…")
+            }
+        }
+    }
+
+    // MARK: - Address row
+
+    private var addressRow: some View {
+        Button { showAddressQR = true } label: {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 7, height: 7)
+                    .accessibilityHidden(true)
+
+                Text(npcService.lightningAddress)
+                    .font(.system(.body, design: .monospaced))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "qrcode")
+                    .font(.body.weight(.medium))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Lightning address: \(npcService.lightningAddress). \(statusLabel).")
+        .accessibilityHint("Shows QR code. Long-press for copy and share.")
+        .contextMenu {
+            Button {
+                copyLightningAddress()
+            } label: {
+                Label("Copy address", systemImage: "doc.on.doc")
+            }
+            ShareLink(item: npcService.lightningAddress) {
+                Label("Share address", systemImage: "square.and.arrow.up")
+            }
+        }
+    }
+
+    private var statusColor: Color {
+        if npcService.errorMessage != nil { return .red }
+        return npcService.isConnected ? .green : .orange
+    }
+
+    private var statusLabel: String {
+        if let error = npcService.errorMessage { return error }
+        return npcService.isConnected ? "Connected" : "Connecting"
+    }
+
+    // MARK: - Receiving Mint row
+
+    private var receivingMintRow: some View {
+        Button {
+            HapticFeedback.selection()
+            showMintPicker = true
+        } label: {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Receiving mint")
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    Text(selectedMintDisplayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Receiving mint: \(selectedMintDisplayName)")
+        .accessibilityHint("Choose which mint claims incoming Lightning payments")
+    }
+
+    private var selectedMintDisplayName: String {
+        if let url = npcService.selectedMintUrl,
+           let mint = walletManager.mints.first(where: { $0.url == url }) {
+            return mint.name
+        }
+        return "Select a mint"
+    }
+
+    // MARK: - Check for Payments row
+
+    private var checkForPaymentsRow: some View {
+        Button(action: checkForPayments) {
+            HStack(spacing: 14) {
+                Group {
+                    if isCheckingPayments {
+                        ProgressView()
+                            .controlSize(.small)
+                    } else {
+                        Image(systemName: "arrow.clockwise")
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Check for payments")
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    if let lastCheck = npcService.lastCheck {
+                        Text("Last checked \(formatRelativeTime(lastCheck))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isCheckingPayments)
+        .accessibilityLabel("Check for new payments")
+    }
+
+    // MARK: - Actions
 
     private func copyLightningAddress() {
-        let address = npcService.lightningAddress
-        UIPasteboard.general.string = address
-        copiedLightningAddress = true
+        UIPasteboard.general.string = npcService.lightningAddress
+        HapticFeedback.selection()
+        withAnimation(.snappy(duration: 0.18)) { copiedLightningAddress = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            copiedLightningAddress = false
+            withAnimation(.snappy(duration: 0.18)) { copiedLightningAddress = false }
         }
     }
 
     private func checkForPayments() {
         isCheckingPayments = true
+        HapticFeedback.selection()
         Task {
             await npcService.checkAndClaimPayments()
             await MainActor.run {
@@ -154,17 +252,10 @@ struct LightningAddressSettingsSection: View {
         }
     }
 
-    private func selectedMintName() -> String {
-        if let selectedUrl = npcService.selectedMintUrl,
-           let mint = walletManager.mints.first(where: { $0.url == selectedUrl }) {
-            return mint.name
-        }
-        return "Select Mint"
-    }
-
     private func formatRelativeTime(_ date: Date) -> String {
         let formatter = RelativeDateTimeFormatter()
         formatter.unitsStyle = .abbreviated
         return formatter.localizedString(for: date, relativeTo: Date())
     }
 }
+

--- a/CashuWallet/Views/Settings/SettingsView.swift
+++ b/CashuWallet/Views/Settings/SettingsView.swift
@@ -232,17 +232,18 @@ struct SettingsView: View {
     }
 
     private var lightningDetailView: some View {
-        List {
-            Section {
-                LightningAddressSettingsSection(
-                    copiedLightningAddress: $copiedLightningAddress,
-                    isCheckingPayments: $isCheckingPayments,
-                    showMintPicker: $showMintPicker
-                )
-            }
-            .listRowSeparator(.hidden)
+        ScrollView {
+            LightningAddressSettingsSection(
+                copiedLightningAddress: $copiedLightningAddress,
+                isCheckingPayments: $isCheckingPayments,
+                showMintPicker: $showMintPicker
+            )
+            .padding(.horizontal)
+            .padding(.bottom, 32)
         }
-        .listStyle(.plain)
+        .refreshable {
+            await npcService.checkAndClaimPayments()
+        }
         .navigationTitle("Lightning")
         .toolbarBackground(.hidden, for: .navigationBar)
     }
@@ -385,11 +386,17 @@ struct QRCodeDetailSheet: View {
                     .truncationMode(.middle)
                     .padding(.horizontal)
 
-                Button(action: copyToClipboard) {
-                    Label(copied ? "Copied" : "Copy",
-                          systemImage: copied ? "checkmark" : "doc.on.doc")
+                HStack(spacing: 12) {
+                    Button(action: copyToClipboard) {
+                        Text(copied ? "Copied" : "Copy")
+                    }
+                    .glassButton()
+
+                    ShareLink(item: content) {
+                        Text("Share")
+                    }
+                    .glassButton()
                 }
-                .glassButton()
                 .padding(.horizontal)
 
                 Spacer()


### PR DESCRIPTION
## Summary

Restructure Settings → Lightning so the screen reads as real iOS Settings instead of stacked custom controls on a black canvas. The user-facing change is most visible on the Lightning address itself: a clean canvas row replaces the nested Liquid Glass card.

- Address is now a single canvas row — status dot + monospaced address + qrcode glyph. **Tap** opens the QR sheet, **long-press** opens a `.contextMenu` with *Copy address* / *Share address* (the canonical iOS pattern for identifier rows like Personal Hotspot password, Apple ID email).
- New `SettingsSectionGroup` + `SettingsSectionFooter` helpers (`LiquidGlassModifiers.swift`) so the detail screen uses the same section grammar as the parent `SettingsView`. `CanvasDivider`s between rows per the project's CanvasDivider Rule.
- Intro / setup / error copy moved into native section footers; the standalone "Connected to npubx.cash" pill is gone (replaced by the inline status dot).
- `ScrollView` gains `.refreshable` wired to `checkAndClaimPayments`; the manual "Check for payments" row stays for discoverability.
- Receiving Mint row: no decorative bank icon, shows mint name (not URL), tail-truncated.
- Auto-claim subtitle removed; footer trimmed to one sentence. "Pull down to refresh" training-wheels subtitle removed.
- `QRCodeDetailSheet` gains a `ShareLink` next to `Copy`; both are text-only glass capsules per the Iconless-CTA Rule.

## Test plan

- [ ] Build (`xcodebuild -scheme CashuWallet -destination 'generic/platform=iOS' -configuration Debug build`) succeeds with no new warnings
- [ ] Settings → Lightning: section grammar reads correctly (Lightning Address, Preferences, no-header sync section)
- [ ] Address row: tap opens QR sheet; long-press shows Copy address + Share address context menu items
- [ ] QR sheet: Copy flips to "Copied" for 2s; Share opens iOS share sheet
- [ ] Pull down on the list — `checkAndClaimPayments` fires; manual row still works as a fallback
- [ ] Toggle Enable Lightning Address off — only the master toggle + intro footer remain
- [ ] Status dot reflects connection state (green / orange / red) and reacts to relay state changes
- [ ] Dynamic Type AX5 — address row truncates middle, never breaks layout
- [ ] VoiceOver — address row announced as "Lightning address: \<full\>. \<status\>. Shows QR code. Long-press for copy and share."

🤖 Generated with [Claude Code](https://claude.com/claude-code)