### PR TITLE
fix: use CDK default on-chain mint splits

### DIFF
--- a/CashuWallet/Core/Services/LightningService.swift
+++ b/CashuWallet/Core/Services/LightningService.swift
@@ -196,7 +196,7 @@ class LightningService: ObservableObject {
             }
 
             mintUrl = normalizedQuote.mintUrl
-            amountSplitTarget = mintAmountSplitTarget(for: normalizedQuote)
+            amountSplitTarget = .none
 
             if storedPaymentMethod == .onchain,
                normalizedQuote.amountPaid.value <= normalizedQuote.amountIssued.value {
@@ -735,26 +735,6 @@ class LightningService: ObservableObject {
         }
 
         return nil
-    }
-
-    private func mintAmountSplitTarget(for quote: MintQuote) -> SplitTarget {
-        guard PaymentMethodKind.from(quote.paymentMethod) == .onchain else {
-            return .none
-        }
-
-        if let amount = quote.amount?.value, amount > 0 {
-            return .value(amount: Amount(value: amount))
-        }
-
-        if quote.amountPaid.value > 0 {
-            return .value(amount: Amount(value: quote.amountPaid.value))
-        }
-
-        if quote.amountIssued.value > 0 {
-            return .value(amount: Amount(value: quote.amountIssued.value))
-        }
-
-        return .none
     }
 
     private func mintQuoteClearingOrphanedReservationIfNeeded(

--- a/android/app/src/main/java/org/cashu/wallet/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/org/cashu/wallet/Core/CDK/CdkWalletGatewayImpl.kt
@@ -205,7 +205,7 @@ class CdkWalletGatewayImpl : CdkWalletGateway {
         normalizedQuote.usedByOperation?.let { releaseMintQuoteReservation(it, quoteId) }
         val proofs = walletFor(normalizedQuote.mintUrl.url).mintUnified(
             quoteId = quoteId,
-            amountSplitTarget = normalizedQuote.mintAmountSplitTarget(method),
+            amountSplitTarget = CdkSplitTarget.None,
             spendingConditions = null,
         )
         return proofsTotalAmount(proofs).value.toLong()

--- a/android/app/src/main/java/org/cashu/wallet/Core/CDK/MintQuoteCdkMetadata.kt
+++ b/android/app/src/main/java/org/cashu/wallet/Core/CDK/MintQuoteCdkMetadata.kt
@@ -5,7 +5,6 @@ import org.cashu.wallet.Models.PaymentMethodKind
 import org.cashudevkit.Amount as CdkAmount
 import org.cashudevkit.MintQuote as CdkMintQuote
 import org.cashudevkit.PaymentMethod as CdkPaymentMethod
-import org.cashudevkit.SplitTarget as CdkSplitTarget
 
 internal fun CdkMintQuote.withLocalMintQuoteMetadata(
     method: PaymentMethodKind,
@@ -50,17 +49,6 @@ internal fun CdkMintQuote.clearingReservation(): CdkMintQuote =
 
 internal fun CdkMintQuote.hasUnissuedOnchainCredit(): Boolean =
     amountPaid.value > amountIssued.value
-
-internal fun CdkMintQuote.mintAmountSplitTarget(method: PaymentMethodKind): CdkSplitTarget {
-    if (method != PaymentMethodKind.Onchain) return CdkSplitTarget.None
-
-    val amount = amount?.value?.takeIf { it > 0uL }
-        ?: amountPaid.value.takeIf { it > 0uL }
-        ?: amountIssued.value.takeIf { it > 0uL }
-        ?: return CdkSplitTarget.None
-
-    return CdkSplitTarget.Value(CdkAmount(amount))
-}
 
 private fun CdkMintQuote.localMintQuoteAmount(
     method: PaymentMethodKind,

--- a/android/app/src/test/java/org/cashu/wallet/Core/CDK/MintQuoteCdkMetadataTest.kt
+++ b/android/app/src/test/java/org/cashu/wallet/Core/CDK/MintQuoteCdkMetadataTest.kt
@@ -8,7 +8,6 @@ import org.cashudevkit.MintQuote as CdkMintQuote
 import org.cashudevkit.MintUrl as CdkMintUrl
 import org.cashudevkit.PaymentMethod as CdkPaymentMethod
 import org.cashudevkit.QuoteState as CdkQuoteState
-import org.cashudevkit.SplitTarget as CdkSplitTarget
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -87,37 +86,6 @@ class MintQuoteCdkMetadataTest {
         val normalized = quote.withLocalMintQuoteMetadata(PaymentMethodKind.Onchain, fallbackAmount = 42)
 
         assertEquals(21uL, normalized.amount?.value)
-    }
-
-    @Test
-    fun onchainMintSplitTargetUsesStoredAmount() {
-        val target = quote(
-            amount = CdkAmount(64uL),
-            paymentMethod = CdkPaymentMethod.Onchain,
-            amountPaid = CdkAmount(80uL),
-        ).mintAmountSplitTarget(PaymentMethodKind.Onchain)
-
-        assertTrue(target is CdkSplitTarget.Value)
-        assertEquals(64uL, (target as CdkSplitTarget.Value).amount.value)
-    }
-
-    @Test
-    fun onchainMintSplitTargetFallsBackToCreditedAmount() {
-        val target = quote(
-            amount = null,
-            paymentMethod = CdkPaymentMethod.Onchain,
-            amountPaid = CdkAmount(80uL),
-        ).mintAmountSplitTarget(PaymentMethodKind.Onchain)
-
-        assertTrue(target is CdkSplitTarget.Value)
-        assertEquals(80uL, (target as CdkSplitTarget.Value).amount.value)
-    }
-
-    @Test
-    fun nonOnchainMintSplitTargetIsNone() {
-        val target = quote(amount = CdkAmount(64uL)).mintAmountSplitTarget(PaymentMethodKind.Bolt11)
-
-        assertTrue(target is CdkSplitTarget.None)
     }
 
     @Test


### PR DESCRIPTION
On-chain minting used the requested quote amount as the CDK split target. When a quote was overpaid, CDK repeated that quote-sized split across the full credited amount. For example, a 2555 sat quote with 504662 sats paid expanded to 1780 blinded outputs and exceeded the mint max_outputs limit.

Use CDK's default split target for mint issuance on iOS and Android so the wallet does not force repeated quote-sized output groups for on-chain credits.