### PR TITLE
Add Android NFC ecash receiving

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-feature
         android:name="android.hardware.nfc"
         android:required="false" />
+    <uses-feature
+        android:name="android.hardware.nfc.hce"
+        android:required="false" />
 
     <application
         android:name=".App.CashuWalletApplication"
@@ -47,6 +50,19 @@
                 <data android:scheme="cashu" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name=".Core.NfcReceive.CashuNfcHostApduService"
+            android:exported="true"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/nfc_receive_aid_list" />
+        </service>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
+++ b/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
@@ -12,6 +12,7 @@ import com.cashu.me.Core.Navigation.NavigationManager
 import com.cashu.me.Core.NostrMintBackupService
 import com.cashu.me.Core.NostrService
 import com.cashu.me.Core.NwcManager
+import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
 import com.cashu.me.Core.Platform.AndroidConnectivityObserver
 import com.cashu.me.Core.Platform.AndroidSecureStorage
 import com.cashu.me.Core.Platform.WalletDatabasePathManager
@@ -70,6 +71,11 @@ class AppContainer(context: Context) {
         settingsManager = settingsManager,
         walletManager = walletManager,
         cashuRequestStore = cashuRequestStore,
+    )
+    val nfcReceiveCoordinator = NfcReceiveCoordinator(
+        context = appContext,
+        walletManager = walletManager,
+        requestStore = cashuRequestStore,
     )
 
     init {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -53,10 +53,18 @@ interface CdkWalletGateway {
     suspend fun meltTokens(quoteId: String, mintUrl: String? = null): MeltPaymentResult
     suspend fun sendEcashToken(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String, unit: String = "sat", p2pkSigningKeys: List<String> = emptyList()): SendTokenResult
     suspend fun receiveEcashToken(tokenString: String, p2pkSigningKeys: List<String> = emptyList()): Long
+    suspend fun settleForeignNfcToken(tokenString: String, settlementMintUrl: String): ForeignNfcSettlement
     suspend fun calculateReceiveFee(tokenString: String): Long
     suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean
     suspend fun listTransactions(mintUrls: List<String>): List<WalletTransaction>
     suspend fun payCashuPaymentRequest(encoded: String, customAmountSats: Long?, preferredMintURL: String?)
 }
+
+data class ForeignNfcSettlement(
+    val amountReceived: Long,
+    val feePaid: Long,
+    val sourceMintUrl: String,
+    val settlementMintUrl: String,
+)
 
 class CdkGatewayUnavailable(message: String) : IllegalStateException(message)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -53,6 +53,10 @@ interface CdkWalletGateway {
     suspend fun meltTokens(quoteId: String, mintUrl: String? = null): MeltPaymentResult
     suspend fun sendEcashToken(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String, unit: String = "sat", p2pkSigningKeys: List<String> = emptyList()): SendTokenResult
     suspend fun receiveEcashToken(tokenString: String, p2pkSigningKeys: List<String> = emptyList()): Long
+    suspend fun receiveNfcEcashToken(
+        tokenString: String,
+        p2pkSigningKeys: List<String> = emptyList(),
+    ): NfcReceiveReceipt
     suspend fun settleForeignNfcToken(tokenString: String, settlementMintUrl: String): ForeignNfcSettlement
     suspend fun calculateReceiveFee(tokenString: String): Long
     suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean
@@ -62,9 +66,15 @@ interface CdkWalletGateway {
 
 data class ForeignNfcSettlement(
     val amountReceived: Long,
+    val transactionId: String,
     val feePaid: Long,
     val sourceMintUrl: String,
     val settlementMintUrl: String,
+)
+
+data class NfcReceiveReceipt(
+    val amountReceived: Long,
+    val transactionId: String,
 )
 
 class CdkGatewayUnavailable(message: String) : IllegalStateException(message)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -55,6 +55,7 @@ import org.cashudevkit.TransactionDirection as CdkTransactionDirection
 import org.cashudevkit.Wallet as CdkWallet
 import org.cashudevkit.WalletRepository as CdkWalletRepository
 import org.cashudevkit.WalletSqliteDatabase as CdkWalletSqliteDatabase
+import com.cashu.me.Core.NfcReceive.settleForeignNfcTokenWithCdk
 import org.cashudevkit.customWalletStore
 import org.cashudevkit.decodePaymentRequest
 import org.cashudevkit.generateMnemonic as cdkGenerateMnemonic
@@ -411,6 +412,13 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
             ),
         )
         amount.value.toLong()
+    }
+
+    override suspend fun settleForeignNfcToken(
+        tokenString: String,
+        settlementMintUrl: String,
+    ): ForeignNfcSettlement = cdkCall {
+        settleForeignNfcTokenWithCdk(requireRepository(), database, tokenString, settlementMintUrl)
     }
 
     override suspend fun calculateReceiveFee(tokenString: String): Long = cdkCall {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -414,6 +414,34 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         amount.value.toLong()
     }
 
