### PR TITLE
fix(ui): expand tap targets on close and icon buttons

### DIFF
--- a/CashuWallet/Views/Components/AmountEntryView.swift
+++ b/CashuWallet/Views/Components/AmountEntryView.swift
@@ -67,12 +67,10 @@ struct AmountEntryView: View {
     private var headerSection: some View {
         HStack {
             // Close button (floating left)
-            Button(action: { dismiss() }) {
-                Image(systemName: "xmark")
-                    .font(.title3)
-                    .foregroundStyle(.secondary)
-            }
-            
+            SheetCloseButton()
+                .font(.title3)
+                .foregroundStyle(.secondary)
+
             Spacer()
             
             // Title
@@ -218,9 +216,7 @@ struct MintPickerView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
+                    SheetCloseButton()
                 }
             }
         }
@@ -326,24 +322,23 @@ struct TokenDisplayView: View {
         VStack(spacing: 24) {
                 // Header
                 HStack {
-                    Button(action: { onDismiss?() }) {
-                        Image(systemName: "xmark")
-                            .font(.title3)
-                            .foregroundStyle(.secondary)
-                    }
-                    
+                    SheetCloseButton { onDismiss?() }
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
+
                     Spacer()
-                    
+
                     Text("Ecash Token")
                         .font(.headline)
-                    
+
                     Spacer()
-                    
+
                     // Share button
                     ShareLink(item: token) {
                         Image(systemName: "square.and.arrow.up")
                             .font(.title3)
-        .foregroundStyle(Color.accentColor)
+                            .foregroundStyle(Color.accentColor)
+                            .toolbarIconTapTarget()
                     }
                 }
                 .padding(.horizontal, 20)

--- a/CashuWallet/Views/Components/ErrorBannerView.swift
+++ b/CashuWallet/Views/Components/ErrorBannerView.swift
@@ -84,9 +84,13 @@ struct ErrorBannerView: View {
 
             if let onDismiss {
                 Button(action: onDismiss) {
+                    // Compact banner: 32pt target (not the full 44) so a short
+                    // single-line banner doesn't visibly inflate.
                     Image(systemName: "xmark")
                         .font(.caption2.weight(.semibold))
                         .foregroundStyle(.secondary)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Dismiss")

--- a/CashuWallet/Views/Components/LiquidGlassModifiers.swift
+++ b/CashuWallet/Views/Components/LiquidGlassModifiers.swift
@@ -57,6 +57,40 @@ extension View {
 
 }
 
+// MARK: - Sheet Close Button
+
+/// Close ("xmark") button for sheet / full-screen-cover chrome with a full
+/// 44×44pt tap target. A Button whose label is a bare SF Symbol is only
+/// hit-testable on the glyph itself (~17pt), which made the sheet close
+/// buttons feel broken — near-misses did nothing. Font and color propagate
+/// from the call site (`.font`, `.foregroundStyle`), so styled headers can
+/// use it too. Defaults to dismissing the enclosing presentation.
+struct SheetCloseButton: View {
+    @Environment(\.dismiss) private var dismiss
+    var action: (() -> Void)? = nil
+
+    var body: some View {
+        Button {
+            if let action { action() } else { dismiss() }
+        } label: {
+            Image(systemName: "xmark")
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel("Close")
+    }
+}
+
+extension View {
+    /// Expands an icon-only toolbar button's label to the HIG-minimum 44×44pt
+    /// tap target. Apply inside the label, on the `Image`.
+    func toolbarIconTapTarget() -> some View {
+        self
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+    }
+}
+
 // MARK: - Screen Entry Fade
 
 /// A subtle opacity-only entrance for a screen's content. Because it carries its

--- a/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -205,11 +205,8 @@ struct ScannerWrapperView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                            .foregroundStyle(.primary)
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
+                        .foregroundStyle(.primary)
                 }
             }
             .onAppear {
@@ -550,10 +547,7 @@ struct CashuPaymentRequestPayView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     // No dismissing mid-authorization (payment is in flight).
                     if paymentPhase != .processing {
-                        Button(action: { dismiss() }) {
-                            Image(systemName: "xmark")
-                        }
-                        .accessibilityLabel("Close")
+                        SheetCloseButton()
                     }
                 }
             }
@@ -1419,10 +1413,7 @@ struct CashuTopUpInvoiceSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
             }
             .onAppear { startMonitoring() }

--- a/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/CashuWallet/Views/History/TransactionDetailView.swift
@@ -142,10 +142,7 @@ struct TransactionDetailView: View {
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
                 ToolbarItem(placement: .principal) {
                     Text(transaction.displayTitle).font(.headline)
@@ -154,6 +151,7 @@ struct TransactionDetailView: View {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(action: { showShareSheet = true }) {
                             Image(systemName: "square.and.arrow.up")
+                                .toolbarIconTapTarget()
                         }
                         .accessibilityLabel("Share")
                     }

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -56,6 +56,7 @@ struct MainWalletView: View {
                     } label: {
                         Image(systemName: "viewfinder")
                             .font(.body.weight(.semibold))
+                            .toolbarIconTapTarget()
                     }
                     .accessibilityLabel("Scan QR Code")
                     .accessibilityHint("Opens the QR scanner")
@@ -883,11 +884,8 @@ private struct WalletActionSheetView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
-                    .accessibilityIdentifier("wallet-chooser-close")
+                    SheetCloseButton(action: onClose)
+                        .accessibilityIdentifier("wallet-chooser-close")
                 }
             }
         }

--- a/CashuWallet/Views/Main/OnboardingView.swift
+++ b/CashuWallet/Views/Main/OnboardingView.swift
@@ -1292,6 +1292,8 @@ struct OnboardingView: View {
             Button(action: { mintsToRestore.removeAll { $0 == url } }) {
                 Image(systemName: "xmark.circle")
                     .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .accessibilityLabel("Remove mint")
             .accessibilityHint("Removes this mint before restoring")

--- a/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/CashuWallet/Views/Mints/MintDetailView.swift
@@ -91,6 +91,7 @@ struct MintDetailView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 ShareLink(item: mint.url) {
                     Image(systemName: "square.and.arrow.up")
+                        .toolbarIconTapTarget()
                 }
                 .accessibilityLabel("Share mint")
             }

--- a/CashuWallet/Views/Receive/CashuRequestAmountPickerSheet.swift
+++ b/CashuWallet/Views/Receive/CashuRequestAmountPickerSheet.swift
@@ -80,13 +80,9 @@ struct CashuRequestAmountPickerSheet: View {
                 .font(.headline)
 
             HStack {
-                Button(action: { dismiss() }) {
-                    Image(systemName: "xmark")
-                        .font(.body.weight(.semibold))
-                        .foregroundStyle(.secondary)
-                        .contentShape(Rectangle())
-                }
-                .accessibilityLabel("Close")
+                SheetCloseButton()
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.secondary)
 
                 Spacer()
             }

--- a/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -49,17 +49,15 @@ struct CashuRequestDetailView: View {
                     .font(.headline)
             }
             ToolbarItem(placement: .cancellationAction) {
-                Button {
+                SheetCloseButton {
                     if let onClose { onClose() } else { dismiss() }
-                } label: {
-                    Image(systemName: "xmark")
                 }
-                .accessibilityLabel("Close")
             }
             ToolbarItem(placement: .topBarTrailing) {
                 if let request {
                     ShareLink(item: request.encoded) {
                         Image(systemName: "square.and.arrow.up")
+                            .toolbarIconTapTarget()
                     }
                     .accessibilityLabel("Share request")
                 }

--- a/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
+++ b/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
@@ -59,10 +59,7 @@ struct CashuRequestMintPickerSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
             }
         }

--- a/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -68,10 +68,7 @@ struct ReceiveLightningView: View {
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
 
                 ToolbarItem(placement: .principal) {
@@ -83,6 +80,7 @@ struct ReceiveLightningView: View {
                     ToolbarItem(placement: .topBarTrailing) {
                         ShareLink(item: quote.request) {
                             Image(systemName: "square.and.arrow.up")
+                                .toolbarIconTapTarget()
                         }
                         .accessibilityLabel("Share request")
                     }
@@ -98,6 +96,7 @@ struct ReceiveLightningView: View {
                         } label: {
                             Image(systemName: selectedOption.navSymbol)
                                 .contentTransition(.symbolEffect(.replace))
+                                .toolbarIconTapTarget()
                         }
                         // Both reusable options share title + glyph, so the
                         // descriptor is what tells "fixed" from "any amount".

--- a/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
+++ b/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
@@ -56,14 +56,12 @@ struct ReceiveTokenDetailView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: {
+                    SheetCloseButton {
                         switch phase {
                         case .none:              dismiss()
                         case .success, .failure: finish()
                         default:                 break   // .processing — button stays disabled
                         }
-                    }) {
-                        Image(systemName: "xmark")
                     }
                     .disabled(phase == .processing)
                 }

--- a/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/CashuWallet/Views/Receive/ReceiveView.swift
@@ -275,10 +275,7 @@ struct ReceiveEcashView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -287,6 +284,7 @@ struct ReceiveEcashView: View {
                     } label: {
                         Image(systemName: "viewfinder")
                             .font(.body.weight(.semibold))
+                            .toolbarIconTapTarget()
                     }
                     .accessibilityLabel("Scan QR Code")
                     .accessibilityHint("Opens the camera to scan an ecash token")

--- a/CashuWallet/Views/Send/SendView.swift
+++ b/CashuWallet/Views/Send/SendView.swift
@@ -67,10 +67,7 @@ struct SendView: View {
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
 
                 ToolbarItem(placement: .principal) {
@@ -85,6 +82,7 @@ struct SendView: View {
                             showLockScanner = true
                         } label: {
                             Image(systemName: "lock")
+                                .toolbarIconTapTarget()
                         }
                         .accessibilityLabel("Lock ecash")
                         .accessibilityHint("Lock this ecash to a public key")
@@ -95,6 +93,7 @@ struct SendView: View {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(action: { showShareSheet = true }) {
                             Image(systemName: "square.and.arrow.up")
+                                .toolbarIconTapTarget()
                         }
                         .accessibilityLabel("Share token")
                     }
@@ -1007,10 +1006,7 @@ struct UnifiedSendView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: onClose) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton(action: onClose)
                 }
             }
             .sheet(isPresented: $showingScanner) {
@@ -1129,9 +1125,14 @@ struct UnifiedSendView: View {
                     HapticFeedback.selection()
                     destination = ""
                 } label: {
+                    // Padding expands the hit area; the negative outer padding
+                    // cancels the layout growth so the field row keeps its height.
                     Image(systemName: "xmark.circle.fill")
                         .font(.title3)
                         .foregroundStyle(.secondary)
+                        .padding(10)
+                        .contentShape(Rectangle())
+                        .padding(-10)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Clear")
@@ -2591,10 +2592,7 @@ struct MeltView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     // No dismissing mid-authorization (payment is in flight).
                     if paymentPhase != .processing {
-                        Button(action: close) {
-                            Image(systemName: "xmark")
-                        }
-                        .accessibilityLabel("Close")
+                        SheetCloseButton(action: close)
                     }
                 }
 
@@ -3423,10 +3421,7 @@ struct MintSelectorSheet: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(action: { dismiss() }) {
-                    Image(systemName: "xmark")
-                }
-                .accessibilityLabel("Close")
+                SheetCloseButton()
             }
         }
     }
@@ -3653,10 +3648,7 @@ struct AddMintToPaySheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
             }
         }
