### PR TITLE
Send Max: send the full balance; receiver pays fees

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -381,16 +381,20 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         val cdkUnit = cdkUnit(unit)
         if (!unit.equals("sat", ignoreCase = true)) ensureWalletUnlocked(mintUrl, cdkUnit)
         val conditions = p2pkPubkey?.let { CdkSpendingConditions.P2pk(it, null) }
-        // includeFee = true — the token carries the recipient's redeem fee on top
-        // of the requested amount, so receiving it credits the full amount and
-        // the fee returned below is the sender's real cost. Mirrors the iOS
-        // TokenService.sendTokens and CDK's pay_request.
+        // includeFee = false — the token carries exactly the requested amount;
+        // the redeem fee is the recipient's cost and their wallet shows it
+        // (see ReceiveFeeEstimator). Crucially this lets Send Max move the
+        // whole balance: all proofs go out as-is, no swap, no fee — also on
+        // fee-charging mints. The fee returned below is only the sender-side
+        // change-swap fee (zero for a max send). Payment requests stay
+        // includeFee = true — there the requester must net the asked amount.
+        // Mirrors iOS TokenService.sendTokens.
         val sendOptions = CdkSendOptions(
             memo = memo?.let { CdkSendMemo(it, true) },
             conditions = conditions,
             amountSplitTarget = CdkSplitTarget.None,
             sendKind = CdkSendKind.OnlineExact,
-            includeFee = true,
+            includeFee = false,
             useP2bk = false,
             maxProofs = null,
             metadata = emptyMap(),

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
@@ -27,6 +27,15 @@ val Throwable.walletMessage: WalletMessage
 val Throwable.userFacingWalletMessage: String
     get() = walletMessage.text
 
+/**
+ * Whether the error classifies as insufficient balance (iOS
+ * `isInsufficientBalanceError`). Call sites holding balance context use it to
+ * upgrade the copy — e.g. the amount fits the balance but the change-swap fee
+ * doesn't.
+ */
+val Throwable.isInsufficientBalance: Boolean
+    get() = walletMessage.text == "Not enough balance."
+
 object WalletErrorMessages {
 
     private const val GENERIC_FALLBACK =

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -73,6 +73,7 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
+import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Models.SendTokenResult
@@ -337,7 +338,17 @@ fun SendEcashScreen(
                                 face = SendFace.Generated(result, mintUrl, effectiveUnit, amountValue)
                                 amount = ""
                             } catch (t: Throwable) {
-                                errorText = t.userFacingWalletMessage
+                                errorText = if (t.isInsufficientBalance && amountValue <= mintBalance) {
+                                    // The balance covers the amount, but the
+                                    // swap that makes change for it carries a
+                                    // fee the remainder can't absorb — the
+                                    // plain "Not enough balance." reads as a
+                                    // wallet bug when the user typed exactly
+                                    // what the screen says they hold.
+                                    "Not enough balance to cover the mint fee. Try Send Max."
+                                } else {
+                                    t.userFacingWalletMessage
+                                }
                             } finally {
                                 sending = false
                             }

--- a/ios/CashuWallet/Core/Services/TokenService.swift
+++ b/ios/CashuWallet/Core/Services/TokenService.swift
@@ -79,17 +79,20 @@ class TokenService: ObservableObject {
         let localP2PKSigningKeys = SettingsManager.shared.allP2PKSigningKeyHexes().map { SecretKey(hex: $0) }
 
         // Create SendOptions
-        // includeFee: true — the token carries the recipient's redeem fee on top
-        // of `amount`, so receiving it credits the full amount and the fee we
-        // return below is the sender's real cost. Matches CDK's pay_request
-        // (see estimateCashuPaymentFee). With false, sending 755 produced a
-        // 755 token that redeemed to 754 while the send screen showed "no fee".
+        // includeFee: false — the token carries exactly `amount`; the redeem
+        // fee is the recipient's cost and their wallet shows it (see
+        // ReceiveTokenDetailView's fee preview). Crucially this lets Send Max
+        // move the whole balance: all proofs go out as-is, no swap, no fee —
+        // also on fee-charging mints. The fee we return below is only the
+        // sender-side change-swap fee (zero for a max send). Payment requests
+        // stay includeFee: true — there the requester must net the asked
+        // amount (see estimateCashuPaymentFee).
         let sendOptions = SendOptions(
             memo: sendMemo,
             conditions: spendingConditions,
             amountSplitTarget: SplitTarget.none,
             sendKind: SendKind.onlineExact,
-            includeFee: true,
+            includeFee: false,
             useP2bk: false,
             maxProofs: nil,
             metadata: [:],

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -686,8 +686,13 @@ struct SendView: View {
                     // Detail rows on canvas with hairline dividers — same
                     // pattern as the Lightning Invoice screen.
                     VStack(spacing: 0) {
-                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText)
-                        canvasDivider
+                        // Sender's send fee — zero unless the send needed a
+                        // change swap. The receiver's redeem fee is shown on
+                        // their side, so a "0 sat" row here only misleads.
+                        if tokenFee > 0 {
+                            detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText)
+                            canvasDivider
+                        }
                         detailRow(icon: "banknote", label: "Unit", value: generatedTokenUnit.uppercased())
                         // Fiat conversion is only meaningful for sats; a non-sat
                         // account unit has no BTC-price equivalent.
@@ -742,8 +747,10 @@ struct SendView: View {
             : CurrencyAmount(value: generatedAmount, currency: generatedUnitCurrency).formatted()
         var rows: [PaymentStatusView.DetailRow] = [
             .init(icon: "bitcoinsign", label: "Amount", value: amountText),
-            .init(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText),
         ]
+        if tokenFee > 0 {
+            rows.append(.init(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText))
+        }
         if let mintURL = generatedTokenMintURL {
             rows.append(.init(
                 icon: "bitcoinsign.bank.building",

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -15,6 +15,9 @@ struct SendView: View {
     @State private var errorMessage: String?
     @State private var errorSeverity: ErrorSeverity = .error
     @State private var errorShowsMintAction = false
+    // Optional second line under the error notice (e.g. the change-fee hint);
+    // overrides the generic insufficient-balance detail when set.
+    @State private var errorDetail: String?
     @State private var showMintPicker = false
     @State private var selectedSendMint: MintInfo?
 
@@ -225,7 +228,7 @@ struct SendView: View {
                     } else if let error = errorMessage {
                         sendInputNotice(
                             message: error,
-                            detail: errorShowsMintAction ? insufficientBalanceDetail : nil,
+                            detail: errorDetail ?? (errorShowsMintAction ? insufficientBalanceDetail : nil),
                             severity: errorSeverity
                         )
                     }
@@ -420,12 +423,29 @@ struct SendView: View {
 
     private func useMax(mint: MintInfo) {
         HapticFeedback.impact(.light)
+        // The gross balance is always sendable: sends don't include fees
+        // (TokenService includeFee: false), and a full-balance send matches
+        // the proof set exactly — no swap, no fee, also on fee-charging mints.
+        fillAmount(baseUnits: effectiveSendBalance)
+    }
+
+    /// Writes a base-unit amount into the keypad string in the current entry
+    /// mode. Fiat entry is coarser than sats, so the cents round-trip can land
+    /// above the target — which would leave a Send Max fill unsendable — and
+    /// gets trimmed a cent at a time until it fits.
+    private func fillAmount(baseUnits: UInt64) {
         if isSatSend {
             // Balance is sats; express it in the current entry unit so the keypad
             // string keeps its meaning.
-            amountString = AmountFormatter.entryConverted(raw: String(mint.balance), from: .sats, to: entryUnit)
+            amountString = AmountFormatter.entryConverted(raw: String(baseUnits), from: .sats, to: entryUnit)
+            guard entryUnit == .fiat else { return }
+            var cents = AmountFormatter.entryBaseUnits(raw: amountString, decimals: 2)
+            while cents > 0, AmountFormatter.entrySats(raw: amountString, unit: .fiat) > baseUnits {
+                cents -= 1
+                amountString = AmountFormatter.entryString(baseUnits: cents, decimals: 2)
+            }
         } else {
-            amountString = AmountFormatter.entryString(baseUnits: effectiveSendBalance, decimals: sendUnitDecimals)
+            amountString = AmountFormatter.entryString(baseUnits: baseUnits, decimals: sendUnitDecimals)
         }
     }
 
@@ -774,10 +794,11 @@ struct SendView: View {
         return "You have \(sendBalanceText) in \(mint.name)."
     }
 
-    private func presentError(_ message: String, severity: ErrorSeverity = .error, showsMintAction: Bool = false) {
+    private func presentError(_ message: String, severity: ErrorSeverity = .error, showsMintAction: Bool = false, detail: String? = nil) {
         errorMessage = message
         errorSeverity = severity
         errorShowsMintAction = showsMintAction
+        errorDetail = detail
     }
 
     private func extractMintHost(_ url: String) -> String {
@@ -820,11 +841,23 @@ struct SendView: View {
                 HapticFeedback.notification(.success)
             } catch {
                 let walletMessage = error.walletMessage
-                presentError(
-                    walletMessage.text,
-                    severity: walletMessage.severity,
-                    showsMintAction: error.isInsufficientBalanceError
-                )
+                if error.isInsufficientBalanceError, amount <= effectiveSendBalance {
+                    // The balance covers the amount, but the swap that makes
+                    // change for it carries a fee the remainder can't absorb —
+                    // the plain "Not enough balance." reads as a wallet bug when
+                    // the user typed exactly what the screen says they hold.
+                    presentError(
+                        "Not enough balance to cover the mint fee.",
+                        severity: .caution,
+                        detail: "The mint charges a fee to make change for this amount. Try Send Max."
+                    )
+                } else {
+                    presentError(
+                        walletMessage.text,
+                        severity: walletMessage.severity,
+                        showsMintAction: error.isInsufficientBalanceError
+                    )
+                }
                 HapticFeedback.notification(.error)
             }
             isGenerating = false


### PR DESCRIPTION
Fixes #144.

Reworked per maintainer feedback — the first version of this PR treated a symptom of the wrong send semantics.

## What changed

Sends no longer include fees: `prepareSend` now runs `includeFee: false` on both platforms. The token carries exactly the shown amount; the redeem fee is the receiver's cost, and both receive screens already preview and deduct it (`ReceiveTokenDetailView` on iOS, `ReceiveFeeEstimator` on Android).

This makes Send Max just work: filling the gross balance selects every proof as an exact match — no swap, no fee — also on fee-charging mints. The fee-probe machinery from the first version (`prepareSend → fee() → cancel`, `SendMaxCalculator` / `SendMaxEstimator`) is gone; the max button is back to an instant fill.

Payment requests are unchanged (`includeFee: true`) — there the requester must net the asked amount.

## Kept from the first version

- iOS fiat-entry cent trim: fiat rounding could push a max fill a cent past the balance and fail the send on any mint.
- Clearer error copy for the rare case where the typed amount fits the balance but the change-swap fee doesn't ("Not enough balance to cover the mint fee. Try Send Max." — and Send Max now always works).

## Why the first version was wrong

Sends ran `prepareSend(includeFee: true)`, so the wallet needed proofs worth amount + fee and a gross-balance fill failed on fee-charging mints. The first version kept that semantics and probed the mint for the exact fee-adjusted max. But the sender shouldn't be paying the receiver's redeem fee at all — with `includeFee: false` the whole problem disappears, along with the probe latency this PR was called out for.

## Verification

- Android compile + unit tests, full iOS simulator suite (unit + Nutshell/CDK integration tests against live local mints) — all green.
- Live check against a local cdk-mintd with `input_fee_ppk = 100`: minted 89 sats, `prepareSend(89, includeFee: false)` confirms with **fee 0** (no swap), sender balance goes to 0, receiver nets **87** with the redeem fee shown on their side. The old `includeFee: true` on the same fill fails with `Insufficient funds` — the original #144 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
