### PR TITLE
Add close button to MeltView

### DIFF
--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -2873,6 +2873,11 @@ struct MeltView: View {
             .animation(.smooth(duration: 0.3), value: meltViewStateKey)
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(screenTitle)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton()
+                }
+            }
             .sheet(isPresented: $showingScanner) {
                 ScannerWrapperView(onScanned: handleScannedRequest)
                     .environmentObject(walletManager)


### PR DESCRIPTION
## Summary
- add the shared close button to MeltView
- restore dismissal for the scanner full-screen payment flow

## Testing
- git diff --check
- xcodebuild unavailable because full Xcode is not selected in the environment