### PR TITLE
Fix restore flow UI polish on Android, sync copy with iOS

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Cancel
@@ -20,6 +21,7 @@ import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.CellTower
 import androidx.compose.material.icons.outlined.ContentPaste
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -68,6 +70,7 @@ import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.SecondaryButton
 import com.cashu.me.ui.theme.CapsuleShape
 import com.cashu.me.ui.theme.CashuTheme
+import com.cashu.me.ui.theme.withMonoDigits
 import kotlinx.coroutines.launch
 
 // iOS restore twin: OnboardingView seed branch + Settings RestoreWalletView.
@@ -99,6 +102,14 @@ fun restoreOnboardingTitleStyle(): TextStyle =
         letterSpacing = (-0.5).sp,
         lineHeight = 40.sp,
     )
+
+// Single-line onboarding titles render at full display size and step down only
+// when the line would overflow (narrow devices / large font scales).
+private val OnboardingTitleAutoSize = TextAutoSize.StepBased(
+    minFontSize = 26.sp,
+    maxFontSize = 36.sp,
+    stepSize = 1.sp,
+)
 
 @Composable
 private fun restoreInAppTitleStyle(): TextStyle =
@@ -156,7 +167,7 @@ fun RestoreSeedStep(
     val title = if (presentation == RestorePresentation.InApp) {
         "Restore Wallet"
     } else {
-        "Restore\nWallet."
+        "Restore Wallet."
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -179,6 +190,8 @@ fun RestoreSeedStep(
                 style = restoreTitleStyle(presentation),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = titleTextAlign,
+                maxLines = if (presentation == RestorePresentation.Onboarding) 1 else Int.MAX_VALUE,
+                autoSize = if (presentation == RestorePresentation.Onboarding) OnboardingTitleAutoSize else null,
             )
             Text(
                 text = "Enter your 12 words in order.",
@@ -198,20 +211,22 @@ fun RestoreSeedStep(
                 .fillMaxWidth()
                 .padding(horizontal = HeaderPadding)
                 .padding(top = CashuTheme.spacing.section),
-            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
         ) {
-            Box(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            ) {
                 CashuTextField(
                     value = input,
                     onValueChange = {
                         input = it
                         onClearError()
                     },
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxSize(),
                     placeholder = "word1 word2 word3 …",
                     textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
-                    minLines = 5,
-                    maxLines = 8,
                     isError = errorText != null || (wordCount >= 12 && invalidCount > 0),
                     keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
                 )
@@ -240,8 +255,12 @@ fun RestoreSeedStep(
                 }
             }
             Row(
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
+                horizontalArrangement = Arrangement.spacedBy(
+                    CashuTheme.spacing.micro,
+                    Alignment.CenterHorizontally,
+                ),
             ) {
                 Text(
                     text = "$wordCount / 12 words",
@@ -268,6 +287,7 @@ fun RestoreSeedStep(
         Column(
             modifier = Modifier
                 .padding(horizontal = CtaPadding)
+                .padding(top = CashuTheme.spacing.comfortable)
                 .padding(bottom = BottomPadding),
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.tight),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -437,11 +457,11 @@ fun RestoreMintsStep(
     }
     val (title, subtitle) = when (presentation) {
         RestorePresentation.Onboarding ->
-            "Recover\nYour Ecash." to
-                "Add the mints you used before to recover ecash from this seed."
+            "Recover Funds." to
+                "Add the mints you used before to recover funds from this seed."
         RestorePresentation.InApp ->
-            "Restore Ecash" to
-                "Add the mints you used before to recover ecash from this seed."
+            "Restore Funds" to
+                "Add the mints you used before to recover funds from this seed."
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -459,6 +479,8 @@ fun RestoreMintsStep(
                 style = restoreTitleStyle(presentation),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = titleTextAlign,
+                maxLines = if (presentation == RestorePresentation.Onboarding) 1 else Int.MAX_VALUE,
+                autoSize = if (presentation == RestorePresentation.Onboarding) OnboardingTitleAutoSize else null,
             )
             Text(
                 text = subtitle,
@@ -717,9 +739,9 @@ fun RestoreProgressStep(
         (phase as? RestoreMintPhase.Recovered)?.result?.unspent ?: 0L
     }
     val subhead = when {
-        !allSettled -> "Recovering ecash from your mints…"
+        !allSettled -> "Recovering funds from your mints…"
         totalRecovered > 0L -> "Here's what we recovered."
-        else -> "No ecash found on these mints."
+        else -> "No funds found on these mints."
     }
 
     val titleAlign = if (presentation == RestorePresentation.InApp) {
@@ -733,7 +755,7 @@ fun RestoreProgressStep(
         TextAlign.Start
     }
     val title = when (presentation) {
-        RestorePresentation.Onboarding -> "Recover\nYour Ecash."
+        RestorePresentation.Onboarding -> "Recover Funds."
         RestorePresentation.InApp ->
             if (allSettled) "Restore Complete" else "Restoring…"
     }
@@ -753,6 +775,8 @@ fun RestoreProgressStep(
                 style = restoreTitleStyle(presentation),
                 color = MaterialTheme.colorScheme.onSurface,
                 textAlign = titleTextAlign,
+                maxLines = if (presentation == RestorePresentation.Onboarding) 1 else Int.MAX_VALUE,
+                autoSize = if (presentation == RestorePresentation.Onboarding) OnboardingTitleAutoSize else null,
             )
             Text(
                 text = subhead,
@@ -785,10 +809,9 @@ fun RestoreProgressStep(
                     )
                     Text(
                         text = "Recovered: $totalRecovered sats",
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            fontWeight = FontWeight.SemiBold,
-                            fontFamily = FontFamily.Monospace,
-                        ),
+                        style = MaterialTheme.typography.bodyMedium
+                            .copy(fontWeight = FontWeight.SemiBold)
+                            .withMonoDigits(),
                         color = CashuTheme.colors.received,
                     )
                     if (presentation == RestorePresentation.InApp) {
@@ -832,6 +855,7 @@ fun RestoreProgressStep(
                 },
                 enabled = allSettled && !finishing,
                 loading = finishing,
+                colors = ButtonDefaults.filledTonalButtonColors(),
             )
         }
     }
@@ -920,14 +944,15 @@ private fun RestoreProgressRow(
                     )
                     Text(
                         text = "${phase.result.unspent} sats",
-                        style = MaterialTheme.typography.bodyMedium.copy(
-                            fontWeight = if (phase.result.unspent > 0) {
-                                FontWeight.SemiBold
-                            } else {
-                                FontWeight.Normal
-                            },
-                            fontFamily = FontFamily.Monospace,
-                        ),
+                        style = MaterialTheme.typography.bodyMedium
+                            .copy(
+                                fontWeight = if (phase.result.unspent > 0) {
+                                    FontWeight.SemiBold
+                                } else {
+                                    FontWeight.Normal
+                                },
+                            )
+                            .withMonoDigits(),
                         color = if (phase.result.unspent > 0) {
                             MaterialTheme.colorScheme.onSurface
                         } else {

--- a/android/app/src/main/java/com/cashu/me/ui/settings/BackupRestoreScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/BackupRestoreScreen.kt
@@ -90,7 +90,7 @@ fun BackupRestoreScreen(
             )
             NavRow(
                 title = "Restore",
-                subtitle = "Restore a wallet and recover ecash from mints.",
+                subtitle = "Restore a wallet and recover funds from mints.",
                 leadingIcon = Icons.Outlined.Restore,
                 onClick = onOpenRestore,
             )

--- a/android/app/src/main/java/com/cashu/me/ui/theme/Color.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/theme/Color.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.Color
 // Semantic state hues. Received/pending/error communicate payment state and are
 // the only chromatic colors in the app. Everything else is the monochrome
 // "inverted ink" scheme below.
-val ReceivedGreen = Color(0xFF2E7D32)
+val ReceivedGreen = Color(0xFF34C759)
 val PendingOrange = Color(0xFFEF6C00)
 val ErrorRed = Color(0xFFC62828)
 
@@ -123,7 +123,7 @@ internal val LightCashuColors = CashuColors(
 )
 
 internal val DarkCashuColors = CashuColors(
-    received = Color(0xFF81C784),
+    received = Color(0xFF30D158),
     pending = Color(0xFFFFB74D),
     receivedContainer = ReceivedGreen.copy(alpha = 0.20f),
     pendingContainer = PendingOrange.copy(alpha = 0.18f),

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -494,7 +494,7 @@ struct OnboardingView: View {
                 Text("Restoring Wallet")
                     .font(.title2.weight(.semibold))
 
-                Text("Recovering your ecash from \(mintCount) mint\(mintCount == 1 ? "" : "s")…")
+                Text("Recovering your funds from \(mintCount) mint\(mintCount == 1 ? "" : "s")…")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -544,7 +544,7 @@ struct OnboardingView: View {
                     if walletManager.balance > 0 && count > 0 {
                         Text("across \(count) mint\(count == 1 ? "" : "s")")
                     } else {
-                        Text("Your ecash is ready.")
+                        Text("Your funds are ready.")
                     }
                 }
                 .font(.callout)
@@ -1028,10 +1028,11 @@ struct OnboardingView: View {
         return VStack(spacing: 16) {
             stagger(appeared: restoreInputAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Restore\nWallet.")
+                    Text("Restore Wallet.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
 
                     Text("Enter your 12 words in order.")
                         .font(.callout)
@@ -1146,12 +1147,13 @@ struct OnboardingView: View {
             // status bar, no matter how tall the list or whether the keyboard is up.
             stagger(appeared: restoreMintsAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Recover\nYour Ecash.")
+                    Text("Recover Funds.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
 
-                    Text("Add the mints you used before to recover ecash from this seed.")
+                    Text("Add the mints you used before to recover funds from this seed.")
                         .font(.callout)
                         .foregroundStyle(.secondary)
                 }
@@ -1344,20 +1346,21 @@ struct OnboardingView: View {
     }
 
     private var restoreSubhead: String {
-        if !restoreAllSettled { return "Recovering ecash from your mints…" }
+        if !restoreAllSettled { return "Recovering funds from your mints…" }
         return restoreTotalRecovered > 0
             ? "Here's what we recovered."
-            : "No ecash found on these mints."
+            : "No funds found on these mints."
     }
 
     private var restoreProgressView: some View {
         VStack(spacing: 0) {
             stagger(appeared: restoreProgressAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Recover\nYour Ecash.")
+                    Text("Recover Funds.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
-                        .fixedSize(horizontal: false, vertical: true)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
 
                     Text(restoreSubhead)
                         .font(.callout)

--- a/ios/CashuWallet/Views/Settings/BackupSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/BackupSettingsSection.swift
@@ -25,7 +25,7 @@ struct BackupSettingsSection: View {
                 } label: {
                     backupRestoreRow(
                         title: "Restore",
-                        subtitle: "Restore a wallet and recover ecash from mints.",
+                        subtitle: "Restore a wallet and recover funds from mints.",
                         systemImage: "arrow.counterclockwise.circle.fill"
                     )
                 }

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -665,10 +665,10 @@ struct RestoreWalletView: View {
         VStack(spacing: 0) {
             // Fixed header — stays put below the nav bar / top safe area.
             VStack(spacing: 6) {
-                Text("Restore Ecash")
+                Text("Restore Funds")
                     .font(.title2.weight(.semibold))
 
-                Text("Add the mints you used before to recover ecash from this seed.")
+                Text("Add the mints you used before to recover funds from this seed.")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -850,10 +850,10 @@ struct RestoreWalletView: View {
     }
 
     private var restoreSubhead: String {
-        if !restoreAllSettled { return "Recovering ecash from your mints…" }
+        if !restoreAllSettled { return "Recovering funds from your mints…" }
         return restoreTotalRecovered > 0
             ? "Here's what we recovered."
-            : "No ecash found on these mints."
+            : "No funds found on these mints."
     }
 
     private var progressStep: some View {


### PR DESCRIPTION
## Summary
- Android restore flow: single-line onboarding titles (auto-sized instead of hardcoded line breaks), seed input now fills available height with a centered word counter (Material-spaced), gray tonal Continue button to match onboarding, success green updated to match iOS system green, and amount text switched from full monospace to tabular figures (matches iOS `.monospacedDigit()`).
- Both platforms: "Recover Your Ecash." → "Recover Funds." and related ecash→funds copy across the restore flow (mint-entry screen, results screen, Settings restore, iCloud restore on iOS).

## Test plan
- [x] Android: `./gradlew :app:compileDebugKotlin` / `:app:assembleDebug` pass
- [x] iOS: `xcodebuild -project CashuWallet.xcodeproj -scheme CashuWallet -destination 'generic/platform=iOS Simulator' build` passes
- [x] Walked the full Android onboarding restore flow on an emulator (seed entry, keyboard-open state, mints, results) in both light and dark mode, confirmed the new spacing, green, font, and copy
- [ ] Manual pass on iOS simulator/device for the copy + title changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)