### PR TITLE
Recover asynchronous Android melts

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -51,6 +51,8 @@ interface CdkWalletGateway {
     suspend fun createMeltQuote(request: String, amountSats: Long? = null, preferredMintURL: String? = null): MeltQuoteInfo
     suspend fun listMeltQuotes(): List<MeltQuoteInfo>
     suspend fun meltTokens(quoteId: String, mintUrl: String? = null): MeltPaymentResult
+    fun awaitPendingMelt(quoteId: String): Flow<MeltPaymentResult>
+    suspend fun checkMeltQuoteStatus(quoteId: String, mintUrl: String): MeltQuoteInfo
     suspend fun sendEcashToken(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String, unit: String = "sat", p2pkSigningKeys: List<String> = emptyList()): SendTokenResult
     suspend fun receiveEcashToken(tokenString: String, p2pkSigningKeys: List<String> = emptyList()): Long
     suspend fun receiveNfcEcashToken(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -31,6 +31,8 @@ interface CdkWalletGateway {
     suspend fun removeWallet(mintUrl: String, unit: String = "sat")
     suspend fun fetchMintInfo(mintUrl: String): MintInfo?
     suspend fun restoreMint(mintUrl: String): RestoreMintResult
+    suspend fun recoverIncompleteSagas(mintUrl: String, unit: String = "sat"): WalletSagaRecoveryResult
+    suspend fun refreshKeysets(mintUrl: String, unit: String = "sat"): Int
     suspend fun totalBalance(mintUrl: String): Long
 
     /** Balance of the (mint, unit) wallet, registering the unit wallet if needed. */
@@ -64,6 +66,19 @@ interface CdkWalletGateway {
     suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean
     suspend fun listTransactions(unitsByMint: Map<String, List<String>>): List<WalletTransaction>
     suspend fun payCashuPaymentRequest(encoded: String, customAmountSats: Long?, preferredMintURL: String?)
+}
+
+data class WalletSagaRecoveryResult(
+    val recovered: Long,
+    val compensated: Long,
+    val skipped: Long,
+    val failed: Long,
+) {
+    val changedWalletState: Boolean
+        get() = recovered > 0 || compensated > 0
+
+    val hasActivity: Boolean
+        get() = changedWalletState || skipped > 0 || failed > 0
 }
 
 data class ForeignNfcSettlement(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -695,7 +695,13 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         mintUrl = mintUrl,
         paymentMethod = quote?.paymentMethod?.toDomain() ?: fallbackQuote?.paymentMethod,
         request = quote?.request ?: fallbackQuote?.request,
-        settlement = MeltSettlement.Settled,
+        // wait()/confirm can finish paid or failed (compensated). Only paid is settled.
+        settlement = when (state) {
+            CdkQuoteState.PAID,
+            CdkQuoteState.ISSUED -> MeltSettlement.Settled
+            CdkQuoteState.UNPAID,
+            CdkQuoteState.PENDING -> MeltSettlement.Failed
+        },
     )
 
     private fun CdkNotificationPayload.referencesMintQuote(quoteId: String): Boolean = when (this) {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -197,6 +197,20 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         )
     }
 
+    override suspend fun recoverIncompleteSagas(mintUrl: String, unit: String): WalletSagaRecoveryResult = cdkCall {
+        val report = walletFor(mintUrl, cdkUnit(unit)).recoverIncompleteSagas()
+        WalletSagaRecoveryResult(
+            recovered = report.recovered.toLong(),
+            compensated = report.compensated.toLong(),
+            skipped = report.skipped.toLong(),
+            failed = report.failed.toLong(),
+        )
+    }
+
+    override suspend fun refreshKeysets(mintUrl: String, unit: String): Int = cdkCall {
+        walletFor(mintUrl, cdkUnit(unit)).refreshKeysets().size
+    }
+
     override suspend fun totalBalance(mintUrl: String): Long = cdkCall {
         walletFor(mintUrl).totalBalance().value.toLong()
     }

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -1,5 +1,6 @@
 package com.cashu.me.Core.CDK
 
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -18,6 +19,7 @@ import com.cashu.me.Core.PaymentRequestParser
 import com.cashu.me.Models.MeltPaymentResult
 import com.cashu.me.Models.MeltQuoteInfo
 import com.cashu.me.Models.MeltQuoteState
+import com.cashu.me.Models.MeltSettlement
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
 import com.cashu.me.Models.NutSupport
@@ -33,7 +35,9 @@ import org.cashudevkit.Amount as CdkAmount
 import org.cashudevkit.BackupOptions as CdkBackupOptions
 import org.cashudevkit.BitcoinNetwork as CdkBitcoinNetwork
 import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
+import org.cashudevkit.FinalizedMelt as CdkFinalizedMelt
 import org.cashudevkit.MeltQuote as CdkMeltQuote
+import org.cashudevkit.MeltConfirmOutcome as CdkMeltConfirmOutcome
 import org.cashudevkit.MintInfo as CdkMintInfo
 import org.cashudevkit.MintQuote as CdkMintQuote
 import org.cashudevkit.MintUrl as CdkMintUrl
@@ -41,6 +45,7 @@ import org.cashudevkit.NotificationPayload as CdkNotificationPayload
 import org.cashudevkit.NwcService as CdkNwcService
 import org.cashudevkit.P2pkLockedProofSendMode as CdkP2pkLockedProofSendMode
 import org.cashudevkit.PaymentMethod as CdkPaymentMethod
+import org.cashudevkit.PendingMelt as CdkPendingMelt
 import org.cashudevkit.QuoteState as CdkQuoteState
 import org.cashudevkit.ReceiveOptions as CdkReceiveOptions
 import org.cashudevkit.RestoreOptions as CdkRestoreOptions
@@ -66,9 +71,15 @@ import org.cashudevkit.nwcDeriveServiceSecretKeyFromSeed
 import org.cashudevkit.proofsTotalAmount
 
 class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
+    private data class PendingMeltEntry(
+        val pending: CdkPendingMelt,
+        val quote: MeltQuoteInfo,
+    )
+
     private var database: CdkWalletSqliteDatabase? = null
     private var repository: CdkWalletRepository? = null
     private val operationMutex = Mutex()
+    private val pendingMeltEntries = ConcurrentHashMap<String, PendingMeltEntry>()
 
     override suspend fun initializeLogging(level: String) = cdkCall {
         initLogging(level)
@@ -147,6 +158,8 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
     }
 
     private fun closeWalletRepositoryUnlocked() {
+        pendingMeltEntries.values.forEach { entry -> runCatching { entry.pending.close() } }
+        pendingMeltEntries.clear()
         runCatching { repository?.close() }
         runCatching { database?.close() }
         repository = null
@@ -366,15 +379,59 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         val quote = database?.getMeltQuote(quoteId)
         val wallet = walletFor(mintUrl ?: quote?.mintUrl?.url ?: firstWallet().mintUrl().url)
         val prepared = wallet.prepareMelt(quoteId)
-        val finalized = prepared.confirm()
-        MeltPaymentResult(
-            preimage = finalized.preimage,
-            amount = finalized.amount.value.toLong(),
-            feePaid = finalized.feePaid.value.toLong(),
-            mintUrl = wallet.mintUrl().url,
-            paymentMethod = quote?.paymentMethod?.toDomain(),
-            request = quote?.request,
-        )
+        when (val outcome = prepared.confirmPreferAsync()) {
+            is CdkMeltConfirmOutcome.Paid -> outcome.finalized.toDomainMeltPayment(
+                mintUrl = wallet.mintUrl().url,
+                quote = quote,
+            )
+            is CdkMeltConfirmOutcome.Pending -> {
+                val pendingQuote = quote?.toDomain(fallbackMethod = quote.paymentMethod.toDomain())
+                    ?: run {
+                        outcome.pending.close()
+                        throw CdkGatewayUnavailable("No stored melt quote for $quoteId.")
+                    }
+                pendingMeltEntries.put(quoteId, PendingMeltEntry(outcome.pending, pendingQuote))
+                    ?.pending
+                    ?.close()
+                MeltPaymentResult(
+                    preimage = null,
+                    amount = pendingQuote.amount,
+                    feePaid = pendingQuote.feeReserve,
+                    mintUrl = wallet.mintUrl().url,
+                    paymentMethod = pendingQuote.paymentMethod,
+                    request = pendingQuote.request,
+                    settlement = MeltSettlement.Pending,
+                )
+            }
+        }
+    }
+
+    /**
+     * Wait outside [operationMutex]: this can remain suspended for a long time while
+     * CDK listens for NUT-17 updates. The saga is already durable, so cancellation or
+     * process death is recovered later through [checkMeltQuoteStatus].
+     */
+    override fun awaitPendingMelt(quoteId: String): Flow<MeltPaymentResult> = flow {
+        val entry = pendingMeltEntries.remove(quoteId) ?: return@flow
+        try {
+            emit(
+                entry.pending.wait().toDomainMeltPayment(
+                    mintUrl = entry.quote.mintUrl,
+                    quote = null,
+                    fallbackQuote = entry.quote,
+                ),
+            )
+        } finally {
+            entry.pending.close()
+        }
+    }.flowOn(Dispatchers.IO)
+
+    override suspend fun checkMeltQuoteStatus(quoteId: String, mintUrl: String): MeltQuoteInfo = cdkCall {
+        val stored = database?.getMeltQuote(quoteId)
+            ?: throw CdkGatewayUnavailable("No stored melt quote for $quoteId.")
+        walletFor(mintUrl, stored.unit)
+            .checkMeltQuoteStatus(quoteId)
+            .toDomain(fallbackMethod = stored.paymentMethod.toDomain())
     }
 
     override suspend fun sendEcashToken(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String, unit: String, p2pkSigningKeys: List<String>): SendTokenResult = cdkCall {
@@ -612,6 +669,20 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         CdkQuoteState.PENDING -> MeltQuoteState.Pending
         CdkQuoteState.ISSUED -> MeltQuoteState.Paid
     }
+
+    private fun CdkFinalizedMelt.toDomainMeltPayment(
+        mintUrl: String,
+        quote: CdkMeltQuote?,
+        fallbackQuote: MeltQuoteInfo? = null,
+    ) = MeltPaymentResult(
+        preimage = preimage,
+        amount = amount.value.toLong(),
+        feePaid = feePaid.value.toLong(),
+        mintUrl = mintUrl,
+        paymentMethod = quote?.paymentMethod?.toDomain() ?: fallbackQuote?.paymentMethod,
+        request = quote?.request ?: fallbackQuote?.request,
+        settlement = MeltSettlement.Settled,
+    )
 
     private fun CdkNotificationPayload.referencesMintQuote(quoteId: String): Boolean = when (this) {
         is CdkNotificationPayload.MintQuoteUpdate -> quote.quote == quoteId

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -55,6 +55,7 @@ object StorageKeys {
     const val walletSavedTokens = "wallet.savedTokens"
     const val walletPaymentPreimages = "wallet.paymentPreimages"
     const val walletMeltQuoteFees = "wallet.meltQuoteFees"
+    const val walletPendingMeltQuotes = "wallet.pendingMeltQuotes"
     const val walletMintQuoteTimestamps = "wallet.mintQuoteTimestamps"
     const val walletProcessedNPCQuotes = "wallet.processedNPCQuotes"
     const val walletProcessedCashuRequests = "wallet.processedCashuRequests"
@@ -122,6 +123,7 @@ object StorageKeys {
         walletSavedTokens,
         walletPaymentPreimages,
         walletMeltQuoteFees,
+        walletPendingMeltQuotes,
         walletMintQuoteTimestamps,
         walletProcessedNPCQuotes,
         walletProcessedCashuRequests,

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -56,6 +56,7 @@ object StorageKeys {
     const val walletPaymentPreimages = "wallet.paymentPreimages"
     const val walletMeltQuoteFees = "wallet.meltQuoteFees"
     const val walletPendingMeltQuotes = "wallet.pendingMeltQuotes"
+    const val walletMintKeysetRefreshTimestamps = "wallet.mintKeysetRefreshTimestamps"
     const val walletMintQuoteTimestamps = "wallet.mintQuoteTimestamps"
     const val walletProcessedNPCQuotes = "wallet.processedNPCQuotes"
     const val walletProcessedCashuRequests = "wallet.processedCashuRequests"
@@ -124,6 +125,7 @@ object StorageKeys {
         walletPaymentPreimages,
         walletMeltQuoteFees,
         walletPendingMeltQuotes,
+        walletMintKeysetRefreshTimestamps,
         walletMintQuoteTimestamps,
         walletProcessedNPCQuotes,
         walletProcessedCashuRequests,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -647,12 +647,28 @@ class WalletManager(
                                 forgetPendingMeltQuote(quoteId)
                                 changed = true
                             }
-                            MeltQuoteState.Failed -> {
+                            // After async accept, Unpaid is terminal: the mint failed the
+                            // payment and the CDK saga compensated (proofs returned). Same
+                            // as iOS. Failed is kept for domain completeness.
+                            MeltQuoteState.Failed,
+                            MeltQuoteState.Unpaid -> {
+                                transactionLoader.saveMeltPaymentMetadata(
+                                    quoteId = quoteId,
+                                    result = MeltPaymentResult(
+                                        preimage = null,
+                                        amount = quote.amount,
+                                        feePaid = quote.feeReserve,
+                                        mintUrl = quote.mintUrl.ifBlank { mintUrl },
+                                        paymentMethod = quote.paymentMethod,
+                                        request = quote.request,
+                                        settlement = MeltSettlement.Failed,
+                                    ),
+                                    persistFee = false,
+                                )
                                 forgetPendingMeltQuote(quoteId)
                                 changed = true
                             }
                             MeltQuoteState.Pending,
-                            MeltQuoteState.Unpaid,
                             MeltQuoteState.Unknown -> Unit
                         }
                     }
@@ -671,7 +687,13 @@ class WalletManager(
         scope.launch(Dispatchers.IO) {
             try {
                 val finalized = gateway.awaitPendingMelt(quoteId).firstOrNull() ?: return@launch
-                transactionLoader.saveMeltPaymentMetadata(quoteId, finalized)
+                // Settled or Failed only — wait() never leaves a mid-flight pending.
+                // Non-paid states must not be written as Completed.
+                transactionLoader.saveMeltPaymentMetadata(
+                    quoteId = quoteId,
+                    result = finalized,
+                    persistFee = finalized.settlement == MeltSettlement.Settled,
+                )
                 forgetPendingMeltQuote(quoteId)
                 refreshBalance()
                 loadTransactions()

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -2,6 +2,7 @@ package com.cashu.me.Core
 
 import java.net.URL
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -10,6 +11,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -21,6 +23,8 @@ import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Core.Protocols.WalletServiceProtocol
 import com.cashu.me.Models.MeltPaymentResult
 import com.cashu.me.Models.MeltQuoteInfo
+import com.cashu.me.Models.MeltQuoteState
+import com.cashu.me.Models.MeltSettlement
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
 import com.cashu.me.Models.PaymentMethodKind
@@ -49,6 +53,8 @@ class WalletManager(
     private val mutableState = MutableStateFlow(WalletState())
     val state: StateFlow<WalletState> = mutableState.asStateFlow()
     private val initializationMutex = Mutex()
+    private val pendingMeltSyncMutex = Mutex()
+    private val pendingMeltWatchers = ConcurrentHashMap.newKeySet<String>()
     private val mintMetadataFetcher = WalletMintMetadataFetcher()
     private val mintQuoteSyncService = WalletMintQuoteSyncService(gateway, walletStore)
     private val transactionLoader = WalletTransactionLoader(walletStore, gateway)
@@ -495,11 +501,104 @@ class WalletManager(
     override suspend fun meltTokens(quoteId: String, mintUrl: String?): MeltPaymentResult =
         withLoadingResult {
             val result = gateway.meltTokens(quoteId, mintUrl)
-            transactionLoader.saveMeltPaymentMetadata(quoteId, result)
-            refreshBalance()
-            loadTransactions()
+            if (result.settlement == MeltSettlement.Pending) {
+                rememberPendingMeltQuote(quoteId, result.mintUrl)
+            }
+            // Once CDK accepts the melt, local bookkeeping must not turn that
+            // outcome into a user-visible payment failure and encourage a retry.
+            runCatching { transactionLoader.saveMeltPaymentMetadata(quoteId, result) }
+                .onFailure { AppLogger.wallet.error("Failed to save melt metadata for $quoteId", it) }
+            runCatching {
+                refreshBalance()
+                loadTransactions()
+            }.onFailure { AppLogger.wallet.error("Failed to refresh after melt $quoteId", it) }
+            if (result.settlement == MeltSettlement.Pending) {
+                // Start waiting only after the pending row is stored, otherwise a
+                // fast settlement could be overwritten by the pending metadata.
+                watchPendingMelt(quoteId)
+            }
             result
         }
+
+    /**
+     * Reconcile async-accepted NUT-05 melts after launch/foreground. A pending
+     * quote is never paid again; CDK only checks the existing quote and completes
+     * its persisted saga when the mint reports a terminal state.
+     */
+    suspend fun syncPendingMeltQuotes() {
+        pendingMeltSyncMutex.withLock {
+            val tracked = walletStore.loadPendingMeltQuotes()
+            if (tracked.isEmpty()) return@withLock
+
+            var changed = false
+            tracked.forEach { (quoteId, mintUrl) ->
+                if (quoteId in pendingMeltWatchers) return@forEach
+                runCatching { gateway.checkMeltQuoteStatus(quoteId, mintUrl) }
+                    .onSuccess { quote ->
+                        when (quote.state) {
+                            MeltQuoteState.Paid -> {
+                                transactionLoader.saveMeltPaymentMetadata(
+                                    quoteId = quoteId,
+                                    result = MeltPaymentResult(
+                                        preimage = quote.paymentProof,
+                                        amount = quote.amount,
+                                        feePaid = quote.feeReserve,
+                                        mintUrl = quote.mintUrl,
+                                        paymentMethod = quote.paymentMethod,
+                                        request = quote.request,
+                                        settlement = MeltSettlement.Settled,
+                                    ),
+                                    // A status response exposes the reserve, not the final fee.
+                                    // Let CDK's transaction row supply the exact fee when available.
+                                    persistFee = false,
+                                )
+                                forgetPendingMeltQuote(quoteId)
+                                changed = true
+                            }
+                            MeltQuoteState.Failed -> {
+                                forgetPendingMeltQuote(quoteId)
+                                changed = true
+                            }
+                            MeltQuoteState.Pending,
+                            MeltQuoteState.Unpaid,
+                            MeltQuoteState.Unknown -> Unit
+                        }
+                    }
+                    .onFailure { error ->
+                        AppLogger.wallet.error("Pending melt status check failed for $quoteId", error)
+                    }
+            }
+
+            if (changed) refreshBalance()
+            loadTransactions()
+        }
+    }
+
+    private fun watchPendingMelt(quoteId: String) {
+        if (!pendingMeltWatchers.add(quoteId)) return
+        scope.launch(Dispatchers.IO) {
+            try {
+                val finalized = gateway.awaitPendingMelt(quoteId).firstOrNull() ?: return@launch
+                transactionLoader.saveMeltPaymentMetadata(quoteId, finalized)
+                forgetPendingMeltQuote(quoteId)
+                refreshBalance()
+                loadTransactions()
+            } catch (error: Throwable) {
+                // Keep the durable quote record. Foreground/startup reconciliation retries it.
+                AppLogger.wallet.error("Pending melt wait failed for $quoteId", error)
+            } finally {
+                pendingMeltWatchers.remove(quoteId)
+            }
+        }
+    }
+
+    private fun rememberPendingMeltQuote(quoteId: String, mintUrl: String) {
+        walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() + (quoteId to mintUrl))
+    }
+
+    private fun forgetPendingMeltQuote(quoteId: String) {
+        walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() - quoteId)
+    }
 
     override suspend fun sendTokens(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String?, unit: String): SendTokenResult {
         val selectedMint = mintUrl ?: mutableState.value.activeMint?.url ?: throw IllegalStateException("No active mint.")

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -54,6 +54,7 @@ class WalletManager(
     val state: StateFlow<WalletState> = mutableState.asStateFlow()
     private val initializationMutex = Mutex()
     private val pendingMeltSyncMutex = Mutex()
+    private val pendingMeltStoreMutex = Mutex()
     private val pendingMeltWatchers = ConcurrentHashMap.newKeySet<String>()
     private val mintMetadataFetcher = WalletMintMetadataFetcher()
     private val mintQuoteSyncService = WalletMintQuoteSyncService(gateway, walletStore)
@@ -119,10 +120,101 @@ class WalletManager(
             if (hasStoredWallet) {
                 runCatching { refreshBalance() }
                     .onFailure { AppLogger.wallet.error("Deferred balance refresh failed", it) }
+
+                val recoveredWalletState = runCatching { performBestEffortWalletStartupMaintenance() }
+                    .onFailure { AppLogger.wallet.error("Deferred wallet maintenance failed", it) }
+                    .getOrDefault(false)
+                if (recoveredWalletState) {
+                    runCatching {
+                        refreshBalance()
+                        loadTransactions()
+                    }.onFailure { AppLogger.wallet.error("Failed to refresh recovered wallet state", it) }
+                }
             }
             runCatching { nwcManager.startIfEnabled() }
                 .onFailure { AppLogger.wallet.error("Deferred NWC startup failed", it) }
         }
+    }
+
+    /**
+     * Mirrors iOS startup maintenance: recover CDK's persisted sagas for every
+     * tracked sat wallet, refresh keysets at most hourly, then re-arm melts that
+     * remain pending after CDK's single recovery poll.
+     */
+    private suspend fun performBestEffortWalletStartupMaintenance(): Boolean {
+        val mintUrls = trackedMintUrlsForWalletAccess()
+        if (mintUrls.isEmpty()) return false
+
+        val now = System.currentTimeMillis()
+        val storedTimestamps = walletStore.loadMintKeysetRefreshTimestamps()
+        val keysetRefreshTimestamps = storedTimestamps
+            .filterKeys { it in mintUrls }
+            .toMutableMap()
+        var timestampsChanged = keysetRefreshTimestamps != storedTimestamps
+        var recoveredWalletState = false
+
+        mintUrls.forEach { mintUrl ->
+            if (recoverIncompleteSagasIfNeeded(mintUrl)) {
+                recoveredWalletState = true
+            }
+            if (
+                refreshKeysetsIfNeeded(
+                    mintUrl = mintUrl,
+                    lastRefreshEpochMillis = keysetRefreshTimestamps[mintUrl],
+                    nowEpochMillis = now,
+                )
+            ) {
+                keysetRefreshTimestamps[mintUrl] = now
+                timestampsChanged = true
+            }
+        }
+
+        if (timestampsChanged) {
+            walletStore.saveMintKeysetRefreshTimestamps(keysetRefreshTimestamps)
+        }
+
+        runCatching { syncPendingMeltQuotes() }
+            .onFailure { AppLogger.wallet.error("Failed to resume pending melts during startup", it) }
+        return recoveredWalletState
+    }
+
+    private suspend fun recoverIncompleteSagasIfNeeded(mintUrl: String): Boolean {
+        return runCatching { gateway.recoverIncompleteSagas(mintUrl) }
+            .onSuccess { report ->
+                if (report.hasActivity) {
+                    AppLogger.wallet.info(
+                        "Recovered wallet sagas for mint $mintUrl: " +
+                            "recovered=${report.recovered} compensated=${report.compensated} " +
+                            "skipped=${report.skipped} failed=${report.failed}",
+                    )
+                }
+            }
+            .onFailure { AppLogger.wallet.error("Failed to recover wallet sagas for mint $mintUrl", it) }
+            .getOrNull()
+            ?.changedWalletState == true
+    }
+
+    private suspend fun refreshKeysetsIfNeeded(
+        mintUrl: String,
+        lastRefreshEpochMillis: Long?,
+        nowEpochMillis: Long,
+    ): Boolean {
+        if (!WalletStartupPolicy.shouldRefreshKeysets(lastRefreshEpochMillis, nowEpochMillis)) return false
+
+        return runCatching { gateway.refreshKeysets(mintUrl) }
+            .onSuccess { count -> AppLogger.wallet.info("Refreshed $count keysets for mint $mintUrl") }
+            .onFailure { AppLogger.wallet.error("Failed to refresh keysets for mint $mintUrl", it) }
+            .isSuccess
+    }
+
+    private fun trackedMintUrlsForWalletAccess(): List<String> {
+        val urls = linkedSetOf<String>()
+        mutableState.value.activeMint?.url?.takeIf(String::isNotBlank)?.let(urls::add)
+        mutableState.value.mints
+            .map(MintInfo::url)
+            .filter(String::isNotBlank)
+            .forEach(urls::add)
+        return urls.toList()
     }
 
     override suspend fun createNewWallet() {
@@ -527,7 +619,7 @@ class WalletManager(
      */
     suspend fun syncPendingMeltQuotes() {
         pendingMeltSyncMutex.withLock {
-            val tracked = walletStore.loadPendingMeltQuotes()
+            val tracked = pendingMeltStoreMutex.withLock { walletStore.loadPendingMeltQuotes() }
             if (tracked.isEmpty()) return@withLock
 
             var changed = false
@@ -592,12 +684,16 @@ class WalletManager(
         }
     }
 
-    private fun rememberPendingMeltQuote(quoteId: String, mintUrl: String) {
-        walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() + (quoteId to mintUrl))
+    private suspend fun rememberPendingMeltQuote(quoteId: String, mintUrl: String) {
+        pendingMeltStoreMutex.withLock {
+            walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() + (quoteId to mintUrl))
+        }
     }
 
-    private fun forgetPendingMeltQuote(quoteId: String) {
-        walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() - quoteId)
+    private suspend fun forgetPendingMeltQuote(quoteId: String) {
+        pendingMeltStoreMutex.withLock {
+            walletStore.savePendingMeltQuotes(walletStore.loadPendingMeltQuotes() - quoteId)
+        }
     }
 
     override suspend fun sendTokens(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String?, unit: String): SendTokenResult {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletStartupPolicy.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletStartupPolicy.kt
@@ -1,0 +1,11 @@
+package com.cashu.me.Core
+
+internal object WalletStartupPolicy {
+    const val keysetRefreshIntervalMillis = 60 * 60 * 1_000L
+
+    fun shouldRefreshKeysets(lastRefreshEpochMillis: Long?, nowEpochMillis: Long): Boolean {
+        val lastRefresh = lastRefreshEpochMillis ?: return true
+        if (lastRefresh > nowEpochMillis) return true
+        return nowEpochMillis - lastRefresh >= keysetRefreshIntervalMillis
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -3,6 +3,7 @@ package com.cashu.me.Core
 import com.cashu.me.Core.CDK.CdkWalletGateway
 import com.cashu.me.Models.ClaimedToken
 import com.cashu.me.Models.MeltPaymentResult
+import com.cashu.me.Models.MeltSettlement
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.Models.PendingReceiveToken
@@ -121,11 +122,17 @@ internal class WalletTransactionLoader(
         return TokenHistoryMutation(pendingTokens = pending, claimedTokens = claimed)
     }
 
-    fun saveMeltPaymentMetadata(quoteId: String, result: MeltPaymentResult) {
+    fun saveMeltPaymentMetadata(
+        quoteId: String,
+        result: MeltPaymentResult,
+        persistFee: Boolean = result.settlement == MeltSettlement.Settled,
+    ) {
         result.preimage?.let { preimage ->
             walletStore.savePaymentPreimages(walletStore.loadPaymentPreimages() + (quoteId to preimage))
         }
-        walletStore.saveMeltQuoteFees(walletStore.loadMeltQuoteFees() + (quoteId to result.feePaid))
+        if (persistFee) {
+            walletStore.saveMeltQuoteFees(walletStore.loadMeltQuoteFees() + (quoteId to result.feePaid))
+        }
 
         val current = walletStore.loadTransactions()
         val existing = current.firstOrNull { it.quoteId == quoteId || it.id == quoteId }
@@ -139,11 +146,15 @@ internal class WalletTransactionLoader(
             },
             dateEpochMillis = existing?.dateEpochMillis ?: System.currentTimeMillis(),
             memo = existing?.memo,
-            status = TransactionStatus.Completed,
+            status = if (result.settlement == MeltSettlement.Pending) {
+                TransactionStatus.Pending
+            } else {
+                TransactionStatus.Completed
+            },
             mintUrl = result.mintUrl,
             preimage = result.preimage ?: existing?.preimage,
             invoice = result.request ?: existing?.invoice,
-            fee = result.feePaid,
+            fee = if (persistFee) result.feePaid else existing?.fee ?: result.feePaid,
             unit = existing?.unit ?: "sat",
             quoteId = quoteId,
         )

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -146,10 +146,10 @@ internal class WalletTransactionLoader(
             },
             dateEpochMillis = existing?.dateEpochMillis ?: System.currentTimeMillis(),
             memo = existing?.memo,
-            status = if (result.settlement == MeltSettlement.Pending) {
-                TransactionStatus.Pending
-            } else {
-                TransactionStatus.Completed
+            status = when (result.settlement) {
+                MeltSettlement.Pending -> TransactionStatus.Pending
+                MeltSettlement.Settled -> TransactionStatus.Completed
+                MeltSettlement.Failed -> TransactionStatus.Failed
             },
             mintUrl = result.mintUrl,
             preimage = result.preimage ?: existing?.preimage,

--- a/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
@@ -62,6 +62,11 @@ class WalletStore(
     fun savePendingMeltQuotes(quotes: Map<String, String>) =
         saveMap(StorageKeys.walletPendingMeltQuotes, String.serializer(), quotes)
 
+    fun loadMintKeysetRefreshTimestamps(): Map<String, Long> =
+        loadMap(StorageKeys.walletMintKeysetRefreshTimestamps, Long.serializer())
+    fun saveMintKeysetRefreshTimestamps(timestamps: Map<String, Long>) =
+        saveMap(StorageKeys.walletMintKeysetRefreshTimestamps, Long.serializer(), timestamps)
+
     fun loadMintQuoteTimestamps(): Map<String, Long> =
         loadMap(StorageKeys.walletMintQuoteTimestamps, Long.serializer())
     fun saveMintQuoteTimestamps(timestamps: Map<String, Long>) =

--- a/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
@@ -57,6 +57,11 @@ class WalletStore(
     fun saveMeltQuoteFees(fees: Map<String, Long>) =
         saveMap(StorageKeys.walletMeltQuoteFees, Long.serializer(), fees)
 
+    fun loadPendingMeltQuotes(): Map<String, String> =
+        loadMap(StorageKeys.walletPendingMeltQuotes, String.serializer())
+    fun savePendingMeltQuotes(quotes: Map<String, String>) =
+        saveMap(StorageKeys.walletPendingMeltQuotes, String.serializer(), quotes)
+
     fun loadMintQuoteTimestamps(): Map<String, Long> =
         loadMap(StorageKeys.walletMintQuoteTimestamps, Long.serializer())
     fun saveMintQuoteTimestamps(timestamps: Map<String, Long>) =

--- a/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
@@ -64,6 +64,12 @@ data class MeltQuoteInfo(
 }
 
 @Serializable
+enum class MeltSettlement {
+    Settled,
+    Pending,
+}
+
+@Serializable
 data class MeltPaymentResult(
     val preimage: String?,
     val amount: Long,
@@ -71,4 +77,5 @@ data class MeltPaymentResult(
     val mintUrl: String,
     val paymentMethod: PaymentMethodKind? = null,
     val request: String? = null,
+    val settlement: MeltSettlement = MeltSettlement.Settled,
 )

--- a/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
@@ -67,6 +67,8 @@ data class MeltQuoteInfo(
 enum class MeltSettlement {
     Settled,
     Pending,
+    /** Async-accepted melt that the mint later reported as unpaid/compensated. */
+    Failed,
 }
 
 @Serializable

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -69,6 +69,7 @@ import com.cashu.me.Core.Wallet.walletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.routeForCashuPaymentRequest
 import com.cashu.me.Models.MeltPaymentResult
+import com.cashu.me.Models.MeltSettlement
 import com.cashu.me.Models.MeltQuoteInfo
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
@@ -401,9 +402,10 @@ fun UnifiedSendScreen(
                 val sentAmount = current.result?.amount ?: confirmAmount
                 val sentFee = current.result?.feePaid ?: 0L
                 val sentMint = current.result?.mintUrl ?: activeMintUrl
+                val settlementPending = current.result?.settlement == MeltSettlement.Pending
                 PaymentStatusScreen(
                     phase = PaymentStatusPhase.Success,
-                    title = "Payment sent",
+                    title = if (settlementPending) "Payment processing" else "Payment sent",
                     onDone = onClose,
                     rows = {
                         if (sentAmount > 0L) {

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -113,6 +113,7 @@ private fun CashuAppContent(container: AppContainer) {
             if (settings.checkPendingOnStartup && settings.checkSentTokens) {
                 container.walletManager.checkAllPendingTokens()
             }
+            container.walletManager.syncPendingMeltQuotes()
         } else {
             container.cashuRequestListener.stop()
         }
@@ -125,6 +126,11 @@ private fun CashuAppContent(container: AppContainer) {
                 Lifecycle.Event.ON_RESUME -> {
                     container.appLockManager.appBecameActive()
                     container.cashuRequestListener.start()
+                    if (event == Lifecycle.Event.ON_START) {
+                        container.walletManager.launch {
+                            container.walletManager.syncPendingMeltQuotes()
+                        }
+                    }
                 }
                 Lifecycle.Event.ON_PAUSE,
                 Lifecycle.Event.ON_STOP -> {

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Core.CDK
 
 import java.io.File
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -41,6 +42,24 @@ class CdkGatewayThreadingTest {
         assertTrue(source.contains("val subscription = cdkCall"))
         assertTrue(source.contains("subscription.recv()"))
         assertTrue(source.contains("}.flowOn(Dispatchers.IO)"))
+    }
+
+    @Test
+    fun pendingMeltWaitDoesNotHoldGatewayLockOrRetryPayment() {
+        val source = sourceFile(
+            "src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+            "app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+        ).readText()
+
+        assertTrue(source.contains("prepared.confirmPreferAsync()"))
+        val waitStart = source.indexOf("override fun awaitPendingMelt")
+        val waitEnd = source.indexOf("override suspend fun checkMeltQuoteStatus", waitStart)
+        assertTrue("Missing pending melt waiter", waitStart >= 0 && waitEnd > waitStart)
+        val waitBlock = source.substring(waitStart, waitEnd)
+        assertTrue(waitBlock.contains("entry.pending.wait()"))
+        assertFalse(waitBlock.contains("prepareMelt("))
+        assertFalse(waitBlock.contains("= cdkCall"))
+        assertTrue(source.contains(".checkMeltQuoteStatus(quoteId)"))
     }
 
     private fun sourceFile(vararg candidates: String): File {

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
@@ -62,6 +62,17 @@ class CdkGatewayThreadingTest {
         assertTrue(source.contains(".checkMeltQuoteStatus(quoteId)"))
     }
 
+    @Test
+    fun startupMaintenanceUsesCdkSagaRecoveryAndKeysetRefresh() {
+        val source = sourceFile(
+            "src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+            "app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+        ).readText()
+
+        assertTrue(source.contains(".recoverIncompleteSagas()"))
+        assertTrue(source.contains(".refreshKeysets()"))
+    }
+
     private fun sourceFile(vararg candidates: String): File {
         val roots = generateSequence(File("").absoluteFile) { it.parentFile }
         return roots

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
@@ -60,6 +60,10 @@ class CdkGatewayThreadingTest {
         assertFalse(waitBlock.contains("prepareMelt("))
         assertFalse(waitBlock.contains("= cdkCall"))
         assertTrue(source.contains(".checkMeltQuoteStatus(quoteId)"))
+        // wait()/confirm must map FinalizedMelt.state — unpaid is Failed, not Settled.
+        assertTrue(source.contains("when (state)"))
+        assertTrue(source.contains("MeltSettlement.Failed"))
+        assertTrue(source.contains("CdkQuoteState.UNPAID"))
     }
 
     @Test
@@ -71,6 +75,25 @@ class CdkGatewayThreadingTest {
 
         assertTrue(source.contains(".recoverIncompleteSagas()"))
         assertTrue(source.contains(".refreshKeysets()"))
+    }
+
+    @Test
+    fun pendingMeltResyncTreatsUnpaidAsTerminalFailure() {
+        val source = sourceFile(
+            "src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt",
+            "app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt",
+        ).readText()
+
+        val syncStart = source.indexOf("suspend fun syncPendingMeltQuotes")
+        val syncEnd = source.indexOf("private fun watchPendingMelt", syncStart)
+        assertTrue("Missing pending melt resync", syncStart >= 0 && syncEnd > syncStart)
+        val syncBlock = source.substring(syncStart, syncEnd)
+        assertTrue(syncBlock.contains("MeltQuoteState.Failed"))
+        assertTrue(syncBlock.contains("MeltQuoteState.Unpaid"))
+        assertTrue(syncBlock.contains("MeltSettlement.Failed"))
+        // Still in-flight only:
+        assertTrue(syncBlock.contains("MeltQuoteState.Pending"))
+        assertTrue(syncBlock.contains("MeltQuoteState.Unknown"))
     }
 
     private fun sourceFile(vararg candidates: String): File {

--- a/android/app/src/test/java/com/cashu/me/Core/WalletStartupPolicyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletStartupPolicyTest.kt
@@ -1,0 +1,38 @@
+package com.cashu.me.Core
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WalletStartupPolicyTest {
+    @Test
+    fun refreshesKeysetsWhenTimestampIsMissingOrStale() {
+        val now = 10_000_000L
+
+        assertTrue(WalletStartupPolicy.shouldRefreshKeysets(lastRefreshEpochMillis = null, nowEpochMillis = now))
+        assertTrue(
+            WalletStartupPolicy.shouldRefreshKeysets(
+                lastRefreshEpochMillis = now - WalletStartupPolicy.keysetRefreshIntervalMillis,
+                nowEpochMillis = now,
+            ),
+        )
+    }
+
+    @Test
+    fun skipsFreshKeysetRefreshAndRetriesFutureTimestamp() {
+        val now = 10_000_000L
+
+        assertFalse(
+            WalletStartupPolicy.shouldRefreshKeysets(
+                lastRefreshEpochMillis = now - WalletStartupPolicy.keysetRefreshIntervalMillis + 1,
+                nowEpochMillis = now,
+            ),
+        )
+        assertTrue(
+            WalletStartupPolicy.shouldRefreshKeysets(
+                lastRefreshEpochMillis = now + 1,
+                nowEpochMillis = now,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Prefer CDK's asynchronous melt confirmation and represent accepted-but-unsettled melts as pending.
- Persist pending quote IDs and reconcile the same quote on app startup and foreground.
- Wait for CDK settlement without holding the global gateway mutex.
- Show **Payment processing** while settlement is pending.
- Prevent local metadata or refresh failures after CDK acceptance from being reported as payment failures.

## Why

Android used synchronous melt confirmation and had no recovery path for a payment that settled after the client request failed or timed out. A mint could therefore complete the Lightning payment while the wallet displayed a failure. Post-payment bookkeeping errors could produce the same misleading result.

Recovery only checks the original quote status; it never retries the Lightning invoice.

## User impact

Slow or temporarily ambiguous melts, including those observed with `8333.space:3338`, remain pending and reconcile safely instead of being shown as failed after the Lightning payment succeeds.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --stacktrace`
  - 307 tests completed, 6 skipped
- `./gradlew --no-daemon :app:lintDebug --stacktrace`
  - **BUILD SUCCESSFUL**
