### PR TITLE
Fix Android home balance order (sats primary, fiat secondary)

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -121,7 +121,7 @@ fun HomeScreen(
     val balanceDisplay = remember(walletState.balance, settings, priceState) {
         formatter.displayText(
             amountSats = walletState.balance,
-            preferredPrimary = settings.amountDisplayPrimary,
+            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
             showFiat = settings.showFiatBalance && priceState.btcPrice > 0,
             btcPrice = priceState.btcPrice,
             currencyCode = settings.bitcoinPriceCurrency,


### PR DESCRIPTION
## Summary
- Android home hero no longer follows `amountDisplayPrimary` (send/receive flip).
- When USD/fiat is enabled, large balance stays in keyset units (BTC/sats) and small grey secondary is the converted fiat amount.

## Test plan
- [ ] On Android, with fiat off: home shows sats only as primary
- [ ] Enable USD in settings: large balance remains sats/₿, small grey is $ fiat
- [ ] Flip primary on send/receive still works and does not swap home hero order