### PR TITLE
Fix NFC receive gating for paid requests

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
@@ -88,6 +88,12 @@ class NfcReceiveCoordinator(
             mutableState.value = availability
             return
         }
+        if (!request.shouldOfferNfcReceive()) {
+            session = null
+            armed = false
+            mutableState.value = NfcReceiveState(NfcReceivePhase.Inactive)
+            return
+        }
         if (!request.canReceiveByNfc()) {
             session = null
             armed = false

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
@@ -4,7 +4,10 @@ import com.cashu.me.Models.CashuRequest
 
 internal enum class NfcSettlementRoute { Direct, Foreign }
 
-internal fun CashuRequest.canReceiveByNfc(): Boolean = amount?.let { it > 0 } == true
+internal fun CashuRequest.shouldOfferNfcReceive(): Boolean = receivedPayments.isEmpty()
+
+internal fun CashuRequest.canReceiveByNfc(): Boolean =
+    shouldOfferNfcReceive() && amount?.let { it > 0 } == true
 
 internal fun validateNfcReceiveTerms(
     request: CashuRequest,

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -68,6 +68,7 @@ import com.cashu.me.Core.CashuRequestStore
 import com.cashu.me.Core.NostrService
 import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
 import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Core.NfcReceive.shouldOfferNfcReceive
 import com.cashu.me.Core.PaymentRequestBuilder
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
@@ -126,7 +127,8 @@ fun CashuRequestDetailScreen(
     var mintPickerOpen by remember { mutableStateOf(false) }
     var amountPickerOpen by remember { mutableStateOf(false) }
     var regenerateError by remember { mutableStateOf<String?>(null) }
-    val nfcTransferActive = nfcState.phase.isNfcTransferActive()
+    val offerNfcReceive = request?.shouldOfferNfcReceive() == true
+    val nfcTransferActive = offerNfcReceive && nfcState.phase.isNfcTransferActive()
 
     // Re-signs the same NUT-18 request in place (same id/history entry) — used
     // by the Mint sheet, the Amount sheet's Done, and "New Request" (called
@@ -266,11 +268,13 @@ fun CashuRequestDetailScreen(
             return@Scaffold
         }
 
-        NfcReceiveLifecycle(
-            coordinator = nfcReceiveCoordinator,
-            request = request,
-            settlementMintUrl = walletState.activeMint?.url,
-        )
+        if (offerNfcReceive) {
+            NfcReceiveLifecycle(
+                coordinator = nfcReceiveCoordinator,
+                request = request,
+                settlementMintUrl = walletState.activeMint?.url,
+            )
+        }
 
         Column(
             modifier = Modifier
@@ -307,7 +311,9 @@ fun CashuRequestDetailScreen(
                 )
             }
 
-            NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
+            if (offerNfcReceive) {
+                NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
+            }
 
             StatusBlock(
                 received = request.receivedPayments.isNotEmpty(),
@@ -420,7 +426,9 @@ fun CashuRequestDetailScreen(
         )
     }
 
-    NfcReceiveOverlay(coordinator = nfcReceiveCoordinator)
+    if (offerNfcReceive) {
+        NfcReceiveOverlay(coordinator = nfcReceiveCoordinator)
+    }
 }
 
 private fun NfcReceivePhase.isNfcTransferActive(): Boolean = this in setOf(

--- a/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Core.NfcReceive
 
 import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.CashuRequestPayment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,6 +12,13 @@ class NfcReceiveTermsTest {
         assertTrue(!request(amount = null).canReceiveByNfc())
         assertTrue(!request(amount = 0).canReceiveByNfc())
         assertTrue(request(amount = 1).canReceiveByNfc())
+    }
+
+    @Test
+    fun `nfc receive is only offered for unpaid requests`() {
+        assertTrue(request(amount = 1).shouldOfferNfcReceive())
+        assertTrue(!paidRequest().shouldOfferNfcReceive())
+        assertTrue(!paidRequest().canReceiveByNfc())
     }
 
     @Test
@@ -58,5 +66,15 @@ class NfcReceiveTermsTest {
         amount = amount,
         unit = "sat",
         mints = mints,
+    )
+
+    private fun paidRequest() = request(amount = 1).copy(
+        receivedPayments = listOf(
+            CashuRequestPayment(
+                transactionId = "transaction",
+                amount = 1,
+                receivedAtEpochMillis = 1,
+            ),
+        ),
     )
 }


### PR DESCRIPTION
## Summary
- show and activate NFC receive only for unpaid Cashu payment requests
- keep NFC receive available for new requests and unpaid requests opened from history
- add coordinator-level protection and regression coverage for paid requests

## Tests
- `./gradlew testDebugUnitTest`