### PR TITLE
Multi-unit ecash support: send, receive, mint, requests + home balance

### DIFF
--- a/CI/IntegrationTests/Tests/CurrencyTests.swift
+++ b/CI/IntegrationTests/Tests/CurrencyTests.swift
@@ -112,33 +112,35 @@ final class CurrencyAmountTests: XCTestCase {
 final class CurrencyRegistryTests: XCTestCase {
 
     func testLookupSatByMintUnit() {
-        let currency = CurrencyRegistry.currency(forMintUnit: "sat")
-        XCTAssertNotNil(currency)
-        XCTAssertEqual(currency?.code, "SAT")
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "sat").code, "SAT")
     }
 
     func testLookupSatsByMintUnit() {
-        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "sats")?.code, "SAT")
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "sats").code, "SAT")
     }
 
     func testLookupSatoshiByMintUnit() {
-        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "satoshi")?.code, "SAT")
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "satoshi").code, "SAT")
     }
 
     func testLookupUSDByMintUnit() {
-        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "usd")?.code, "USD")
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "usd").code, "USD")
     }
 
     func testLookupEURByMintUnit() {
-        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "eur")?.code, "EUR")
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "eur").code, "EUR")
     }
 
-    func testLookupUnknownMintUnitReturnsNil() {
-        XCTAssertNil(CurrencyRegistry.currency(forMintUnit: "xyz"))
+    // Unknown/custom units now fall back to a GenericCurrency (never nil) so
+    // arbitrary mint units are supported, not just SAT/USD/EUR.
+    func testLookupUnknownMintUnitFallsBackToGeneric() {
+        let currency = CurrencyRegistry.currency(forMintUnit: "xyz")
+        XCTAssertEqual(currency.code, "XYZ")
+        XCTAssertEqual(currency.decimals, 0)
     }
 
-    func testLookupEmptyMintUnitReturnsNil() {
-        XCTAssertNil(CurrencyRegistry.currency(forMintUnit: ""))
+    func testLookupEmptyMintUnitFallsBackToGeneric() {
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "").decimals, 0)
     }
 
     func testLookupSATByCode() {

--- a/CashuWallet/Core/AmountFormatter.swift
+++ b/CashuWallet/Core/AmountFormatter.swift
@@ -85,6 +85,70 @@ enum AmountFormatter {
         }
     }
 
+    // MARK: - Live amount entry in an explicit mint unit
+    //
+    // A mint *account* unit (sat, eur, usd, or a custom string) is entered
+    // directly in that unit — no BTC-price conversion. `decimals` comes from the
+    // unit's `Currency` (0 for sat/custom, 2 for usd/eur). `decimals == 0` is an
+    // integer append; `decimals > 0` is a minor-unit accumulator (digits shift
+    // in from the right), mirroring the fiat cents keypad but yielding the
+    // unit's own base amount instead of converting to sats.
+
+    /// The integer base-unit value of a typed string for a unit with `decimals`
+    /// fraction digits ("5.00", 2 → 500; "500", 0 → 500).
+    static func entryBaseUnits(raw: String, decimals: Int) -> UInt64 {
+        guard decimals > 0 else { return UInt64(raw) ?? 0 }
+        return UInt64(raw.filter { $0.isNumber }) ?? 0
+    }
+
+    /// Append a keypad digit for direct unit entry. Integer units collapse a
+    /// lone leading zero; fractional units accumulate minor units from the right.
+    /// Returns the unchanged string when the key is rejected (so the caller can
+    /// skip the haptic).
+    static func entryAppendUnit(_ key: String, to raw: String, decimals: Int) -> String {
+        guard key.count == 1, let ch = key.first, ch.isNumber else { return raw }
+        guard decimals > 0 else {
+            return raw == "0" ? key : raw + key
+        }
+        let minor = entryBaseUnits(raw: raw, decimals: decimals)
+        guard minor < maxMinorUnits else { return raw }
+        let updated = minor * 10 + UInt64(ch.wholeNumberValue ?? 0)
+        return updated == 0 ? "" : minorUnitString(updated, decimals: decimals)
+    }
+
+    /// Remove the last keypad input for direct unit entry (mirrors `entryBackspace`).
+    static func entryBackspaceUnit(_ raw: String, decimals: Int) -> String {
+        guard !raw.isEmpty else { return raw }
+        guard decimals > 0 else { return String(raw.dropLast()) }
+        let minor = entryBaseUnits(raw: raw, decimals: decimals) / 10
+        return minor == 0 ? "" : minorUnitString(minor, decimals: decimals)
+    }
+
+    /// The typed-entry string for a base-unit amount in a unit with `decimals`
+    /// fraction digits — the inverse of `entryBaseUnits` (500, 2 → "5.00").
+    /// Empty for a zero amount so the keypad shows its placeholder.
+    static func entryString(baseUnits: UInt64, decimals: Int) -> String {
+        guard baseUnits > 0 else { return "" }
+        return minorUnitString(baseUnits, decimals: decimals)
+    }
+
+    /// Ceiling on the minor-unit accumulator, matching the fiat entry cap so a
+    /// held key can't run past sane bounds.
+    private static let maxMinorUnits: UInt64 = 99_999_999_999
+
+    /// A locale-separated string with `decimals` fraction digits for a minor-unit
+    /// integer (1454, 2 → "14.54"); no grouping/symbol — those are added at
+    /// display time via the unit's `Currency`.
+    private static func minorUnitString(_ minor: UInt64, decimals: Int) -> String {
+        guard decimals > 0 else { return String(minor) }
+        var divisor: UInt64 = 1
+        for _ in 0..<decimals { divisor *= 10 }
+        let intPart = minor / divisor
+        let fracPart = Int(minor % divisor)
+        let frac = String(format: "%0\(decimals)d", fracPart)
+        return "\(intPart)\(decimalSeparator)\(frac)"
+    }
+
     /// Re-express a typed string when the entry unit flips, preserving the
     /// amount through sats so the displayed value stays economically equal.
     @MainActor

