### PR TITLE
design: surface wallet's own mints in restore suggestions

### DIFF
--- a/CashuWallet/Views/Components/ActivityOrbView.swift
+++ b/CashuWallet/Views/Components/ActivityOrbView.swift
@@ -226,48 +226,82 @@ struct RecommendedMint: Identifiable {
     ]
 }
 
-/// Quick-add suggestion rows shown in the restore-mints empty state. Converts
-/// the "type a mint URL from memory" recall task into recognition: tap a known
-/// mint to stage it for restore. Rows sit on the bare canvas with hairline
-/// dividers — the same shape as the staged-mint list, no card.
+/// Quick-add suggestion rows shown in the restore-mints flow. Converts the
+/// "type a mint URL from memory" recall task into recognition. Shows the
+/// wallet's own mints first ("Your mints"), then falls back to curated
+/// suggestions for users who have none configured yet. Rows sit on the bare
+/// canvas with hairline dividers — the same shape as the staged-mint list.
 struct SuggestedMintsSection: View {
     /// URLs already staged or restored — filtered out of the suggestions.
     let existingURLs: Set<String>
     let onAdd: (String) -> Void
+    /// Mints already configured in the wallet — surfaced first so users
+    /// recognise them without having to remember URLs.
+    var walletMints: [RecommendedMint] = []
 
-    private var available: [RecommendedMint] {
-        RecommendedMint.suggested.filter { !existingURLs.contains($0.url) }
+    private var availableWalletMints: [RecommendedMint] {
+        walletMints.filter { !existingURLs.contains($0.url) }
+    }
+
+    private var availableCurated: [RecommendedMint] {
+        let walletUrls = Set(walletMints.map(\.url))
+        return RecommendedMint.suggested.filter {
+            !existingURLs.contains($0.url) && !walletUrls.contains($0.url)
+        }
     }
 
     var body: some View {
-        if !available.isEmpty {
+        let hasWallet = !availableWalletMints.isEmpty
+        let hasCurated = !availableCurated.isEmpty
+
+        if hasWallet || hasCurated {
             VStack(alignment: .leading, spacing: 0) {
-                Text("Suggested mints")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                    .tracking(1.2)
-                    .padding(.horizontal, 4)
-                    .padding(.bottom, 8)
-
-                ForEach(Array(available.enumerated()), id: \.element.id) { index, mint in
-                    Button {
-                        onAdd(mint.url)
-                        HapticFeedback.selection()
-                    } label: {
-                        row(for: mint)
+                if hasWallet {
+                    sectionHeader("Your mints")
+                    ForEach(Array(availableWalletMints.enumerated()), id: \.element.id) { index, mint in
+                        mintButton(mint)
+                        if index < availableWalletMints.count - 1 || hasCurated {
+                            CanvasDivider()
+                        }
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Add \(mint.name)")
-                    .accessibilityHint("Stages \(displayHost(mint.url)) for recovery")
-
-                    if index < available.count - 1 {
-                        CanvasDivider()
+                }
+                if hasCurated {
+                    sectionHeader("Suggested mints")
+                        .padding(.top, hasWallet ? 16 : 0)
+                    ForEach(Array(availableCurated.enumerated()), id: \.element.id) { index, mint in
+                        mintButton(mint)
+                        if index < availableCurated.count - 1 {
+                            CanvasDivider()
+                        }
                     }
                 }
             }
             .padding(.horizontal)
         }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+            .tracking(1.2)
+            .padding(.horizontal, 4)
+            .padding(.bottom, 8)
+    }
+
+    @ViewBuilder
+    private func mintButton(_ mint: RecommendedMint) -> some View {
+        Button {
+            onAdd(mint.url)
+            HapticFeedback.selection()
+        } label: {
+            row(for: mint)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add \(mint.name)")
+        .accessibilityHint("Stages \(displayHost(mint.url)) for recovery")
     }
 
     private func row(for mint: RecommendedMint) -> some View {

--- a/CashuWallet/Views/Main/OnboardingView.swift
+++ b/CashuWallet/Views/Main/OnboardingView.swift
@@ -730,12 +730,13 @@ struct OnboardingView: View {
                     .padding(.horizontal)
                 }
                 .frame(maxHeight: 280)
-            } else {
-                SuggestedMintsSection(
-                    existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
-                    onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) }
-                )
             }
+
+            SuggestedMintsSection(
+                existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
+                onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) },
+                walletMints: walletManager.mints.map { RecommendedMint(name: $0.name, url: $0.url) }
+            )
 
             // Error display
             if let error = restoreMintError {

--- a/CashuWallet/Views/Main/OnboardingView.swift
+++ b/CashuWallet/Views/Main/OnboardingView.swift
@@ -16,6 +16,7 @@ struct OnboardingView: View {
     @State private var isRestoringMints = false
     @State private var currentRestoringMint: String?
     @State private var restoreMintError: String?
+    @State private var previousWalletMintSuggestions: [RecommendedMint] = []
 
     // Seed phrase reveal / acknowledge state
     @State private var seedRevealed = false
@@ -735,7 +736,7 @@ struct OnboardingView: View {
             SuggestedMintsSection(
                 existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
                 onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) },
-                walletMints: walletManager.mints.map { RecommendedMint(name: $0.name, url: $0.url) }
+                walletMints: previousWalletMintSuggestions
             )
 
             // Error display
@@ -944,6 +945,9 @@ struct OnboardingView: View {
             .lowercased()
             .split(separator: " ")
             .joined(separator: " ")
+        let currentMintSuggestions = walletManager.mints.map {
+            RecommendedMint(name: $0.name, url: $0.url)
+        }
 
         guard walletManager.validateMnemonic(cleanedMnemonic) else {
             errorMessage = "That seed phrase doesn't look right. Check the spelling and try again."
@@ -956,6 +960,9 @@ struct OnboardingView: View {
         Task {
             do {
                 try await walletManager.initializeRestoredWallet(mnemonic: cleanedMnemonic)
+                if !currentMintSuggestions.isEmpty {
+                    previousWalletMintSuggestions = currentMintSuggestions
+                }
                 advance(to: .restoreMints)
             } catch {
                 errorMessage = "Couldn't open the wallet. \(error.userFacingWalletMessage)"

--- a/CashuWallet/Views/Settings/SettingsView.swift
+++ b/CashuWallet/Views/Settings/SettingsView.swift
@@ -523,14 +523,13 @@ struct RestoreWalletView: View {
             }
             .padding(.horizontal)
 
-            if isEmpty {
-                SuggestedMintsSection(
-                    existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
-                    onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) }
-                )
-            } else {
-                restoreMintList
-            }
+            restoreMintList
+
+            SuggestedMintsSection(
+                existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
+                onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) },
+                walletMints: walletManager.mints.map { RecommendedMint(name: $0.name, url: $0.url) }
+            )
 
             if let mintError {
                 Text(mintError)

--- a/CashuWallet/Views/Settings/SettingsView.swift
+++ b/CashuWallet/Views/Settings/SettingsView.swift
@@ -359,6 +359,7 @@ struct RestoreWalletView: View {
     @State private var isRestoringMints = false
     @State private var currentRestoringMint: String?
     @State private var mintError: String?
+    @State private var previousWalletMintSuggestions: [RecommendedMint] = []
 
     private enum RestoreStep {
         case seed
@@ -528,7 +529,7 @@ struct RestoreWalletView: View {
             SuggestedMintsSection(
                 existingURLs: Set(mintsToRestore).union(restoreResults.map(\.mintUrl)),
                 onAdd: { addMintUrlToRestoreList($0, showDuplicateError: false, showValidationError: false) },
-                walletMints: walletManager.mints.map { RecommendedMint(name: $0.name, url: $0.url) }
+                walletMints: previousWalletMintSuggestions
             )
 
             if let mintError {
@@ -725,6 +726,9 @@ struct RestoreWalletView: View {
 
     private func initializeAndProceed() {
         let cleanedMnemonic = normalizedWords(from: restoreMnemonic).joined(separator: " ")
+        let currentMintSuggestions = walletManager.mints.map {
+            RecommendedMint(name: $0.name, url: $0.url)
+        }
 
         guard walletManager.validateMnemonic(cleanedMnemonic) else {
             seedError = "That seed phrase doesn't look right. Check the spelling and try again."
@@ -739,6 +743,9 @@ struct RestoreWalletView: View {
 
             do {
                 try await walletManager.initializeRestoredWallet(mnemonic: cleanedMnemonic)
+                if !currentMintSuggestions.isEmpty {
+                    previousWalletMintSuggestions = currentMintSuggestions
+                }
                 step = .mints
             } catch {
                 seedError = "Couldn't open the wallet. \(error.userFacingWalletMessage)"


### PR DESCRIPTION
SuggestedMintsSection now accepts walletMints param and renders a "Your mints" section above the curated list. Wallet mints are filtered against existingURLs (already staged/restored) and deduplicated against the curated list so nothing appears twice.

Both RestoreWalletView (SettingsView) and the onboarding restore flow (OnboardingView) now pass walletManager.mints and render SuggestedMintsSection unconditionally — always visible regardless of whether the staged list is empty.