### PR TITLE
Disable Send Continue button when amount exceeds mint balance

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -775,6 +775,8 @@ private fun AmountFace(
     onContinue: () -> Unit,
 ) {
     val amountValue = amount.toLongOrNull() ?: 0L
+    val mintBalance = mint?.balance ?: 0L
+    val insufficient = amountValue > 0 && amountValue > mintBalance
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -803,12 +805,19 @@ private fun AmountFace(
             formatter = formatter,
         )
         Spacer(Modifier.weight(1f))
+        if (insufficient) {
+            InlineNotice(
+                text = "Insufficient balance",
+                severity = NoticeSeverity.Warning,
+            )
+            Spacer(Modifier.height(CashuTheme.spacing.default))
+        }
         NumberPadFooter(
             amount = amount,
             onAmountChange = onAmountChange,
             buttonText = "Continue",
             onButtonClick = onContinue,
-            buttonEnabled = amountValue > 0,
+            buttonEnabled = amountValue > 0 && !insufficient,
         )
     }
 }


### PR DESCRIPTION
## Summary
- The unified send `AmountFace` enabled its "Continue" button based only on `amountValue > 0`, ignoring the selected mint's balance. A user with zero or insufficient balance could type any positive amount and proceed to the confirm step.
- **Root cause:** the balance gate was never wired into `UnifiedSendScreen.kt`. The iOS `SendView` (`canSend`) and Android `SendEcashScreen` (`amountValue in 1..mintBalance`) both already validate against balance — `UnifiedSendScreen` was the only send path missing this check.
- The fix gates the Continue button on `amountValue <= mintBalance` and surfaces an "Insufficient balance" `InlineNotice`, matching the existing `SendEcashScreen` UX.

## Test plan
- [ ] CI passes
- [ ] With a mint holding 0 sats, enter any amount in the send amount step — Continue button stays disabled
- [ ] With a mint holding e.g. 100 sats, enter 101 — Continue disabled + "Insufficient balance" notice shown
- [ ] With a mint holding 100 sats, enter 100 — Continue enabled (boundary check)