### PR TITLE
Android: Settings back button + quieter transaction-detail Copy CTA

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
@@ -92,13 +92,29 @@ private fun rememberPressAlpha(interactionSource: MutableInteractionSource): Flo
 }
 
 /**
+ * Quiet neutral tonal fill for equally-weighted or secondary CTAs — the home
+ * screen's Receive/Send pair and the transaction detail's Copy action. Matches
+ * the history row's arrow chips instead of the loud inverted-ink primary, and
+ * adapts to light/dark via the theme's surface roles. Pass to [PrimaryButton]'s
+ * `colors`.
+ */
+@Composable
+fun neutralActionButtonColors(): ButtonColors = ButtonDefaults.buttonColors(
+    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+    contentColor = MaterialTheme.colorScheme.onSurface,
+    disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+    disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+)
+
+/**
  * The primary full-width CTA: filled M3 button on the theme's primary color
  * (inverted ink: black in light mode, white in dark), spring press-scale,
  * expressive loading indicator.
  *
  * Pass [colors] to override the default filled treatment (e.g. the home
- * screen's tonal Receive/Send pair, which matches the history row's arrow
- * chips instead of using the inverted-ink primary color).
+ * screen's tonal Receive/Send pair via [neutralActionButtonColors], which
+ * matches the history row's arrow chips instead of using the inverted-ink
+ * primary color).
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/android/app/src/main/java/com/cashu/me/ui/components/TabTopBar.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/TabTopBar.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.text.font.FontWeight
  * collapsed states while preserving each state's size. The native
  * collapse-on-scroll behavior is kept — a scrolled History still shrinks its
  * title, exactly as iOS does. See DESIGN-ANDROID.md §1.
+ *
+ * [navigationIcon] defaults to empty (History/Mints are bottom-nav tabs with no
+ * back affordance); Settings — a pushed wallet-origin destination — supplies a
+ * top-left back arrow while keeping this same large brand title.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -29,12 +33,14 @@ fun TabTopBar(
     title: String,
     scrollBehavior: TopAppBarScrollBehavior,
     modifier: Modifier = Modifier,
+    navigationIcon: @Composable () -> Unit = {},
     actions: @Composable RowScope.() -> Unit = {},
 ) {
     LargeFlexibleTopAppBar(
         title = { Text(title, fontWeight = FontWeight.Bold) },
         modifier = modifier,
         scrollBehavior = scrollBehavior,
+        navigationIcon = navigationIcon,
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = MaterialTheme.colorScheme.background,
             scrolledContainerColor = MaterialTheme.colorScheme.background,

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -60,6 +60,7 @@ import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.ToolbarIcon
+import com.cashu.me.ui.components.neutralActionButtonColors
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withMonoDigits
@@ -211,12 +212,16 @@ fun TransactionDetailScreen(
                             onClick = { onClaimReceiveToken(pendingReceiveToken) },
                         )
                     } else if (copyableContent != null) {
+                        // Copy is a secondary convenience, not a primary action —
+                        // quiet neutral tonal fill (matches Home's Send/Receive)
+                        // rather than the loud inverted-ink primary.
                         PrimaryButton(
                             text = if (copied) "Copied" else "Copy",
                             onClick = {
                                 clipboard.setText(AnnotatedString(copyableContent))
                                 copied = true
                             },
+                            colors = neutralActionButtonColors(),
                         )
                     }
                 }

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.QrCodeScanner
 import androidx.compose.material.icons.outlined.Settings
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -79,6 +78,7 @@ import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.TransactionRow
 import com.cashu.me.ui.components.TransactionRowModel
 import com.cashu.me.ui.components.ToolbarIcon
+import com.cashu.me.ui.components.neutralActionButtonColors
 import com.cashu.me.ui.components.formatRelativeTimestamp
 import com.cashu.me.ui.theme.CashuTheme
 
@@ -543,12 +543,7 @@ private fun ActionDuet(
     // tonal pills (same fill/content colors as the history row's arrow
     // chips) rather than the inverted-ink PrimaryButton default, which reads
     // as too strong for a pair of equally-weighted actions.
-    val actionColors = ButtonDefaults.buttonColors(
-        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        contentColor = MaterialTheme.colorScheme.onSurface,
-        disabledContainerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
-        disabledContentColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
-    )
+    val actionColors = neutralActionButtonColors()
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -143,6 +143,7 @@ fun CashuNavHost(
                 walletManager = container.walletManager,
                 settingsManager = container.settingsManager,
                 priceService = container.priceService,
+                onClose = { navController.popBackStack() },
                 onOpenBackupRestore = { navController.navigate(Routes.SETTINGS_BACKUP_RESTORE) },
                 onOpenLightning = { navController.navigate(Routes.SETTINGS_LIGHTNING) },
                 onOpenLockedEcash = { navController.navigate(Routes.SETTINGS_P2PK) },

--- a/android/app/src/main/java/com/cashu/me/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.ArrowOutward
 import androidx.compose.material.icons.outlined.Bolt
@@ -26,6 +27,7 @@ import androidx.compose.material.icons.outlined.VpnKey
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -50,6 +52,7 @@ import com.cashu.me.ui.components.NavRow
 import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.TabTopBar
 import com.cashu.me.ui.components.ToggleRow
+import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.theme.CashuTheme
 
 /**
@@ -64,6 +67,7 @@ fun SettingsScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
     priceService: PriceService,
+    onClose: () -> Unit,
     onOpenBackupRestore: () -> Unit,
     onOpenLightning: () -> Unit,
     onOpenLockedEcash: () -> Unit,
@@ -87,7 +91,15 @@ fun SettingsScreen(
             .consumeWindowInsets(contentPadding)
             .nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
-            TabTopBar(title = "Settings", scrollBehavior = scrollBehavior)
+            TabTopBar(
+                title = "Settings",
+                scrollBehavior = scrollBehavior,
+                navigationIcon = {
+                    IconButton(onClick = onClose) {
+                        ToolbarIcon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
         },
     ) { padding ->
         LazyColumn(


### PR DESCRIPTION
## Summary

Two small **Android-only** UI fixes (iOS untouched).

### 1. Settings has no back button
Settings is a pushed wallet-origin destination (opened from the Home gear icon), **not** a bottom-nav tab — when it's open the bottom bar slides away, leaving only the system back gesture. Every Settings *sub*-screen (Privacy, Lightning, Nostr, …) already shows a top-left back arrow, so the Settings root was the odd one out.

- `TabTopBar` gains an optional `navigationIcon` slot (defaults to empty, so the History/Mints tabs are unaffected).
- `SettingsScreen` takes an `onClose` callback and renders a top-left back arrow using the same `ToolbarIcon` + `ArrowBack` pattern the sub-screens use, **keeping its large collapsing brand title**.
- `CashuNavHost` wires `onClose = { navController.popBackStack() }`.

### 2. The transaction-detail "Copy" CTA was too loud
On the "Ecash sent" detail the Copy button used the default inverted-ink primary fill, over-weighting a secondary convenience action.

- Extracted the Home Send/Receive tonal spec (`surfaceContainerHigh` / `onSurface`) into a shared `neutralActionButtonColors()` helper in `Buttons.kt` — single source of truth, adapts to light/dark.
- `HomeScreen`'s `ActionDuet` now uses the helper (behavior identical; de-duplicated).
- The transaction-detail Copy button adopts the quiet tonal fill. The sibling **Receive** (claim pending token) button stays primary since it's a genuine primary action.

## Test plan
- From Home, tap the gear → Settings opens with the large title **and** a top-left back arrow that returns to Home; History/Mints tabs still show no back arrow. (light + dark)
- Open a **sent** ecash transaction from History → the Copy button is a quiet neutral tonal pill (not white/inverted), still copies and swaps to "Copied", and matches the Home Send/Receive fill. (light + dark)
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)