--- a/CashuWallet/Core/CashuRequestStore.swift
+++ b/CashuWallet/Core/CashuRequestStore.swift
@@ -120,14 +120,14 @@ class CashuRequestStore: ObservableObject {
     /// request — the original amountless one and any later amounted re-encoding —
     /// keeps attaching payments to this single row instead of spawning a new
     /// request (and a new thing to track) per edit.
-    func update(id: String, amount: UInt64?, mints: [String], encoded: String) {
+    func update(id: String, amount: UInt64?, unit: String, mints: [String], encoded: String) {
         guard let index = requests.firstIndex(where: { $0.id == id }) else { return }
         let old = requests[index]
         requests[index] = CashuRequest(
             id: old.id,
             encoded: encoded,
             amount: amount,
-            unit: old.unit,
+            unit: unit,
             mints: mints,
             memo: old.memo,
             createdAt: old.createdAt,

--- a/CashuWallet/Core/PaymentRequestDecoder.swift
+++ b/CashuWallet/Core/PaymentRequestDecoder.swift
@@ -324,6 +324,26 @@ enum PaymentRequestDecoder {
         }
     }
 
+    /// Inverse of `unitDescription`: maps a mint's unit string to a CDK
+    /// `CurrencyUnit`. Unknown strings pass through as `.custom(unit:)` so
+    /// arbitrary mint units are supported, not just sat/usd/eur.
+    static func currencyUnit(from unit: String) -> Cdk.CurrencyUnit {
+        switch unit.lowercased() {
+        case "sat":
+            return .sat
+        case "msat":
+            return .msat
+        case "usd":
+            return .usd
+        case "eur":
+            return .eur
+        case "auth":
+            return .auth
+        default:
+            return .custom(unit: unit)
+        }
+    }
+
     private static func bitcoinPaymentURI(from raw: String) -> BitcoinPaymentURI? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let components = URLComponents(string: trimmed),

--- a/CashuWallet/Core/Protocols/CurrencyProtocol.swift
+++ b/CashuWallet/Core/Protocols/CurrencyProtocol.swift
@@ -62,6 +62,23 @@ struct EURCurrency: Currency {
     let symbolPosition = CurrencySymbolPosition.before
 }
 
+/// Fallback for an arbitrary mint unit the registry doesn't know about (any
+/// custom unit string a mint might advertise). Treated as an integer base unit
+/// (no decimals) and displayed with the raw code as a trailing label.
+struct GenericCurrency: Currency {
+    let code: String
+    let symbol = ""
+    let decimals = 0
+    let displayName: String
+    let symbolPosition = CurrencySymbolPosition.after
+
+    init(unit: String) {
+        let normalized = unit.uppercased()
+        self.code = normalized
+        self.displayName = normalized
+    }
+}
+
 // MARK: - Currency Amount
 
 /// A value with an associated currency
@@ -147,9 +164,11 @@ enum CurrencyRegistry {
         supportedCurrencies.first { $0.code.uppercased() == code.uppercased() }
     }
     
-    /// Map from mint unit string to currency
-    /// Mints may use "sat", "usd", "eur" as unit identifiers
-    static func currency(forMintUnit unit: String) -> (any Currency)? {
+    /// Map a mint unit string to a currency for entry precision + display.
+    /// Known units resolve to their built-in currency; any other (custom) unit
+    /// falls back to a `GenericCurrency` so the result is never nil and
+    /// arbitrary mint units are supported.
+    static func currency(forMintUnit unit: String) -> any Currency {
         switch unit.lowercased() {
         case "sat", "sats", "satoshi", "satoshis":
             return SatoshiCurrency()
@@ -158,7 +177,7 @@ enum CurrencyRegistry {
         case "eur", "euro", "euros":
             return EURCurrency()
         default:
-            return nil
+            return GenericCurrency(unit: unit)
         }
     }
 }

--- a/CashuWallet/Core/Protocols/CurrencyProtocol.swift
+++ b/CashuWallet/Core/Protocols/CurrencyProtocol.swift
@@ -148,6 +148,37 @@ struct CurrencyAmount: Equatable {
     }
 }
 
+// MARK: - Home Balance Ordering
+
+/// Ordering for the multi-unit home balance pager. Sat is always first (the
+/// wallet's base unit and identity); every other unit the user actually holds a
+/// positive balance in follows, sorted. A wallet with only sat — or no non-sat
+/// balance — yields just `["sat"]`, so the home shows its single hero unchanged.
+enum HomeBalance {
+    static func homeBalanceUnits(_ balancesByUnit: [String: UInt64]) -> [String] {
+        let nonSat = balancesByUnit
+            .filter { $0.key.lowercased() != "sat" && $0.value > 0 }
+            .keys
+            .sorted()
+        return ["sat"] + nonSat
+    }
+
+    /// Resolves a stored/last-viewed unit against the currently available units,
+    /// falling back to "sat" when that unit no longer carries a balance.
+    static func resolvedUnit(_ unit: String, in units: [String]) -> String {
+        units.contains(unit) ? unit : "sat"
+    }
+
+    /// The home hero pages (swipe/dots) only when the active/default mint is
+    /// multi-unit AND the wallet holds a non-sat balance. A single-unit default
+    /// mint keeps the single sat hero even if a non-sat balance exists at another
+    /// mint (that balance stays visible on Send + Mint Detail).
+    static func showsUnitPager(activeMintSupportsMultipleUnits: Bool,
+                               balancesByUnit: [String: UInt64]) -> Bool {
+        activeMintSupportsMultipleUnits && homeBalanceUnits(balancesByUnit).count > 1
+    }
+}
+
 // MARK: - Currency Registry
 
 /// Registry for looking up currencies by code

--- a/CashuWallet/Core/Services/LightningService.swift
+++ b/CashuWallet/Core/Services/LightningService.swift
@@ -58,12 +58,13 @@ class LightningService: ObservableObject {
     func createMintQuote(
         amount: UInt64?,
         method: PaymentMethodKind = .bolt11,
-        targetMintURL: String? = nil
+        targetMintURL: String? = nil,
+        unit: Cdk.CurrencyUnit = .sat
     ) async throws -> MintQuoteInfo {
         guard let activeMint = getActiveMint() else {
             throw WalletError.notInitialized
         }
-        
+
         isLoading = true
         defer { isLoading = false }
 
@@ -82,7 +83,13 @@ class LightningService: ObservableObject {
         }
 
         let mintUrl = MintUrl(url: targetMintURL ?? activeMint.url)
-        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+        // Mint into the selected unit's wallet (amount is in that unit's base
+        // units). Ensure a non-sat per-unit wallet exists first (sat is always
+        // tracked) — mirrors TokenService.sendTokens.
+        if PaymentRequestDecoder.unitDescription(unit) != "sat" {
+            try await repo.createWallet(mintUrl: mintUrl, unit: unit, targetProofCount: nil)
+        }
+        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: unit)
 
         let quote = try await wallet.mintQuote(
             paymentMethod: method.cdkMethod,
@@ -147,7 +154,8 @@ class LightningService: ObservableObject {
                 await persistMintQuoteIfNeeded(existingQuote, paymentMethod: .bolt12)
             }
 
-            let wallet = try await repo.getWallet(mintUrl: existingQuote.mintUrl, unit: .sat)
+            // Poll through the quote's own unit wallet, not an assumed sat one.
+            let wallet = try await repo.getWallet(mintUrl: existingQuote.mintUrl, unit: existingQuote.unit)
             let quote = try await wallet.checkMintQuote(quoteId: quoteId)
             let paymentMethod = PaymentMethodKind.from(quote.paymentMethod) ?? storedPaymentMethod ?? .bolt11
             let refreshedQuote = mintQuoteForLocalStorage(
@@ -197,6 +205,9 @@ class LightningService: ObservableObject {
 
         let mintUrl: MintUrl
         let amountSplitTarget: SplitTarget
+        // Redeem into the quote's own unit wallet (also makes resuming a
+        // persisted non-sat quote correct). Defaults to sat when no stored quote.
+        let quoteUnit: Cdk.CurrencyUnit
 
         if let walletDatabase = walletDatabase(),
            let existingQuote = try await walletDatabase.getMintQuote(quoteId: quoteId) {
@@ -222,6 +233,7 @@ class LightningService: ObservableObject {
 
             mintUrl = normalizedQuote.mintUrl
             amountSplitTarget = .none
+            quoteUnit = normalizedQuote.unit
 
             if storedPaymentMethod == .onchain,
                normalizedQuote.amountPaid.value <= normalizedQuote.amountIssued.value {
@@ -254,11 +266,12 @@ class LightningService: ObservableObject {
         } else if let activeMint = getActiveMint() {
             mintUrl = MintUrl(url: activeMint.url)
             amountSplitTarget = .none
+            quoteUnit = .sat
         } else {
             throw WalletError.notInitialized
         }
 
-        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: quoteUnit)
         let proofs = try await wallet.mintUnified(
             quoteId: quoteId,
             amountSplitTarget: amountSplitTarget,
@@ -629,7 +642,8 @@ class LightningService: ObservableObject {
             paymentMethod: paymentMethod,
             state: mintQuoteState(from: quote, paymentMethod: paymentMethod),
             expiry: displayExpiry(quote.expiry),
-            createdAt: createdAt
+            createdAt: createdAt,
+            unit: PaymentRequestDecoder.unitDescription(quote.unit)
         )
     }
 

--- a/CashuWallet/Core/Services/MintService.swift
+++ b/CashuWallet/Core/Services/MintService.swift
@@ -417,6 +417,7 @@ class MintService: ObservableObject {
             mintInfo.iconUrl = fetchedInfo.iconUrl ?? mintInfo.iconUrl
 
             mintInfo.units = supportedUnits(from: fetchedInfo.nuts)
+            mintInfo.mintUnits = mintableUnits(from: fetchedInfo.nuts)
 
             let mintMethods = supportedMintPaymentMethods(from: fetchedInfo.nuts.nut04.methods)
             if !mintMethods.isEmpty {
@@ -438,8 +439,9 @@ class MintService: ObservableObject {
     }
 
     private func supportedMintPaymentMethods(from methods: [Cdk.MintMethodSettings]) -> [PaymentMethodKind] {
+        // No unit filter: a mint that offers bolt11 only in a non-sat unit must
+        // still surface the Lightning mint method (the unit is chosen separately).
         let mappedMethods = methods
-            .filter { isSatUnit($0.unit) }
             .compactMap { PaymentMethodKind.from($0.method) }
         return PaymentMethodKind.allCases.filter { mappedMethods.contains($0) }
     }
@@ -454,6 +456,14 @@ class MintService: ObservableObject {
     private func supportedUnits(from nuts: Cdk.Nuts) -> [String] {
         let units = (nuts.mintUnits + nuts.meltUnits)
             .map(PaymentRequestDecoder.unitDescription)
+        let uniqueUnits = Array(Set(units)).sorted()
+        return uniqueUnits.isEmpty ? ["sat"] : uniqueUnits
+    }
+
+    /// Units the mint can MINT (NUT-04) — used to gate the Receive unit selector
+    /// so we never offer a melt-only unit for minting.
+    private func mintableUnits(from nuts: Cdk.Nuts) -> [String] {
+        let units = nuts.mintUnits.map(PaymentRequestDecoder.unitDescription)
         let uniqueUnits = Array(Set(units)).sorted()
         return uniqueUnits.isEmpty ? ["sat"] : uniqueUnits
     }

--- a/CashuWallet/Core/Services/TokenService.swift
+++ b/CashuWallet/Core/Services/TokenService.swift
@@ -42,7 +42,7 @@ class TokenService: ObservableObject {
     ///   - amount: Amount to send in satoshis
     ///   - memo: Optional memo to include
     /// - Returns: Result containing token string and fee paid
-    func sendTokens(amount: UInt64, memo: String? = nil, p2pkPubkey: String? = nil, mintUrl preferredMintURL: String? = nil) async throws -> SendTokenResult {
+    func sendTokens(amount: UInt64, memo: String? = nil, p2pkPubkey: String? = nil, mintUrl preferredMintURL: String? = nil, unit: Cdk.CurrencyUnit = .sat) async throws -> SendTokenResult {
         guard let repo = walletRepository() else {
             throw WalletError.notInitialized
         }
@@ -59,7 +59,14 @@ class TokenService: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
-        let wallet = try await repo.getWallet(mintUrl: MintUrl(url: mintUrlString), unit: .sat)
+        let mintUrl = MintUrl(url: mintUrlString)
+        // For a non-sat unit, ensure the per-unit wallet exists before fetching
+        // it (the sat wallet is always already tracked). `amount` is denominated
+        // in this unit's base units (e.g. eur/usd cents).
+        if PaymentRequestDecoder.unitDescription(unit) != "sat" {
+            try await repo.createWallet(mintUrl: mintUrl, unit: unit, targetProofCount: nil)
+        }
+        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: unit)
         
         let sendMemo = memo.map { SendMemo(memo: $0, includeMemo: true) }
         let normalizedP2PKPubkey = try normalizedP2PKPubkey(p2pkPubkey)
@@ -126,9 +133,12 @@ class TokenService: ObservableObject {
         // Parse the token string
         let token = try Token.decode(encodedToken: tokenString)
         let tokenMintUrl = try token.mintUrl()
-        
+        // Redeem into the token's own unit (sat, eur, usd, …) rather than
+        // assuming sat, so non-sat tokens land in the matching per-unit wallet.
+        let tokenUnit = token.unit() ?? .sat
+
         // Ensure the mint is added with the correct unit
-        try await repo.createWallet(mintUrl: tokenMintUrl, unit: .sat, targetProofCount: nil)
+        try await repo.createWallet(mintUrl: tokenMintUrl, unit: tokenUnit, targetProofCount: nil)
 
         // Offer the full signing set (primary seed-derived key + stored keys) so a
         // token locked to the user's own identity is redeemable.
@@ -172,7 +182,7 @@ class TokenService: ObservableObject {
         var lastError: Error?
         var didRestore = false
         for attempt in 0..<maxAttempts {
-            let wallet = try await repo.getWallet(mintUrl: tokenMintUrl, unit: .sat)
+            let wallet = try await repo.getWallet(mintUrl: tokenMintUrl, unit: tokenUnit)
             do {
                 let amount = try await wallet.receive(token: token, options: receiveOptions)
                 if let matchingLocalP2PKKey {
@@ -230,12 +240,13 @@ class TokenService: ObservableObject {
         let token = try Token.decode(encodedToken: tokenString)
         let mintUrl = try token.mintUrl()
         let proofs = try token.proofsSimple()
-        
+        let tokenUnit = token.unit() ?? .sat
+
         // Ensure the mint is added with the correct unit
-        try await repo.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
-        
+        try await repo.createWallet(mintUrl: mintUrl, unit: tokenUnit, targetProofCount: nil)
+
         // Get the wallet for this mint
-        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+        let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: tokenUnit)
         
         guard let firstProof = proofs.first else {
             return 0
@@ -275,8 +286,9 @@ class TokenService: ObservableObject {
         do {
             let tokenObj = try Token.decode(encodedToken: token)
             let mintUrlObj = MintUrl(url: mintUrl)
+            let tokenUnit = tokenObj.unit() ?? .sat
 
-            let wallet = try await repo.getWallet(mintUrl: mintUrlObj, unit: .sat)
+            let wallet = try await repo.getWallet(mintUrl: mintUrlObj, unit: tokenUnit)
             let keysets = try await wallet.getMintKeysets(filter: .all)
             let proofs = try tokenObj.proofs(mintKeysets: keysets)
 

--- a/CashuWallet/Core/TokenParser.swift
+++ b/CashuWallet/Core/TokenParser.swift
@@ -29,7 +29,7 @@ enum TokenParser {
         return TokenInfo(
             amount: amount,
             mint: mint,
-            unit: "sat",
+            unit: PaymentRequestDecoder.unitDescription(token.unit() ?? .sat),
             memo: token.memo(),
             proofCount: proofs.count
         )

--- a/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
@@ -7,12 +7,14 @@ extension WalletManager {
     func createMintQuote(
         amount: UInt64?,
         method: PaymentMethodKind = .bolt11,
-        targetMintURL: String? = nil
+        targetMintURL: String? = nil,
+        unit: String = "sat"
     ) async throws -> MintQuoteInfo {
         let quote = try await lightningService.createMintQuote(
             amount: amount,
             method: method,
-            targetMintURL: targetMintURL
+            targetMintURL: targetMintURL,
+            unit: PaymentRequestDecoder.currencyUnit(from: unit)
         )
         await loadTransactions()
         return quote

--- a/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -73,28 +73,47 @@ extension WalletManager {
         
         guard !mintUrls.isEmpty else {
             balance = 0
+            balancesByUnit = [:]
             return
         }
-        
+
         var total: UInt64 = 0
         var balancesByMintURL: [String: UInt64] = [:]
-        
+        // Per-unit totals across all mints (sat plus any held eur/usd/custom).
+        var unitTotals: [String: UInt64] = [:]
+
         for mintUrlString in mintUrls {
+            let mintUrl = MintUrl(url: mintUrlString)
             do {
-                let mintUrl = MintUrl(url: mintUrlString)
                 let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
                 let walletBalance = try await wallet.totalBalance()
-                
+
                 total += walletBalance.value
                 balancesByMintURL[mintUrlString] = walletBalance.value
+                unitTotals["sat", default: 0] += walletBalance.value
             } catch {
                 balancesByMintURL[mintUrlString] = 0
                 AppLogger.wallet.error("Failed to refresh balance for mint \(mintUrlString): \(error)")
             }
+
+            // Add this mint's non-sat unit balances. Only the units it advertises
+            // are queried; a never-used unit wallet throws getWallet → skipped as
+            // zero (no createWallet — the sat wallet above is reused for sat).
+            let nonSatUnits = mintService.mints
+                .first(where: { $0.url == mintUrlString })?
+                .units.filter { $0.lowercased() != "sat" } ?? []
+            for unit in nonSatUnits {
+                let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
+                if let unitWallet = try? await walletRepository.getWallet(mintUrl: mintUrl, unit: currencyUnit),
+                   let unitBalance = try? await unitWallet.totalBalance() {
+                    unitTotals[unit, default: 0] += unitBalance.value
+                }
+            }
         }
-        
+
         mintService.updateMintBalances(balancesByMintURL)
         balance = total
+        balancesByUnit = unitTotals
     }
 }
 

--- a/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -8,13 +8,15 @@ extension WalletManager {
         amount: UInt64,
         memo: String? = nil,
         p2pkPubkey: String? = nil,
-        mintUrl preferredMintURL: String? = nil
+        mintUrl preferredMintURL: String? = nil,
+        unit: String = "sat"
     ) async throws -> SendTokenResult {
         let result = try await tokenService.sendTokens(
             amount: amount,
             memo: memo,
             p2pkPubkey: p2pkPubkey,
-            mintUrl: preferredMintURL
+            mintUrl: preferredMintURL,
+            unit: PaymentRequestDecoder.currencyUnit(from: unit)
         )
         let tokenMintURL = preferredMintURL ?? activeMint?.url ?? ""
         
@@ -35,6 +37,27 @@ extension WalletManager {
         await loadTransactions()
         SentryService.breadcrumb("Token sent", category: "wallet.token")
         return result
+    }
+
+    /// Balance of a specific (mint, unit) wallet, in that unit's base units.
+    /// "sat" resolves from the cached per-mint balance; other units query CDK
+    /// directly since the app doesn't cache non-sat balances. Returns nil on any
+    /// failure (e.g. a mint that doesn't actually support the unit).
+    func unitBalance(mintURL: String, unit: String) async -> UInt64? {
+        if unit.lowercased() == "sat" {
+            return mints.first(where: { $0.url == mintURL })?.balance
+        }
+        guard let repo = walletRepository else { return nil }
+        do {
+            let mintUrl = MintUrl(url: mintURL)
+            let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
+            try await repo.createWallet(mintUrl: mintUrl, unit: currencyUnit, targetProofCount: nil)
+            let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: currencyUnit)
+            return try await wallet.totalBalance().value
+        } catch {
+            AppLogger.wallet.debug("unitBalance(\(unit)) failed: \(String(describing: error))")
+            return nil
+        }
     }
 
     func receiveTokens(tokenString: String) async throws -> UInt64 {
@@ -102,7 +125,9 @@ extension WalletManager {
         do {
             let token = try Token.decode(encodedToken: tokenString)
             let mintUrl = try token.mintUrl()
-            let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+            // Match the wallet the receive actually swapped into (the token's own
+            // unit), so tx attribution works for non-sat receives too.
+            let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: token.unit() ?? .sat)
             let txs = try await wallet.listTransactions(direction: .incoming)
             return Set(txs.map { $0.id.hex })
         } catch {

--- a/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/CashuWallet/Core/Wallet/WalletManager.swift
@@ -15,7 +15,12 @@ class WalletManager: ObservableObject {
     
     /// Total wallet balance in satoshis
     @Published var balance: UInt64 = 0
-    
+
+    /// Per-unit balance totals summed across all mints, in each unit's base
+    /// units (sat, or eur/usd cents, …). Drives the multi-unit home hero;
+    /// `balance` mirrors `balancesByUnit["sat"]`.
+    @Published var balancesByUnit: [String: UInt64] = [:]
+
     /// Pending balance (invoices not yet claimed)
     @Published var pendingBalance: UInt64 = 0
     

--- a/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/CashuWallet/Core/Wallet/WalletManager.swift
@@ -21,6 +21,11 @@ class WalletManager: ObservableObject {
     /// `balance` mirrors `balancesByUnit["sat"]`.
     @Published var balancesByUnit: [String: UInt64] = [:]
 
+    /// True when the wallet holds spendable ecash in *any* unit (sat or
+    /// otherwise). Send gates on this rather than `balance` (sats only) so a
+    /// USD-only wallet isn't told it has "nothing to send".
+    var hasAnyBalance: Bool { balancesByUnit.values.contains { $0 > 0 } }
+
     /// Pending balance (invoices not yet claimed)
     @Published var pendingBalance: UInt64 = 0
     

--- a/CashuWallet/Models/Mints/MintInfo.swift
+++ b/CashuWallet/Models/Mints/MintInfo.swift
@@ -11,8 +11,12 @@ struct MintInfo: Identifiable, Equatable, Codable {
     /// Icon URL (if available from mint info)
     var iconUrl: String?
     
-    /// Supported units
+    /// Supported units — the union of the mint's mintable and meltable units.
     var units: [String] = ["sat"]
+
+    /// Units the mint can MINT (NUT-04), a subset of `units`. Drives the Receive
+    /// unit selector so we never offer a melt-only unit for minting.
+    var mintUnits: [String] = ["sat"]
 
     /// Supported NUT-04 payment methods for receiving
     var supportedMintMethods: [PaymentMethodKind] = [.bolt11]
@@ -28,6 +32,41 @@ struct MintInfo: Identifiable, Equatable, Codable {
 }
 
 extension MintInfo {
+    /// True when the mint advertises more than one unit, so a unit chooser is
+    /// worth surfacing. Single-unit mints hide the selector entirely.
+    var supportsMultipleUnits: Bool { units.count > 1 }
+
+    /// Preferred unit for this mint: "sat" when supported, otherwise the first
+    /// unit alphabetically, falling back to "sat" for a malformed empty list.
+    var defaultUnit: String {
+        units.contains("sat") ? "sat" : (units.sorted().first ?? "sat")
+    }
+
+    /// Returns `unit` when this mint supports it, otherwise `defaultUnit`. Used
+    /// to reset a stale selection when the active mint changes.
+    func resolvedUnit(_ unit: String?) -> String {
+        guard let unit, units.contains(unit) else { return defaultUnit }
+        return unit
+    }
+
+    // MARK: - Mintable units (NUT-04)
+
+    /// True when the mint can mint more than one unit — gates the Receive selector.
+    var supportsMultipleMintUnits: Bool { mintUnits.count > 1 }
+
+    /// Preferred mintable unit: "sat" when mintable, else the first sorted unit.
+    var defaultMintUnit: String {
+        mintUnits.contains("sat") ? "sat" : (mintUnits.sorted().first ?? "sat")
+    }
+
+    /// Returns `unit` when the mint can mint it, otherwise `defaultMintUnit`.
+    func resolvedMintUnit(_ unit: String?) -> String {
+        guard let unit, mintUnits.contains(unit) else { return defaultMintUnit }
+        return unit
+    }
+}
+
+extension MintInfo {
     private enum CodingKeys: String, CodingKey {
         case url
         case name
@@ -36,6 +75,7 @@ extension MintInfo {
         case balance
         case iconUrl
         case units
+        case mintUnits
         case supportedMintMethods
         case supportedMeltMethods
         case onchainMintConfirmations
@@ -51,6 +91,9 @@ extension MintInfo {
         balance = try container.decodeIfPresent(UInt64.self, forKey: .balance) ?? 0
         iconUrl = try container.decodeIfPresent(String.self, forKey: .iconUrl)
         units = try container.decodeIfPresent([String].self, forKey: .units) ?? ["sat"]
+        // Older records predate mintUnits — fall back to the full unit set so a
+        // multi-unit mint keeps offering units until its next refresh repopulates.
+        mintUnits = try container.decodeIfPresent([String].self, forKey: .mintUnits) ?? units
         supportedMintMethods = try container.decodeIfPresent([PaymentMethodKind].self, forKey: .supportedMintMethods) ?? [.bolt11]
         supportedMeltMethods = try container.decodeIfPresent([PaymentMethodKind].self, forKey: .supportedMeltMethods) ?? [.bolt11]
         onchainMintConfirmations = try container.decodeIfPresent(Int.self, forKey: .onchainMintConfirmations)
@@ -66,6 +109,7 @@ extension MintInfo {
         try container.encode(balance, forKey: .balance)
         try container.encodeIfPresent(iconUrl, forKey: .iconUrl)
         try container.encode(units, forKey: .units)
+        try container.encode(mintUnits, forKey: .mintUnits)
         try container.encode(supportedMintMethods, forKey: .supportedMintMethods)
         try container.encode(supportedMeltMethods, forKey: .supportedMeltMethods)
         try container.encodeIfPresent(onchainMintConfirmations, forKey: .onchainMintConfirmations)

--- a/CashuWallet/Models/Quotes/QuoteModels.swift
+++ b/CashuWallet/Models/Quotes/QuoteModels.swift
@@ -12,6 +12,10 @@ struct MintQuoteInfo: Identifiable {
     /// `MintQuoteCreatedAtStore`. nil for every other rail.
     let createdAt: Date?
 
+    /// The unit the quote mints into ("sat", "eur", …). `amount` is denominated
+    /// in this unit's base units. Defaults to "sat" for older/sat quotes.
+    var unit: String = "sat"
+
     var isExpired: Bool {
         guard let expiry = expiry, expiry > 0 else { return false }
         return Date().timeIntervalSince1970 > Double(expiry)

--- a/CashuWallet/Views/Components/ActivityOrbView.swift
+++ b/CashuWallet/Views/Components/ActivityOrbView.swift
@@ -131,6 +131,11 @@ struct NativeEmptyState: View {
     let systemImage: String
     var description: String?
     var style: Style = .fullScreen
+    // Optional text-only glass CTA grouped inside the centered cluster (e.g. Send's
+    // zero-balance "Receive"). Both nil by default, so icon+title+description call sites
+    // are unaffected.
+    var actionTitle: String? = nil
+    var action: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPresented = false
@@ -138,20 +143,31 @@ struct NativeEmptyState: View {
 
     var body: some View {
         VStack(spacing: style.spacing) {
-            animatedIcon
+            VStack(spacing: style.spacing) {
+                animatedIcon
 
-            VStack(spacing: 4) {
-                Text(title)
-                    .font(style.titleFont)
-                    .multilineTextAlignment(.center)
-
-                if let description {
-                    Text(description)
-                        .font(style.descriptionFont)
-                        .foregroundStyle(.secondary)
+                VStack(spacing: 4) {
+                    Text(title)
+                        .font(style.titleFont)
                         .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let description {
+                        Text(description)
+                            .font(style.descriptionFont)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
+            }
+            // Combine only the glyph + copy; the CTA below stays a separate,
+            // activatable accessibility element.
+            .accessibilityElement(children: .combine)
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .glassButton()
+                    .padding(.top, 8)
             }
         }
         .padding(.horizontal, 32)
@@ -170,7 +186,6 @@ struct NativeEmptyState: View {
             guard !reduceMotion else { return }
             symbolTrigger.toggle()
         }
-        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder

--- a/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
+++ b/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
@@ -37,13 +37,15 @@ struct CashuRequestAmountColumn: View {
             }
         } else if let amount = request.amount, amount > 0 {
             VStack(alignment: .trailing, spacing: 2) {
-                Text(settings.formatAmountShort(amount))
+                Text(expectedAmountText(amount))
                     .font(.system(.body, design: .rounded).weight(.semibold))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
-                if showFiat {
+                // Fiat sub-line only makes sense for a sat request; a non-sat
+                // unit is already shown in its own currency above.
+                if isSatRequest && showFiat {
                     Text(priceService.formatSatsAsFiat(amount))
                         .font(.caption)
                         .monospacedDigit()
@@ -52,6 +54,16 @@ struct CashuRequestAmountColumn: View {
             }
         }
         // "any amount" + waiting: no trailing element.
+    }
+
+    private var isSatRequest: Bool { request.unit.lowercased() == "sat" }
+
+    /// The waiting request's fixed amount, in its own unit: sats keep the
+    /// abbreviated style; other units render via their `Currency` (e.g. "$5.00").
+    private func expectedAmountText(_ amount: UInt64) -> String {
+        isSatRequest
+            ? settings.formatAmountShort(amount)
+            : CurrencyAmount(value: amount, currency: CurrencyRegistry.currency(forMintUnit: request.unit)).formatted()
     }
 
     private var showFiat: Bool {

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -80,6 +80,12 @@ struct MainWalletView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: .cashuTokenReceived)) { note in
             guard let amount = note.userInfo?["amount"] as? UInt64 else { return }
+            // The home balance + delta are sat-denominated. A non-sat receive
+            // (eur/usd/…) doesn't move the sat balance and is confirmed on its own
+            // success screen, so skip the delta rather than flash a misleading
+            // "+N sat".
+            let unit = note.userInfo?["unit"] as? String ?? "sat"
+            guard unit.lowercased() == "sat" else { return }
             let fee = note.userInfo?["fee"] as? UInt64
             // Only background receives (poster sets "homeHaptic") buzz here; in-flow
             // receives own the success haptic on their confirmation surface.

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -22,9 +22,38 @@ struct MainWalletView: View {
     @State private var selectedTransaction: WalletTransaction?
     @State private var selectedRequest: CashuRequest?
     @State private var topInsetHeight: CGFloat = 0
+    /// Last-viewed home balance unit, persisted so the wallet reopens on it.
+    /// Clamped back to "sat" whenever that unit no longer carries a balance.
+    @AppStorage("homeBalanceUnit") private var storedHomeUnit: String = "sat"
 
     private let recentRowCap = 5
     private let scrollFadeBand: CGFloat = 24
+    /// Fixed height for the multi-unit balance pager so the pinned-top inset
+    /// measurement (and the scroll-fade mask) stays stable across unit swipes.
+    private let heroPagerHeight: CGFloat = 118
+
+    /// Units the home hero can page through: sat, then each held non-sat unit.
+    private var homeUnits: [String] {
+        HomeBalance.homeBalanceUnits(walletManager.balancesByUnit)
+    }
+
+    /// Whether to show the swipe/dots pager: only when the active (default) mint
+    /// is multi-unit AND a non-sat balance is held. A single-unit default mint
+    /// keeps the single sat hero.
+    private var showsUnitPager: Bool {
+        HomeBalance.showsUnitPager(
+            activeMintSupportsMultipleUnits: walletManager.activeMint?.supportsMultipleUnits ?? false,
+            balancesByUnit: walletManager.balancesByUnit
+        )
+    }
+
+    /// TabView selection clamped to the currently available units.
+    private var selectedHomeUnit: Binding<String> {
+        Binding(
+            get: { HomeBalance.resolvedUnit(storedHomeUnit, in: homeUnits) },
+            set: { storedHomeUnit = $0 }
+        )
+    }
 
     var body: some View {
         NavigationStack {
@@ -145,26 +174,59 @@ struct MainWalletView: View {
         VStack(spacing: 0) {
             mintChip
 
-            // Primary balance — tap to toggle Bitcoin / Satoshi display
-            VStack(spacing: 6) {
+            Group {
+                let units = homeUnits
+                if !showsUnitPager {
+                    // Single-unit default mint, or no non-sat balance held: the
+                    // single hero, unchanged.
+                    unitBalanceHero("sat")
+                } else {
+                    // Multi-unit: a swipeable pager, one unit's balance per page
+                    // (Apple Wallet-card idiom). Carve-out to the retired
+                    // home mint-card swiper — this is a single-hero *unit*
+                    // switcher, canvas stays bare. See DESIGN.md.
+                    TabView(selection: selectedHomeUnit) {
+                        ForEach(units, id: \.self) { unit in
+                            unitBalanceHero(unit)
+                                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                                .tag(unit)
+                        }
+                    }
+                    .tabViewStyle(.page(indexDisplayMode: .always))
+                    .frame(height: heroPagerHeight)
+                }
+            }
+            .padding(.top, 18)
+        }
+    }
+
+    /// One unit's balance hero. Sat keeps the ₿/sat tap-toggle + fiat/received
+    /// sub-line; other units render their amount directly in that currency
+    /// (no fiat conversion — eur is already fiat) with a reserved sub-line slot
+    /// so every page is the same height and the page dots don't jump.
+    @ViewBuilder
+    private func unitBalanceHero(_ unit: String) -> some View {
+        VStack(spacing: 6) {
+            if unit.lowercased() == "sat" {
+                let sats = walletManager.balancesByUnit["sat"] ?? walletManager.balance
                 Button(action: {
                     HapticFeedback.selection()
                     settings.useBitcoinSymbol.toggle()
                 }) {
-                    Text(formatBalanceWithUnit(walletManager.balance))
+                    Text(formatBalanceWithUnit(sats))
                         .font(.system(size: 44, weight: .bold))
                         .monospacedDigit()
                         .minimumScaleFactor(0.5)
                         .lineLimit(1)
-                        .contentTransition(.numericText(value: Double(walletManager.balance)))
+                        .contentTransition(.numericText(value: Double(sats)))
                         // Roll the total on any balance change (receive up, send
                         // down) and cross-fade the ₿/sat unit swap — mirrors the
                         // Send/Receive amount display (CurrencyAmountDisplay).
-                        .animation(.snappy, value: walletManager.balance)
+                        .animation(.snappy, value: sats)
                         .animation(.snappy, value: settings.useBitcoinSymbol)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Balance: \(formatBalanceWithUnit(walletManager.balance))")
+                .accessibilityLabel("Balance: \(formatBalanceWithUnit(sats))")
                 .accessibilityHint("Tap to toggle between Bitcoin and Satoshi")
 
                 // Status line under the balance: a transient monochrome
@@ -172,8 +234,23 @@ struct MainWalletView: View {
                 // then fiat fades back. Same slot, so the swap doesn't reflow the
                 // balance. (De-greened 2026-07-05 — the balance roll carries the moment.)
                 balanceStatusLine
+            } else {
+                let amount = walletManager.balancesByUnit[unit] ?? 0
+                let formatted = CurrencyAmount(
+                    value: amount,
+                    currency: CurrencyRegistry.currency(forMintUnit: unit)
+                ).formatted()
+                Text(formatted)
+                    .font(.system(size: 44, weight: .bold))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(1)
+                    .contentTransition(.numericText(value: Double(amount)))
+                    .animation(.snappy, value: amount)
+                    .accessibilityLabel("Balance: \(formatted)")
+                // Reserve the sub-line height so pages match the sat page.
+                Color.clear.frame(height: 22)
             }
-            .padding(.top, 18)
         }
     }
 

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -1058,27 +1058,13 @@ private struct WalletActionSheetView: View {
 
     /// State B — mints connected but zero balance. The way forward is funds.
     private var noBalanceState: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "banknote")
-                .font(.system(size: 40))
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: 6) {
-                Text("Nothing to send yet")
-                    .font(.title3.weight(.medium))
-                Text("Receive some ecash before you can send.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            Button("Receive", action: onReceive)
-                .glassButton()
-                .padding(.top, 4)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 24)
-        .padding(.top, 24)
+        NativeEmptyState(
+            title: "Nothing to send yet",
+            systemImage: "arrow.down.circle",
+            description: "Receive some ecash before you can send.",
+            actionTitle: "Receive",
+            action: onReceive
+        )
     }
 
     private func addMint(_ url: String) {

--- a/CashuWallet/Views/Main/MainWalletView.swift
+++ b/CashuWallet/Views/Main/MainWalletView.swift
@@ -710,7 +710,7 @@ struct MainWalletView: View {
     /// picker; mints but zero balance → the "receive first" prompt. Reactive to
     /// `mints`/`balance` so it shrinks once a mint is added (no mints → mints).
     private func chooserHeight(for action: WalletActionSheet) -> CGFloat {
-        if action == .send, walletManager.balance == 0 {
+        if action == .send, !walletManager.hasAnyBalance {
             return walletManager.mints.isEmpty ? 470 : 260
         }
         return action.detentHeight
@@ -908,7 +908,7 @@ private struct WalletActionSheetView: View {
     /// Send is impossible with nothing to spend — intercept before the chooser.
     /// Receive is never gated (it's the cure), so this only fires for `.send`.
     private var isSendEmptyState: Bool {
-        action == .send && walletManager.balance == 0
+        action == .send && !walletManager.hasAnyBalance
     }
 
     /// The single piece of state the sheet body switches on, so phase changes

--- a/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/CashuWallet/Views/Mints/MintDetailView.swift
@@ -19,6 +19,14 @@ struct MintDetailView: View {
     @State private var showNavTitle = false
     @State private var isSettingDefault = false
     @State private var actionError: String?
+    /// Balances for the mint's non-sat units, loaded on demand (the sat balance
+    /// is the cached `mint.balance`). Where a freshly-minted eur/usd shows up.
+    @State private var unitBalances: [String: UInt64] = [:]
+
+    /// The mint's non-sat units (sat is shown by `balanceRow`).
+    private var nonSatUnits: [String] {
+        mint.units.filter { $0.lowercased() != "sat" }.sorted()
+    }
 
     private var isDefaultMint: Bool {
         walletManager.activeMint?.url == mint.url
@@ -51,6 +59,11 @@ struct MintDetailView: View {
                 // Identity stats — available immediately from local mint data.
                 VStack(spacing: 0) {
                     balanceRow
+                    // Per-unit balances for a multi-unit mint (e.g. a minted €5).
+                    ForEach(nonSatUnits, id: \.self) { unit in
+                        CanvasDivider()
+                        unitBalanceRow(unit)
+                    }
                     CanvasDivider()
                     connectionRow
                 }
@@ -96,6 +109,7 @@ struct MintDetailView: View {
             }
         }
         .task { await loadMintInfo() }
+        .task { await loadUnitBalances() }
         .alert("Remove Mint", isPresented: $showRemoveConfirmation) {
             Button("Remove", role: .destructive) { removeMint() }
             Button("Cancel", role: .cancel) {}
@@ -194,6 +208,21 @@ struct MintDetailView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+        }
+        .font(.body)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 14)
+    }
+
+    private func unitBalanceRow(_ unit: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Label("Balance (\(unit.uppercased()))", systemImage: "banknote")
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(unitBalances[unit].map {
+                CurrencyAmount(value: $0, currency: CurrencyRegistry.currency(forMintUnit: unit)).formatted()
+            } ?? "…")
+                .monospacedDigit()
         }
         .font(.body)
         .padding(.horizontal, 4)
@@ -761,6 +790,16 @@ struct MintDetailView: View {
             errorMessage = error.userFacingWalletMessage
         }
         isLoading = false
+    }
+
+    /// Fetch each non-sat unit's balance so a minted eur/usd is visible here
+    /// (the app's aggregate balance is sat-only).
+    private func loadUnitBalances() async {
+        for unit in nonSatUnits {
+            if let balance = await walletManager.unitBalance(mintURL: mint.url, unit: unit) {
+                unitBalances[unit] = balance
+            }
+        }
     }
 
     private func removeMint() {

--- a/CashuWallet/Views/Receive/CashuRequestAmountPickerSheet.swift
+++ b/CashuWallet/Views/Receive/CashuRequestAmountPickerSheet.swift
@@ -5,59 +5,85 @@ struct CashuRequestAmountPickerSheet: View {
     @ObservedObject private var settings = SettingsManager.shared
     @ObservedObject private var priceService = PriceService.shared
 
-    /// Current value for the request: `nil` = Any amount, value = fixed amount in sats.
+    /// Current value for the request: `nil` = Any amount, value = fixed amount in
+    /// the request's own unit base units (sats for `sat`, cents for usd/eur,
+    /// integer for a custom unit).
     let currentAmount: UInt64?
-    /// Called with the new amount on Done (`nil` = Any). Sheet dismisses afterwards.
+    /// The request's unit ("sat", "usd", "eur", or a custom unit string). Drives
+    /// whether entry is the sats↔fiat display flip or direct unit entry.
+    let unit: String
+    /// Called with the new amount on Done (`nil` = Any), in `unit`'s base units.
+    /// Sheet dismisses afterwards.
     let onSelect: (UInt64?) -> Void
 
     @State private var amountString: String
 
-    init(currentAmount: UInt64?, onSelect: @escaping (UInt64?) -> Void) {
+    init(currentAmount: UInt64?, unit: String, onSelect: @escaping (UInt64?) -> Void) {
         self.currentAmount = currentAmount
+        self.unit = unit
         self.onSelect = onSelect
-        // Seed the keypad string in whatever unit entry is currently in, so a
-        // sats `currentAmount` isn't misread as fiat.
-        let unit: AmountDisplayPrimary =
-            (SettingsManager.shared.amountDisplayPrimary == .fiat && PriceService.shared.btcPriceUSD > 0)
-                ? .fiat : .sats
-        let seed = currentAmount.map {
-            AmountFormatter.entryConverted(raw: String($0), from: .sats, to: unit)
-        } ?? ""
-        self._amountString = State(initialValue: seed)
+        // Seed the keypad string in the request's own unit so an existing amount
+        // round-trips exactly — sats convert to the current display flip, other
+        // units seed their minor-unit entry string directly.
+        if unit.lowercased() == "sat" {
+            let entry: AmountDisplayPrimary =
+                (SettingsManager.shared.amountDisplayPrimary == .fiat && PriceService.shared.btcPriceUSD > 0)
+                    ? .fiat : .sats
+            let seed = currentAmount.map {
+                AmountFormatter.entryConverted(raw: String($0), from: .sats, to: entry)
+            } ?? ""
+            self._amountString = State(initialValue: seed)
+        } else {
+            let decimals = CurrencyRegistry.currency(forMintUnit: unit).decimals
+            let seed = currentAmount.map {
+                AmountFormatter.entryString(baseUnits: $0, decimals: decimals)
+            } ?? ""
+            self._amountString = State(initialValue: seed)
+        }
     }
 
-    /// The unit the keypad is entering in: fiat only when fiat is primary AND a
-    /// price is loaded, else sats (mirrors `CurrencyAmountDisplay.effectivePrimary`).
+    private var isSat: Bool { unit.lowercased() == "sat" }
+    private var unitCurrency: any Currency { CurrencyRegistry.currency(forMintUnit: unit) }
+    private var unitDecimals: Int { unitCurrency.decimals }
+
+    /// The unit the sats keypad is entering in: fiat only when fiat is primary AND
+    /// a price is loaded, else sats (mirrors `CurrencyAmountDisplay.effectivePrimary`).
+    /// Unused for non-sat requests, which enter directly in their own unit.
     private var entryUnit: AmountDisplayPrimary {
         (settings.amountDisplayPrimary == .fiat && priceService.btcPriceUSD > 0) ? .fiat : .sats
     }
 
-    /// Satoshis represented by the typed amount, interpreted per `entryUnit`.
-    private var amountSats: UInt64 { AmountFormatter.entrySats(raw: amountString, unit: entryUnit) }
+    /// The typed amount in the request's base units — sats for a sat request
+    /// (interpreted per `entryUnit`), else the unit's own minor units.
+    private var amountBaseUnits: UInt64 {
+        isSat
+            ? AmountFormatter.entrySats(raw: amountString, unit: entryUnit)
+            : AmountFormatter.entryBaseUnits(raw: amountString, decimals: unitDecimals)
+    }
 
     var body: some View {
         // Mirrors the app's other amount-entry surfaces (ReceiveLightningView's
-        // `amountEntryView`, SendView): amount centered between two flexible
-        // spacers, full-width keypad, action button directly beneath the keypad.
+        // `amountHero`, SendView): amount centered between two flexible spacers,
+        // full-width keypad, action button directly beneath the keypad.
         VStack(spacing: 0) {
             header
 
             Spacer(minLength: 0)
 
-            CurrencyAmountDisplay(
-                sats: amountSats,
-                primary: $settings.amountDisplayPrimary,
-                primarySize: 56,
-                entryRaw: amountString
-            )
-            .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) sats")
-            .padding(.horizontal)
-            .frame(maxWidth: .infinity)
+            amountDisplay
+                .padding(.horizontal)
+                .frame(maxWidth: .infinity)
 
             Spacer(minLength: 0)
 
-            NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
-                .padding(.horizontal, 24)
+            Group {
+                if isSat {
+                    NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
+                } else {
+                    NumberPadAmountInput(amountString: $amountString, decimals: unitDecimals)
+                }
+            }
+            .padding(.horizontal, 24)
 
             Button(action: confirm) {
                 Text("Done")
@@ -70,7 +96,33 @@ struct CashuRequestAmountPickerSheet: View {
         .presentationDetents([.large])
         .presentationDragIndicator(.visible)
         .onChange(of: entryUnit) { oldUnit, newUnit in
+            // Only the sats keypad flips between fiat and sats; a non-sat request
+            // stays in its own unit regardless of the display setting.
+            guard isSat else { return }
             amountString = AmountFormatter.entryConverted(raw: amountString, from: oldUnit, to: newUnit)
+        }
+    }
+
+    @ViewBuilder
+    private var amountDisplay: some View {
+        if isSat {
+            CurrencyAmountDisplay(
+                sats: amountBaseUnits,
+                primary: $settings.amountDisplayPrimary,
+                primarySize: 56,
+                entryRaw: amountString
+            )
+            .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) sats")
+        } else {
+            // Non-sat mint unit: show it directly, no BTC-price flip.
+            Text(CurrencyAmount(value: amountBaseUnits, currency: unitCurrency).formatted())
+                .font(.system(size: 56, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .minimumScaleFactor(0.4)
+                .lineLimit(1)
+                .contentTransition(.numericText(value: Double(amountBaseUnits)))
+                .animation(.snappy, value: amountBaseUnits)
+                .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) \(unit)")
         }
     }
 
@@ -97,7 +149,7 @@ struct CashuRequestAmountPickerSheet: View {
 
     private func confirm() {
         HapticFeedback.selection()
-        let value = amountSats
+        let value = amountBaseUnits
         onSelect(value > 0 ? value : nil)
         dismiss()
     }

--- a/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -15,6 +15,7 @@ struct CashuRequestDetailView: View {
     @State private var paymentJustReceived = false
     @State private var showMintPicker = false
     @State private var showAmountPicker = false
+    @State private var showUnitPicker = false
     @State private var receiveBaselineBalance: UInt64?
     @State private var didAutoComplete = false
 
@@ -83,6 +84,16 @@ struct CashuRequestDetailView: View {
                     regenerate(amount: amount)
                 }
             )
+        }
+        .sheet(isPresented: $showUnitPicker) {
+            if let request, let mint = requestMint(for: request) {
+                CashuRequestUnitPickerSheet(
+                    units: mint.units,
+                    currentUnit: request.unit,
+                    onSelect: { unit in regenerate(unit: unit) }
+                )
+                .presentationDetents([.medium])
+            }
         }
         .onAppear {
             // Baseline for the receive-flow balance watcher below.
@@ -192,7 +203,16 @@ struct CashuRequestDetailView: View {
                             )
                         }
                         canvasDivider
-                        detailRow(icon: "creditcard", label: "Unit", value: request.unit.uppercased())
+                        if unitEditable(for: request) {
+                            editableRow(
+                                icon: "creditcard",
+                                label: "Unit",
+                                value: request.unit.uppercased(),
+                                action: { showUnitPicker = true }
+                            )
+                        } else {
+                            detailRow(icon: "creditcard", label: "Unit", value: request.unit.uppercased())
+                        }
                         canvasDivider
                         detailRow(
                             icon: "calendar",
@@ -321,7 +341,10 @@ struct CashuRequestDetailView: View {
 
     private func amountDisplayValue(for request: CashuRequest) -> String {
         guard let amount = request.amount, amount > 0 else { return "Any" }
-        return "\(amount) \(request.unit)"
+        return CurrencyAmount(
+            value: amount,
+            currency: CurrencyRegistry.currency(forMintUnit: request.unit)
+        ).formatted()
     }
 
     // MARK: - Actions
@@ -340,7 +363,7 @@ struct CashuRequestDetailView: View {
     /// edits re-parameterize the one live request in place — payments to any
     /// previously shared copy still land on this row, and history never grows a
     /// second entry for the same receive intent.
-    private func regenerate(amount: UInt64?? = nil, mints: [String]? = nil) {
+    private func regenerate(amount: UInt64?? = nil, unit: String? = nil, mints: [String]? = nil) {
         HapticFeedback.selection()
         let nostr = NostrService.shared
         guard nostr.isInitialized, !nostr.publicKeyHex.isEmpty,
@@ -351,19 +374,37 @@ struct CashuRequestDetailView: View {
         case .some(let inner): nextAmount = inner
         }
         let nextMints = mints ?? existing.mints
+        // Validate the unit against the (possibly newly chosen) mint: keep the
+        // requested/existing unit when that mint supports it, else fall back to
+        // the mint's default. Covers both explicit unit edits and mint changes.
+        let requestedUnit = unit ?? existing.unit
+        let nextUnit = walletManager.mints.first { $0.url == nextMints.first }?
+            .resolvedUnit(requestedUnit) ?? requestedUnit
         do {
             let encoded = try PaymentRequestBuilder.build(
                 id: existing.id,
                 amount: nextAmount,
-                unit: existing.unit,
+                unit: nextUnit,
                 mints: nextMints,
                 description: existing.memo,
                 nostrPubkeyHex: nostr.publicKeyHex,
                 relays: SettingsManager.shared.nostrRelays
             )
-            store.update(id: existing.id, amount: nextAmount, mints: nextMints, encoded: encoded)
+            store.update(id: existing.id, amount: nextAmount, unit: nextUnit, mints: nextMints, encoded: encoded)
         } catch {
             AppLogger.wallet.error("Could not regenerate request: \(String(describing: error))")
         }
+    }
+
+    /// The tracked mint backing a request (nil for "any mint" / untracked).
+    private func requestMint(for request: CashuRequest) -> MintInfo? {
+        guard let mintUrl = request.mints.first else { return nil }
+        return walletManager.mints.first { $0.url == mintUrl }
+    }
+
+    /// The Unit row is editable only for an ecash request whose mint advertises
+    /// more than one unit.
+    private func unitEditable(for request: CashuRequest) -> Bool {
+        request.rail == .ecash && (requestMint(for: request)?.supportsMultipleUnits ?? false)
     }
 }

--- a/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -80,6 +80,7 @@ struct CashuRequestDetailView: View {
         .sheet(isPresented: $showAmountPicker) {
             CashuRequestAmountPickerSheet(
                 currentAmount: request?.amount,
+                unit: request?.unit ?? "sat",
                 onSelect: { amount in
                     regenerate(amount: amount)
                 }
@@ -161,11 +162,23 @@ struct CashuRequestDetailView: View {
                         }
 
                     if let amount = request.amount, amount > 0 {
-                        CurrencyAmountDisplay(
-                            sats: amount,
-                            primary: $settings.amountDisplayPrimary,
-                            primarySize: 32
-                        )
+                        if request.unit.lowercased() == "sat" {
+                            CurrencyAmountDisplay(
+                                sats: amount,
+                                primary: $settings.amountDisplayPrimary,
+                                primarySize: 32
+                            )
+                        } else {
+                            // Non-sat unit: render in its own currency, no sats flip.
+                            Text(CurrencyAmount(
+                                value: amount,
+                                currency: CurrencyRegistry.currency(forMintUnit: request.unit)
+                            ).formatted())
+                                .font(.system(size: 32, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .minimumScaleFactor(0.4)
+                                .lineLimit(1)
+                        }
                     }
 
                     statusBadge
@@ -368,11 +381,6 @@ struct CashuRequestDetailView: View {
         let nostr = NostrService.shared
         guard nostr.isInitialized, !nostr.publicKeyHex.isEmpty,
               let existing = request else { return }
-        let nextAmount: UInt64?
-        switch amount {
-        case .none: nextAmount = existing.amount
-        case .some(let inner): nextAmount = inner
-        }
         let nextMints = mints ?? existing.mints
         // Validate the unit against the (possibly newly chosen) mint: keep the
         // requested/existing unit when that mint supports it, else fall back to
@@ -380,6 +388,17 @@ struct CashuRequestDetailView: View {
         let requestedUnit = unit ?? existing.unit
         let nextUnit = walletManager.mints.first { $0.url == nextMints.first }?
             .resolvedUnit(requestedUnit) ?? requestedUnit
+        let nextAmount: UInt64?
+        switch amount {
+        case .some(let inner):
+            nextAmount = inner
+        case .none:
+            // Preserve the fixed amount only while the unit is unchanged — a
+            // stored number means different things across units (500 sat is not
+            // $5.00), so a unit change resets it to "Any" and the user re-enters
+            // in the new unit.
+            nextAmount = (nextUnit == existing.unit) ? existing.amount : nil
+        }
         do {
             let encoded = try PaymentRequestBuilder.build(
                 id: existing.id,

--- a/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
+++ b/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
@@ -113,3 +113,63 @@ struct CashuRequestMintPickerSheet: View {
             )
     }
 }
+
+/// Unit chooser for a Cashu request the user created. Lists the units the
+/// request's mint advertises; selecting one re-encodes the request in that unit.
+struct CashuRequestUnitPickerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let units: [String]
+    let currentUnit: String
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(units, id: \.self) { unit in
+                Button(action: { select(unit) }) {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(unit.uppercased())
+                                .font(.body.weight(.medium))
+                            if let subtitle = unitSubtitle(unit) {
+                                Text(subtitle)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        if currentUnit == unit {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .listRowSeparator(.hidden)
+                .buttonStyle(.plain)
+            }
+            .listStyle(.plain)
+            .navigationTitle("Unit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+    }
+
+    private func select(_ unit: String) {
+        HapticFeedback.selection()
+        onSelect(unit)
+        dismiss()
+    }
+
+    private func unitSubtitle(_ unit: String) -> String? {
+        let name = CurrencyRegistry.currency(forMintUnit: unit).displayName
+        return name.uppercased() == unit.uppercased() ? nil : name
+    }
+}

--- a/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -544,6 +544,7 @@ struct ReceiveLightningView: View {
         .sheet(isPresented: $showReusableAmountPicker) {
             CashuRequestAmountPickerSheet(
                 currentAmount: quote.amount,
+                unit: quote.unit,
                 onSelect: { setReusableOfferAmount($0) }
             )
         }

--- a/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -31,6 +31,11 @@ struct ReceiveLightningView: View {
     @State private var quoteCreatedAt: Date?
     @State private var monitoredQuoteId: String?
 
+    // Multi-unit mint: the user's explicit unit pick for this receive (nil = the
+    // mint's default mintable unit), plus the picker flag.
+    @State private var selectedReceiveUnit: String?
+    @State private var showUnitPicker = false
+
     var body: some View {
         NavigationStack {
             Group {
@@ -105,6 +110,24 @@ struct ReceiveLightningView: View {
                         .accessibilityHint("Opens the receive method picker")
                     }
                 }
+
+                // Unit selector — only in the amount-entry state, for a mint that
+                // can mint more than one unit (on-chain is amountless, no unit).
+                // Declared after the method button so it sits to its right.
+                if mintQuote == nil, !isCreatingRequest, selectedMethod != .onchain,
+                   let mint = walletManager.activeMint, mint.supportsMultipleMintUnits {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            HapticFeedback.selection()
+                            showUnitPicker = true
+                        } label: {
+                            Text(effectiveUnit.uppercased())
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .accessibilityLabel("Unit: \(effectiveUnit.uppercased())")
+                        .accessibilityHint("Choose the unit to mint")
+                    }
+                }
             }
             .sheet(isPresented: $showMintPicker) {
                 MintSelectorSheet(selectedMint: $walletManager.activeMint)
@@ -116,6 +139,14 @@ struct ReceiveLightningView: View {
                     selectedOption: selectedOption,
                     options: availableMethodOptions,
                     onSelect: { applyMethodOption($0) }
+                )
+                .presentationDetents([.medium])
+            }
+            .sheet(isPresented: $showUnitPicker) {
+                UnitSelectorSheet(
+                    units: walletManager.activeMint?.mintUnits ?? ["sat"],
+                    selectedUnit: effectiveUnit,
+                    onSelect: selectReceiveUnit
                 )
                 .presentationDetents([.medium])
             }
@@ -133,6 +164,10 @@ struct ReceiveLightningView: View {
                 // field here — that would fight the user's explicit picker choice.
             }
             .onChange(of: entryUnit) { oldUnit, newUnit in
+                // Only the sats↔fiat display flip re-expresses the typed string.
+                // A non-sat mint unit is entered directly and must not be
+                // reinterpreted through the sat price.
+                guard isSatReceive else { return }
                 // Flip (or a price load that changes the effective unit): carry
                 // the typed amount across, converted, so it stays equivalent.
                 amountString = AmountFormatter.entryConverted(raw: amountString, from: oldUnit, to: newUnit)
@@ -193,7 +228,51 @@ struct ReceiveLightningView: View {
     }
 
     /// Satoshis represented by the typed amount, interpreted per `entryUnit`.
-    private var amountSats: UInt64 { AmountFormatter.entrySats(raw: amountString, unit: entryUnit) }
+    /// Zero outside sat mode (a non-sat amount has no sat value).
+    private var amountSats: UInt64 {
+        guard isSatReceive else { return 0 }
+        return AmountFormatter.entrySats(raw: amountString, unit: entryUnit)
+    }
+
+    // MARK: - Active mint unit
+
+    /// The unit this receive will mint into — the user's pick when the mint can
+    /// mint it, otherwise the mint's default mintable unit. Auto-resets when the
+    /// active mint changes to one that can't mint the selection.
+    private var effectiveUnit: String {
+        walletManager.activeMint?.resolvedMintUnit(selectedReceiveUnit) ?? "sat"
+    }
+
+    private var isSatReceive: Bool { effectiveUnit.lowercased() == "sat" }
+    private var receiveUnitCurrency: any Currency { CurrencyRegistry.currency(forMintUnit: effectiveUnit) }
+    private var receiveUnitDecimals: Int { receiveUnitCurrency.decimals }
+
+    /// The amount actually minted, in the active unit's base units (sats for
+    /// sat; cents for eur/usd; integer for a custom unit).
+    private var amountBaseUnits: UInt64 {
+        isSatReceive ? amountSats : AmountFormatter.entryBaseUnits(raw: amountString, decimals: receiveUnitDecimals)
+    }
+
+    /// Big-number display for a non-sat entry, formatted in the active unit.
+    private var receiveUnitEntryDisplay: String {
+        CurrencyAmount(value: amountBaseUnits, currency: receiveUnitCurrency).formatted()
+    }
+
+    private func selectReceiveUnit(_ unit: String) {
+        selectedReceiveUnit = unit
+        // The typed amount's meaning changes with the unit — clear it.
+        amountString = ""
+        errorMessage = nil
+        HapticFeedback.selection()
+    }
+
+    /// Format a mint-quote amount in its own unit: sats keep the existing style,
+    /// other units render via their `Currency` (e.g. "€5.00").
+    private func formatQuoteAmount(_ amount: UInt64, unit: String) -> String {
+        unit.lowercased() == "sat"
+            ? AmountFormatter.sats(amount, useBitcoinSymbol: settings.useBitcoinSymbol)
+            : CurrencyAmount(value: amount, currency: CurrencyRegistry.currency(forMintUnit: unit)).formatted()
+    }
 
     /// The one path that submits no amount: a BOLT12 offer with "Any amount" lit.
     /// Everything else (BOLT11, on-chain, a BOLT12 offer with a typed amount)
@@ -205,7 +284,7 @@ struct ReceiveLightningView: View {
     private var canCreateRequest: Bool {
         guard !isCreatingRequest else { return false }
         if isAmountlessOffer { return true }
-        return amountSats > 0
+        return amountBaseUnits > 0
     }
 
     // MARK: - Amount Input View
@@ -230,12 +309,18 @@ struct ReceiveLightningView: View {
 
             Spacer()
 
-            NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
-                .padding(.horizontal, 24)
-                .onChange(of: amountString) { _, newValue in
-                    // Typing a digit takes over from the amountless offer.
-                    if isAmountless && !newValue.isEmpty { isAmountless = false }
+            Group {
+                if isSatReceive {
+                    NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
+                } else {
+                    NumberPadAmountInput(amountString: $amountString, decimals: receiveUnitDecimals)
                 }
+            }
+            .padding(.horizontal, 24)
+            .onChange(of: amountString) { _, newValue in
+                // Typing a digit takes over from the amountless offer.
+                if isAmountless && !newValue.isEmpty { isAmountless = false }
+            }
 
             Button(action: createRequest) {
                 if isCreatingRequest {
@@ -260,13 +345,25 @@ struct ReceiveLightningView: View {
                     .transition(.opacity)
             }
 
-            CurrencyAmountDisplay(
-                sats: amountSats,
-                primary: $settings.amountDisplayPrimary,
-                entryRaw: amountString
-            )
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) sats")
+            if isSatReceive {
+                CurrencyAmountDisplay(
+                    sats: amountSats,
+                    primary: $settings.amountDisplayPrimary,
+                    entryRaw: amountString
+                )
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) sats")
+            } else {
+                // Non-sat mint unit: show it directly, no BTC-price flip.
+                Text(receiveUnitEntryDisplay)
+                    .font(.system(size: 64, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.4)
+                    .lineLimit(1)
+                    .contentTransition(.numericText(value: Double(amountBaseUnits)))
+                    .animation(.snappy, value: amountBaseUnits)
+                    .accessibilityLabel("Request amount: \(amountString.isEmpty ? "0" : amountString) \(effectiveUnit)")
+            }
         }
         .animation(.snappy, value: selectedMethod)
     }
@@ -392,12 +489,19 @@ struct ReceiveLightningView: View {
                         }
 
                     if let amount = quote.amount, amount > 0 {
-                        CurrencyAmountDisplay(
-                            sats: amount,
-                            primary: $settings.amountDisplayPrimary,
-                            primarySize: 32
-                        )
-                        .accessibilityLabel("Offer amount: \(amount) sats")
+                        if quote.unit.lowercased() == "sat" {
+                            CurrencyAmountDisplay(
+                                sats: amount,
+                                primary: $settings.amountDisplayPrimary,
+                                primarySize: 32
+                            )
+                            .accessibilityLabel("Offer amount: \(amount) sats")
+                        } else {
+                            Text(formatQuoteAmount(amount, unit: quote.unit))
+                                .font(.system(size: 32, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .accessibilityLabel("Offer amount: \(amount) \(quote.unit)")
+                        }
                     }
 
                     statusBadge
@@ -412,7 +516,7 @@ struct ReceiveLightningView: View {
                         editableRow(
                             icon: "bitcoinsign",
                             label: "Amount",
-                            value: quote.amount.flatMap { $0 > 0 ? formatBalance($0) : nil } ?? "Any",
+                            value: quote.amount.flatMap { $0 > 0 ? formatQuoteAmount($0, unit: quote.unit) : nil } ?? "Any",
                             action: { showReusableAmountPicker = true }
                         )
                         if let created = quote.createdAt {
@@ -473,7 +577,7 @@ struct ReceiveLightningView: View {
             rows.append(.init(
                 icon: "bitcoinsign",
                 label: "Amount",
-                value: AmountFormatter.sats(amount, useBitcoinSymbol: settings.useBitcoinSymbol)
+                value: formatQuoteAmount(amount, unit: quote.unit)
             ))
         }
         if let mint = walletManager.activeMint {
@@ -567,7 +671,7 @@ struct ReceiveLightningView: View {
                         .font(.system(size: 32, weight: .semibold, design: .rounded))
                         .monospacedDigit()
                         .accessibilityLabel("Amount received: \(amount) sats")
-                } else {
+                } else if quote.unit.lowercased() == "sat" {
                     // Smaller than the QR — the QR is the focal element on this
                     // screen; the amount confirms it.
                     CurrencyAmountDisplay(
@@ -576,6 +680,12 @@ struct ReceiveLightningView: View {
                         primarySize: 32
                     )
                     .accessibilityLabel("Request amount: \(amount) sats")
+                } else {
+                    // Non-sat mint unit: show it directly, no BTC-price flip.
+                    Text(formatQuoteAmount(amount, unit: quote.unit))
+                        .font(.system(size: 32, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .accessibilityLabel("Request amount: \(amount) \(quote.unit)")
                 }
             } else {
                 if isCreatingRequest {
@@ -813,6 +923,9 @@ struct ReceiveLightningView: View {
     }
 
     private func syncSelectedMethodWithActiveMint() {
+        // A different mint may not mint the previously-picked unit — clear the
+        // explicit choice so `effectiveUnit` falls back to the new mint's default.
+        selectedReceiveUnit = nil
         guard availableMintMethods.contains(selectedMethod) else {
             let fallback = availableMintMethods.first ?? .bolt11
             selectedMethod = fallback
@@ -950,7 +1063,8 @@ struct ReceiveLightningView: View {
 
     private func createRequest(method requestMethod: PaymentMethodKind, amountless: Bool, forceNew: Bool = false) {
         // Onchain is always amountless (sender decides). Lightning/BOLT12 require a value.
-        let requestAmount: UInt64? = (amountless || requestMethod == .onchain) ? nil : (amountSats > 0 ? amountSats : nil)
+        // Amount is in the active unit's base units (sats, or eur/usd cents, …).
+        let requestAmount: UInt64? = (amountless || requestMethod == .onchain) ? nil : (amountBaseUnits > 0 ? amountBaseUnits : nil)
 
         if !amountless, requestMethod != .onchain, (requestAmount ?? 0) == 0 {
             return
@@ -978,7 +1092,8 @@ struct ReceiveLightningView: View {
                 } else {
                     quote = try await walletManager.createMintQuote(
                         amount: requestAmount,
-                        method: requestMethod
+                        method: requestMethod,
+                        unit: effectiveUnit
                     )
                 }
                 quoteCreatedAt = Date()
@@ -1213,11 +1328,13 @@ struct ReceiveLightningView: View {
         // Fire the home-screen toast (same notification the NPC mint flow
         // posts from WalletManager) so the user sees the receipt on the home
         // screen after dismiss.
-        if let amount = mintQuote?.amount {
+        if let quote = mintQuote, let amount = quote.amount {
             NotificationCenter.default.post(
                 name: .cashuTokenReceived,
                 object: nil,
-                userInfo: ["amount": amount]
+                // Pass the unit so the home delta skips a misleading "+N sat" for
+                // a non-sat mint (the sat balance didn't move).
+                userInfo: ["amount": amount, "unit": quote.unit]
             )
         }
 

--- a/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
+++ b/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
@@ -10,6 +10,9 @@ struct ReceiveTokenDetailView: View {
 
     @State private var decodedToken: Token?
     @State private var tokenAmount: UInt64
+    /// The token's own unit ("sat", "eur", "usd", or a custom string). Drives
+    /// unit-native amount/fee formatting so a non-sat token isn't shown as sats.
+    @State private var tokenUnit: String
     @State private var receiveFee: UInt64 = 0
     @State private var mintUrl: String = ""
     @State private var errorMessage: String?
@@ -35,8 +38,30 @@ struct ReceiveTokenDetailView: View {
         // .animation(value: sats) while PayFlowScaffold's GeometryReader is still
         // resolving — sliding the hero in from the top-left. Env-dependent state
         // (mintIsKnown / tokenLockedToKnownKey / fee) still resolves in onAppear.
-        let amount = (try? Token.decode(encodedToken: tokenString).value().value) ?? 0
+        let decoded = try? Token.decode(encodedToken: tokenString)
+        let amount = decoded.flatMap { try? $0.value().value } ?? 0
         _tokenAmount = State(initialValue: amount)
+        let unit = (decoded?.unit() ?? nil).map(PaymentRequestDecoder.unitDescription) ?? "sat"
+        _tokenUnit = State(initialValue: unit)
+    }
+
+    /// Whether the token is denominated in sats (the common path — keep the
+    /// sats↔fiat hero) versus a mint account unit (eur/usd/custom).
+    private var isSatUnit: Bool { tokenUnit.lowercased() == "sat" }
+
+    private var unitCurrency: any Currency { CurrencyRegistry.currency(forMintUnit: tokenUnit) }
+
+    /// Format a base-unit amount in the token's unit: sats keep the existing
+    /// style; other units render via their `Currency` (e.g. "€5.00", "500 EUR").
+    private func formatAmount(_ base: UInt64) -> String {
+        isSatUnit
+            ? AmountFormatter.sats(base, useBitcoinSymbol: settings.useBitcoinSymbol)
+            : CurrencyAmount(value: base, currency: unitCurrency).formatted()
+    }
+
+    /// Fee formatted in the token's unit. Sats keep the terse "N sat" style.
+    private func formatFee(_ base: UInt64) -> String {
+        isSatUnit ? "\(base) sat" : CurrencyAmount(value: base, currency: unitCurrency).formatted()
     }
 
     var body: some View {
@@ -86,10 +111,19 @@ struct ReceiveTokenDetailView: View {
     /// rows are hairline-on-canvas, matching every other detail surface.
     private var confirmContent: some View {
         PayFlowScaffold {
-            CurrencyAmountDisplay(
-                sats: tokenAmount,
-                primary: $settings.amountDisplayPrimary
-            )
+            if isSatUnit {
+                CurrencyAmountDisplay(
+                    sats: tokenAmount,
+                    primary: $settings.amountDisplayPrimary
+                )
+            } else {
+                // Non-sat account unit: show it directly, no BTC-price flip.
+                Text(formatAmount(tokenAmount))
+                    .font(.system(size: 64, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.4)
+                    .lineLimit(1)
+            }
         } details: {
             VStack(spacing: 16) {
                 VStack(spacing: 0) {
@@ -104,7 +138,7 @@ struct ReceiveTokenDetailView: View {
                         .padding(.horizontal, 4)
                         .padding(.vertical, 14)
                     } else {
-                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: "\(receiveFee) sat")
+                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: formatFee(receiveFee))
                     }
                     canvasDivider
                     detailRow(icon: "bitcoinsign.bank.building", label: "Mint", value: shortMintUrl(mintUrl))
@@ -171,9 +205,9 @@ struct ReceiveTokenDetailView: View {
             .init(
                 icon: "bitcoinsign",
                 label: "Amount",
-                value: AmountFormatter.sats(tokenAmount, useBitcoinSymbol: settings.useBitcoinSymbol)
+                value: formatAmount(tokenAmount)
             ),
-            .init(icon: "arrow.up.arrow.down", label: "Fee", value: "\(receiveFee) sat"),
+            .init(icon: "arrow.up.arrow.down", label: "Fee", value: formatFee(receiveFee)),
         ]
         if !mintUrl.isEmpty {
             rows.append(.init(
@@ -320,7 +354,7 @@ struct ReceiveTokenDetailView: View {
                     NotificationCenter.default.post(
                         name: .cashuTokenReceived,
                         object: nil,
-                        userInfo: ["amount": receivedAmount, "fee": UInt64(0)]
+                        userInfo: ["amount": receivedAmount, "fee": UInt64(0), "unit": tokenUnit]
                     )
                     withAnimation(.smooth(duration: 0.3)) { phase = .success }
                 }

--- a/CashuWallet/Views/Send/Components/NumberPadAmountInput.swift
+++ b/CashuWallet/Views/Send/Components/NumberPadAmountInput.swift
@@ -6,10 +6,30 @@ import SwiftUI
 /// Per-keypress selection haptics, long-press on delete clears the whole value.
 struct NumberPadAmountInput: View {
     @Binding var amountString: String
-    /// The active entry unit. Sats is an integer; fiat is a cents accumulator
-    /// (digits shift in from the right). Either way the bottom-left slot stays
-    /// blank — there is no decimal key, the fiat decimal is implied.
-    var unit: AmountDisplayPrimary = .sats
+
+    /// How keystrokes are interpreted:
+    /// - `.display`: sats (integer) or fiat (a cents accumulator, digits shift in
+    ///   from the right) — the sats↔fiat display flip.
+    /// - `.mintUnit`: a mint account unit entered directly, with `decimals`
+    ///   fraction digits (0 → integer like sats, 2 → cents like fiat).
+    /// Either way the bottom-left slot stays blank — there is no decimal key.
+    private enum Mode {
+        case display(AmountDisplayPrimary)
+        case mintUnit(decimals: Int)
+    }
+    private let mode: Mode
+
+    /// Sats/fiat display-flip entry (existing call sites).
+    init(amountString: Binding<String>, unit: AmountDisplayPrimary = .sats) {
+        self._amountString = amountString
+        self.mode = .display(unit)
+    }
+
+    /// Direct entry in a mint account unit with the given fraction-digit count.
+    init(amountString: Binding<String>, decimals: Int) {
+        self._amountString = amountString
+        self.mode = .mintUnit(decimals: decimals)
+    }
 
     @ScaledMetric(relativeTo: .title) private var keyHeight: CGFloat = 64
 
@@ -68,14 +88,26 @@ struct NumberPadAmountInput: View {
     }
 
     private func append(_ key: String) {
-        let updated = AmountFormatter.entryAppend(key, to: amountString, unit: unit)
+        let updated: String
+        switch mode {
+        case .display(let unit):
+            updated = AmountFormatter.entryAppend(key, to: amountString, unit: unit)
+        case .mintUnit(let decimals):
+            updated = AmountFormatter.entryAppendUnit(key, to: amountString, decimals: decimals)
+        }
         guard updated != amountString else { return }
         HapticFeedback.selection()
         amountString = updated
     }
 
     private func backspace() {
-        let updated = AmountFormatter.entryBackspace(amountString, unit: unit)
+        let updated: String
+        switch mode {
+        case .display(let unit):
+            updated = AmountFormatter.entryBackspace(amountString, unit: unit)
+        case .mintUnit(let decimals):
+            updated = AmountFormatter.entryBackspaceUnit(amountString, decimals: decimals)
+        }
         guard updated != amountString else { return }
         HapticFeedback.selection()
         amountString = updated

--- a/CashuWallet/Views/Send/SendView.swift
+++ b/CashuWallet/Views/Send/SendView.swift
@@ -292,10 +292,32 @@ struct SendView: View {
     }
 
     /// The unit this send is denominated in — the user's pick when the mint
-    /// supports it, otherwise the mint's default. Auto-resets when the mint
-    /// changes to one lacking the selected unit.
+    /// supports it, otherwise a unit the wallet can actually spend. Auto-resets
+    /// when the mint changes to one lacking the selected unit.
     private var effectiveSendUnit: String {
-        unitContextMint?.resolvedUnit(selectedSendUnit) ?? "sat"
+        guard let mint = unitContextMint else { return "sat" }
+        if let selectedSendUnit, mint.units.contains(selectedSendUnit) {
+            return selectedSendUnit
+        }
+        return defaultSpendableUnit(for: mint)
+    }
+
+    /// The unit to default to when the user hasn't chosen one: the mint's
+    /// preferred unit while it holds a balance, otherwise the first supported
+    /// unit the wallet can spend — so a USD-only wallet lands on USD instead of
+    /// an empty sat form.
+    private func defaultSpendableUnit(for mint: MintInfo) -> String {
+        let preferred = mint.defaultUnit
+        if unitHasSpendableBalance(preferred, mint: mint) { return preferred }
+        return mint.units.first { unitHasSpendableBalance($0, mint: mint) } ?? preferred
+    }
+
+    /// Whether `unit` currently holds a spendable balance. Sat reads the cached
+    /// per-mint balance; other units use the wallet-wide per-unit totals (the
+    /// same source as the home hero) since non-sat per-mint balances load async.
+    private func unitHasSpendableBalance(_ unit: String, mint: MintInfo) -> Bool {
+        if unit.lowercased() == "sat" { return mint.balance > 0 }
+        return (walletManager.balancesByUnit[unit] ?? 0) > 0
     }
 
     private var isSatSend: Bool { effectiveSendUnit.lowercased() == "sat" }
@@ -1209,7 +1231,7 @@ struct UnifiedSendView: View {
     private var inputContent: some View {
         if walletManager.mints.isEmpty {
             noMintsState
-        } else if walletManager.balance == 0 {
+        } else if !walletManager.hasAnyBalance {
             noBalanceState
         } else {
             inputForm

--- a/CashuWallet/Views/Send/SendView.swift
+++ b/CashuWallet/Views/Send/SendView.swift
@@ -2595,27 +2595,13 @@ struct UnifiedSendView: View {
     }
 
     private var noBalanceState: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "banknote")
-                .font(.system(size: 40))
-                .foregroundStyle(.secondary)
-
-            VStack(spacing: 6) {
-                Text("Nothing to send yet")
-                    .font(.title3.weight(.medium))
-                Text("Receive some ecash before you can send.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            Button("Receive", action: onReceive)
-                .glassButton()
-                .padding(.top, 4)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 24)
-        .padding(.top, 24)
+        NativeEmptyState(
+            title: "Nothing to send yet",
+            systemImage: "arrow.down.circle",
+            description: "Receive some ecash before you can send.",
+            actionTitle: "Receive",
+            action: onReceive
+        )
     }
 
     private func addMint(_ url: String) {

--- a/CashuWallet/Views/Send/SendView.swift
+++ b/CashuWallet/Views/Send/SendView.swift
@@ -1065,47 +1065,88 @@ struct UnifiedSendView: View {
                         .padding(.top, 10)
                 }
 
-                // Two (or three) plain action rows, generously spaced — no header,
-                // no divider.
-                VStack(alignment: .leading, spacing: 14) {
-                    actionRow(
-                        icon: "qrcode.viewfinder",
-                        title: "Scan QR Code",
-                        subtitle: "Pay or receive by scanning",
-                        showsChevron: false,
-                        action: openScanner
-                    )
-
-                    actionRow(
-                        icon: "banknote",
-                        title: "Create ecash",
-                        subtitle: "Generate a bearer token to share",
-                        showsChevron: false,
-                        action: {
-                            HapticFeedback.selection()
-                            route = .ecash
-                        }
-                    )
-
-                    if NFCNDEFReaderSession.readingAvailable {
-                        actionRow(
-                            icon: "wave.3.right.circle.fill",
-                            title: "Contactless",
-                            subtitle: "Tap to pay nearby",
-                            showsChevron: false,
-                            action: {
-                                HapticFeedback.selection()
-                                onContactless()
-                            }
-                        )
-                    }
-                }
-                .padding(.horizontal)
-                .padding(.top, 40)
+                // A centered row of round Liquid Glass icon buttons — the primary
+                // "ways to send" (Scan · Ecash · Tap), one-word label under each.
+                sendMethodRow
+                    .padding(.horizontal)
+                    .padding(.top, 32)
             }
             .padding(.bottom, 24)
         }
         .scrollDismissesKeyboard(.interactively)
+    }
+
+    // MARK: Send-method buttons
+
+    /// The primary "ways to send" as a centered row of round Liquid Glass icon
+    /// buttons. The `HStack` is wrapped in a `GlassEffectContainer` on iOS 26 so
+    /// the adjacent circular glass surfaces sample light consistently (glass
+    /// can't sample other glass) — same technique as the home Receive/Send row.
+    private var sendMethodRow: some View {
+        let row = HStack(spacing: 28) {
+            sendMethodButton(icon: "qrcode.viewfinder", label: "Scan",
+                             a11y: "Scan QR code", action: openScanner)
+
+            sendMethodButton(icon: "banknote", label: "Ecash",
+                             a11y: "Create ecash") {
+                HapticFeedback.selection()
+                route = .ecash
+            }
+
+            if NFCNDEFReaderSession.readingAvailable {
+                sendMethodButton(icon: "wave.3.right", label: "Tap",
+                                 a11y: "Contactless, tap to pay nearby") {
+                    HapticFeedback.selection()
+                    onContactless()
+                }
+            }
+        }
+
+        return Group {
+            if #available(iOS 26, *) {
+                GlassEffectContainer(spacing: 28) { row }
+            } else {
+                row
+            }
+        }
+        .frame(maxWidth: .infinity)   // center the group on the leading-aligned canvas
+    }
+
+    /// One round glass icon button with a one-word caption on the canvas below it.
+    /// iOS 26 uses Apple's native circular glass button style (which owns its own
+    /// interactive press); iOS 18–25 falls back to a `.quaternary` circle.
+    @ViewBuilder
+    private func sendMethodButton(
+        icon: String, label: String, a11y: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(spacing: 8) {
+            if #available(iOS 26, *) {
+                Button(action: action) {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .frame(width: 60, height: 60)
+                }
+                .buttonStyle(.glass)
+                .buttonBorderShape(.circle)
+            } else {
+                Button(action: action) {
+                    Image(systemName: icon)
+                        .font(.title2)
+                        .foregroundStyle(.primary)
+                        .frame(width: 60, height: 60)
+                        .background(.quaternary, in: Circle())
+                }
+                .buttonStyle(PressableButtonStyle())
+            }
+
+            Text(label)
+                .font(.caption.weight(.medium))
+                .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(a11y)
+        .accessibilityAddTraits(.isButton)
     }
 
     private var destinationField: some View {
@@ -2286,49 +2327,7 @@ struct UnifiedSendView: View {
             .padding(.horizontal, 4)
     }
 
-    // MARK: Action row + input actions
-
-    private func actionRow(
-        icon: String,
-        title: String,
-        subtitle: String,
-        showsChevron: Bool = true,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            HStack(spacing: 14) {
-                Image(systemName: icon)
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(.primary)
-                    .frame(width: 36, height: 36)
-                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10))
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.primary)
-                    Text(subtitle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-
-                Spacer(minLength: 8)
-
-                // The "ways to send" rows are actions (invoke a tool/mode/sheet),
-                // not navigation pushes, so they omit the disclosure chevron. The
-                // Matching / Receive-this rows keep it — they advance the pay flow.
-                if showsChevron {
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.tertiary)
-                }
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
+    // MARK: Input actions
 
     private func openScanner() {
         HapticFeedback.selection()

--- a/CashuWallet/Views/Send/SendView.swift
+++ b/CashuWallet/Views/Send/SendView.swift
@@ -17,6 +17,17 @@ struct SendView: View {
     @State private var errorShowsMintAction = false
     @State private var showMintPicker = false
     @State private var selectedSendMint: MintInfo?
+
+    // Multi-unit send: the user's explicit unit choice for this flow (nil = use
+    // the mint's default), the picker sheet flag, and the async-loaded balance
+    // for the active non-sat unit (sat uses the cached mint balance instead).
+    @State private var selectedSendUnit: String?
+    @State private var showUnitPicker = false
+    @State private var selectedUnitBalance: UInt64?
+    // Unit + amount captured at generation time so the pending-token screen keeps
+    // showing the right denomination even if the live selection later changes.
+    @State private var generatedTokenUnit: String = "sat"
+    @State private var generatedAmount: UInt64 = 0
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     // Token claim detection
@@ -91,6 +102,22 @@ struct SendView: View {
                     }
                 }
 
+                // Unit selector — only when the active mint offers more than one
+                // unit. Declared after the lock so it sits to the lock's right.
+                if generatedToken == nil, let mint = unitContextMint, mint.supportsMultipleUnits {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            HapticFeedback.selection()
+                            showUnitPicker = true
+                        } label: {
+                            Text(effectiveSendUnit.uppercased())
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .accessibilityLabel("Unit: \(effectiveSendUnit.uppercased())")
+                        .accessibilityHint("Choose the unit for this ecash")
+                    }
+                }
+
                 if generatedToken != nil && !tokenClaimed {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button(action: { showShareSheet = true }) {
@@ -108,6 +135,14 @@ struct SendView: View {
                 )
                     .environmentObject(walletManager)
                     .presentationDetents([.medium])
+            }
+            .sheet(isPresented: $showUnitPicker) {
+                UnitSelectorSheet(
+                    units: unitContextMint?.units ?? ["sat"],
+                    selectedUnit: effectiveSendUnit,
+                    onSelect: selectSendUnit
+                )
+                .presentationDetents([.medium])
             }
             .sheet(isPresented: $showShareSheet) {
                 if let token = generatedToken {
@@ -127,7 +162,14 @@ struct SendView: View {
                 checkingTask?.cancel()
             }
             .onChange(of: entryUnit) { oldUnit, newUnit in
+                // Only the sats↔fiat display flip re-expresses the typed string.
+                // A non-sat mint unit is entered directly and must not be
+                // reinterpreted through the sat price.
+                guard isSatSend else { return }
                 amountString = AmountFormatter.entryConverted(raw: amountString, from: oldUnit, to: newUnit)
+            }
+            .task(id: unitBalanceKey) {
+                await loadUnitBalance()
             }
         }
     }
@@ -152,12 +194,23 @@ struct SendView: View {
 
             Spacer()
 
-            // Amount display — fiat-primary with tap-to-flip ↕ pill
-            CurrencyAmountDisplay(
-                sats: amountSats,
-                primary: $settings.amountDisplayPrimary,
-                entryRaw: amountString
-            )
+            // Amount display — sats keep the fiat-primary tap-to-flip ↕ pill; a
+            // non-sat mint unit is shown directly in that unit (no price flip).
+            if isSatSend {
+                CurrencyAmountDisplay(
+                    sats: amountSats,
+                    primary: $settings.amountDisplayPrimary,
+                    entryRaw: amountString
+                )
+            } else {
+                Text(sendUnitEntryDisplay)
+                    .font(.system(size: 64, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.4)
+                    .lineLimit(1)
+                    .contentTransition(.numericText(value: Double(amountBaseUnits)))
+                    .animation(.snappy, value: amountBaseUnits)
+            }
 
             if let error = errorMessage {
                 InlineNotice(
@@ -172,9 +225,16 @@ struct SendView: View {
 
             Spacer()
 
-            // Number pad
-            NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
-                .padding(.horizontal, 24)
+            // Number pad — sats/fiat display entry, or direct entry in the
+            // active mint unit's own precision (0 decimals for sat, 2 for eur/usd).
+            Group {
+                if isSatSend {
+                    NumberPadAmountInput(amountString: $amountString, unit: entryUnit)
+                } else {
+                    NumberPadAmountInput(amountString: $amountString, decimals: sendUnitDecimals)
+                }
+            }
+            .padding(.horizontal, 24)
 
             Button(action: {
                 HapticFeedback.impact(.light)
@@ -200,7 +260,7 @@ struct SendView: View {
     private func mintSelector(mint: MintInfo) -> some View {
         MintAmountSelectorRow(
             mint: mint,
-            balanceText: formatBalance(mint.balance),
+            balanceText: sendBalanceText,
             onChooseMint: { showMintPicker = true },
             onUseMax: { useMax(mint: mint) }
         )
@@ -213,21 +273,101 @@ struct SendView: View {
     }
 
     /// Satoshis represented by the typed amount, interpreted per `entryUnit`.
-    private var amountSats: UInt64 { AmountFormatter.entrySats(raw: amountString, unit: entryUnit) }
+    /// Zero outside sat mode (a non-sat amount has no sat value) — this also
+    /// keeps `displaySendMint`'s balance-minimum from filtering on a garbage
+    /// value while the keypad holds a eur/usd amount.
+    private var amountSats: UInt64 {
+        guard isSatSend else { return 0 }
+        return AmountFormatter.entrySats(raw: amountString, unit: entryUnit)
+    }
+
+    // MARK: - Active unit
+
+    /// The mint whose supported units drive the selector. Uses no sat-minimum,
+    /// so resolving the active unit never (recursively) depends on the entered
+    /// amount. Equals `displaySendMint` whenever a mint is explicitly chosen or
+    /// the unit is non-sat.
+    private var unitContextMint: MintInfo? {
+        resolvedSelectedSendMint ?? recommendedSendMint(minimumAmount: nil)
+    }
+
+    /// The unit this send is denominated in — the user's pick when the mint
+    /// supports it, otherwise the mint's default. Auto-resets when the mint
+    /// changes to one lacking the selected unit.
+    private var effectiveSendUnit: String {
+        unitContextMint?.resolvedUnit(selectedSendUnit) ?? "sat"
+    }
+
+    private var isSatSend: Bool { effectiveSendUnit.lowercased() == "sat" }
+    private var sendUnitCurrency: any Currency { CurrencyRegistry.currency(forMintUnit: effectiveSendUnit) }
+    private var sendUnitDecimals: Int { sendUnitCurrency.decimals }
+
+    /// The amount actually created, in the active unit's base units (sats for
+    /// sat; cents for eur/usd; integer for a custom unit).
+    private var amountBaseUnits: UInt64 {
+        isSatSend ? amountSats : AmountFormatter.entryBaseUnits(raw: amountString, decimals: sendUnitDecimals)
+    }
+
+    /// The active unit's spendable balance: sat from the cached mint balance,
+    /// other units from the async-loaded `selectedUnitBalance`.
+    private var effectiveSendBalance: UInt64 {
+        isSatSend ? (displaySendMint?.balance ?? 0) : (selectedUnitBalance ?? 0)
+    }
+
+    /// Big-number display for a non-sat entry, formatted in the active unit.
+    private var sendUnitEntryDisplay: String {
+        CurrencyAmount(value: amountBaseUnits, currency: sendUnitCurrency).formatted()
+    }
+
+    /// The mint-row balance line, in the active unit ("…" while non-sat loads).
+    private var sendBalanceText: String {
+        if isSatSend { return formatBalance(displaySendMint?.balance ?? 0) }
+        guard let bal = selectedUnitBalance else { return "…" }
+        return CurrencyAmount(value: bal, currency: sendUnitCurrency).formatted()
+    }
+
+    /// Re-loads `selectedUnitBalance` whenever the (mint, unit) pair changes.
+    private var unitBalanceKey: String { "\(displaySendMint?.url ?? "")|\(effectiveSendUnit)" }
+
+    private func selectSendUnit(_ unit: String) {
+        selectedSendUnit = unit
+        // The typed amount's meaning changes with the unit — clear it and its
+        // now-stale balance rather than reinterpret the digits.
+        amountString = ""
+        selectedUnitBalance = nil
+        errorMessage = nil
+        HapticFeedback.selection()
+    }
+
+    private func loadUnitBalance() async {
+        guard !isSatSend, let mint = displaySendMint else {
+            selectedUnitBalance = nil
+            return
+        }
+        let unit = effectiveSendUnit
+        let balance = await walletManager.unitBalance(mintURL: mint.url, unit: unit)
+        // Ignore a result that arrived after the user moved on to another unit/mint.
+        guard effectiveSendUnit == unit, displaySendMint?.url == mint.url else { return }
+        selectedUnitBalance = balance
+    }
 
     private func useMax(mint: MintInfo) {
         HapticFeedback.impact(.light)
-        // Balance is sats; express it in the current entry unit so the keypad
-        // string keeps its meaning.
-        amountString = AmountFormatter.entryConverted(raw: String(mint.balance), from: .sats, to: entryUnit)
+        if isSatSend {
+            // Balance is sats; express it in the current entry unit so the keypad
+            // string keeps its meaning.
+            amountString = AmountFormatter.entryConverted(raw: String(mint.balance), from: .sats, to: entryUnit)
+        } else {
+            amountString = AmountFormatter.entryString(baseUnits: effectiveSendBalance, decimals: sendUnitDecimals)
+        }
     }
 
     private var canSend: Bool {
-        let amount = amountSats
+        let amount = amountBaseUnits
         guard amount > 0 else { return false }
-        guard let mint = displaySendMint else { return false }
+        guard displaySendMint != nil else { return false }
         if lockWithP2PK && normalizedP2PKPubkeyInput == nil { return false }
-        return amount <= mint.balance
+        return amount <= effectiveSendBalance
     }
 
     private var availableSendMints: [MintInfo] {
@@ -395,12 +535,21 @@ struct SendView: View {
                             }
                         }
 
-                    // Amount
-                    CurrencyAmountDisplay(
-                        sats: amountSats,
-                        primary: $settings.amountDisplayPrimary,
-                        primarySize: 32
-                    )
+                    // Amount — sats keep the fiat-flip display; a non-sat token
+                    // shows its own unit directly.
+                    if generatedIsSat {
+                        CurrencyAmountDisplay(
+                            sats: generatedAmount,
+                            primary: $settings.amountDisplayPrimary,
+                            primarySize: 32
+                        )
+                    } else {
+                        Text(CurrencyAmount(value: generatedAmount, currency: generatedUnitCurrency).formatted())
+                            .font(.system(size: 32, weight: .semibold, design: .rounded))
+                            .monospacedDigit()
+                            .minimumScaleFactor(0.4)
+                            .lineLimit(1)
+                    }
 
                     // Status — inline badge transition, then dismiss + toast.
                     Group {
@@ -441,13 +590,17 @@ struct SendView: View {
                     // Detail rows on canvas with hairline dividers — same
                     // pattern as the Lightning Invoice screen.
                     VStack(spacing: 0) {
-                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: "\(tokenFee) sat")
+                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText)
                         canvasDivider
-                        detailRow(icon: "banknote", label: "Unit", value: settings.unitLabel.uppercased())
-                        canvasDivider
-                        detailRow(icon: "banknote", label: "Fiat",
-                                  value: priceService.btcPriceUSD > 0
-                                      ? priceService.formatSatsAsFiat(amountSats) : "—")
+                        detailRow(icon: "banknote", label: "Unit", value: generatedTokenUnit.uppercased())
+                        // Fiat conversion is only meaningful for sats; a non-sat
+                        // account unit has no BTC-price equivalent.
+                        if generatedIsSat {
+                            canvasDivider
+                            detailRow(icon: "banknote", label: "Fiat",
+                                      value: priceService.btcPriceUSD > 0
+                                          ? priceService.formatSatsAsFiat(generatedAmount) : "—")
+                        }
                         if let mintURL = generatedTokenMintURL {
                             canvasDivider
                             detailRow(icon: "bitcoinsign.bank.building", label: "Mint",
@@ -488,13 +641,12 @@ struct SendView: View {
     }
 
     private var claimedSuccessRows: [PaymentStatusView.DetailRow] {
+        let amountText = generatedIsSat
+            ? AmountFormatter.sats(generatedAmount, useBitcoinSymbol: settings.useBitcoinSymbol)
+            : CurrencyAmount(value: generatedAmount, currency: generatedUnitCurrency).formatted()
         var rows: [PaymentStatusView.DetailRow] = [
-            .init(
-                icon: "bitcoinsign",
-                label: "Amount",
-                value: AmountFormatter.sats(amountSats, useBitcoinSymbol: settings.useBitcoinSymbol)
-            ),
-            .init(icon: "arrow.up.arrow.down", label: "Fee", value: "\(tokenFee) sat"),
+            .init(icon: "bitcoinsign", label: "Amount", value: amountText),
+            .init(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText),
         ]
         if let mintURL = generatedTokenMintURL {
             rows.append(.init(
@@ -504,6 +656,14 @@ struct SendView: View {
             ))
         }
         return rows
+    }
+
+    // MARK: - Generated-token display helpers
+
+    private var generatedIsSat: Bool { generatedTokenUnit.lowercased() == "sat" }
+    private var generatedUnitCurrency: any Currency { CurrencyRegistry.currency(forMintUnit: generatedTokenUnit) }
+    private var generatedFeeText: String {
+        generatedIsSat ? "\(tokenFee) sat" : CurrencyAmount(value: tokenFee, currency: generatedUnitCurrency).formatted()
     }
 
     private func detailRow(icon: String, label: String, value: String) -> some View {
@@ -551,12 +711,13 @@ struct SendView: View {
     // MARK: - Actions
 
     private func generateToken() {
-        let amount = amountSats
+        let amount = amountBaseUnits
         guard amount > 0 else { return }
         guard let mint = displaySendMint else {
             presentError("No mint available.")
             return
         }
+        let unit = effectiveSendUnit
         let selectedP2PKPubkey = lockWithP2PK ? normalizedP2PKPubkeyInput : nil
         guard !lockWithP2PK || selectedP2PKPubkey != nil else {
             presentError("Choose a valid key to lock to.")
@@ -572,10 +733,13 @@ struct SendView: View {
                     amount: amount,
                     memo: memo.isEmpty ? nil : memo,
                     p2pkPubkey: selectedP2PKPubkey,
-                    mintUrl: mint.url
+                    mintUrl: mint.url,
+                    unit: unit
                 )
                 generatedToken = result.token
                 generatedTokenMintURL = mint.url
+                generatedTokenUnit = unit
+                generatedAmount = amount
                 tokenFee = result.fee
                 HapticFeedback.notification(.success)
             } catch {
@@ -3384,6 +3548,69 @@ struct MeltViewWithAddress: View {
 }
 
 // MARK: - Mint Selector Sheet (for Send/Receive flows)
+
+/// Bottom-sheet unit chooser for the Send / Create-Ecash flow. Lists the units
+/// a mint advertises; the current one is checkmarked. Mirrors `MintSelectorSheet`.
+struct UnitSelectorSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let units: [String]
+    let selectedUnit: String
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(units, id: \.self) { unit in
+                Button(action: { select(unit) }) {
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(unit.uppercased())
+                                .font(.body.weight(.medium))
+                            if let subtitle = unitSubtitle(unit) {
+                                Text(subtitle)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        if unit == selectedUnit {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+            .navigationTitle("Select Unit")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark")
+                    }
+                    .accessibilityLabel("Close")
+                }
+            }
+        }
+    }
+
+    private func select(_ unit: String) {
+        HapticFeedback.selection()
+        onSelect(unit)
+        dismiss()
+    }
+
+    /// Full currency name (e.g. "Euro"), omitted for a custom unit whose name is
+    /// just its own code to avoid a redundant second line.
+    private func unitSubtitle(_ unit: String) -> String? {
+        let name = CurrencyRegistry.currency(forMintUnit: unit).displayName
+        return name.uppercased() == unit.uppercased() ? nil : name
+    }
+}
 
 struct MintSelectorSheet: View {
     @Environment(\.dismiss) private var dismiss

--- a/CashuWalletTests/MintServiceTests.swift
+++ b/CashuWalletTests/MintServiceTests.swift
@@ -255,6 +255,75 @@ final class MultiUnitSupportTests: XCTestCase {
         XCTAssertEqual(mint(units: ["sat", "eur"], mintUnits: ["sat"]).resolvedMintUnit("eur"), "sat")
     }
 
+    // MARK: - Home balance pager ordering
+
+    func testHomeBalanceSatOnly() {
+        XCTAssertEqual(HomeBalance.homeBalanceUnits(["sat": 1000]), ["sat"])
+    }
+
+    func testHomeBalanceEmptyIsSat() {
+        XCTAssertEqual(HomeBalance.homeBalanceUnits([:]), ["sat"])
+    }
+
+    func testHomeBalanceIncludesHeldNonSatSorted() {
+        XCTAssertEqual(
+            HomeBalance.homeBalanceUnits(["sat": 1000, "usd": 500, "eur": 200]),
+            ["sat", "eur", "usd"]
+        )
+    }
+
+    func testHomeBalanceExcludesZeroNonSat() {
+        // A unit the mint lists but the user doesn't hold gets no page.
+        XCTAssertEqual(
+            HomeBalance.homeBalanceUnits(["sat": 1000, "eur": 0, "usd": 300]),
+            ["sat", "usd"]
+        )
+    }
+
+    func testHomeBalanceAllZeroNonSatIsSat() {
+        XCTAssertEqual(HomeBalance.homeBalanceUnits(["sat": 0, "eur": 0]), ["sat"])
+    }
+
+    func testResolvedHomeUnitKeepsAvailable() {
+        XCTAssertEqual(HomeBalance.resolvedUnit("eur", in: ["sat", "eur"]), "eur")
+    }
+
+    func testResolvedHomeUnitFallsBackToSat() {
+        // Stored unit dropped to zero balance and left the pager → back to sat.
+        XCTAssertEqual(HomeBalance.resolvedUnit("eur", in: ["sat"]), "sat")
+    }
+
+    // MARK: - Pager gate (active/default mint)
+
+    func testShowsPagerWhenMultiUnitDefaultAndNonSatHeld() {
+        XCTAssertTrue(HomeBalance.showsUnitPager(
+            activeMintSupportsMultipleUnits: true,
+            balancesByUnit: ["sat": 100, "eur": 5]
+        ))
+    }
+
+    func testNoPagerWhenDefaultMintIsSingleUnit() {
+        // Non-sat balance held elsewhere, but the default mint is single-unit.
+        XCTAssertFalse(HomeBalance.showsUnitPager(
+            activeMintSupportsMultipleUnits: false,
+            balancesByUnit: ["sat": 100, "eur": 5]
+        ))
+    }
+
+    func testNoPagerWhenNoNonSatBalance() {
+        XCTAssertFalse(HomeBalance.showsUnitPager(
+            activeMintSupportsMultipleUnits: true,
+            balancesByUnit: ["sat": 100]
+        ))
+    }
+
+    func testNoPagerWhenNonSatBalanceIsZero() {
+        XCTAssertFalse(HomeBalance.showsUnitPager(
+            activeMintSupportsMultipleUnits: true,
+            balancesByUnit: ["sat": 100, "eur": 0]
+        ))
+    }
+
     func testResolvedUnitNilUsesDefault() {
         XCTAssertEqual(mint(units: ["eur", "usd"]).resolvedUnit(nil), "eur")
     }

--- a/CashuWalletTests/MintServiceTests.swift
+++ b/CashuWalletTests/MintServiceTests.swift
@@ -187,3 +187,152 @@ final class MintServiceTests: XCTestCase {
         MintInfo(url: url, name: name, description: nil, isActive: true, balance: 0)
     }
 }
+
+/// Multi-unit support: mint unit discovery/selection, unit string ↔ CurrencyUnit
+/// mapping, and unit-native amount entry.
+final class MultiUnitSupportTests: XCTestCase {
+    private func mint(units: [String], mintUnits: [String] = ["sat"]) -> MintInfo {
+        MintInfo(url: "https://mint.example", name: "Mint", description: nil,
+                 isActive: true, balance: 0, iconUrl: nil, units: units, mintUnits: mintUnits)
+    }
+
+    // MARK: - MintInfo unit helpers
+
+    func testSingleUnitMintHidesSelector() {
+        XCTAssertFalse(mint(units: ["sat"]).supportsMultipleUnits)
+    }
+
+    func testMultiUnitMintShowsSelector() {
+        XCTAssertTrue(mint(units: ["sat", "eur"]).supportsMultipleUnits)
+    }
+
+    func testDefaultUnitPrefersSat() {
+        XCTAssertEqual(mint(units: ["eur", "sat", "usd"]).defaultUnit, "sat")
+    }
+
+    func testDefaultUnitFallsBackToFirstSorted() {
+        XCTAssertEqual(mint(units: ["usd", "eur"]).defaultUnit, "eur")
+    }
+
+    func testDefaultUnitEmptyIsSat() {
+        XCTAssertEqual(mint(units: []).defaultUnit, "sat")
+    }
+
+    func testResolvedUnitKeepsSupported() {
+        XCTAssertEqual(mint(units: ["sat", "eur"]).resolvedUnit("eur"), "eur")
+    }
+
+    func testResolvedUnitResetsUnsupported() {
+        // usd isn't supported → falls back to the mint's default (sat).
+        XCTAssertEqual(mint(units: ["sat", "eur"]).resolvedUnit("usd"), "sat")
+    }
+
+    // MARK: - MintInfo mintable-unit helpers (Receive/mint selector)
+
+    func testSingleMintUnitHidesReceiveSelector() {
+        // A mint that MELTS eur but only MINTS sat must not offer eur for minting.
+        XCTAssertFalse(mint(units: ["sat", "eur"], mintUnits: ["sat"]).supportsMultipleMintUnits)
+    }
+
+    func testMultiMintUnitShowsReceiveSelector() {
+        XCTAssertTrue(mint(units: ["sat", "eur"], mintUnits: ["sat", "eur"]).supportsMultipleMintUnits)
+    }
+
+    func testDefaultMintUnitPrefersSat() {
+        XCTAssertEqual(mint(units: ["sat", "eur"], mintUnits: ["eur", "sat"]).defaultMintUnit, "sat")
+    }
+
+    func testDefaultMintUnitFallsBackToFirstSorted() {
+        XCTAssertEqual(mint(units: ["usd", "eur"], mintUnits: ["usd", "eur"]).defaultMintUnit, "eur")
+    }
+
+    func testResolvedMintUnitKeepsMintable() {
+        XCTAssertEqual(mint(units: ["sat", "eur"], mintUnits: ["sat", "eur"]).resolvedMintUnit("eur"), "eur")
+    }
+
+    func testResolvedMintUnitResetsNonMintable() {
+        // eur is meltable but not mintable → falls back to the default mint unit.
+        XCTAssertEqual(mint(units: ["sat", "eur"], mintUnits: ["sat"]).resolvedMintUnit("eur"), "sat")
+    }
+
+    func testResolvedUnitNilUsesDefault() {
+        XCTAssertEqual(mint(units: ["eur", "usd"]).resolvedUnit(nil), "eur")
+    }
+
+    // MARK: - Unit string ↔ CurrencyUnit round-trip
+
+    func testCurrencyUnitRoundTripsKnownUnits() {
+        for unit in ["sat", "msat", "usd", "eur", "auth"] {
+            let roundTripped = PaymentRequestDecoder.unitDescription(
+                PaymentRequestDecoder.currencyUnit(from: unit)
+            )
+            XCTAssertEqual(roundTripped, unit)
+        }
+    }
+
+    func testCurrencyUnitPreservesCustomUnit() {
+        let roundTripped = PaymentRequestDecoder.unitDescription(
+            PaymentRequestDecoder.currencyUnit(from: "hour")
+        )
+        XCTAssertEqual(roundTripped, "hour")
+    }
+
+    // MARK: - Currency lookup is never nil (arbitrary units supported)
+
+    func testCurrencyForKnownUnits() {
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "sat").decimals, 0)
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "eur").decimals, 2)
+        XCTAssertEqual(CurrencyRegistry.currency(forMintUnit: "usd").decimals, 2)
+    }
+
+    func testCurrencyForCustomUnitFallsBack() {
+        let currency = CurrencyRegistry.currency(forMintUnit: "hour")
+        XCTAssertEqual(currency.decimals, 0)
+        XCTAssertEqual(currency.code, "HOUR")
+    }
+
+    // MARK: - Unit-native amount entry
+
+    func testEntryBaseUnitsTwoDecimals() {
+        XCTAssertEqual(AmountFormatter.entryBaseUnits(raw: "5.00", decimals: 2), 500)
+        XCTAssertEqual(AmountFormatter.entryBaseUnits(raw: "14.54", decimals: 2), 1454)
+    }
+
+    func testEntryBaseUnitsInteger() {
+        XCTAssertEqual(AmountFormatter.entryBaseUnits(raw: "500", decimals: 0), 500)
+    }
+
+    func testCentsAccumulatorBuildsUpFromRight() {
+        // Digits shift in from the right: 5 → 0.05 → 0.50 → 5.00 (= 500 cents).
+        var raw = ""
+        for key in ["5", "0", "0"] {
+            raw = AmountFormatter.entryAppendUnit(key, to: raw, decimals: 2)
+        }
+        XCTAssertEqual(AmountFormatter.entryBaseUnits(raw: raw, decimals: 2), 500)
+    }
+
+    func testIntegerAppendCollapsesLeadingZero() {
+        XCTAssertEqual(AmountFormatter.entryAppendUnit("5", to: "0", decimals: 0), "5")
+    }
+
+    func testBackspaceUnitShiftsCentsRight() {
+        var raw = ""
+        for key in ["5", "0", "0"] {   // 5.00
+            raw = AmountFormatter.entryAppendUnit(key, to: raw, decimals: 2)
+        }
+        raw = AmountFormatter.entryBackspaceUnit(raw, decimals: 2)   // → 0.50
+        XCTAssertEqual(AmountFormatter.entryBaseUnits(raw: raw, decimals: 2), 50)
+    }
+
+    func testEntryStringRoundTrips() {
+        XCTAssertEqual(
+            AmountFormatter.entryBaseUnits(
+                raw: AmountFormatter.entryString(baseUnits: 500, decimals: 2),
+                decimals: 2
+            ),
+            500
+        )
+        XCTAssertEqual(AmountFormatter.entryString(baseUnits: 500, decimals: 0), "500")
+        XCTAssertEqual(AmountFormatter.entryString(baseUnits: 0, decimals: 2), "")
+    }
+}

--- a/CashuWalletTests/WalletStoreTests.swift
+++ b/CashuWalletTests/WalletStoreTests.swift
@@ -328,6 +328,7 @@ final class CashuRequestStoreTests: XCTestCase {
         store.update(
             id: "request-id",
             amount: 42,
+            unit: "eur",
             mints: ["https://mint.example.com"],
             encoded: "creqAamounted"
         )
@@ -335,6 +336,7 @@ final class CashuRequestStoreTests: XCTestCase {
         XCTAssertEqual(store.requests.count, 1)
         let updated = store.request(withId: "request-id")
         XCTAssertEqual(updated?.amount, 42)
+        XCTAssertEqual(updated?.unit, "eur")
         XCTAssertEqual(updated?.mints, ["https://mint.example.com"])
         XCTAssertEqual(updated?.encoded, "creqAamounted")
         XCTAssertEqual(updated?.receivedPayments.first?.transactionId, "tx-1")
@@ -343,5 +345,6 @@ final class CashuRequestStoreTests: XCTestCase {
         let reloaded = CashuRequestStore(userDefaults: defaults)
         XCTAssertEqual(reloaded.requests.count, 1)
         XCTAssertEqual(reloaded.request(withId: "request-id")?.encoded, "creqAamounted")
+        XCTAssertEqual(reloaded.request(withId: "request-id")?.unit, "eur")
     }
 }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -499,6 +499,17 @@ right tool for the job.
   Typography and padding match `FullWidthCapsuleButtonStyle` exactly
   (`.body.weight(.semibold)`, `.padding(.vertical, 18)`) so it reads as one
   family.
+- **Send-method row (carve-out) — round glass icon buttons.** The Send chooser
+  (`UnifiedSendView`) offers its "ways to send" — Scan · Ecash · Tap — as a
+  centered row of **circular** Liquid Glass icon buttons, each a monochrome SF
+  Symbol over a one-word `.caption.weight(.medium)` label on the canvas. On
+  iOS 26 each circle uses Apple's native `.buttonStyle(.glass)` +
+  `.buttonBorderShape(.circle)` inside a `GlassEffectContainer`; iOS 18–25 falls
+  back to a `.quaternary` circle with `PressableButtonStyle`. This is a
+  deliberate, bounded expansion of the surface vocabulary beyond the full-width
+  capsule — justified because here the SF Symbol *is* the affordance (icon-only,
+  no text on the surface) and it echoes the circular glass button the home row
+  itself once carried (see Capsule + Circle + Capsule, above).
 - **Press feedback — `PressableButtonStyle`**: 0.97 scale on press down
   (`.snappy(0.09)`), spring back on release (`.snappy(0.18)`). Apply only
   where the glass style doesn't already carry feedback (the chooser

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -809,6 +809,28 @@ fixed top section (BTC chip, balance, fiat line, Receive/Send) is pinned via
 it, with a `LinearGradient` opacity mask fading rows to clear before they
 reach the buttons. See `MainWalletView.swift` for the current implementation.
 
+*Carve-out (Multi-unit balance pager, 2026-07-06).* When the wallet holds a
+balance in more than one **unit** (sat + eur/usd/custom — mints can advertise
+multiple units, NUT-04/05), the balance hero becomes a horizontal **pager**:
+one unit's balance per page, swipeable, with system page dots
+(`TabView`/`.tabViewStyle(.page)` in `MainWalletView.unitBalanceHero`). This is a
+**deliberate, user-chosen** re-introduction of a horizontal swiper on the home
+balance — surfaced against this retired-mint-card precedent with two flat
+alternatives (a unit-chip menu, a supplementary sub-line) before the swipe idiom
+was picked. It does **not** revive the mint-card switcher: it browses *units of
+the same wallet*, not accounts; there is exactly **one hero number visible at a
+time** (the Only-Hero-Number rule holds — no stat panel, no card stack); the
+canvas underneath stays bare; and the pager appears **only** when the **active
+(default) mint** advertises multiple units **and** a non-sat balance is held
+(`HomeBalance.showsUnitPager`, 2026-07-06 refinement). A sat-only default mint
+renders the single hero verbatim — no pager, no dots — even if a non-sat balance
+is held at another mint (that balance still shows on Send + Mint Detail); switching
+the default mint chip re-evaluates the gate live. Each page keeps the Tabular
+Figure Rule (`.monospacedDigit()` +
+`.contentTransition(.numericText())`); the sat page keeps its ₿/sat tap-toggle
+and fiat sub-line, non-sat pages show the amount in its own currency (no fiat
+conversion — eur is already fiat).
+
 **The Share-At-Top Rule.** Any sheet that displays a shareable QR artifact —
 Lightning Invoice (`ReceiveLightningView`), Cashu Request
 (`CashuRequestDetailView`), generated ecash token (`SendView`), historical


### PR DESCRIPTION
## Summary

Makes the wallet **unit-aware** for mints that advertise more than one unit (sat, eur,
usd, or arbitrary custom units, per NUT-04/05), instead of assuming sat everywhere.
Sat-only mints and wallets are unchanged.

### Send / Create ecash
- Unit selector next to the lock icon (only when the selected mint supports >1 unit);
  unit-native amount entry (2-decimal eur/usd cents, integer sat); per-unit balance.

### Cashu requests (NUT-18)
- Editable **Unit** row on the request detail screen (multi-unit mints only) that
  re-encodes the request in the chosen unit and rotates the QR.

### Receive
- Paste/scan **receive-token** redeems into the token's own unit.
- **Mint via Lightning** in a non-sat unit: unit selector on the Receive screen; the mint
  quote + redeem (and quote resume) thread the unit through; Mint Detail shows per-unit
  balances.

### Home balance
- When the active (default) mint is multi-unit **and** a non-sat balance is held, the
  balance hero becomes a swipeable pager (one unit per page, page dots). Sat-only default
  mints keep the single hero verbatim.

### Shared / infra
- `String → Cdk.CurrencyUnit` mapper, `GenericCurrency` fallback for arbitrary units,
  `MintInfo` unit/mintUnits helpers, unit-native `AmountFormatter` entry,
  `WalletManager.unitBalance` / `balancesByUnit` aggregation.

Also includes a small Send-screen polish (round Liquid Glass Scan · Ecash · Tap button row).

### Deliberately deferred (not in this PR)
- Melt of non-sat units to Lightning; pay-side handling of non-sat Cashu requests;
  per-unit balances in the Mints-list totals and History (`WalletTransaction` has no unit).

## Testing
- `xcodebuild` build succeeds; `MultiUnitSupportTests` (unit discovery, unit-native amount
  entry, currency mapping, home-pager gating) pass.
- Live multi-unit-mint flows (e.g. minting EUR end-to-end) still need a EUR-capable test
  mint to exercise on-device.

## Design
- Follows the repo's `DESIGN.md`; the swipeable balance hero is documented there as an
  intentional carve-out to the retired home mint-card swiper (surfaced with flat
  alternatives before the swipe idiom was chosen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