+    override suspend fun receiveNfcEcashToken(
+        tokenString: String,
+        p2pkSigningKeys: List<String>,
+    ): NfcReceiveReceipt = cdkCall {
+        val token = CdkToken.decode(tokenString)
+        val mintUrl = token.mintUrl().url
+        val tokenUnit = token.unit() ?: CdkCurrencyUnit.Sat
+        ensureWalletUnlocked(mintUrl, tokenUnit)
+        val wallet = walletFor(mintUrl, tokenUnit)
+        val existingIds = wallet.listTransactions(CdkTransactionDirection.INCOMING)
+            .map { it.id.hex }
+            .toSet()
+        val amount = wallet.receive(
+            token = token,
+            options = CdkReceiveOptions(
+                amountSplitTarget = CdkSplitTarget.None,
+                p2pkSigningKeys = p2pkSigningKeys.map(::CdkSecretKey),
+                preimages = emptyList(),
+                metadata = emptyMap(),
+            ),
+        ).value.toLong()
+        val transactionId = wallet.listTransactions(CdkTransactionDirection.INCOMING)
+            .firstOrNull { it.id.hex !in existingIds }
+            ?.id?.hex
+            ?: throw CdkGatewayUnavailable("CDK did not record the received NFC transaction.")
+        NfcReceiveReceipt(amountReceived = amount, transactionId = transactionId)
+    }
+
     override suspend fun settleForeignNfcToken(
         tokenString: String,
         settlementMintUrl: String,

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/CashuNfcHostApduService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/CashuNfcHostApduService.kt
@@ -2,16 +2,52 @@ package com.cashu.me.Core.NfcReceive
 
 import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import com.cashu.me.App.CashuWalletApplication
 
 class CashuNfcHostApduService : HostApduService() {
+    private val timeoutHandler = Handler(Looper.getMainLooper())
+    private var isWriting = false
+    private val timeout = Runnable {
+        coordinator.onTransportTimeout(isWriting)
+        isWriting = false
+    }
     private val coordinator: NfcReceiveCoordinator
         get() = (application as CashuWalletApplication).container.nfcReceiveCoordinator
 
-    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray =
-        commandApdu?.let { coordinator.type4Tag.process(it) } ?: byteArrayOf(0x67, 0x00)
+    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray {
+        val command = commandApdu ?: return byteArrayOf(0x67, 0x00)
+        if (isSelectAid(command)) isWriting = false
+        if (command.size >= 2 && command[0] == 0.toByte() && command[1] == 0xD6.toByte()) {
+            isWriting = true
+        }
+        val response = coordinator.type4Tag.process(command)
+        timeoutHandler.removeCallbacks(timeout)
+        if (coordinator.isAdvertising) {
+            timeoutHandler.postDelayed(timeout, NFC_TIMEOUT_MS)
+        } else {
+            isWriting = false
+        }
+        return response
+    }
 
     override fun onDeactivated(reason: Int) {
-        coordinator.type4Tag.deactivate()
+        // Match Numo: brief RF deactivation is not failed immediately. The
+        // inactivity timer decides whether this was a harmless read-only tap
+        // or a connection loss in the middle of UPDATE BINARY.
+    }
+
+    override fun onDestroy() {
+        timeoutHandler.removeCallbacks(timeout)
+        super.onDestroy()
+    }
+
+    private fun isSelectAid(command: ByteArray): Boolean =
+        command.size >= 2 && command[0] == 0.toByte() && command[1] == 0xA4.toByte() &&
+            command.size >= 3 && command[2] == 0x04.toByte()
+
+    private companion object {
+        const val NFC_TIMEOUT_MS = 3_500L
     }
 }

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/CashuNfcHostApduService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/CashuNfcHostApduService.kt
@@ -1,0 +1,17 @@
+package com.cashu.me.Core.NfcReceive
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import com.cashu.me.App.CashuWalletApplication
+
+class CashuNfcHostApduService : HostApduService() {
+    private val coordinator: NfcReceiveCoordinator
+        get() = (application as CashuWalletApplication).container.nfcReceiveCoordinator
+
+    override fun processCommandApdu(commandApdu: ByteArray?, extras: Bundle?): ByteArray =
+        commandApdu?.let { coordinator.type4Tag.process(it) } ?: byteArrayOf(0x67, 0x00)
+
+    override fun onDeactivated(reason: Int) {
+        coordinator.type4Tag.deactivate()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
@@ -47,6 +47,9 @@ internal suspend fun settleForeignNfcTokenWithCdk(
         require(proofs.isNotEmpty()) { "The foreign-mint token contains no proofs." }
 
         val targetWallet = repository.getWallet(org.cashudevkit.MintUrl(targetMint), CurrencyUnit.Sat)
+        val existingTransactionIds = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
+            .map { it.id.hex }
+            .toSet()
         val maximumFee = kotlin.math.ceil(gross * 0.05).toLong().coerceAtLeast(1L)
         val estimateAmount = gross - maximumFee
         require(estimateAmount > 0) { "Payment is too small after the conversion fee limit." }
@@ -82,8 +85,13 @@ internal suspend fun settleForeignNfcTokenWithCdk(
             QuoteState.ISSUED -> targetAmount
             else -> throw CdkGatewayUnavailable("Settlement mint has not credited the paid quote yet.")
         }
+        val transactionId = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
+            .firstOrNull { it.id.hex !in existingTransactionIds && it.quoteId == targetQuote.id }
+            ?.id?.hex
+            ?: throw CdkGatewayUnavailable("CDK did not record the NFC settlement transaction.")
         return ForeignNfcSettlement(
             amountReceived = credited,
+            transactionId = transactionId,
             feePaid = gross - credited,
             sourceMintUrl = sourceMint,
             settlementMintUrl = targetMint,

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
@@ -1,0 +1,97 @@
+package com.cashu.me.Core.NfcReceive
+
+import kotlinx.coroutines.delay
+import com.cashu.me.Core.CDK.CdkGatewayUnavailable
+import com.cashu.me.Core.CDK.ForeignNfcSettlement
+import org.cashudevkit.Amount
+import org.cashudevkit.CurrencyUnit
+import org.cashudevkit.MeltConfirmOptions
+import org.cashudevkit.PaymentMethod
+import org.cashudevkit.QuoteState
+import org.cashudevkit.SplitTarget
+import org.cashudevkit.Token
+import org.cashudevkit.Wallet
+import org.cashudevkit.WalletConfig
+import org.cashudevkit.WalletRepository
+import org.cashudevkit.WalletSqliteDatabase
+import org.cashudevkit.WalletStore
+import org.cashudevkit.generateMnemonic
+import org.cashudevkit.proofsTotalAmount
+
+/** CDK implementation of Numo-style foreign-mint settlement. */
+internal suspend fun settleForeignNfcTokenWithCdk(
+    repository: WalletRepository,
+    database: WalletSqliteDatabase?,
+    tokenString: String,
+    settlementMintUrl: String,
+): ForeignNfcSettlement {
+    val token = Token.decode(tokenString)
+    val sourceMint = normalizeMint(token.mintUrl().url)
+    val targetMint = normalizeMint(settlementMintUrl)
+    require(sourceMint != targetMint) { "Source and settlement mint are the same." }
+    require(token.unit() == CurrencyUnit.Sat) { "Foreign-mint conversion supports sat tokens only." }
+    val gross = token.value().value.toLong()
+    require(gross > 1L) { "Payment is too small to convert." }
+
+    val tempDatabase = WalletSqliteDatabase.newInMemory()
+    val tempWallet = Wallet(
+        sourceMint,
+        CurrencyUnit.Sat,
+        generateMnemonic(),
+        WalletStore.Custom(tempDatabase),
+        WalletConfig(targetProofCount = 10u),
+    )
+    try {
+        val keysets = tempWallet.refreshKeysets()
+        val proofs = token.proofs(keysets)
+        require(proofs.isNotEmpty()) { "The foreign-mint token contains no proofs." }
+
+        val targetWallet = repository.getWallet(org.cashudevkit.MintUrl(targetMint), CurrencyUnit.Sat)
+        val maximumFee = kotlin.math.ceil(gross * 0.05).toLong().coerceAtLeast(1L)
+        val estimateAmount = gross - maximumFee
+        require(estimateAmount > 0) { "Payment is too small after the conversion fee limit." }
+
+        val estimateQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(estimateAmount.toULong()), null, null)
+        val estimateMelt = tempWallet.meltQuote(PaymentMethod.Bolt11, estimateQuote.request, null, null)
+        val reserve = estimateMelt.feeReserve.value.toLong()
+        runCatching { database?.removeMintQuote(estimateQuote.id) }
+        require(reserve <= maximumFee) { "Foreign mint fee exceeds the 5% safety limit." }
+
+        val minimumOverhead = kotlin.math.ceil(gross * 0.005).toLong().coerceAtLeast(1L)
+        val targetAmount = gross - reserve - minimumOverhead
+        require(targetAmount > 0) { "Payment is too small after conversion fees." }
+        val targetQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(targetAmount.toULong()), null, null)
+        val meltQuote = tempWallet.meltQuote(PaymentMethod.Bolt11, targetQuote.request, null, null)
+        require(meltQuote.amount.value.toLong() + meltQuote.feeReserve.value.toLong() <= gross) {
+            "Foreign mint requires more ecash than was received."
+        }
+        val finalized = tempWallet.prepareMeltProofs(meltQuote.id, proofs)
+            .confirmWithOptions(MeltConfirmOptions(skipSwap = true))
+        require(finalized.state == QuoteState.PAID) { "Foreign mint did not settle the payment." }
+
+        var checked = targetWallet.checkMintQuote(targetQuote.id)
+        for (attempt in 0 until 20) {
+            if (checked.state == QuoteState.PAID || checked.state == QuoteState.ISSUED) break
+            delay(500)
+            checked = targetWallet.checkMintQuote(targetQuote.id)
+        }
+        val credited = when (checked.state) {
+            QuoteState.PAID -> proofsTotalAmount(
+                targetWallet.mintUnified(targetQuote.id, SplitTarget.None, null),
+            ).value.toLong()
+            QuoteState.ISSUED -> targetAmount
+            else -> throw CdkGatewayUnavailable("Settlement mint has not credited the paid quote yet.")
+        }
+        return ForeignNfcSettlement(
+            amountReceived = credited,
+            feePaid = gross - credited,
+            sourceMintUrl = sourceMint,
+            settlementMintUrl = targetMint,
+        )
+    } finally {
+        runCatching { tempWallet.close() }
+        runCatching { tempDatabase.close() }
+    }
+}
+
+private fun normalizeMint(url: String): String = url.trim().trimEnd('/')

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcNdefCodec.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcNdefCodec.kt
@@ -1,0 +1,133 @@
+package com.cashu.me.Core.NfcReceive
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+internal sealed interface NfcNdefPayload {
+    data class Text(val value: String) : NfcNdefPayload
+    data class CashuBinary(val bytes: ByteArray) : NfcNdefPayload
+}
+
+/** Pure NDEF codec for the single-record messages used by the Numo protocol. */
+internal object NfcNdefCodec {
+    private const val TNF_WELL_KNOWN = 0x01
+    private const val TNF_MIME_MEDIA = 0x02
+    private const val FLAG_MB = 0x80
+    private const val FLAG_ME = 0x40
+    private const val FLAG_CF = 0x20
+    private const val FLAG_SR = 0x10
+    private const val FLAG_IL = 0x08
+    private const val TNF_MASK = 0x07
+    private const val CASHU_BINARY_MIME = "application/octet-stream"
+
+    fun textFile(text: String): ByteArray {
+        val language = "en".toByteArray(StandardCharsets.US_ASCII)
+        val textBytes = text.toByteArray(StandardCharsets.UTF_8)
+        val payload = ByteArray(1 + language.size + textBytes.size)
+        payload[0] = language.size.toByte()
+        language.copyInto(payload, 1)
+        textBytes.copyInto(payload, 1 + language.size)
+        return type4File(type = byteArrayOf('T'.code.toByte()), payload = payload, tnf = TNF_WELL_KNOWN)
+    }
+
+    fun parseType4File(file: ByteArray): NfcNdefPayload {
+        require(file.size >= 2) { "NDEF file is incomplete." }
+        val nlen = ((file[0].toInt() and 0xff) shl 8) or (file[1].toInt() and 0xff)
+        require(nlen > 0 && nlen + 2 <= file.size) { "NDEF length is invalid." }
+        return parseRecord(file.copyOfRange(2, nlen + 2))
+    }
+
+    private fun type4File(type: ByteArray, payload: ByteArray, tnf: Int): ByteArray {
+        val short = payload.size <= 0xff
+        val headerSize = if (short) 3 else 6
+        val record = ByteArray(headerSize + type.size + payload.size)
+        record[0] = (FLAG_MB or FLAG_ME or (if (short) FLAG_SR else 0) or tnf).toByte()
+        record[1] = type.size.toByte()
+        var cursor: Int
+        if (short) {
+            record[2] = payload.size.toByte()
+            cursor = 3
+        } else {
+            ByteBuffer.wrap(record, 2, 4).putInt(payload.size)
+            cursor = 6
+        }
+        type.copyInto(record, cursor)
+        cursor += type.size
+        payload.copyInto(record, cursor)
+        require(record.size <= NfcType4Tag.MAX_NDEF_SIZE) { "NDEF message is too large." }
+        return ByteArray(record.size + 2).also {
+            it[0] = (record.size ushr 8).toByte()
+            it[1] = record.size.toByte()
+            record.copyInto(it, 2)
+        }
+    }
+
+    private fun parseRecord(record: ByteArray): NfcNdefPayload {
+        require(record.size >= 3) { "NDEF record is incomplete." }
+        val header = record[0].toInt() and 0xff
+        require(header and FLAG_MB != 0 && header and FLAG_ME != 0) { "Only one complete NDEF record is supported." }
+        require(header and FLAG_CF == 0 && header and FLAG_IL == 0) { "Chunked or identified NDEF records are unsupported." }
+        val typeLength = record[1].toInt() and 0xff
+        require(typeLength > 0) { "NDEF record type is missing." }
+        val short = header and FLAG_SR != 0
+        val payloadLength: Int
+        var cursor: Int
+        if (short) {
+            payloadLength = record[2].toInt() and 0xff
+            cursor = 3
+        } else {
+            require(record.size >= 6) { "NDEF payload length is incomplete." }
+            payloadLength = ByteBuffer.wrap(record, 2, 4).int
+            require(payloadLength >= 0) { "NDEF payload length is invalid." }
+            cursor = 6
+        }
+        require(cursor + typeLength + payloadLength <= record.size) { "NDEF payload is incomplete." }
+        val type = record.copyOfRange(cursor, cursor + typeLength)
+        cursor += typeLength
+        val payload = record.copyOfRange(cursor, cursor + payloadLength)
+        return when (header and TNF_MASK) {
+            TNF_WELL_KNOWN -> parseWellKnown(type, payload)
+            TNF_MIME_MEDIA -> {
+                require(String(type, StandardCharsets.US_ASCII).equals(CASHU_BINARY_MIME, ignoreCase = true)) {
+                    "Unsupported NDEF MIME record."
+                }
+                NfcNdefPayload.CashuBinary(payload)
+            }
+            else -> throw IllegalArgumentException("Unsupported NDEF record type.")
+        }
+    }
+
+    private fun parseWellKnown(type: ByteArray, payload: ByteArray): NfcNdefPayload.Text {
+        require(type.size == 1 && payload.isNotEmpty()) { "Unsupported NDEF well-known record." }
+        return when (type[0].toInt().toChar()) {
+            'T' -> {
+                val status = payload[0].toInt() and 0xff
+                val languageLength = status and 0x3f
+                require(status and 0x80 == 0) { "UTF-16 NDEF text is unsupported." }
+                require(1 + languageLength <= payload.size) { "NDEF language code is invalid." }
+                NfcNdefPayload.Text(String(payload, 1 + languageLength, payload.size - 1 - languageLength, StandardCharsets.UTF_8))
+            }
+            'U' -> {
+                val prefix = uriPrefix(payload[0].toInt() and 0xff)
+                NfcNdefPayload.Text(prefix + String(payload, 1, payload.size - 1, StandardCharsets.UTF_8))
+            }
+            else -> throw IllegalArgumentException("Unsupported NDEF well-known record.")
+        }
+    }
+
+    private fun uriPrefix(code: Int): String = when (code) {
+        0x01 -> "http://www."
+        0x02 -> "https://www."
+        0x03 -> "http://"
+        0x04 -> "https://"
+        0x05 -> "tel:"
+        0x06 -> "mailto:"
+        0x0d -> "ftp://"
+        0x13 -> "urn:"
+        0x15 -> "sip:"
+        0x16 -> "sips:"
+        0x1d -> "file://"
+        0x23 -> "urn:nfc:"
+        else -> ""
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
@@ -1,0 +1,221 @@
+package com.cashu.me.Core.NfcReceive
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.nfc.NfcAdapter
+import java.security.MessageDigest
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import com.cashu.me.Core.CashuRequestStore
+import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.PaymentRequestBuilder
+import com.cashu.me.Models.CashuRequest
+import org.cashudevkit.Token as CdkToken
+
+enum class NfcReceivePhase {
+    Unavailable,
+    Disabled,
+    Inactive,
+    Waiting,
+    Connected,
+    Receiving,
+    Validating,
+    Redeeming,
+    Converting,
+    Success,
+    Failure,
+}
+
+data class NfcReceiveState(
+    val phase: NfcReceivePhase = NfcReceivePhase.Inactive,
+    val message: String? = null,
+    val amount: Long? = null,
+    val sourceMint: String? = null,
+    val settlementMint: String? = null,
+)
+
+/**
+ * Application-scoped bridge between the Android HCE transport and wallet logic.
+ * This is the only feature class allowed to know about both sides.
+ */
+class NfcReceiveCoordinator(
+    context: Context,
+    private val walletManager: WalletManager,
+    private val requestStore: CashuRequestStore,
+) {
+    private data class Session(val request: CashuRequest, val settlementMint: String)
+
+    private val appContext = context.applicationContext
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mutableState = MutableStateFlow(initialState())
+    val state: StateFlow<NfcReceiveState> = mutableState.asStateFlow()
+    private val inFlight = ConcurrentHashMap.newKeySet<String>()
+    @Volatile private var session: Session? = null
+    @Volatile private var processing = false
+
+    internal val type4Tag = NfcType4Tag(
+        requestFile = {
+            session?.request?.let { request ->
+                NfcNdefCodec.textFile(
+                    PaymentRequestBuilder.buildNfc(
+                        id = request.id,
+                        amount = request.amount,
+                        unit = request.unit,
+                        mints = request.mints,
+                        description = request.memo,
+                    ),
+                )
+            }
+        },
+        onEvent = ::onTransportEvent,
+    )
+
+    fun activate(request: CashuRequest, settlementMint: String?) {
+        val availability = initialState()
+        if (availability.phase == NfcReceivePhase.Unavailable || availability.phase == NfcReceivePhase.Disabled) {
+            session = null
+            mutableState.value = availability
+            return
+        }
+        val target = settlementMint?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
+        if (target == null) {
+            session = null
+            mutableState.value = NfcReceiveState(NfcReceivePhase.Unavailable, "Choose an active mint to receive by NFC.")
+            return
+        }
+        session = Session(request, target)
+        if (!processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
+    }
+
+    fun deactivate() {
+        session = null
+        type4Tag.deactivate()
+        if (!processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Inactive)
+    }
+
+    fun clearResult() {
+        if (session != null && !processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
+    }
+
+    private fun initialState(): NfcReceiveState {
+        val manager = appContext.packageManager
+        val adapter = NfcAdapter.getDefaultAdapter(appContext)
+        return when {
+            adapter == null || !manager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION) ->
+                NfcReceiveState(NfcReceivePhase.Unavailable, "Tap to receive is not available on this device.")
+            !adapter.isEnabled -> NfcReceiveState(NfcReceivePhase.Disabled, "Turn on NFC to receive by tap.")
+            else -> NfcReceiveState(NfcReceivePhase.Inactive)
+        }
+    }
+
+    private fun onTransportEvent(event: NfcType4Event) {
+        if (session == null) return
+        when (event) {
+            NfcType4Event.Connected -> if (!processing) {
+                mutableState.value = NfcReceiveState(NfcReceivePhase.Connected, "Phone detected")
+            }
+            NfcType4Event.WritingStarted -> if (!processing) {
+                mutableState.value = NfcReceiveState(NfcReceivePhase.Receiving, "Keep phones together")
+            }
+            is NfcType4Event.MessageReceived -> submit(event.payload)
+        }
+    }
+
+    private fun submit(payload: NfcNdefPayload) {
+        val snapshot = session ?: return
+        if (processing) return
+        processing = true
+        scope.launch {
+            var fingerprint: String? = null
+            try {
+                val token = when (payload) {
+                    is NfcNdefPayload.Text -> extractToken(payload.value)
+                    is NfcNdefPayload.CashuBinary -> CdkToken.fromRawBytes(payload.bytes).encode()
+                } ?: error("No valid Cashu token was received.")
+                fingerprint = tokenFingerprint(token)
+                require(inFlight.add(fingerprint)) { "This payment is already being received." }
+                require(snapshot.request.receivedPayments.none { it.transactionId == fingerprint }) {
+                    "This payment was already received."
+                }
+                process(snapshot, token, fingerprint)
+            } catch (error: Throwable) {
+                mutableState.value = NfcReceiveState(
+                    phase = NfcReceivePhase.Failure,
+                    message = error.message ?: "NFC payment failed.",
+                )
+            } finally {
+                processing = false
+                fingerprint?.let(inFlight::remove)
+            }
+        }
+    }
+
+    private suspend fun process(session: Session, tokenString: String, fingerprint: String) {
+        mutableState.value = NfcReceiveState(NfcReceivePhase.Validating, "Checking payment")
+        val token = CdkToken.decode(tokenString)
+        val sourceMint = normalizeNfcMint(token.mintUrl().url)
+        val unit = token.unit()?.toUnitString() ?: "sat"
+        val grossAmount = token.value().value.toLong()
+        val route = validateNfcReceiveTerms(
+            request = session.request,
+            sourceMint = sourceMint,
+            tokenUnit = unit,
+            grossAmount = grossAmount,
+            settlementMint = session.settlementMint,
+        )
+        val amount = if (route == NfcSettlementRoute.Direct) {
+            mutableState.value = NfcReceiveState(NfcReceivePhase.Redeeming, "Securing ecash", sourceMint = sourceMint)
+            walletManager.receiveCashuRequestPayment(
+                tokenString = tokenString,
+                requestId = session.request.id,
+                processedId = fingerprint,
+            )
+        } else {
+            mutableState.value = NfcReceiveState(
+                NfcReceivePhase.Converting,
+                "Moving payment to your active mint",
+                sourceMint = sourceMint,
+                settlementMint = session.settlementMint,
+            )
+            walletManager.settleForeignNfcToken(tokenString, session.settlementMint).amountReceived
+        }
+        require(amount > 0) { "The payment was not credited." }
+        requestStore.attachPayment(session.request.id, fingerprint, amount)
+        mutableState.value = NfcReceiveState(
+            phase = NfcReceivePhase.Success,
+            message = "Payment received",
+            amount = amount,
+            sourceMint = sourceMint,
+            settlementMint = session.settlementMint,
+        )
+    }
+
+    private fun extractToken(value: String): String? {
+        val start = listOf("cashuA", "cashuB", "crawB")
+            .map(value::indexOf)
+            .filter { it >= 0 }
+            .minOrNull() ?: return null
+        return value.substring(start).takeWhile { it.isLetterOrDigit() || it == '-' || it == '_' || it == '=' }
+            .takeIf { it.startsWith("cashu") || it.startsWith("craw") }
+    }
+
+    private fun tokenFingerprint(token: String): String = "nfc:" + MessageDigest.getInstance("SHA-256")
+        .digest(token.toByteArray(Charsets.UTF_8))
+        .take(16)
+        .joinToString("") { "%02x".format(it) }
+
+    private fun org.cashudevkit.CurrencyUnit.toUnitString(): String = when (this) {
+        is org.cashudevkit.CurrencyUnit.Sat -> "sat"
+        is org.cashudevkit.CurrencyUnit.Msat -> "msat"
+        is org.cashudevkit.CurrencyUnit.Usd -> "usd"
+        is org.cashudevkit.CurrencyUnit.Eur -> "eur"
+        is org.cashudevkit.CurrencyUnit.Custom -> unit
+        else -> toString().lowercase()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
@@ -21,6 +21,7 @@ import org.cashudevkit.Token as CdkToken
 enum class NfcReceivePhase {
     Unavailable,
     Disabled,
+    NeedsAmount,
     Inactive,
     Waiting,
     Connected,
@@ -58,10 +59,13 @@ class NfcReceiveCoordinator(
     private val inFlight = ConcurrentHashMap.newKeySet<String>()
     @Volatile private var session: Session? = null
     @Volatile private var processing = false
+    @Volatile private var armed = false
+
+    val isAdvertising: Boolean get() = armed && session != null
 
     internal val type4Tag = NfcType4Tag(
         requestFile = {
-            session?.request?.let { request ->
+            session?.request?.takeIf { armed }?.let { request ->
                 NfcNdefCodec.textFile(
                     PaymentRequestBuilder.buildNfc(
                         id = request.id,
@@ -80,27 +84,56 @@ class NfcReceiveCoordinator(
         val availability = initialState()
         if (availability.phase == NfcReceivePhase.Unavailable || availability.phase == NfcReceivePhase.Disabled) {
             session = null
+            armed = false
             mutableState.value = availability
+            return
+        }
+        if (!request.canReceiveByNfc()) {
+            session = null
+            armed = false
+            mutableState.value = NfcReceiveState(
+                NfcReceivePhase.NeedsAmount,
+                "Add an amount to enable Tap to receive.",
+            )
             return
         }
         val target = settlementMint?.trim()?.trimEnd('/')?.takeIf { it.isNotEmpty() }
         if (target == null) {
             session = null
+            armed = false
             mutableState.value = NfcReceiveState(NfcReceivePhase.Unavailable, "Choose an active mint to receive by NFC.")
             return
         }
         session = Session(request, target)
+        armed = true
         if (!processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
     }
 
     fun deactivate() {
         session = null
+        armed = false
         type4Tag.deactivate()
         if (!processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Inactive)
     }
 
     fun clearResult() {
-        if (session != null && !processing) mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
+        if (session != null && !processing) {
+            armed = true
+            mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
+        }
+    }
+
+    internal fun onTransportTimeout(wasWriting: Boolean) {
+        if (session == null || processing) return
+        if (wasWriting) {
+            armed = false
+            mutableState.value = NfcReceiveState(
+                NfcReceivePhase.Failure,
+                "Connection lost while receiving. Keep the phones together and try again.",
+            )
+        } else {
+            mutableState.value = NfcReceiveState(NfcReceivePhase.Waiting)
+        }
     }
 
     private fun initialState(): NfcReceiveState {
@@ -115,7 +148,7 @@ class NfcReceiveCoordinator(
     }
 
     private fun onTransportEvent(event: NfcType4Event) {
-        if (session == null) return
+        if (session == null || !armed) return
         when (event) {
             NfcType4Event.Connected -> if (!processing) {
                 mutableState.value = NfcReceiveState(NfcReceivePhase.Connected, "Phone detected")
@@ -129,7 +162,8 @@ class NfcReceiveCoordinator(
 
     private fun submit(payload: NfcNdefPayload) {
         val snapshot = session ?: return
-        if (processing) return
+        if (processing || !armed) return
+        armed = false
         processing = true
         scope.launch {
             var fingerprint: String? = null
@@ -140,9 +174,6 @@ class NfcReceiveCoordinator(
                 } ?: error("No valid Cashu token was received.")
                 fingerprint = tokenFingerprint(token)
                 require(inFlight.add(fingerprint)) { "This payment is already being received." }
-                require(snapshot.request.receivedPayments.none { it.transactionId == fingerprint }) {
-                    "This payment was already received."
-                }
                 process(snapshot, token, fingerprint)
             } catch (error: Throwable) {
                 mutableState.value = NfcReceiveState(
@@ -169,13 +200,12 @@ class NfcReceiveCoordinator(
             grossAmount = grossAmount,
             settlementMint = session.settlementMint,
         )
-        val amount = if (route == NfcSettlementRoute.Direct) {
+        val (amountReceived, transactionId) = if (route == NfcSettlementRoute.Direct) {
             mutableState.value = NfcReceiveState(NfcReceivePhase.Redeeming, "Securing ecash", sourceMint = sourceMint)
-            walletManager.receiveCashuRequestPayment(
+            walletManager.receiveNfcCashuRequestPayment(
                 tokenString = tokenString,
-                requestId = session.request.id,
                 processedId = fingerprint,
-            )
+            ).let { it.amountReceived to it.transactionId }
         } else {
             mutableState.value = NfcReceiveState(
                 NfcReceivePhase.Converting,
@@ -183,14 +213,15 @@ class NfcReceiveCoordinator(
                 sourceMint = sourceMint,
                 settlementMint = session.settlementMint,
             )
-            walletManager.settleForeignNfcToken(tokenString, session.settlementMint).amountReceived
+            walletManager.settleForeignNfcToken(tokenString, session.settlementMint, fingerprint)
+                .let { it.amountReceived to it.transactionId }
         }
-        require(amount > 0) { "The payment was not credited." }
-        requestStore.attachPayment(session.request.id, fingerprint, amount)
+        require(amountReceived > 0) { "The payment was not credited." }
+        requestStore.attachPayment(session.request.id, transactionId, amountReceived)
         mutableState.value = NfcReceiveState(
             phase = NfcReceivePhase.Success,
             message = "Payment received",
-            amount = amount,
+            amount = amountReceived,
             sourceMint = sourceMint,
             settlementMint = session.settlementMint,
         )

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
@@ -4,6 +4,8 @@ import com.cashu.me.Models.CashuRequest
 
 internal enum class NfcSettlementRoute { Direct, Foreign }
 
+internal fun CashuRequest.canReceiveByNfc(): Boolean = amount?.let { it > 0 } == true
+
 internal fun validateNfcReceiveTerms(
     request: CashuRequest,
     sourceMint: String,

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
@@ -1,0 +1,32 @@
+package com.cashu.me.Core.NfcReceive
+
+import com.cashu.me.Models.CashuRequest
+
+internal enum class NfcSettlementRoute { Direct, Foreign }
+
+internal fun validateNfcReceiveTerms(
+    request: CashuRequest,
+    sourceMint: String,
+    tokenUnit: String,
+    grossAmount: Long,
+    settlementMint: String,
+): NfcSettlementRoute {
+    require(grossAmount > 0) { "The received token has no value." }
+    require(tokenUnit.equals(request.unit, ignoreCase = true)) {
+        "Expected ${request.unit.uppercase()} but received ${tokenUnit.uppercase()}."
+    }
+    request.amount?.takeIf { it > 0 }?.let { required ->
+        require(grossAmount >= required) { "Expected at least $required ${request.unit}." }
+    }
+    val source = normalizeNfcMint(sourceMint)
+    val target = normalizeNfcMint(settlementMint)
+    val allowed = request.mints.map(::normalizeNfcMint)
+    if (source == target || source in allowed) return NfcSettlementRoute.Direct
+    require(allowed.isEmpty()) { "This request only accepts ecash from the selected mint." }
+    require(tokenUnit.equals("sat", ignoreCase = true)) {
+        "Foreign-mint conversion is currently available for sat requests only."
+    }
+    return NfcSettlementRoute.Foreign
+}
+
+internal fun normalizeNfcMint(url: String): String = url.trim().trimEnd('/')

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcType4Tag.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcType4Tag.kt
@@ -1,0 +1,140 @@
+package com.cashu.me.Core.NfcReceive
+
+internal sealed interface NfcType4Event {
+    data object Connected : NfcType4Event
+    data object WritingStarted : NfcType4Event
+    data class MessageReceived(val payload: NfcNdefPayload) : NfcType4Event
+}
+
+/** NFC Forum Type 4 tag state machine compatible with Numo's HCE protocol. */
+internal class NfcType4Tag(
+    private val requestFile: () -> ByteArray?,
+    private val onEvent: (NfcType4Event) -> Unit,
+) {
+    private enum class SelectedFile { NONE, CC, NDEF }
+
+    private var selected = SelectedFile.NONE
+    private var outgoing = ByteArray(0)
+    private val incoming = ByteArray(MAX_NDEF_SIZE + 2)
+    private val written = BooleanArray(MAX_NDEF_SIZE + 2)
+    private var expectedLength = -1
+    private var writingStarted = false
+
+    @Synchronized
+    fun process(command: ByteArray): ByteArray {
+        if (isSelectAid(command)) {
+            resetExchange()
+            onEvent(NfcType4Event.Connected)
+            return OK
+        }
+        if (command.size < 2) return WRONG_LENGTH
+        return when (command[1].toInt() and 0xff) {
+            0xA4 -> selectFile(command)
+            0xB0 -> readBinary(command)
+            0xD6 -> updateBinary(command)
+            else -> INSTRUCTION_NOT_SUPPORTED
+        }
+    }
+
+    @Synchronized
+    fun deactivate() {
+        selected = SelectedFile.NONE
+        outgoing = ByteArray(0)
+        resetIncoming()
+    }
+
+    private fun selectFile(command: ByteArray): ByteArray {
+        if (command.size < 7 || !command.copyOfRange(0, 4).contentEquals(SELECT_FILE_HEADER) || command[4].toInt() != 2) {
+            return WRONG_LENGTH
+        }
+        return when {
+            command.copyOfRange(5, 7).contentEquals(CC_FILE_ID) -> {
+                selected = SelectedFile.CC
+                outgoing = CC_FILE
+                OK
+            }
+            command.copyOfRange(5, 7).contentEquals(NDEF_FILE_ID) -> {
+                val file = requestFile() ?: return FILE_NOT_FOUND
+                selected = SelectedFile.NDEF
+                outgoing = file
+                OK
+            }
+            else -> FILE_NOT_FOUND
+        }
+    }
+
+    private fun readBinary(command: ByteArray): ByteArray {
+        if (command.size < 5 || selected == SelectedFile.NONE) return WRONG_LENGTH
+        val offset = ((command[2].toInt() and 0xff) shl 8) or (command[3].toInt() and 0xff)
+        val requested = (command[4].toInt() and 0xff).let { if (it == 0) 256 else it }
+        if (offset > outgoing.size) return WRONG_PARAMETERS
+        val end = minOf(offset + requested, outgoing.size)
+        return outgoing.copyOfRange(offset, end) + OK
+    }
+
+    private fun updateBinary(command: ByteArray): ByteArray {
+        if (selected != SelectedFile.NDEF || command.size < 5) return FILE_NOT_FOUND
+        val offset = ((command[2].toInt() and 0xff) shl 8) or (command[3].toInt() and 0xff)
+        val length = command[4].toInt() and 0xff
+        if (command.size != 5 + length) return WRONG_LENGTH
+        if (offset + length > incoming.size) return WRONG_PARAMETERS
+        if (!writingStarted) {
+            writingStarted = true
+            onEvent(NfcType4Event.WritingStarted)
+        }
+        if (offset == 0 && length >= 2 && command[5] == 0.toByte() && command[6] == 0.toByte()) {
+            resetIncoming()
+            writingStarted = true
+        }
+        command.copyOfRange(5, command.size).copyInto(incoming, offset)
+        for (index in offset until offset + length) written[index] = true
+        if (written[0] && written[1]) {
+            val candidate = ((incoming[0].toInt() and 0xff) shl 8) or (incoming[1].toInt() and 0xff)
+            if (candidate > MAX_NDEF_SIZE) return WRONG_PARAMETERS
+            expectedLength = candidate
+        }
+        if (expectedLength > 0 && (0 until expectedLength + 2).all(written::get)) {
+            val file = incoming.copyOfRange(0, expectedLength + 2)
+            val payload = runCatching { NfcNdefCodec.parseType4File(file) }.getOrNull()
+            resetIncoming()
+            if (payload != null) onEvent(NfcType4Event.MessageReceived(payload))
+        }
+        return OK
+    }
+
+    private fun resetExchange() {
+        selected = SelectedFile.NONE
+        outgoing = ByteArray(0)
+        resetIncoming()
+    }
+
+    private fun resetIncoming() {
+        incoming.fill(0)
+        written.fill(false)
+        expectedLength = -1
+        writingStarted = false
+    }
+
+    private fun isSelectAid(command: ByteArray): Boolean {
+        if (command.size < 12 || command[0] != 0.toByte() || command[1] != 0xA4.toByte() || command[2] != 0x04.toByte()) return false
+        val length = command[4].toInt() and 0xff
+        return length == NDEF_AID.size && command.size >= 5 + length && command.copyOfRange(5, 5 + length).contentEquals(NDEF_AID)
+    }
+
+    companion object {
+        const val MAX_NDEF_SIZE = 0x70ff
+        private val NDEF_AID = byteArrayOf(0xD2.toByte(), 0x76, 0x00, 0x00, 0x85.toByte(), 0x01, 0x01)
+        private val SELECT_FILE_HEADER = byteArrayOf(0x00, 0xA4.toByte(), 0x00, 0x0C)
+        private val CC_FILE_ID = byteArrayOf(0xE1.toByte(), 0x03)
+        private val NDEF_FILE_ID = byteArrayOf(0xE1.toByte(), 0x04)
+        private val CC_FILE = byteArrayOf(
+            0x00, 0x0F, 0x20, 0x00, 0x3B, 0x00, 0x34, 0x04, 0x06,
+            0xE1.toByte(), 0x04, 0x70, 0xFF.toByte(), 0x00, 0x00,
+        )
+        private val OK = byteArrayOf(0x90.toByte(), 0x00)
+        private val FILE_NOT_FOUND = byteArrayOf(0x6A, 0x82.toByte())
+        private val WRONG_PARAMETERS = byteArrayOf(0x6B, 0x00)
+        private val WRONG_LENGTH = byteArrayOf(0x67, 0x00)
+        private val INSTRUCTION_NOT_SUPPORTED = byteArrayOf(0x6D, 0x00)
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
@@ -3,6 +3,27 @@ package com.cashu.me.Core
 import java.util.Base64
 
 object PaymentRequestBuilder {
+    /** Android HCE/Numo variant: NFC is the return transport, so no transport array is advertised. */
+    fun buildNfc(
+        id: String,
+        amount: Long?,
+        unit: String?,
+        singleUse: Boolean? = null,
+        mints: List<String>,
+        description: String?,
+    ): String {
+        val request = buildList {
+            add(Nut18Key.Text("i") to Nut18Value.Text(id))
+            add(Nut18Key.Text("a") to amount?.takeIf { it > 0 }?.let { Nut18Value.UInt(it) }.orNull())
+            add(Nut18Key.Text("u") to unit?.takeIf { it.isNotBlank() }?.let { Nut18Value.Text(it) }.orNull())
+            add(Nut18Key.Text("s") to singleUse?.let { Nut18Value.Bool(it) }.orNull())
+            if (mints.isNotEmpty()) add(Nut18Key.Text("m") to Nut18Value.Array(mints.map { Nut18Value.Text(it) }))
+            add(Nut18Key.Text("d") to description?.takeIf { it.isNotBlank() }?.let { Nut18Value.Text(it) }.orNull())
+        }
+        val cbor = Nut18Cbor.encode(Nut18Value.Map(request))
+        return "creqA" + Base64.getUrlEncoder().encodeToString(cbor)
+    }
+
     fun build(
         id: String,
         amount: Long?,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -429,6 +429,16 @@ class WalletManager(
         return amount
     }
 
+    suspend fun settleForeignNfcToken(
+        tokenString: String,
+        settlementMintUrl: String,
+    ): com.cashu.me.Core.CDK.ForeignNfcSettlement = withLoadingResult {
+        gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
+            refreshBalance()
+            loadTransactions()
+        }
+    }
+
     fun savePendingReceiveToken(token: PendingReceiveToken) {
         val current = walletStore.loadPendingReceiveTokens()
         val updated = current.filterNot { it.tokenId == token.tokenId } + token

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -429,11 +429,38 @@ class WalletManager(
         return amount
     }
 
+    suspend fun receiveNfcCashuRequestPayment(
+        tokenString: String,
+        processedId: String,
+    ): com.cashu.me.Core.CDK.NfcReceiveReceipt = withLoadingResult {
+        require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
+        val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
+        val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
+        gateway.receiveNfcEcashToken(tokenString, signingKeys).also {
+            p2pkPubkeys.forEach(settingsManager::markP2PKKeyUsed)
+            trackMintForReceivedToken(
+                tokenString = tokenString,
+                onTrackingFailed = { AppLogger.wallet.error("Failed to track mint for received NFC token", it) },
+                ensureMintTracked = { ensureMintTracked(it) },
+            )
+            walletStore.saveProcessedCashuRequests(
+                (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
+            )
+            refreshBalance()
+            loadTransactions()
+        }
+    }
+
     suspend fun settleForeignNfcToken(
         tokenString: String,
         settlementMintUrl: String,
+        processedId: String,
     ): com.cashu.me.Core.CDK.ForeignNfcSettlement = withLoadingResult {
+        require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
         gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
+            walletStore.saveProcessedCashuRequests(
+                (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
+            )
             refreshBalance()
             loadTransactions()
         }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -124,6 +124,8 @@ fun CashuNavHost(
                 walletManager = container.walletManager,
                 settingsManager = container.settingsManager,
                 cashuRequestStore = container.cashuRequestStore,
+                nfcReceiveCoordinator = container.nfcReceiveCoordinator,
+                nostrService = container.nostrService,
                 requestId = requestId,
                 onClose = { navController.popBackStack() },
             )

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.CurrencyExchange
 import androidx.compose.material.icons.outlined.IosShare
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -65,6 +66,10 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
+import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Core.NostrService
+import com.cashu.me.Core.PaymentRequestBuilder
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.DestructiveTextButton
@@ -77,6 +82,10 @@ import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.withMonoDigits
+import com.cashu.me.ui.receive.nfc.NfcReceiveIndicator
+import com.cashu.me.ui.receive.nfc.NfcReceiveLifecycle
+import com.cashu.me.ui.receive.nfc.NfcReceiveOverlay
+import com.cashu.me.ui.receive.nfc.NfcRequestEditorSheet
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,12 +93,15 @@ fun CashuRequestDetailScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
     cashuRequestStore: CashuRequestStore,
+    nfcReceiveCoordinator: NfcReceiveCoordinator,
+    nostrService: NostrService,
     requestId: String,
     onClose: () -> Unit,
 ) {
     val storeState by cashuRequestStore.state.collectAsState()
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val nfcState by nfcReceiveCoordinator.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
@@ -97,6 +109,7 @@ fun CashuRequestDetailScreen(
     val request = storeState.requests.firstOrNull { it.id == requestId }
     var copied by remember { mutableStateOf(false) }
     var confirmDelete by remember { mutableStateOf(false) }
+    var editing by remember { mutableStateOf(false) }
 
     LaunchedEffect(copied) {
         if (copied) {
@@ -132,6 +145,16 @@ fun CashuRequestDetailScreen(
                 },
                 actions = {
                     if (request != null) {
+                        val canEdit = nfcState.phase !in setOf(
+                            NfcReceivePhase.Connected,
+                            NfcReceivePhase.Receiving,
+                            NfcReceivePhase.Validating,
+                            NfcReceivePhase.Redeeming,
+                            NfcReceivePhase.Converting,
+                        )
+                        IconButton(onClick = { editing = true }, enabled = canEdit) {
+                            Icon(Icons.Outlined.Edit, contentDescription = "Edit request")
+                        }
                         IconButton(onClick = {
                             context.shareText(request.encoded, subject = "Cashu Request")
                         }) {
@@ -163,6 +186,12 @@ fun CashuRequestDetailScreen(
             return@Scaffold
         }
 
+        NfcReceiveLifecycle(
+            coordinator = nfcReceiveCoordinator,
+            request = request,
+            settlementMintUrl = walletState.activeMint?.url,
+        )
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -190,6 +219,8 @@ fun CashuRequestDetailScreen(
                     style = MaterialTheme.typography.headlineSmall.withMonoDigits(),
                 )
             }
+
+            NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
 
             StatusBlock(
                 received = request.receivedPayments.isNotEmpty(),
@@ -286,6 +317,43 @@ fun CashuRequestDetailScreen(
             },
         )
     }
+
+    if (editing && request != null) {
+        val activeMint = walletState.activeMint
+        NfcRequestEditorSheet(
+            request = request,
+            availableMints = walletState.mints,
+            activeMintUrl = activeMint?.url,
+            onDismiss = { editing = false },
+            onSave = { amount, memo, acceptAnyMint, selectedMintUrl ->
+                val nostr = nostrService.state.value
+                val mints = if (acceptAnyMint) emptyList() else listOfNotNull(selectedMintUrl)
+                runCatching {
+                    PaymentRequestBuilder.build(
+                        id = request.id,
+                        amount = amount,
+                        unit = request.unit,
+                        mints = mints,
+                        description = memo,
+                        nostrPubkeyHex = nostr.publicKeyHex,
+                        relays = settings.nostrRelays,
+                    )
+                }.onSuccess { encoded ->
+                    cashuRequestStore.update(
+                        id = request.id,
+                        amount = amount,
+                        unit = request.unit,
+                        mints = mints,
+                        memo = memo,
+                        encoded = encoded,
+                    )
+                    editing = false
+                }
+            },
+        )
+    }
+
+    NfcReceiveOverlay(coordinator = nfcReceiveCoordinator)
 }
 
 @Composable

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -1,0 +1,233 @@
+package com.cashu.me.ui.receive.nfc
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Context
+import android.content.ContextWrapper
+import android.nfc.NfcAdapter
+import android.nfc.cardemulation.CardEmulation
+import android.os.Build
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Nfc
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.cashu.me.Core.NfcReceive.CashuNfcHostApduService
+import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
+import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.ui.components.PaymentStatusPhase
+import com.cashu.me.ui.components.PaymentStatusScreen
+import com.cashu.me.ui.components.SpinnerRing
+import com.cashu.me.ui.theme.CashuTheme
+
+@Composable
+fun NfcReceiveLifecycle(
+    coordinator: NfcReceiveCoordinator,
+    request: CashuRequest,
+    settlementMintUrl: String?,
+) {
+    val context = LocalContext.current
+    val activity = context.findActivity()
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    DisposableEffect(activity, lifecycle, coordinator, request, settlementMintUrl) {
+        val adapter = NfcAdapter.getDefaultAdapter(context)
+        val component = ComponentName(context, CashuNfcHostApduService::class.java)
+        fun resume() {
+            coordinator.activate(request, settlementMintUrl)
+            if (activity != null && adapter?.isEnabled == true) {
+                runCatching { CardEmulation.getInstance(adapter).setPreferredService(activity, component) }
+                if (Build.VERSION.SDK_INT >= 35) {
+                    runCatching {
+                        adapter.setDiscoveryTechnology(activity, NfcAdapter.FLAG_READER_DISABLE, NfcAdapter.FLAG_LISTEN_KEEP)
+                    }
+                }
+            }
+        }
+        fun pause() {
+            if (activity != null && adapter != null) {
+                runCatching { CardEmulation.getInstance(adapter).unsetPreferredService(activity) }
+                if (Build.VERSION.SDK_INT >= 35) runCatching { adapter.resetDiscoveryTechnology(activity) }
+            }
+            coordinator.deactivate()
+        }
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> resume()
+                Lifecycle.Event.ON_PAUSE -> pause()
+                else -> Unit
+            }
+        }
+        lifecycle.addObserver(observer)
+        if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) resume()
+        onDispose {
+            lifecycle.removeObserver(observer)
+            pause()
+        }
+    }
+}
+
+@Composable
+fun NfcReceiveIndicator(coordinator: NfcReceiveCoordinator, modifier: Modifier = Modifier) {
+    val state by coordinator.state.collectAsState()
+    val active = state.phase in setOf(
+        NfcReceivePhase.Waiting,
+        NfcReceivePhase.Connected,
+        NfcReceivePhase.Receiving,
+        NfcReceivePhase.Validating,
+        NfcReceivePhase.Redeeming,
+        NfcReceivePhase.Converting,
+    )
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.large,
+        color = if (active) CashuTheme.colors.pendingContainer else MaterialTheme.colorScheme.surfaceContainer,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Nfc,
+                contentDescription = null,
+                tint = if (active) CashuTheme.colors.pending else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = when (state.phase) {
+                        NfcReceivePhase.Waiting -> "Tap to pay ready"
+                        NfcReceivePhase.Unavailable -> "NFC receive unavailable"
+                        NfcReceivePhase.Disabled -> "NFC is off"
+                        NfcReceivePhase.Inactive -> "NFC receive inactive"
+                        NfcReceivePhase.Success -> "Payment received"
+                        NfcReceivePhase.Failure -> "NFC payment failed"
+                        else -> "Receiving by NFC"
+                    },
+                    style = MaterialTheme.typography.titleSmall,
+                )
+                Text(
+                    text = state.message ?: if (active) "Another wallet can use Send → Tap" else "Open this request with NFC enabled",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
+    val state by coordinator.state.collectAsState()
+    val visible = state.phase in setOf(
+        NfcReceivePhase.Connected,
+        NfcReceivePhase.Receiving,
+        NfcReceivePhase.Validating,
+        NfcReceivePhase.Redeeming,
+        NfcReceivePhase.Converting,
+        NfcReceivePhase.Success,
+        NfcReceivePhase.Failure,
+    )
+    val haptics = LocalHapticFeedback.current
+    LaunchedEffect(state.phase) {
+        if (state.phase == NfcReceivePhase.Connected) {
+            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        }
+    }
+    AnimatedVisibility(
+        visible = visible,
+        enter = fadeIn(spring(stiffness = Spring.StiffnessMedium)),
+        exit = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
+    ) {
+        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+            when (state.phase) {
+                NfcReceivePhase.Success -> PaymentStatusScreen(
+                    phase = PaymentStatusPhase.Success,
+                    title = "Payment received",
+                    detail = state.amount?.let { "$it sat added to your wallet" } ?: "Ecash added to your wallet",
+                    onDone = coordinator::clearResult,
+                )
+                NfcReceivePhase.Failure -> PaymentStatusScreen(
+                    phase = PaymentStatusPhase.Failure,
+                    title = "Payment failed",
+                    detail = state.message ?: "The payment could not be received.",
+                    doneLabel = "Try again",
+                    onDone = coordinator::clearResult,
+                )
+                NfcReceivePhase.Validating, NfcReceivePhase.Redeeming, NfcReceivePhase.Converting -> PaymentStatusScreen(
+                    phase = PaymentStatusPhase.Processing,
+                    title = when (state.phase) {
+                        NfcReceivePhase.Validating -> "Checking payment"
+                        NfcReceivePhase.Redeeming -> "Securing ecash"
+                        else -> "Moving to your active mint"
+                    },
+                    detail = "Transfer complete — you can move the phones apart.",
+                )
+                else -> NfcTransferScreen()
+            }
+        }
+    }
+}
+
+@Composable
+private fun NfcTransferScreen() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = CashuTheme.spacing.page),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                SpinnerRing(size = 64.dp, color = CashuTheme.colors.pending)
+                Spacer(Modifier.height(CashuTheme.spacing.section))
+                Text(
+                    text = "Keep phones together",
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(CashuTheme.spacing.snug))
+                Text(
+                    text = "Do not move either phone until the transfer finishes.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -8,6 +8,10 @@ import android.nfc.NfcAdapter
 import android.nfc.cardemulation.CardEmulation
 import android.os.Build
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.togetherWith
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.core.Spring
@@ -65,7 +69,7 @@ fun NfcReceiveLifecycle(
         val component = ComponentName(context, CashuNfcHostApduService::class.java)
         fun resume() {
             coordinator.activate(request, settlementMintUrl)
-            if (activity != null && adapter?.isEnabled == true) {
+            if (coordinator.isAdvertising && activity != null && adapter?.isEnabled == true) {
                 runCatching { CardEmulation.getInstance(adapter).setPreferredService(activity, component) }
                 if (Build.VERSION.SDK_INT >= 35) {
                     runCatching {
@@ -108,10 +112,17 @@ fun NfcReceiveIndicator(coordinator: NfcReceiveCoordinator, modifier: Modifier =
         NfcReceivePhase.Redeeming,
         NfcReceivePhase.Converting,
     )
+    val indicatorColor by animateColorAsState(
+        targetValue = if (active) CashuTheme.colors.pendingContainer else MaterialTheme.colorScheme.surfaceContainer,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "nfc-indicator-color",
+    )
     Surface(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .animateContentSize(animationSpec = spring(stiffness = Spring.StiffnessMediumLow)),
         shape = MaterialTheme.shapes.large,
-        color = if (active) CashuTheme.colors.pendingContainer else MaterialTheme.colorScheme.surfaceContainer,
+        color = indicatorColor,
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
@@ -123,24 +134,35 @@ fun NfcReceiveIndicator(coordinator: NfcReceiveCoordinator, modifier: Modifier =
                 contentDescription = null,
                 tint = if (active) CashuTheme.colors.pending else MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = when (state.phase) {
-                        NfcReceivePhase.Waiting -> "Tap to pay ready"
-                        NfcReceivePhase.Unavailable -> "NFC receive unavailable"
-                        NfcReceivePhase.Disabled -> "NFC is off"
-                        NfcReceivePhase.Inactive -> "NFC receive inactive"
-                        NfcReceivePhase.Success -> "Payment received"
-                        NfcReceivePhase.Failure -> "NFC payment failed"
-                        else -> "Receiving by NFC"
-                    },
-                    style = MaterialTheme.typography.titleSmall,
-                )
-                Text(
-                    text = state.message ?: if (active) "Another wallet can use Send → Tap" else "Open this request with NFC enabled",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+            AnimatedContent(
+                targetState = state.phase to state.message,
+                transitionSpec = {
+                    fadeIn(spring(stiffness = Spring.StiffnessMedium)) togetherWith
+                        fadeOut(spring(stiffness = Spring.StiffnessMedium))
+                },
+                label = "nfc-indicator-content",
+                modifier = Modifier.weight(1f),
+            ) { (phase, message) ->
+                Column {
+                    Text(
+                        text = when (phase) {
+                            NfcReceivePhase.Waiting -> "Tap to pay ready"
+                            NfcReceivePhase.NeedsAmount -> "Add an amount for Tap to receive"
+                            NfcReceivePhase.Unavailable -> "NFC receive unavailable"
+                            NfcReceivePhase.Disabled -> "NFC is off"
+                            NfcReceivePhase.Inactive -> "NFC receive inactive"
+                            NfcReceivePhase.Success -> "Payment received"
+                            NfcReceivePhase.Failure -> "NFC payment failed"
+                            else -> "Receiving by NFC"
+                        },
+                        style = MaterialTheme.typography.titleSmall,
+                    )
+                    Text(
+                        text = message ?: if (active) "Another wallet can use Send → Tap" else "Open this request with NFC enabled",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcRequestEditorSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcRequestEditorSheet.kt
@@ -1,0 +1,138 @@
+package com.cashu.me.ui.receive.nfc
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Switch
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.MintInfo
+import com.cashu.me.ui.components.CashuTextField
+import com.cashu.me.ui.components.PrimaryButton
+import com.cashu.me.ui.components.SheetHeader
+import com.cashu.me.ui.theme.CashuTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NfcRequestEditorSheet(
+    request: CashuRequest,
+    availableMints: List<MintInfo>,
+    activeMintUrl: String?,
+    onDismiss: () -> Unit,
+    onSave: (amount: Long?, memo: String?, acceptAnyMint: Boolean, mintUrl: String?) -> Unit,
+) {
+    var amount by remember(request.id) { mutableStateOf(request.amount?.toString().orEmpty()) }
+    var memo by remember(request.id) { mutableStateOf(request.memo.orEmpty()) }
+    var acceptAnyMint by remember(request.id) { mutableStateOf(request.mints.isEmpty()) }
+    var selectedMintUrl by remember(request.id) {
+        mutableStateOf(request.mints.firstOrNull() ?: activeMintUrl ?: availableMints.firstOrNull()?.url)
+    }
+    val parsedAmount = amount.trim().takeIf(String::isNotEmpty)?.toLongOrNull()
+    val amountInvalid = amount.isNotBlank() && (parsedAmount == null || parsedAmount <= 0)
+
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .navigationBarsPadding()
+                .imePadding()
+                .padding(bottom = CashuTheme.spacing.comfortable),
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+        ) {
+            SheetHeader(
+                title = "Edit Cashu Request",
+                navigationIcon = Icons.Outlined.Close,
+                navigationContentDescription = "Close",
+                onNavigationClick = onDismiss,
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = CashuTheme.spacing.page),
+                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+            ) {
+                CashuTextField(
+                    value = amount,
+                    onValueChange = { next -> amount = next.filter(Char::isDigit) },
+                    label = "Amount (${request.unit})",
+                    placeholder = "Any amount",
+                    supportingText = if (amountInvalid) "Enter a positive whole amount or leave it empty." else null,
+                    isError = amountInvalid,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                CashuTextField(
+                    value = memo,
+                    onValueChange = { memo = it },
+                    label = "Description",
+                    placeholder = "Optional",
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                ListItem(
+                    headlineContent = { Text("Accept any mint") },
+                    supportingContent = {
+                        Text(
+                            if (acceptAnyMint) {
+                                val active = availableMints.firstOrNull { it.url == activeMintUrl }
+                                "Foreign-mint payments are converted and settled to ${active?.name ?: activeMintUrl ?: "your active mint"}."
+                            } else {
+                                "Only direct payments from the selected mint are accepted."
+                            },
+                            style = MaterialTheme.typography.bodySmall,
+                        )
+                    },
+                    trailingContent = {
+                        Switch(checked = acceptAnyMint, onCheckedChange = { acceptAnyMint = it })
+                    },
+                )
+                if (!acceptAnyMint) {
+                    Column(verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug)) {
+                        Text("Accepted mint", style = MaterialTheme.typography.labelLarge)
+                        availableMints.forEach { mint ->
+                            ListItem(
+                                headlineContent = { Text(mint.name.ifBlank { mint.url }) },
+                                supportingContent = { Text(mint.url, style = MaterialTheme.typography.bodySmall) },
+                                trailingContent = {
+                                    RadioButton(
+                                        selected = selectedMintUrl == mint.url,
+                                        onClick = { selectedMintUrl = mint.url },
+                                    )
+                                },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                    }
+                }
+                PrimaryButton(
+                    text = "Save request",
+                    enabled = !amountInvalid && (acceptAnyMint || selectedMintUrl != null),
+                    onClick = {
+                        onSave(
+                            parsedAmount,
+                            memo.trim().takeIf(String::isNotEmpty),
+                            acceptAnyMint,
+                            selectedMintUrl,
+                        )
+                    },
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="nfc_receive_service_description">Receive Cashu payments by NFC</string>
+    <string name="nfc_receive_aid_description">Cashu NFC payment request</string>
     <string name="app_name">Cashu</string>
 </resources>

--- a/android/app/src/main/res/xml/nfc_receive_aid_list.xml
+++ b/android/app/src/main/res/xml/nfc_receive_aid_list.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_receive_service_description"
+    android:requireDeviceUnlock="true">
+    <aid-group
+        android:category="other"
+        android:description="@string/nfc_receive_aid_description">
+        <aid-filter android:name="D2760000850101" />
+    </aid-group>
+</host-apdu-service>

--- a/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
@@ -1,0 +1,55 @@
+package com.cashu.me.Core.NfcReceive
+
+import com.cashu.me.Models.CashuRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NfcReceiveTermsTest {
+    @Test
+    fun `selected mint is received directly`() {
+        val request = request(mints = listOf("https://mint.example/"))
+        assertEquals(
+            NfcSettlementRoute.Direct,
+            validateNfcReceiveTerms(request, "https://mint.example", "sat", 21, "https://active.example"),
+        )
+    }
+
+    @Test
+    fun `any mint request routes foreign token to settlement mint`() {
+        assertEquals(
+            NfcSettlementRoute.Foreign,
+            validateNfcReceiveTerms(request(), "https://foreign.example", "sat", 21, "https://active.example"),
+        )
+    }
+
+    @Test
+    fun `fixed amount rejects insufficient token`() {
+        val failure = runCatching {
+            validateNfcReceiveTerms(request(amount = 21), "https://active.example", "sat", 20, "https://active.example")
+        }.exceptionOrNull()
+        assertTrue(failure?.message.orEmpty().contains("at least 21"))
+    }
+
+    @Test
+    fun `strict request rejects foreign mint`() {
+        val failure = runCatching {
+            validateNfcReceiveTerms(
+                request(mints = listOf("https://accepted.example")),
+                "https://foreign.example",
+                "sat",
+                21,
+                "https://active.example",
+            )
+        }.exceptionOrNull()
+        assertTrue(failure?.message.orEmpty().contains("selected mint"))
+    }
+
+    private fun request(amount: Long? = null, mints: List<String> = emptyList()) = CashuRequest(
+        id = "request",
+        encoded = "creqA",
+        amount = amount,
+        unit = "sat",
+        mints = mints,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
@@ -7,6 +7,13 @@ import org.junit.Test
 
 class NfcReceiveTermsTest {
     @Test
+    fun `nfc receive requires a positive request amount`() {
+        assertTrue(!request(amount = null).canReceiveByNfc())
+        assertTrue(!request(amount = 0).canReceiveByNfc())
+        assertTrue(request(amount = 1).canReceiveByNfc())
+    }
+
+    @Test
     fun `selected mint is received directly`() {
         val request = request(mints = listOf("https://mint.example/"))
         assertEquals(

--- a/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcType4TagTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcType4TagTest.kt
@@ -1,0 +1,100 @@
+package com.cashu.me.Core.NfcReceive
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NfcType4TagTest {
+    @Test
+    fun `reader selects and reads payment request`() {
+        val events = mutableListOf<NfcType4Event>()
+        val request = NfcNdefCodec.textFile("creqA-request")
+        val tag = NfcType4Tag({ request }, events::add)
+
+        assertOk(tag.process(selectAid()))
+        assertOk(tag.process(selectNdef()))
+        val response = tag.process(read(offset = 0, length = request.size))
+
+        assertArrayEquals(request, response.dropLast(2).toByteArray())
+        assertEquals(NfcType4Event.Connected, events.first())
+    }
+
+    @Test
+    fun `numo zero-length then body then final length yields text token`() {
+        val events = mutableListOf<NfcType4Event>()
+        val tag = NfcType4Tag({ NfcNdefCodec.textFile("creqA-request") }, events::add)
+        val tokenFile = NfcNdefCodec.textFile("cashuBtoken_payload")
+
+        assertOk(tag.process(selectAid()))
+        assertOk(tag.process(selectNdef()))
+        assertOk(tag.process(update(0, byteArrayOf(0, 0))))
+        tokenFile.copyOfRange(2, tokenFile.size).toList().chunked(17).fold(2) { offset, chunk ->
+            assertOk(tag.process(update(offset, chunk.toByteArray())))
+            offset + chunk.size
+        }
+        assertOk(tag.process(update(0, tokenFile.copyOfRange(0, 2))))
+
+        val received = events.filterIsInstance<NfcType4Event.MessageReceived>().single().payload
+        assertEquals(NfcNdefPayload.Text("cashuBtoken_payload"), received)
+        assertEquals(1, events.count { it == NfcType4Event.WritingStarted })
+    }
+
+    @Test
+    fun `header first chunked write yields uri token`() {
+        val events = mutableListOf<NfcType4Event>()
+        val tag = NfcType4Tag({ NfcNdefCodec.textFile("creqA-request") }, events::add)
+        val file = uriFile("cashu.me/#token=cashuAtoken")
+
+        assertOk(tag.process(selectAid()))
+        assertOk(tag.process(selectNdef()))
+        file.toList().chunked(11).fold(0) { offset, chunk ->
+            assertOk(tag.process(update(offset, chunk.toByteArray())))
+            offset + chunk.size
+        }
+
+        val received = events.filterIsInstance<NfcType4Event.MessageReceived>().single().payload
+        assertEquals(NfcNdefPayload.Text("https://cashu.me/#token=cashuAtoken"), received)
+    }
+
+    @Test
+    fun `write outside advertised file is rejected`() {
+        val tag = NfcType4Tag({ NfcNdefCodec.textFile("request") }) {}
+        assertOk(tag.process(selectAid()))
+        assertOk(tag.process(selectNdef()))
+        val response = tag.process(update(NfcType4Tag.MAX_NDEF_SIZE + 2, byteArrayOf(1)))
+        assertArrayEquals(byteArrayOf(0x6B, 0x00), response)
+    }
+
+    @Test
+    fun `long text request uses non-short ndef record`() {
+        val file = NfcNdefCodec.textFile("x".repeat(400))
+        val payload = NfcNdefCodec.parseType4File(file)
+        assertEquals(NfcNdefPayload.Text("x".repeat(400)), payload)
+        assertTrue(file.size > 400)
+    }
+
+    private fun assertOk(response: ByteArray) = assertArrayEquals(byteArrayOf(0x90.toByte(), 0), response)
+
+    private fun selectAid() = byteArrayOf(
+        0x00, 0xA4.toByte(), 0x04, 0x00, 0x07,
+        0xD2.toByte(), 0x76, 0x00, 0x00, 0x85.toByte(), 0x01, 0x01, 0x00,
+    )
+
+    private fun selectNdef() = byteArrayOf(0x00, 0xA4.toByte(), 0x00, 0x0C, 0x02, 0xE1.toByte(), 0x04)
+
+    private fun read(offset: Int, length: Int) = byteArrayOf(
+        0x00, 0xB0.toByte(), (offset ushr 8).toByte(), offset.toByte(), length.toByte(),
+    )
+
+    private fun update(offset: Int, data: ByteArray) = byteArrayOf(
+        0x00, 0xD6.toByte(), (offset ushr 8).toByte(), offset.toByte(), data.size.toByte(),
+    ) + data
+
+    private fun uriFile(uriWithoutPrefix: String): ByteArray {
+        val type = byteArrayOf('U'.code.toByte())
+        val payload = byteArrayOf(0x04) + uriWithoutPrefix.toByteArray()
+        val record = byteArrayOf(0xD1.toByte(), type.size.toByte(), payload.size.toByte()) + type + payload
+        return byteArrayOf((record.size ushr 8).toByte(), record.size.toByte()) + record
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
@@ -45,6 +45,26 @@ class PaymentRequestBuilderTest {
     }
 
     @Test
+    fun nfcBuilderOmitsRemoteTransportsAndPreservesTerms() {
+        val encoded = PaymentRequestBuilder.buildNfc(
+            id = "tap-1",
+            amount = 42,
+            unit = "sat",
+            mints = listOf("https://mint.example"),
+            description = "coffee",
+        )
+
+        val request = PaymentRequestDecoder.cashuPaymentRequestSummary(encoded)!!
+        assertEquals(42L, request.amount)
+        assertEquals("sat", request.unit)
+        assertEquals(listOf("https://mint.example"), request.mints)
+        // Six top-level CBOR fields: i, a, u, s, m, d. A transport-bearing
+        // request has a seventh `t` field and starts with A7 instead.
+        val cbor = Base64.getUrlDecoder().decode(encoded.removePrefix("creqA"))
+        assertEquals(0xA6.toByte(), cbor.first())
+    }
+
+    @Test
     fun cashuRequestLegacyPaymentIdsArePreservedAsZeroAmountPayments() {
         val request = CashuRequest(
             id = "abc",

--- a/android/app/src/test/java/com/cashu/me/ui/history/NfcRequestHistoryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/history/NfcRequestHistoryTest.kt
@@ -1,0 +1,47 @@
+package com.cashu.me.ui.history
+
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.CashuRequestPayment
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.ui.components.requestRowAmount
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NfcRequestHistoryTest {
+    @Test
+    fun `nfc settlement appears once and request row shows net received`() {
+        val transaction = WalletTransaction(
+            id = "cdk-transaction",
+            amount = 96,
+            type = TransactionType.Incoming,
+            kind = TransactionKind.Lightning,
+            dateEpochMillis = 2,
+            status = TransactionStatus.Completed,
+            mintUrl = "https://active.example",
+        )
+        val request = CashuRequest(
+            id = "request",
+            encoded = "creqA",
+            amount = 100,
+            receivedPayments = listOf(
+                CashuRequestPayment("cdk-transaction", amount = 96, receivedAtEpochMillis = 2),
+            ),
+        )
+
+        val items = unifiedFiltered(
+            transactions = listOf(transaction),
+            requests = listOf(request),
+            filter = com.cashu.me.Core.HistoryFilter.All,
+            query = "",
+        )
+
+        assertEquals(1, items.size)
+        assertTrue(items.single() is HistoryItem.Req)
+        assertEquals("96 sat", requestRowAmount(request, AmountFormatter(), useBitcoinSymbol = false))
+    }
+}


### PR DESCRIPTION
## Summary
- add Android host card emulation support for serving Cashu payment requests and receiving NFC ecash
- integrate waiting, transfer, success, and failure states into the existing Cashu Request screen
- validate amount, unit, mint, and P2PK requirements and settle foreign-mint payments into the active trusted mint
- prevent overlapping transfers and handle interrupted exchanges with APDU inactivity behavior matching Numo
- record the actual CDK transaction ID and net received amount so NFC receipts appear once in history

## Platform scope
- Android-only receive support; existing Android and iOS NFC send flows remain compatible
- NFC receive is advertised only when the request has a positive amount

## Verification
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- `:app:lintDebug`
- history regression verifies one request entry showing the net received amount