@@ -3765,10 +3757,7 @@ struct MethodPickerSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
             }
         }

--- a/CashuWallet/Views/Settings/P2PKSettingsSection.swift
+++ b/CashuWallet/Views/Settings/P2PKSettingsSection.swift
@@ -115,6 +115,7 @@ struct P2PKSettingsSection: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button { HapticFeedback.selection(); showExplainer = true } label: {
                     Image(systemName: "info.circle")
+                        .toolbarIconTapTarget()
                 }
                 .accessibilityLabel("How locking works")
             }

--- a/CashuWallet/Views/Settings/SettingsView.swift
+++ b/CashuWallet/Views/Settings/SettingsView.swift
@@ -503,6 +503,7 @@ struct RestoreWalletView: View {
                 if step != .progress {
                     Button(action: handleBackNavigation) {
                         Image(systemName: "chevron.left")
+                            .toolbarIconTapTarget()
                     }
                     .disabled(isRestoringSeed)
                     .accessibilityLabel(step == .seed ? "Back" : "Back to seed phrase")
@@ -737,6 +738,8 @@ struct RestoreWalletView: View {
             } label: {
                 Image(systemName: "xmark.circle")
                     .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .accessibilityLabel("Remove mint")
             .accessibilityHint("Removes this mint before restoring")
@@ -1156,9 +1159,7 @@ struct QRCodeDetailSheet: View {
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
+                    SheetCloseButton()
                 }
             }
         }
@@ -1204,9 +1205,15 @@ struct ImportP2PKSheet: View {
                         .autocorrectionDisabled()
 
                     Button(action: { nsecText.isEmpty ? paste() : clear() }) {
+                        // Padding expands the hit area; the negative outer
+                        // padding cancels the layout growth so the field row
+                        // keeps its height.
                         Image(systemName: nsecText.isEmpty ? "doc.on.clipboard" : "xmark.circle.fill")
                             .font(.body.weight(.medium))
                             .foregroundStyle(.secondary)
+                            .padding(10)
+                            .contentShape(Rectangle())
+                            .padding(-10)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(nsecText.isEmpty ? "Paste" : "Clear")

--- a/CashuWallet/Views/Settings/ThemeSettingsSection.swift
+++ b/CashuWallet/Views/Settings/ThemeSettingsSection.swift
@@ -128,10 +128,7 @@ struct CurrencyPickerSheet: View {
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
+                    SheetCloseButton()
                 }
             }
             .safeAreaInset(edge: .bottom) {


### PR DESCRIPTION
Sheet close buttons were only hit-testable on the bare SF Symbol glyph (~17pt), so near-misses did nothing. Add SheetCloseButton and toolbarIconTapTarget() with 44x44pt targets (HIG minimum) and apply to all sheet close buttons, icon-only toolbar buttons, and text-field clear buttons.