### PR TITLE
nostr mint list backup and restore

### DIFF
--- a/CashuWallet.xcodeproj/project.pbxproj
+++ b/CashuWallet.xcodeproj/project.pbxproj
@@ -81,12 +81,12 @@
 		D200000000000102 /* WalletManager+NPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000102 /* WalletManager+NPC.swift */; };
 		D200000000000103 /* WalletManager+Mints.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000103 /* WalletManager+Mints.swift */; };
 		D200000000000104 /* WalletManager+Lightning.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000104 /* WalletManager+Lightning.swift */; };
-		D20000000000010A /* WalletManager+PendingMelts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010A /* WalletManager+PendingMelts.swift */; };
 		D200000000000105 /* WalletManager+CashuPaymentRequests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000105 /* WalletManager+CashuPaymentRequests.swift */; };
 		D200000000000106 /* WalletManager+Tokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000106 /* WalletManager+Tokens.swift */; };
 		D200000000000107 /* WalletManager+MintQuoteSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000107 /* WalletManager+MintQuoteSync.swift */; };
 		D200000000000108 /* WalletManager+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000108 /* WalletManager+Backup.swift */; };
 		D200000000000109 /* WalletErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000109 /* WalletErrors.swift */; };
+		D20000000000010A /* WalletManager+PendingMelts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010A /* WalletManager+PendingMelts.swift */; };
 		D200000000000201 /* PaymentMethodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000201 /* PaymentMethodKind.swift */; };
 		D200000000000202 /* PaymentRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000202 /* PaymentRequestParser.swift */; };
 		D200000000000203 /* OnchainExplorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000203 /* OnchainExplorer.swift */; };
@@ -222,12 +222,12 @@
 		D100000000000102 /* WalletManager+NPC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+NPC.swift"; sourceTree = "<group>"; };
 		D100000000000103 /* WalletManager+Mints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+Mints.swift"; sourceTree = "<group>"; };
 		D100000000000104 /* WalletManager+Lightning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+Lightning.swift"; sourceTree = "<group>"; };
-		D10000000000010A /* WalletManager+PendingMelts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+PendingMelts.swift"; sourceTree = "<group>"; };
 		D100000000000105 /* WalletManager+CashuPaymentRequests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+CashuPaymentRequests.swift"; sourceTree = "<group>"; };
 		D100000000000106 /* WalletManager+Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+Tokens.swift"; sourceTree = "<group>"; };
 		D100000000000107 /* WalletManager+MintQuoteSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+MintQuoteSync.swift"; sourceTree = "<group>"; };
 		D100000000000108 /* WalletManager+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+Backup.swift"; sourceTree = "<group>"; };
 		D100000000000109 /* WalletErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletErrors.swift; sourceTree = "<group>"; };
+		D10000000000010A /* WalletManager+PendingMelts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+PendingMelts.swift"; sourceTree = "<group>"; };
 		D100000000000201 /* PaymentMethodKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodKind.swift; sourceTree = "<group>"; };
 		D100000000000202 /* PaymentRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRequestParser.swift; sourceTree = "<group>"; };
 		D100000000000203 /* OnchainExplorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainExplorer.swift; sourceTree = "<group>"; };

--- a/CashuWallet.xcodeproj/project.pbxproj
+++ b/CashuWallet.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		AB00000000000008 /* CashuRequestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC00000000000008 /* CashuRequestDetailView.swift */; };
 		AB0000000000000A /* CashuRequestMintPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000A /* CashuRequestMintPickerSheet.swift */; };
 		AB0000000000000B /* CashuRequestAmountPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000B /* CashuRequestAmountPickerSheet.swift */; };
+		AB0000000000000C /* NostrMintBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000C /* NostrMintBackupService.swift */; };
 		AB00000000000050 /* TransactionAmountColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000052 /* TransactionAmountColumn.swift */; };
 		AB00000000000051 /* CashuRequestAmountColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000053 /* CashuRequestAmountColumn.swift */; };
 		BB00000000000001 /* MintService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000011 /* MintService.swift */; };
