### PR TITLE
Start up tasks 

### DIFF
--- a/CashuWallet/Core/Services/MintService.swift
+++ b/CashuWallet/Core/Services/MintService.swift
@@ -172,30 +172,6 @@ class MintService: ObservableObject {
         }
     }
 
-    func refreshMintInfoIfNeeded(maxAge: TimeInterval) async {
-        guard let repo = walletRepository() else { return }
-        let cutoff = Date().addingTimeInterval(-maxAge)
-        var updated = false
-
-        for i in mints.indices where mints[i].lastUpdated < cutoff {
-            do {
-                if try await refreshMintInfo(at: i, using: repo) {
-                    updated = true
-                }
-            } catch {
-                AppLogger.wallet.error("Failed to refresh stale mint info for \(self.mints[i].url): \(error)")
-            }
-        }
-
-        if updated {
-            if let activeMintUrl = activeMint?.url,
-               let refreshed = mints.first(where: { $0.url == activeMintUrl }) {
-                activeMint = refreshed
-            }
-            saveMints()
-        }
-    }
-
     /// Update balance for a specific mint
     func updateMintBalance(url: String, balance: UInt64) {
         updateMintBalances([url: balance])

--- a/CashuWallet/Core/WalletManager.swift
+++ b/CashuWallet/Core/WalletManager.swift
@@ -805,8 +805,8 @@ class WalletManager: ObservableObject {
         await refreshBalance()
     }
 
-    func refreshMintInfoIfNeeded(maxAge: TimeInterval = 6 * 60 * 60) async {
-        await mintService.refreshMintInfoIfNeeded(maxAge: maxAge)
+    func refreshMintInfo() async {
+        await mintService.refreshMintInfo()
     }
 
     /// Fetch full mint info from the mint's API via CashuDevKit

--- a/CashuWallet/Core/WalletManager.swift
+++ b/CashuWallet/Core/WalletManager.swift
@@ -324,7 +324,8 @@ class WalletManager: ObservableObject {
         try initializeWalletRepository(mnemonic: mnemonic)
 
         mintService.loadCachedMints()
-        balance = mints.reduce(UInt64(0)) { $0 + $1.balance }
+        await performBestEffortWalletStartupMaintenance()
+        await refreshBalance()
         transactionService.loadCachedState()
 
         initializeNostrKeypairLocally(mnemonic: mnemonic)
@@ -628,6 +629,55 @@ class WalletManager: ObservableObject {
         }
         
         return Array(Set(urls))
+    }
+
+    private func performBestEffortWalletStartupMaintenance() async {
+        guard let walletRepository else { return }
+        let mintUrls = trackedMintUrlsForWalletAccess()
+        guard !mintUrls.isEmpty else { return }
+
+        for mintUrlString in mintUrls {
+            do {
+                let wallet = try await walletRepository.getWallet(
+                    mintUrl: MintUrl(url: mintUrlString),
+                    unit: .sat
+                )
+                await recoverIncompleteSagasIfNeeded(wallet: wallet, mintUrl: mintUrlString)
+                await refreshKeysetsIfNeeded(wallet: wallet, mintUrl: mintUrlString)
+            } catch {
+                AppLogger.wallet.error(
+                    "Wallet startup maintenance failed for mint \(mintUrlString, privacy: .public): \(String(describing: error), privacy: .public)"
+                )
+            }
+        }
+    }
+
+    private func recoverIncompleteSagasIfNeeded(wallet: Wallet, mintUrl: String) async {
+        do {
+            let report = try await wallet.recoverIncompleteSagas()
+            if report.recovered > 0 || report.compensated > 0 || report.skipped > 0 || report.failed > 0 {
+                AppLogger.wallet.info(
+                    "Recovered wallet sagas for mint \(mintUrl, privacy: .public): recovered=\(report.recovered, privacy: .public) compensated=\(report.compensated, privacy: .public) skipped=\(report.skipped, privacy: .public) failed=\(report.failed, privacy: .public)"
+                )
+            }
+        } catch {
+            AppLogger.wallet.error(
+                "Failed to recover wallet sagas for mint \(mintUrl, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+
+    private func refreshKeysetsIfNeeded(wallet: Wallet, mintUrl: String) async {
+        do {
+            let keysets = try await wallet.refreshKeysets()
+            AppLogger.wallet.info(
+                "Refreshed \(keysets.count, privacy: .public) keysets for mint \(mintUrl, privacy: .public)"
+            )
+        } catch {
+            AppLogger.wallet.error(
+                "Failed to refresh keysets for mint \(mintUrl, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+        }
     }
     
     private func ensureMintTrackedForToken(_ tokenString: String) async throws {

--- a/CashuWallet/Views/Mints/MintsListView.swift
+++ b/CashuWallet/Views/Mints/MintsListView.swift
@@ -81,7 +81,7 @@ struct MintsListView: View {
                     .environmentObject(walletManager)
             }
             .task {
-                await walletManager.refreshMintInfoIfNeeded()
+                await walletManager.refreshMintInfo()
             }
             .alert("Remove Mint", isPresented: $showRemoveConfirmation) {
                 Button("Remove", role: .destructive) {


### PR DESCRIPTION
We should call the saga recovery on start up to clear any in process operations. 

I also think we should remove the refresh if needed logic from the app layer and let cdk manage this refresh logic from its cache. 

Note: I only made changes to ios and I can't build this not being on mac. 