### PR TITLE
Move settings out of bottom navigation

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.outlined.Inbox
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.QrCodeScanner
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -97,6 +98,7 @@ fun HomeScreen(
     onOpenCashuRequest: (CashuRequest) -> Unit,
     onReceive: (ReceiveAction) -> Unit,
     onSend: () -> Unit,
+    onOpenSettings: () -> Unit,
     onScan: () -> Unit,
     contentPadding: PaddingValues,
 ) {
@@ -214,6 +216,7 @@ fun HomeScreen(
                         sendEnabled = walletState.activeMint != null,
                     )
                 },
+                onOpenSettings = onOpenSettings,
                 onScan = onScan,
             )
         }.first().measure(constraints.copy(minHeight = 0))
@@ -368,6 +371,7 @@ private fun PinnedTop(
     mintChip: @Composable () -> Unit,
     balance: @Composable () -> Unit,
     triptych: @Composable () -> Unit,
+    onOpenSettings: () -> Unit,
     onScan: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -383,9 +387,19 @@ private fun PinnedTop(
         verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        // Top-right scan affordance (iOS parity — minimal toolbar glyph, no tonal fill).
-        // 48dp touch target preserved via minimumInteractiveComponentSize.
-        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
+        // Wallet-level navigation affordances: settings on the leading edge,
+        // scanner on the trailing edge. IconButton preserves a 48dp touch target.
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            IconButton(onClick = onOpenSettings) {
+                Icon(
+                    imageVector = Icons.Outlined.Settings,
+                    contentDescription = "Settings",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
             IconButton(onClick = onScan) {
                 Icon(
                     imageVector = Icons.Outlined.QrCodeScanner,

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -136,6 +136,21 @@ fun CashuNavHost(
             )
         }
 
+        // Settings is a wallet-origin destination, not a bottom navigation tab.
+        composable(Routes.SETTINGS) {
+            SettingsScreen(
+                walletManager = container.walletManager,
+                settingsManager = container.settingsManager,
+                priceService = container.priceService,
+                onOpenBackupRestore = { navController.navigate(Routes.SETTINGS_BACKUP_RESTORE) },
+                onOpenLightning = { navController.navigate(Routes.SETTINGS_LIGHTNING) },
+                onOpenLockedEcash = { navController.navigate(Routes.SETTINGS_P2PK) },
+                onOpenNostr = { navController.navigate(Routes.SETTINGS_NOSTR) },
+                onOpenPrivacy = { navController.navigate(Routes.SETTINGS_PRIVACY) },
+                contentPadding = contentPadding,
+            )
+        }
+
         // Settings sub-screens
         composable(Routes.SETTINGS_BACKUP_RESTORE) {
             BackupRestoreScreen(
@@ -274,6 +289,7 @@ private fun NavGraphBuilder.tabDestinations(
             },
             // Send goes straight to the unified surface — no chooser (iOS parity).
             onSend = onSend,
+            onOpenSettings = { navController.navigate(Routes.SETTINGS) },
             onScan = onScan,
             contentPadding = contentPadding,
         )
@@ -315,25 +331,6 @@ private fun NavGraphBuilder.tabDestinations(
             contentPadding = contentPadding,
             scannedMintUrl = pendingMintScan,
             onScannedMintUrlConsumed = onPendingMintScanConsumed,
-        )
-    }
-    composable(
-        route = Routes.SETTINGS,
-        enterTransition = tabEnter,
-        exitTransition = tabExit,
-        popEnterTransition = tabEnter,
-        popExitTransition = tabExit,
-    ) {
-        SettingsScreen(
-            walletManager = container.walletManager,
-            settingsManager = container.settingsManager,
-            priceService = container.priceService,
-            onOpenBackupRestore = { navController.navigate(Routes.SETTINGS_BACKUP_RESTORE) },
-            onOpenLightning = { navController.navigate(Routes.SETTINGS_LIGHTNING) },
-            onOpenLockedEcash = { navController.navigate(Routes.SETTINGS_P2PK) },
-            onOpenNostr = { navController.navigate(Routes.SETTINGS_NOSTR) },
-            onOpenPrivacy = { navController.navigate(Routes.SETTINGS_PRIVACY) },
-            contentPadding = contentPadding,
         )
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/Routes.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/Routes.kt
@@ -15,7 +15,6 @@ object Routes {
     const val HOME = "home"
     const val HISTORY = "history"
     const val MINTS = "mints"
-    const val SETTINGS = "settings"
 
     // With arguments
     const val MINT_DETAIL = "mints/{mintUrl}"
@@ -24,7 +23,8 @@ object Routes {
     // vs. from history. Only the fresh context takes over full-screen on payment.
     const val CASHU_REQUEST_DETAIL = "request/{requestId}?fresh={fresh}"
 
-    // Settings sub-screens
+    // Wallet settings and sub-screens
+    const val SETTINGS = "settings"
     const val SETTINGS_BACKUP_RESTORE = "settings/backup-restore"
     const val SETTINGS_BACKUP = "settings/backup"
     const val SETTINGS_LIGHTNING = "settings/lightning"
@@ -40,7 +40,6 @@ object Routes {
         TopTab.Home,
         TopTab.History,
         TopTab.Mints,
-        TopTab.Settings,
     )
 }
 
@@ -48,5 +47,4 @@ enum class TopTab(val route: String, val label: String) {
     Home(Routes.HOME, "Wallet"),
     History(Routes.HISTORY, "History"),
     Mints(Routes.MINTS, "Mints"),
-    Settings(Routes.SETTINGS, "Settings"),
 }

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -40,6 +40,7 @@ import com.cashu.me.Core.TokenParser
 import com.cashu.me.Views.Components.ScannerView
 import com.cashu.me.Views.Send.ContactlessPayView
 import com.cashu.me.ui.onboarding.OnboardingScreen
+import com.cashu.me.ui.navigation.Routes
 import com.cashu.me.ui.navigation.TopTab
 import com.cashu.me.ui.navigation.cashuRequestDetailRouteFor
 import com.cashu.me.ui.navigation.navigateToTab
@@ -60,7 +61,7 @@ import com.cashu.me.ui.theme.CashuTheme
  * Gating order matches iOS:
  *   - `!isInitialized`  → centered spinner
  *   - `needsOnboarding` → full-screen onboarding (no bottom nav)
- *   - otherwise         → 4-tab `WalletScaffold` over a `NavHost`
+ *   - otherwise         → 3-tab `WalletScaffold` over a `NavHost`
  *
  * Scanner and Contactless render as full-screen overlays driven by shell state;
  * the money flows (Send / Send Ecash / Receive Ecash / Receive Lightning) are
@@ -206,7 +207,7 @@ private fun AuthenticatedShell(container: AppContainer) {
             }
             CashuRoute.Main -> navController.navigateToTab(TopTab.Home)
             CashuRoute.History -> navController.navigateToTab(TopTab.History)
-            CashuRoute.Settings -> navController.navigateToTab(TopTab.Settings)
+            CashuRoute.Settings -> navController.navigate(Routes.SETTINGS)
             CashuRoute.Scanner -> scannerTarget = ScannerTarget.Auto
             CashuRoute.Contactless -> showContactless = true
         }

--- a/android/app/src/main/java/com/cashu/me/ui/shell/WalletScaffold.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/WalletScaffold.kt
@@ -14,11 +14,9 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBalance
 import androidx.compose.material.icons.filled.AccountBalanceWallet
 import androidx.compose.material.icons.filled.History
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.AccountBalanceWallet
 import androidx.compose.material.icons.outlined.History
-import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -59,7 +57,7 @@ fun WalletScaffold(
 ) {
     val backStack by navController.currentBackStackEntryAsState()
     val currentRoute = backStack?.destination?.route
-    val selectedTab = TopTab.entries.firstOrNull { it.route == currentRoute }
+    val selectedTab = Routes.TopTabs.firstOrNull { it.route == currentRoute }
     Scaffold(
         bottomBar = {
             // Slide the bar away on pushed destinations instead of blinking it out.
@@ -115,7 +113,7 @@ private fun CashuNavigationBar(
     Column {
         CanvasDivider(leadingInset = 0.dp)
         NavigationBar(containerColor = MaterialTheme.colorScheme.background) {
-            TopTab.entries.forEach { tab ->
+            Routes.TopTabs.forEach { tab ->
                 val isSelected = tab == selected
                 NavigationBarItem(
                     selected = isSelected,
@@ -142,7 +140,6 @@ private val TopTab.iconOutlined: ImageVector
         TopTab.Home -> Icons.Outlined.AccountBalanceWallet
         TopTab.History -> Icons.Outlined.History
         TopTab.Mints -> Icons.Outlined.AccountBalance
-        TopTab.Settings -> Icons.Outlined.Settings
     }
 
 private val TopTab.iconSelected: ImageVector
@@ -150,7 +147,6 @@ private val TopTab.iconSelected: ImageVector
         TopTab.Home -> Icons.Filled.AccountBalanceWallet
         TopTab.History -> Icons.Filled.History
         TopTab.Mints -> Icons.Filled.AccountBalance
-        TopTab.Settings -> Icons.Filled.Settings
     }
 
 @Suppress("unused")

--- a/android/macrobenchmark/src/main/java/com/cashu/me/benchmark/WalletMacrobenchmark.kt
+++ b/android/macrobenchmark/src/main/java/com/cashu/me/benchmark/WalletMacrobenchmark.kt
@@ -48,7 +48,9 @@ class WalletMacrobenchmark {
                 device.wait(Until.hasObject(By.text("Wallet")), WaitMs)
             },
         ) {
-            openTab("Settings")
+            val settings = device.wait(Until.findObject(By.desc("Settings")), WaitMs)
+            settings?.click()
+            device.waitForIdle()
             device.wait(Until.hasObject(By.text("Settings")), WaitMs)
             scrollVertical()
             device.findObject(By.text("Privacy"))?.click()

--- a/ios/CashuWallet/App/ContentView.swift
+++ b/ios/CashuWallet/App/ContentView.swift
@@ -101,7 +101,6 @@ struct MainTabView: View {
         case wallet
         case history
         case mints
-        case settings
     }
     
     var body: some View {
@@ -128,13 +127,6 @@ struct MainTabView: View {
                 }
                 .tag(Tab.mints)
             
-            tabContent(for: .settings) {
-                SettingsView()
-            }
-                .tabItem {
-                    Label("Settings", systemImage: "gearshape.fill")
-                }
-                .tag(Tab.settings)
         }
     }
 

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -82,6 +82,19 @@ struct MainWalletView: View {
             }
             .onPreferenceChange(TopInsetHeightKey.self) { topInsetHeight = $0 }
             .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    NavigationLink {
+                        SettingsView()
+                            .toolbar(.hidden, for: .tabBar)
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .font(.body.weight(.semibold))
+                            .toolbarIconTapTarget()
+                    }
+                    .accessibilityLabel("Settings")
+                    .accessibilityHint("Opens wallet settings")
+                    .accessibilityIdentifier("wallet-settings-button")
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         activeSheet = .scanner

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -85,7 +85,6 @@ struct MainWalletView: View {
                 ToolbarItem(placement: .topBarLeading) {
                     NavigationLink {
                         SettingsView()
-                            .toolbar(.hidden, for: .tabBar)
                     } label: {
                         Image(systemName: "gearshape")
                             .font(.body.weight(.semibold))

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import LocalAuthentication
 
 struct SettingsView: View {
+    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var walletManager: WalletManager
     @ObservedObject var settings = SettingsManager.shared
     @ObservedObject var npcService = NPCService.shared
@@ -91,6 +92,18 @@ struct SettingsView: View {
             .padding(.horizontal)
         }
         .navigationTitle("Settings")
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Label("Wallet", systemImage: "chevron.backward")
+                }
+                .accessibilityLabel("Back to Wallet")
+                .accessibilityIdentifier("settings-back-button")
+            }
+        }
         .sheet(isPresented: $showBackup) {
             BackupView()
                 .environmentObject(walletManager)

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -20,98 +20,96 @@ struct SettingsView: View {
     @State private var walletActionError: String?
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    sectionGroup(title: "Display") {
-                        currencyRow
-                        toggleRow(
-                            "Use ₿ symbol",
-                            subtitle: "Use ₿ symbol instead of sats.",
-                            icon: "bitcoinsign",
-                            isOn: $settings.useBitcoinSymbol
-                        )
-                    }
-
-                    sectionGroup(title: "Backup & Security") {
-                        navRow("Backup & Restore", icon: "key.fill") {
-                            backupDetailView
-                        }
-                        navRow("App Lock", icon: "lock.shield") {
-                            securityDetailView
-                        }
-                    }
-
-                    sectionGroup(title: "Payments") {
-                        navRow("Lightning", icon: "bolt.fill") {
-                            lightningDetailView
-                        }
-                        navRow("Locked Ecash", icon: "lock.fill") {
-                            p2pkDetailView
-                        }
-                    }
-
-                    sectionGroup(title: "Integrations") {
-                        navRow("Nostr", icon: "person.circle") {
-                            nostrDetailView
-                        }
-                    }
-
-                    sectionGroup(title: "Privacy") {
-                        navRow("Privacy", icon: "eye.slash") {
-                            privacyDetailView
-                        }
-                    }
-
-                    sectionGroup(title: "About") {
-                        externalLinkRow("Learn about Cashu",
-                                        icon: "globe",
-                                        url: URL(string: "https://cashu.space")!)
-                        externalLinkRow("Protocol Specs (NUTs)",
-                                        icon: "doc.text",
-                                        url: URL(string: "https://github.com/cashubtc/nuts")!)
-                    }
-
-                    sectionGroup(title: "Danger") {
-                        Button(role: .destructive) {
-                            HapticFeedback.selection()
-                            showDeleteConfirm = true
-                        } label: {
-                            settingsRow("Delete Wallet", icon: "trash", isDestructive: true)
-                        }
-                        .buttonStyle(.plain)
-                    }
-
-                    Text("Cashu Wallet · 1.0.0")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.top, 24)
-                        .padding(.bottom, 32)
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                sectionGroup(title: "Display") {
+                    currencyRow
+                    toggleRow(
+                        "Use ₿ symbol",
+                        subtitle: "Use ₿ symbol instead of sats.",
+                        icon: "bitcoinsign",
+                        isOn: $settings.useBitcoinSymbol
+                    )
                 }
-                .padding(.horizontal)
-            }
-            .navigationTitle("Settings")
-            .sheet(isPresented: $showBackup) {
-                BackupView()
-                    .environmentObject(walletManager)
-                    .presentationDetents([.medium, .large])
-            }
-            .sheet(isPresented: $showCurrencySheet) {
-                CurrencyPickerSheet()
-                    .presentationDetents([.medium, .large])
-                    .presentationDragIndicator(.visible)
-            }
-            .alert("Delete Wallet", isPresented: $showDeleteConfirm) {
-                Button("Cancel", role: .cancel) {}
-                Button("Delete", role: .destructive) {
-                    deleteWallet()
+
+                sectionGroup(title: "Backup & Security") {
+                    navRow("Backup & Restore", icon: "key.fill") {
+                        backupDetailView
+                    }
+                    navRow("App Lock", icon: "lock.shield") {
+                        securityDetailView
+                    }
                 }
-            } message: {
-                Text("Are you sure you want to delete your wallet? This action cannot be undone. Make sure you have backed up your seed phrase!")
+
+                sectionGroup(title: "Payments") {
+                    navRow("Lightning", icon: "bolt.fill") {
+                        lightningDetailView
+                    }
+                    navRow("Locked Ecash", icon: "lock.fill") {
+                        p2pkDetailView
+                    }
+                }
+
+                sectionGroup(title: "Integrations") {
+                    navRow("Nostr", icon: "person.circle") {
+                        nostrDetailView
+                    }
+                }
+
+                sectionGroup(title: "Privacy") {
+                    navRow("Privacy", icon: "eye.slash") {
+                        privacyDetailView
+                    }
+                }
+
+                sectionGroup(title: "About") {
+                    externalLinkRow("Learn about Cashu",
+                                    icon: "globe",
+                                    url: URL(string: "https://cashu.space")!)
+                    externalLinkRow("Protocol Specs (NUTs)",
+                                    icon: "doc.text",
+                                    url: URL(string: "https://github.com/cashubtc/nuts")!)
+                }
+
+                sectionGroup(title: "Danger") {
+                    Button(role: .destructive) {
+                        HapticFeedback.selection()
+                        showDeleteConfirm = true
+                    } label: {
+                        settingsRow("Delete Wallet", icon: "trash", isDestructive: true)
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                Text("Cashu Wallet · 1.0.0")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 24)
+                    .padding(.bottom, 32)
             }
-            .errorBanner($walletActionError)
+            .padding(.horizontal)
         }
+        .navigationTitle("Settings")
+        .sheet(isPresented: $showBackup) {
+            BackupView()
+                .environmentObject(walletManager)
+                .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showCurrencySheet) {
+            CurrencyPickerSheet()
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
+        .alert("Delete Wallet", isPresented: $showDeleteConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Delete", role: .destructive) {
+                deleteWallet()
+            }
+        } message: {
+            Text("Are you sure you want to delete your wallet? This action cannot be undone. Make sure you have backed up your seed phrase!")
+        }
+        .errorBanner($walletActionError)
     }
 
     // MARK: - Section + Row Helpers
@@ -1715,6 +1713,8 @@ struct ImportNsecSheet: View {
 }
 
 #Preview {
-    SettingsView()
-        .environmentObject(WalletManager())
+    NavigationStack {
+        SettingsView()
+            .environmentObject(WalletManager())
+    }
 }

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -12,7 +12,7 @@ final class MainTabUITests: UITestBase {
         XCTAssertTrue(tabButton("Wallet").exists)
         XCTAssertTrue(tabButton("History").exists)
         XCTAssertTrue(tabButton("Mints").exists)
-        XCTAssertTrue(tabButton("Settings").exists)
+        XCTAssertEqual(mainTabBar().buttons.count, 3)
     }
 
     func testNavigateToHistoryTab() throws {
@@ -48,10 +48,13 @@ final class MainTabUITests: UITestBase {
         )
     }
 
-    func testNavigateToSettingsTab() throws {
+    func testOpenSettingsFromWallet() throws {
         waitForMainTab()
 
-        tapTab("Settings")
+        let settings = app.buttons["wallet-settings-button"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 5))
+        settings.tap()
+        XCTAssertTrue(app.navigationBars["Settings"].waitForExistence(timeout: 10))
     }
 
     func testWalletTabIsDefaultSelected() throws {
@@ -65,8 +68,8 @@ final class MainTabUITests: UITestBase {
 
         tapTab("Mints")
 
-        tapTab("Settings")
-
         tapTab("Wallet")
+
+        tapTab("History")
     }
 }

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -33,14 +33,18 @@ final class SettingsUITests: UITestBase {
         navigateToSettings()
 
         XCTAssertTrue(app.navigationBars["Settings"].exists)
-        XCTAssertFalse(app.tabBars.firstMatch.exists)
+        let tabBar = mainTabBar(timeout: 5)
+        XCTAssertEqual(tabBar.buttons.count, 3)
+        XCTAssertFalse(tabBar.buttons["Settings"].exists)
     }
 
     func testCanReturnToWalletFromSettings() throws {
         navigateToSettings()
 
-        app.navigationBars["Settings"].buttons.firstMatch.tap()
+        let back = app.buttons["settings-back-button"]
+        XCTAssertTrue(back.waitForExistence(timeout: 5))
+        back.tap()
         XCTAssertTrue(app.buttons["wallet-settings-button"].waitForExistence(timeout: 5))
-        XCTAssertTrue(tabButton("Wallet").isSelected)
+        waitForSelectedTab("Wallet")
     }
 }

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -1,13 +1,16 @@
 import XCTest
 
-/// UI tests for the Settings tab navigation and basic interactions.
+/// UI tests for wallet-header Settings navigation and basic interactions.
 final class SettingsUITests: UITestBase {
     override var launchMode: LaunchMode { .seededWallet }
 
     // MARK: - Helpers
 
     private func navigateToSettings() {
-        tapTab("Settings")
+        waitForMainTab()
+        let settings = app.buttons["wallet-settings-button"]
+        XCTAssertTrue(settings.waitForExistence(timeout: 5))
+        settings.tap()
     }
 
     // MARK: - Tests
@@ -26,17 +29,18 @@ final class SettingsUITests: UITestBase {
         )
     }
 
-    func testSettingsTabIsAccessible() throws {
+    func testSettingsButtonIsAccessible() throws {
         navigateToSettings()
 
-        XCTAssertTrue(mainTabBar(timeout: 5).exists)
-        XCTAssertTrue(tabButton("Settings").isSelected)
+        XCTAssertTrue(app.navigationBars["Settings"].exists)
+        XCTAssertFalse(app.tabBars.firstMatch.exists)
     }
 
     func testCanReturnToWalletFromSettings() throws {
         navigateToSettings()
 
-        tapTab("Wallet")
+        app.navigationBars["Settings"].buttons.firstMatch.tap()
+        XCTAssertTrue(app.buttons["wallet-settings-button"].waitForExistence(timeout: 5))
         XCTAssertTrue(tabButton("Wallet").isSelected)
     }
 }

--- a/ios/CashuWalletUITests/UITestBase.swift
+++ b/ios/CashuWalletUITests/UITestBase.swift
@@ -143,7 +143,7 @@ class UITestBase: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> XCUIElement {
-        let button = mainTabBar(timeout: timeout, file: file, line: line).buttons[title].firstMatch
+        let button = app.tabBars.firstMatch.buttons[title].firstMatch
         XCTAssertTrue(
             button.waitForExistence(timeout: timeout),
             "\(title) tab should appear",
@@ -160,6 +160,16 @@ class UITestBase: XCTestCase {
         line: UInt = #line
     ) {
         let button = tabButton(title, timeout: timeout, file: file, line: line)
+        waitForSelectedTab(button, title: title, timeout: timeout, file: file, line: line)
+    }
+
+    private func waitForSelectedTab(
+        _ button: XCUIElement,
+        title: String,
+        timeout: TimeInterval,
+        file: StaticString,
+        line: UInt
+    ) {
         let selected = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "isSelected == true"),
             object: button
@@ -182,7 +192,7 @@ class UITestBase: XCTestCase {
     ) {
         let button = tabButton(title, timeout: timeout, file: file, line: line)
         button.tap()
-        waitForSelectedTab(title, timeout: timeout, file: file, line: line)
+        waitForSelectedTab(button, title: title, timeout: timeout, file: file, line: line)
     }
 }
 


### PR DESCRIPTION
## Summary
- reduce the iOS and Android bottom navigation bars to Wallet, History, and Mints
- add an accessible Settings icon to the leading edge of the main wallet header
- open Settings as a secondary destination with normal back navigation
- update iOS UI coverage and the Android settings macrobenchmark

## Verification
- `swiftc -frontend -parse` passes for the changed Swift source and UI tests
- `git diff --check` passes
- full platform builds were not run: Java is unavailable and `xcodebuild` is configured for Command Line Tools rather than full Xcode