@@ -204,6 +205,7 @@
 		AC00000000000008 /* CashuRequestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestDetailView.swift; sourceTree = "<group>"; };
 		AC0000000000000A /* CashuRequestMintPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestMintPickerSheet.swift; sourceTree = "<group>"; };
 		AC0000000000000B /* CashuRequestAmountPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestAmountPickerSheet.swift; sourceTree = "<group>"; };
+		AC0000000000000C /* NostrMintBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrMintBackupService.swift; sourceTree = "<group>"; };
 		BB00000000000011 /* MintService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintService.swift; sourceTree = "<group>"; };
 		BB00000000000012 /* TransactionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionService.swift; sourceTree = "<group>"; };
 		BB00000000000013 /* TokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenService.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 				AC00000000000004 /* NIP44.swift */,
 				AC00000000000005 /* NIP17.swift */,
 				AC00000000000006 /* NostrInboxClient.swift */,
+				AC0000000000000C /* NostrMintBackupService.swift */,
 				AC00000000000007 /* CashuRequestListener.swift */,
 			);
 			path = Core;
@@ -956,6 +959,7 @@
 				AB00000000000004 /* NIP44.swift in Sources */,
 				AB00000000000005 /* NIP17.swift in Sources */,
 				AB00000000000006 /* NostrInboxClient.swift in Sources */,
+				AB0000000000000C /* NostrMintBackupService.swift in Sources */,
 				AB00000000000007 /* CashuRequestListener.swift in Sources */,
 				AB00000000000008 /* CashuRequestDetailView.swift in Sources */,
 				AB0000000000000A /* CashuRequestMintPickerSheet.swift in Sources */,

