### PR TITLE
Glass action buttons + sendTokens mint-URL override

### DIFF
--- a/CashuWallet/Core/Services/TokenService.swift
+++ b/CashuWallet/Core/Services/TokenService.swift
@@ -27,7 +27,14 @@ class TokenService: ObservableObject {
         self.walletRepository = walletRepository
         self.getActiveMint = getActiveMint
     }
-    
+
+    // MARK: - State
+
+    /// Reset transient state (called when the wallet is locked/reset).
+    func clearState() {
+        isLoading = false
+    }
+
     // MARK: - Send Operations
     
     /// Send tokens (create ecash token string)
@@ -35,15 +42,24 @@ class TokenService: ObservableObject {
     ///   - amount: Amount to send in satoshis
     ///   - memo: Optional memo to include
     /// - Returns: Result containing token string and fee paid
-    func sendTokens(amount: UInt64, memo: String? = nil, p2pkPubkey: String? = nil) async throws -> SendTokenResult {
-        guard let repo = walletRepository(), let activeMint = getActiveMint() else {
+    func sendTokens(
+        amount: UInt64,
+        memo: String? = nil,
+        p2pkPubkey: String? = nil,
+        mintUrl preferredMintURL: String? = nil
+    ) async throws -> SendTokenResult {
+        guard let repo = walletRepository() else {
             throw WalletError.notInitialized
         }
-        
+
+        guard let mintURLString = preferredMintURL ?? getActiveMint()?.url else {
+            throw WalletError.notInitialized
+        }
+
         isLoading = true
         defer { isLoading = false }
-        
-        let mintUrl = MintUrl(url: activeMint.url)
+
+        let mintUrl = MintUrl(url: mintURLString)
         let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
         
         let sendMemo = memo.map { SendMemo(memo: $0, includeMemo: true) }

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -255,41 +255,24 @@ struct MainWalletView: View {
 
     // MARK: - Action Buttons (Receive + Send)
 
-    /// Scan moved to the toolbar; the action row is now a two-button pair.
+    /// Scan moved to the toolbar; the action row is a two-button pair.
+    /// Interactive glass lives inside `FullWidthCapsuleButtonStyle` (driven by
+    /// `configuration.isPressed`), so a single gesture owns each button — no
+    /// press-warp vs. tap-action conflict, hence no dropped first taps.
     private var actionButtons: some View {
-        Group {
-            if #available(iOS 26, *) {
-                GlassEffectContainer(spacing: 12) {
-                    actionButtonsContent
-                }
-            } else {
-                actionButtonsContent
-            }
-        }
-    }
-
-    private var actionButtonsContent: some View {
         HStack(spacing: 12) {
             Button { activeSheet = .chooser(.receive) } label: {
                 Text("Receive")
-                    .font(.body.weight(.semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
-                    .liquidGlass(in: Capsule(), interactive: true)
             }
+            .glassButton()
             .accessibilityHint("Opens options to receive ecash or lightning payments")
 
             Button { activeSheet = .chooser(.send) } label: {
                 Text("Send")
-                    .font(.body.weight(.semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
-                    .liquidGlass(in: Capsule(), interactive: true)
             }
+            .glassButton()
             .accessibilityHint("Opens options to send ecash or pay lightning invoices")
         }
-        .buttonStyle(.plain)
-        .foregroundStyle(.primary)
     }
 
     // MARK: - Recent Activity


### PR DESCRIPTION
- MainWalletView: drive interactive glass from FullWidthCapsuleButtonStyle via .glassButton() so one gesture owns each button, fixing dropped first taps
- TokenService: add optional mintUrl override to sendTokens and clearState()