--- a/CashuWallet/Core/NostrMintBackupService.swift
+++ b/CashuWallet/Core/NostrMintBackupService.swift
@@ -27,6 +27,8 @@ final class NostrMintBackupService: ObservableObject {
         guard SettingsManager.shared.nostrMintBackupEnabled else { return }
         do {
             try await backupMints()
+        } catch NostrMintBackupError.nothingToBackUp {
+            // Empty wallet — nothing worth publishing, not a failure.
         } catch {
             AppLogger.wallet.error("Nostr mint backup failed: \(error)")
         }
@@ -42,6 +44,14 @@ final class NostrMintBackupService: ObservableObject {
         let relays = normalizedRelays(SettingsManager.shared.nostrRelays)
         guard !relays.isEmpty else {
             throw NostrMintBackupError.noRelays
+        }
+
+        // NUT-27 backups are addressable events: publishing replaces the
+        // previous backup for this seed on the relay. Never push an empty
+        // list — a freshly initialized wallet (e.g. mid-restore) would
+        // otherwise wipe the backup it is about to read.
+        guard await !walletRepository.getWallets().isEmpty else {
+            throw NostrMintBackupError.nothingToBackUp
         }
 
         isBackingUp = true
@@ -102,6 +112,7 @@ enum NostrMintBackupError: LocalizedError {
     case notInitialized
     case noRelays
     case webSocketsDisabled
+    case nothingToBackUp
 
     var errorDescription: String? {
         switch self {
@@ -111,6 +122,8 @@ enum NostrMintBackupError: LocalizedError {
             return "No Nostr relays are configured."
         case .webSocketsDisabled:
             return "Websocket connections are disabled."
+        case .nothingToBackUp:
+            return "There are no mints to back up yet."
         }
     }
 }

--- a/CashuWallet/Core/NostrMintBackupService.swift
+++ b/CashuWallet/Core/NostrMintBackupService.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Cdk
+
+/// Publishes the wallet's mint list as an encrypted NUT-27 backup on Nostr and
+/// finds existing backups during restore. All protocol work (key derivation,
+/// encryption, relay publishing) happens inside cdk via `WalletRepository`;
+/// this service only adds settings gating, relay hygiene, and UI-facing state.
+@MainActor
+final class NostrMintBackupService: ObservableObject {
+    static let shared = NostrMintBackupService()
+
+    @Published private(set) var isBackingUp = false
+    @Published private(set) var isSearching = false
+    @Published private(set) var lastBackupDate: Date?
+
+    /// Injected by `WalletManager` alongside its own repository lifecycle.
+    var walletRepository: WalletRepository?
+
+    private init() {
+        lastBackupDate = UserDefaults.standard.object(forKey: StorageKeys.nostrMintBackupLastBackupDate) as? Date
+    }
+
+    /// Fire-and-forget trigger after mint-list changes — the Nostr twin of
+    /// `performICloudBackup()`. Failures only log; the mint operation that
+    /// triggered the backup must not surface a relay error.
+    func backupCurrentMintsIfEnabled() async {
+        guard SettingsManager.shared.nostrMintBackupEnabled else { return }
+        do {
+            try await backupMints()
+        } catch {
+            AppLogger.wallet.error("Nostr mint backup failed: \(error)")
+        }
+    }
+
+    func backupMints() async throws {
+        guard SettingsManager.shared.useWebsockets else {
+            throw NostrMintBackupError.webSocketsDisabled
+        }
+        guard let walletRepository else {
+            throw NostrMintBackupError.notInitialized
+        }
+        let relays = normalizedRelays(SettingsManager.shared.nostrRelays)
+        guard !relays.isEmpty else {
+            throw NostrMintBackupError.noRelays
+        }
+
+        isBackingUp = true
+        defer { isBackingUp = false }
+
+        _ = try await walletRepository.backupMints(
+            relays: relays,
+            options: BackupOptions(client: "cashu.me")
+        )
+
+        let date = Date()
+        lastBackupDate = date
+        UserDefaults.standard.set(date, forKey: StorageKeys.nostrMintBackupLastBackupDate)
+    }
+
+    /// Fetch the newest mint-list backup for the currently opened wallet seed.
+    /// Returns the backed-up mint URLs (empty when the relays have no backup).
+    func fetchBackedUpMintURLs() async throws -> [String] {
+        guard SettingsManager.shared.useWebsockets else {
+            throw NostrMintBackupError.webSocketsDisabled
+        }
+        guard let walletRepository else {
+            throw NostrMintBackupError.notInitialized
+        }
+        let relays = normalizedRelays(SettingsManager.shared.nostrRelays)
+        guard !relays.isEmpty else {
+            throw NostrMintBackupError.noRelays
+        }
+
+        isSearching = true
+        defer { isSearching = false }
+
+        let backup = try await walletRepository.fetchMintBackup(
+            relays: relays,
+            options: RestoreOptions(timeoutSecs: 4)
+        )
+        return backup.mints.map(\.url)
+    }
+
+    func resetForWalletBoundary() {
+        lastBackupDate = nil
+        UserDefaults.standard.removeObject(forKey: StorageKeys.nostrMintBackupLastBackupDate)
+    }
+
+    private func normalizedRelays(_ relays: [String]) -> [String] {
+        var seen = Set<String>()
+        return relays.compactMap { relay in
+            let trimmed = relay.trimmingCharacters(in: .whitespacesAndNewlines)
+            let lower = trimmed.lowercased()
+            guard lower.hasPrefix("wss://") || lower.hasPrefix("ws://") else { return nil }
+            guard seen.insert(trimmed).inserted else { return nil }
+            return trimmed
+        }
+    }
+}
+
+enum NostrMintBackupError: LocalizedError {
+    case notInitialized
+    case noRelays
+    case webSocketsDisabled
+
+    var errorDescription: String? {
+        switch self {
+        case .notInitialized:
+            return "Wallet is not initialized."
+        case .noRelays:
+            return "No Nostr relays are configured."
+        case .webSocketsDisabled:
+            return "Websocket connections are disabled."
+        }
+    }
+}

--- a/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -97,6 +97,7 @@ enum StorageKeys {
     static let pendingMeltQuotes = "wallet.pendingMeltQuotes"
     static let mintQuoteTimestamps = "wallet.mintQuoteTimestamps"
     static let processedNPCQuotes = "wallet.processedNPCQuotes"
+    static let nostrMintBackupLastBackupDate = "wallet.nostrMintBackup.lastBackupDate"
 
     // Cashu Requests (receive intents shown in History). Key names predate the
     // `wallet.` prefix convention and must stay stable for existing installs,
@@ -120,6 +121,7 @@ enum StorageKeys {
     static let periodicallyCheckIncomingInvoices = "settings.periodicallyCheckIncomingInvoices"
     static let nostrRelays = "settings.nostrRelays"
     static let nostrSignerType = "settings.nostrSignerType"
+    static let nostrMintBackupEnabled = "settings.nostrMintBackupEnabled"
     static let amountDisplayPrimary = "settings.amountDisplayPrimary"
     static let appLockEnabled = "settings.appLockEnabled"
     static let sentryEnabled = "settings.sentryEnabled"
@@ -192,6 +194,7 @@ enum StorageKeys {
         meltQuoteFees,
         mintQuoteTimestamps,
         processedNPCQuotes,
+        nostrMintBackupLastBackupDate,
         cashuRequests,
         cashuRequestsCurrentId,
         cashuRequestsProcessedNIP17Ids
@@ -213,6 +216,7 @@ enum StorageKeys {
         showP2PKButtonInDrawer,
         p2pkKeys,
         nostrSignerType,
+        nostrMintBackupEnabled,
         npcEnabled,
         npcAutomaticClaim,
         npcSelectedMint,

--- a/CashuWallet/Core/SettingsManager.swift
+++ b/CashuWallet/Core/SettingsManager.swift
@@ -128,6 +128,12 @@ class SettingsManager: ObservableObject {
         }
     }
 
+    @Published var nostrMintBackupEnabled: Bool {
+        didSet {
+            settingsStore.nostrMintBackupEnabled = nostrMintBackupEnabled
+        }
+    }
+
     @Published var amountDisplayPrimary: AmountDisplayPrimary {
         didSet {
             settingsStore.amountDisplayPrimary = amountDisplayPrimary.rawValue
@@ -170,6 +176,7 @@ class SettingsManager: ObservableObject {
         self.enablePaymentRequests = settingsStore.enablePaymentRequests
         self.receivePaymentRequestsAutomatically = settingsStore.receivePaymentRequestsAutomatically
         self.nostrRelays = settingsStore.nostrRelays
+        self.nostrMintBackupEnabled = settingsStore.nostrMintBackupEnabled
         self.amountDisplayPrimary = AmountDisplayPrimary(rawValue: settingsStore.amountDisplayPrimary) ?? .fiat
         self.appLockEnabled = settingsStore.appLockEnabled
         self.sentryEnabled = settingsStore.sentryEnabled
@@ -254,6 +261,7 @@ class SettingsManager: ObservableObject {
 
         showP2PKButtonInDrawer = false
         p2pkKeys = []
+        nostrMintBackupEnabled = true
         let previousSuppression = suppressPaymentRequestSideEffects
         suppressPaymentRequestSideEffects = resetRuntimeServices
         defer { suppressPaymentRequestSideEffects = previousSuppression }
@@ -264,6 +272,7 @@ class SettingsManager: ObservableObject {
             NostrService.shared.resetForWalletBoundary()
             NPCService.shared.resetForWalletBoundary()
         }
+        NostrMintBackupService.shared.resetForWalletBoundary()
         settingsStore.clearWalletScopedData()
     }
     

--- a/CashuWallet/Core/SettingsStore.swift
+++ b/CashuWallet/Core/SettingsStore.swift
@@ -103,6 +103,11 @@ final class SettingsStore {
         set { setOptional(newValue, forKey: StorageKeys.nostrSignerType) }
     }
 
+    var nostrMintBackupEnabled: Bool {
+        get { bool(StorageKeys.nostrMintBackupEnabled, default: true) }
+        set { set(newValue, forKey: StorageKeys.nostrMintBackupEnabled) }
+    }
+
     var amountDisplayPrimary: String {
         get { value(StorageKeys.amountDisplayPrimary) ?? "fiat" }
         set { set(newValue, forKey: StorageKeys.amountDisplayPrimary) }

--- a/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -194,6 +194,7 @@ extension WalletManager {
             SettingsManager.shared.resetWalletScopedData(resetRuntimeServices: false)
             try removeWalletFileBackups(fileBackups)
             performICloudBackup()
+            Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         } catch {
             SentryService.capture(error)
             resetRuntimeState()
@@ -277,6 +278,7 @@ extension WalletManager {
         
         db = repository.db
         walletRepository = repository.repository
+        NostrMintBackupService.shared.walletRepository = repository.repository
         processedQuotes = Set(walletStore.loadProcessedNPCQuotes())
     }
 
@@ -301,6 +303,7 @@ extension WalletManager {
         }
 
         walletRepository = nil
+        NostrMintBackupService.shared.walletRepository = nil
         db = nil
         mnemonic = nil
         balance = 0

--- a/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -126,6 +126,10 @@ extension WalletManager {
     /// Restore wallet from mnemonic - Phase 3: Complete restore and dismiss onboarding
     func completeRestore() async {
         completeOnboarding()
+        // The restored mint list is final now — refresh the Nostr backup with it.
+        // (Must not run earlier: publishing while the repository is still empty
+        // would replace the addressable backup event with an empty list.)
+        Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
     }
 
     func completeOnboarding() {
@@ -194,7 +198,6 @@ extension WalletManager {
             SettingsManager.shared.resetWalletScopedData(resetRuntimeServices: false)
             try removeWalletFileBackups(fileBackups)
             performICloudBackup()
-            Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         } catch {
             SentryService.capture(error)
             resetRuntimeState()

--- a/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -8,6 +8,7 @@ extension WalletManager {
         try await mintService.addMint(url: url)
         await refreshBalance()
         performICloudBackup()
+        Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         SentryService.breadcrumb("Mint added", category: "wallet.mint")
     }
 
@@ -15,6 +16,7 @@ extension WalletManager {
         await mintService.removeMint(at: offsets)
         await refreshBalance()
         performICloudBackup()
+        Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         SentryService.breadcrumb("Mint removed", category: "wallet.mint")
     }
 

--- a/CashuWallet/Views/Main/OnboardingView.swift
+++ b/CashuWallet/Views/Main/OnboardingView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct OnboardingView: View {
     @EnvironmentObject var walletManager: WalletManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @ObservedObject private var nostrBackupService = NostrMintBackupService.shared
 
     @State private var currentStep: OnboardingStep = .welcome
     @State private var restoreMnemonic = ""
@@ -1188,6 +1189,17 @@ struct OnboardingView: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel("Paste mint URLs from clipboard")
+
+                        Button(action: searchNostrMintBackups) {
+                            restoreCapsuleChip(
+                                nostrBackupService.isSearching ? "Searching…" : "Nostr",
+                                systemImage: "antenna.radiowaves.left.and.right"
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(nostrBackupService.isSearching)
+                        .opacity(nostrBackupService.isSearching ? 0.4 : 1)
+                        .accessibilityLabel("Find mints from your Nostr backup")
                     }
                     .padding(.horizontal)
 
@@ -1554,6 +1566,31 @@ struct OnboardingView: View {
             setRestoreMintNotice("Added \(addedCount) mint URL\(addedCount == 1 ? "" : "s"). Skipped \(invalidCount) that didn't look like a mint URL.")
         } else {
             restoreMintError = nil
+        }
+    }
+
+    /// Look up the encrypted mint-list backup for this seed on the user's
+    /// relays (NUT-27, fetched by cdk) and stage every mint it contains.
+    private func searchNostrMintBackups() {
+        HapticFeedback.selection()
+
+        Task { @MainActor in
+            do {
+                let urls = try await nostrBackupService.fetchBackedUpMintURLs()
+                var addedCount = 0
+                for url in urls where addMintUrlToRestoreList(url, showDuplicateError: false, showValidationError: false) {
+                    addedCount += 1
+                }
+                if urls.isEmpty {
+                    setRestoreMintNotice("No Nostr mint backup found on your relays.", severity: .caution)
+                } else if addedCount == 0 {
+                    setRestoreMintNotice("Backup found — its mints are already in the list.")
+                } else {
+                    setRestoreMintNotice("Added \(addedCount) mint\(addedCount == 1 ? "" : "s") from your Nostr backup.")
+                }
+            } catch {
+                setRestoreMintNotice(error.localizedDescription, severity: .error)
+            }
         }
     }
 

--- a/CashuWallet/Views/Settings/NostrSettingsSection.swift
+++ b/CashuWallet/Views/Settings/NostrSettingsSection.swift
@@ -356,6 +356,104 @@ struct NostrRelaysSettingsSection: View {
     }
 }
 
+// MARK: - Nostr Mint Backup Section
+
+/// Encrypted mint-list backup on Nostr (NUT-27, handled entirely by cdk), on
+/// the same single-canvas recipe: an auto-backup toggle, a manual backup row,
+/// and a footer carrying the last backup time. Self-contained — owns its own
+/// error state, mirroring the other sections in this file.
+struct NostrMintBackupSettingsSection: View {
+    @EnvironmentObject var walletManager: WalletManager
+    @ObservedObject var settings = SettingsManager.shared
+    @ObservedObject private var backupService = NostrMintBackupService.shared
+
+    @State private var backupError: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            SettingsSectionGroup("Mint backup") {
+                HStack(spacing: 14) {
+                    SettingsRowIcon(systemName: "tray.and.arrow.up")
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Automatic mint backup")
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                        Text("Publish after every mint change.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: 8)
+                    Toggle("", isOn: $settings.nostrMintBackupEnabled)
+                        .labelsHidden()
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 14)
+
+                CanvasDivider()
+
+                Button(action: backupNow) {
+                    HStack(spacing: 14) {
+                        SettingsRowIcon(systemName: "arrow.up.circle")
+                        Text(backupService.isBackingUp ? "Backing up…" : "Back up now")
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                        Spacer(minLength: 8)
+                        if backupService.isBackingUp {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 14)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(backupService.isBackingUp || walletManager.mints.isEmpty)
+                .opacity(walletManager.mints.isEmpty ? 0.5 : 1)
+            }
+
+            if let backupError {
+                InlineNotice(message: backupError, severity: .error)
+                    .padding(.horizontal, 6)
+                    .padding(.top, 4)
+                    .transition(.opacity)
+            }
+
+            SettingsSectionFooter {
+                Text(footerText)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .animation(.easeInOut(duration: 0.2), value: backupError)
+    }
+
+    private var footerText: String {
+        guard !walletManager.mints.isEmpty else {
+            return "Add a mint to back up. The list is encrypted to your seed and published to your relays."
+        }
+        if let date = backupService.lastBackupDate {
+            let formatter = RelativeDateTimeFormatter()
+            formatter.unitsStyle = .short
+            return "Your mint list is encrypted to your seed and published to your relays. Last backup \(formatter.localizedString(for: date, relativeTo: Date()))."
+        }
+        return "Your mint list is encrypted to your seed and published to your relays, so restoring from seed can find your mints."
+    }
+
+    private func backupNow() {
+        HapticFeedback.selection()
+        backupError = nil
+
+        Task { @MainActor in
+            do {
+                try await backupService.backupMints()
+                HapticFeedback.notification(.success)
+            } catch {
+                backupError = error.localizedDescription
+            }
+        }
+    }
+}
+
 // MARK: - Shared row helper
 
 /// A plain single-canvas settings action row (leading glyph + title), matching

--- a/CashuWallet/Views/Settings/SettingsView.swift
+++ b/CashuWallet/Views/Settings/SettingsView.swift
@@ -298,6 +298,7 @@ struct SettingsView: View {
 
                 NostrKeysSettingsSection()
                 NostrRelaysSettingsSection()
+                NostrMintBackupSettingsSection()
             }
             .padding(.horizontal)
             .padding(.bottom, 32)
@@ -438,6 +439,7 @@ struct QRPayload: Identifiable {
 struct RestoreWalletView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var walletManager: WalletManager
+    @ObservedObject private var nostrBackupService = NostrMintBackupService.shared
 
     @State private var step: RestoreStep = .seed
     @State private var restoreMnemonic = ""
@@ -643,6 +645,17 @@ struct RestoreWalletView: View {
                             }
                             .buttonStyle(.plain)
                             .accessibilityLabel("Paste mint URLs from clipboard")
+
+                            Button(action: searchNostrMintBackups) {
+                                capsuleChipLabel(
+                                    nostrBackupService.isSearching ? "Searching…" : "Nostr",
+                                    systemImage: "antenna.radiowaves.left.and.right"
+                                )
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(nostrBackupService.isSearching)
+                            .opacity(nostrBackupService.isSearching ? 0.4 : 1)
+                            .accessibilityLabel("Find mints from your Nostr backup")
                         }
                     }
                     .padding(.horizontal)
@@ -975,6 +988,31 @@ struct RestoreWalletView: View {
             setMintNotice("Added \(addedCount) mint URL\(addedCount == 1 ? "" : "s"). Skipped \(invalidCount) invalid.")
         } else {
             mintError = nil
+        }
+    }
+
+    /// Look up the encrypted mint-list backup for this seed on the user's
+    /// relays (NUT-27, fetched by cdk) and stage every mint it contains.
+    private func searchNostrMintBackups() {
+        HapticFeedback.selection()
+
+        Task { @MainActor in
+            do {
+                let urls = try await nostrBackupService.fetchBackedUpMintURLs()
+                var addedCount = 0
+                for url in urls where addMintUrlToRestoreList(url, showDuplicateError: false, showValidationError: false) {
+                    addedCount += 1
+                }
+                if urls.isEmpty {
+                    setMintNotice("No Nostr mint backup found on your relays.", severity: .caution)
+                } else if addedCount == 0 {
+                    setMintNotice("Backup found — its mints are already in the list.")
+                } else {
+                    setMintNotice("Added \(addedCount) mint\(addedCount == 1 ? "" : "s") from your Nostr backup.")
+                }
+            } catch {
+                setMintNotice(error.localizedDescription, severity: .error)
+            }
         }
     }
 


### PR DESCRIPTION
Mint list backup on Nostr (NUT-27) and restore discovery, implemented entirely through cdk's `WalletRepository` FFI (`backupMints` / `fetchMintBackup`, from https://github.com/cashubtc/cdk/pull/2153 — in the already-pinned cdk-swift 0.17.3-rc.0).

- Settings → Nostr: automatic mint backup toggle + manual "Back up now", last-backup time in the footer
- Restore (settings + onboarding): "Nostr" chip fetches the seed's encrypted backup from the configured relays and stages its mints
- Automatic backups fire at the same sites as `performICloudBackup()` (mint add/remove, new wallet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)