### PR TITLE
Hide sub-cent fiat amounts; align the Pending Ecash fiat row

### DIFF
--- a/CI/IntegrationTests/Tests/AmountFormatterTests.swift
+++ b/CI/IntegrationTests/Tests/AmountFormatterTests.swift
@@ -25,6 +25,27 @@ final class AmountFormatterTests: XCTestCase {
         XCTAssertEqual(AmountFormatter.sats(0, useBitcoinSymbol: false), "0 sat")
     }
 
+    // MARK: - Fiat conversion
+
+    func testFiatConversionFormats() {
+        XCTAssertEqual(AmountFormatter.fiat(sats: 300_000, btcPrice: 20_000, currencyCode: "USD"), "$60.00")
+    }
+
+    func testFiatConversionExactlyOneCent() {
+        // 50 sats at $20k/BTC = $0.01 — the smallest displayable amount.
+        XCTAssertEqual(AmountFormatter.fiat(sats: 50, btcPrice: 20_000, currencyCode: "USD"), "$0.01")
+    }
+
+    func testFiatConversionUnderOneCentHidden() {
+        // 49 sats at $20k/BTC = $0.0098 — sub-cent conversions are never shown.
+        XCTAssertNil(AmountFormatter.fiat(sats: 49, btcPrice: 20_000, currencyCode: "USD"))
+    }
+
+    func testFiatConversionMissingPriceHidden() {
+        XCTAssertNil(AmountFormatter.fiat(sats: 1_000, btcPrice: nil, currencyCode: "USD"))
+        XCTAssertNil(AmountFormatter.fiat(sats: 1_000, btcPrice: 0, currencyCode: "USD"))
+    }
+
     // MARK: - Bitcoin symbol
 
     func testSmallAmountBitcoinSymbol() {

--- a/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
@@ -65,6 +65,9 @@ class AmountFormatter(
     override fun formatFiat(amountSats: Long, btcPrice: Double?, currencyCode: String): String? {
         val price = btcPrice ?: return null
         val fiat = amountSats.toDouble() / 100_000_000.0 * price
+        // Sub-cent conversions are never displayed — dust would render as a
+        // misleading "$0.00". Mirrors iOS AmountFormatter.fiat(sats:btcPrice:).
+        if (fiat < 0.01) return null
         // Wallet amounts use one stable currency presentation regardless of the
         // device locale. In particular, USD must be "$60.00", not "US$60.00"
         // or "60.00 $" on devices whose locale is outside the US.

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -381,16 +381,20 @@ class CdkWalletGatewayImpl : CdkWalletGateway, NwcServiceGateway {
         val cdkUnit = cdkUnit(unit)
         if (!unit.equals("sat", ignoreCase = true)) ensureWalletUnlocked(mintUrl, cdkUnit)
         val conditions = p2pkPubkey?.let { CdkSpendingConditions.P2pk(it, null) }
-        // includeFee = true — the token carries the recipient's redeem fee on top
-        // of the requested amount, so receiving it credits the full amount and
-        // the fee returned below is the sender's real cost. Mirrors the iOS
-        // TokenService.sendTokens and CDK's pay_request.
+        // includeFee = false — the token carries exactly the requested amount;
+        // the redeem fee is the recipient's cost and their wallet shows it
+        // (see ReceiveFeeEstimator). Crucially this lets Send Max move the
+        // whole balance: all proofs go out as-is, no swap, no fee — also on
+        // fee-charging mints. The fee returned below is only the sender-side
+        // change-swap fee (zero for a max send). Payment requests stay
+        // includeFee = true — there the requester must net the asked amount.
+        // Mirrors iOS TokenService.sendTokens.
         val sendOptions = CdkSendOptions(
             memo = memo?.let { CdkSendMemo(it, true) },
             conditions = conditions,
             amountSplitTarget = CdkSplitTarget.None,
             sendKind = CdkSendKind.OnlineExact,
-            includeFee = true,
+            includeFee = false,
             useP2bk = false,
             maxProofs = null,
             metadata = emptyMap(),

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
@@ -27,6 +27,15 @@ val Throwable.walletMessage: WalletMessage
 val Throwable.userFacingWalletMessage: String
     get() = walletMessage.text
 
+/**
+ * Whether the error classifies as insufficient balance (iOS
+ * `isInsufficientBalanceError`). Call sites holding balance context use it to
+ * upgrade the copy — e.g. the amount fits the balance but the change-swap fee
+ * doesn't.
+ */
+val Throwable.isInsufficientBalance: Boolean
+    get() = walletMessage.text == "Not enough balance."
+
 object WalletErrorMessages {
 
     private const val GENERIC_FALLBACK =

--- a/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
@@ -92,11 +92,9 @@ private fun rememberPressAlpha(interactionSource: MutableInteractionSource): Flo
 }
 
 /**
- * Quiet neutral tonal fill for equally-weighted or secondary CTAs — the home
- * screen's Receive/Send pair and the transaction detail's Copy action. Matches
- * the history row's arrow chips instead of the loud inverted-ink primary, and
- * adapts to light/dark via the theme's surface roles. Pass to [PrimaryButton]'s
- * `colors`.
+ * Quiet neutral tonal fill — [PrimaryButton]'s default treatment, the analog
+ * of iOS's non-prominent glass capsule (`.glassButton()`). Matches the history
+ * row's arrow chips and adapts to light/dark via the theme's surface roles.
  */
 @Composable
 fun neutralActionButtonColors(): ButtonColors = ButtonDefaults.buttonColors(
@@ -107,14 +105,12 @@ fun neutralActionButtonColors(): ButtonColors = ButtonDefaults.buttonColors(
 )
 
 /**
- * The primary full-width CTA: filled M3 button on the theme's primary color
- * (inverted ink: black in light mode, white in dark), spring press-scale,
+ * The primary full-width CTA: gray tonal fill by default (iOS parity — every
+ * iOS bottom CTA is the non-prominent gray glass capsule), spring press-scale,
  * expressive loading indicator.
  *
- * Pass [colors] to override the default filled treatment (e.g. the home
- * screen's tonal Receive/Send pair via [neutralActionButtonColors], which
- * matches the history row's arrow chips instead of using the inverted-ink
- * primary color).
+ * Pass [colors] to override — the sole inverted-ink case is the Receive Ecash
+ * commit button, mirroring iOS's single `.glassButton(prominent: true)`.
  */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -139,7 +135,7 @@ fun PrimaryButton(
             },
         enabled = enabled && !loading,
         interactionSource = interactionSource,
-        colors = colors ?: ButtonDefaults.buttonColors(),
+        colors = colors ?: neutralActionButtonColors(),
         contentPadding = PaddingValues(horizontal = CashuTheme.spacing.section, vertical = ButtonContentVertical),
     ) {
         Box(contentAlignment = Alignment.Center) {

--- a/android/app/src/main/java/com/cashu/me/ui/components/NumberPad.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/NumberPad.kt
@@ -134,6 +134,11 @@ fun NumberPadFooter(
             enabled = buttonEnabled,
             loading = buttonLoading,
         )
+        // Breathing room above the gesture area — the app-wide bottom-CTA
+        // margin (see AddMintSheet/PaymentStatusScreen), matching iOS's
+        // .padding(.bottom, 16). The raw inset alone left the button flush
+        // against the screen edge.
+        Spacer(Modifier.height(CashuTheme.spacing.comfortable))
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -236,6 +237,10 @@ private fun ConfirmContent(
                 // Disabled until the fee/lock preview lands (net amount must be
                 // known before committing) and while P2PK-locked to foreign keys.
                 enabled = review != null && !review.locked,
+                // The app's one inverted-ink CTA — mirrors iOS's sole
+                // .glassButton(prominent: true) on the receive commit
+                // (ReceiveView.swift); every other bottom CTA is neutral gray.
+                colors = ButtonDefaults.buttonColors(),
             )
             Spacer(Modifier.height(CashuTheme.spacing.snug))
             GhostButton(

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -73,6 +73,7 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
+import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Models.SendTokenResult
@@ -337,7 +338,17 @@ fun SendEcashScreen(
                                 face = SendFace.Generated(result, mintUrl, effectiveUnit, amountValue)
                                 amount = ""
                             } catch (t: Throwable) {
-                                errorText = t.userFacingWalletMessage
+                                errorText = if (t.isInsufficientBalance && amountValue <= mintBalance) {
+                                    // The balance covers the amount, but the
+                                    // swap that makes change for it carries a
+                                    // fee the remainder can't absorb — the
+                                    // plain "Not enough balance." reads as a
+                                    // wallet bug when the user typed exactly
+                                    // what the screen says they hold.
+                                    "Not enough balance to cover the mint fee. Try Send Max."
+                                } else {
+                                    t.userFacingWalletMessage
+                                }
                             } finally {
                                 sending = false
                             }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -745,6 +745,7 @@ private fun GeneratedFace(
                 start = CashuTheme.spacing.comfortable,
                 end = CashuTheme.spacing.comfortable,
                 top = CashuTheme.spacing.micro,
+                bottom = CashuTheme.spacing.comfortable,
             ),
         )
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -85,6 +85,7 @@ import com.cashu.me.ui.components.MintPickerSheet
 import com.cashu.me.ui.components.MintSelectorRow
 import com.cashu.me.ui.components.NumberPadFooter
 import com.cashu.me.ui.components.PrimaryButton
+import com.cashu.me.ui.components.neutralActionButtonColors
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SheetHeader
 import com.cashu.me.ui.components.TwoFaceScreen
@@ -673,66 +674,78 @@ private fun GeneratedFace(
         return
     }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(rememberScrollState())
-            .padding(
-                horizontal = CashuTheme.spacing.comfortable,
-                vertical = CashuTheme.spacing.comfortable,
-            ),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.loose),
-    ) {
-        QrCard(
-            content = result.token,
-            shareSubject = "Cashu token",
-        )
-        Text(
-            text = amountLabel,
-            style = MaterialTheme.typography.headlineMedium.withMonoDigits(),
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        ClaimStatusRow(claimState = claimState)
-        // Detail rows: Fee -> Unit -> Fiat (sat-only) -> Mint (iOS order).
-        Column(modifier = Modifier.fillMaxWidth()) {
-            if (result.fee > 0L) {
-                com.cashu.me.ui.components.InspectorRow(
-                    label = "Fee",
-                    value = if (unit.equals("sat", ignoreCase = true)) {
-                        "${result.fee} sat"
-                    } else {
-                        CurrencyAmount(result.fee, CurrencyRegistry.currencyForMintUnit(unit)).formatted()
-                    },
-                    valueMonospaced = true,
-                )
-                com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
-            }
-            com.cashu.me.ui.components.InspectorRow(
-                label = "Unit",
-                value = unit.uppercase(),
+    // Scroll region + pinned footer, mirroring iOS (ScrollView with the Copy
+    // button outside it) and TransactionDetailScreen's Copy action.
+    Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(
+                    horizontal = CashuTheme.spacing.comfortable,
+                    vertical = CashuTheme.spacing.comfortable,
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.loose),
+        ) {
+            QrCard(
+                content = result.token,
+                shareSubject = "Cashu token",
             )
-            if (fiatLabel != null) {
+            Text(
+                text = amountLabel,
+                style = MaterialTheme.typography.headlineMedium.withMonoDigits(),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            ClaimStatusRow(claimState = claimState)
+            // Detail rows: Fee -> Unit -> Fiat (sat-only) -> Mint (iOS order).
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (result.fee > 0L) {
+                    com.cashu.me.ui.components.InspectorRow(
+                        label = "Fee",
+                        value = if (unit.equals("sat", ignoreCase = true)) {
+                            "${result.fee} sat"
+                        } else {
+                            CurrencyAmount(result.fee, CurrencyRegistry.currencyForMintUnit(unit)).formatted()
+                        },
+                        valueMonospaced = true,
+                    )
+                    com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
+                }
+                com.cashu.me.ui.components.InspectorRow(
+                    label = "Unit",
+                    value = unit.uppercase(),
+                )
+                if (fiatLabel != null) {
+                    com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
+                    com.cashu.me.ui.components.InspectorRow(
+                        label = "Fiat",
+                        value = fiatLabel,
+                        valueMonospaced = true,
+                    )
+                }
                 com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
                 com.cashu.me.ui.components.InspectorRow(
-                    label = "Fiat",
-                    value = fiatLabel,
-                    valueMonospaced = true,
+                    label = "Mint",
+                    value = com.cashu.me.Core.shortenMintUrl(mintUrl),
                 )
             }
-            com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
-            com.cashu.me.ui.components.InspectorRow(
-                label = "Mint",
-                value = com.cashu.me.Core.shortenMintUrl(mintUrl),
-            )
         }
-        Spacer(modifier = Modifier.height(CashuTheme.spacing.micro))
+        // Gray tonal fill instead of the inverted-ink primary — the analog of
+        // iOS's non-prominent glass capsule; adapts to light/dark.
         PrimaryButton(
             text = if (copied) "Copied" else "Copy",
             onClick = {
                 clipboard.setText(AnnotatedString(result.token))
                 copied = true
             },
+            colors = neutralActionButtonColors(),
+            modifier = Modifier.padding(
+                start = CashuTheme.spacing.comfortable,
+                end = CashuTheme.spacing.comfortable,
+                top = CashuTheme.spacing.micro,
+            ),
         )
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -625,22 +625,28 @@ private fun GeneratedFace(
             copied = false
         }
     }
-    // Poll the mint every 4s to detect when the recipient redeems the token.
+    // Poll the mint to detect when the recipient redeems the token. Mirrors
+    // iOS startClaimPolling: the spinner shows for the whole watch session
+    // (flipping Pending↔Checking per probe made the row flicker), intervals
+    // back off 5s → 15s, and after 10 checks the row rests at Pending.
     LaunchedEffect(result.token, mintUrl, pollingEnabled) {
         if (!pollingEnabled) return@LaunchedEffect
-        while (claimState != ClaimState.Claimed) {
-            delay(4_000)
-            claimState = ClaimState.Checking
+        claimState = ClaimState.Checking
+        var interval = 5_000L
+        repeat(10) {
+            delay(interval)
             // checkTokenSpent returns true once any proof is spent (redeemed);
-            // null means the check failed — stay Pending, never fake a claim.
+            // null means the check failed — keep watching, never fake a claim.
             val spent = runCatching {
                 walletManager.checkTokenSpent(result.token, mintUrl)
             }.getOrNull()
-            claimState = when {
-                spent == true -> ClaimState.Claimed
-                else -> ClaimState.Pending
+            if (spent == true) {
+                claimState = ClaimState.Claimed
+                return@LaunchedEffect
             }
+            interval = (interval + 1_000L).coerceAtMost(15_000L)
         }
+        claimState = ClaimState.Pending
     }
 
     // Claimed resolves to the shared full-screen terminal (iOS parity), with

--- a/android/app/src/test/java/com/cashu/me/Core/AmountFormatterTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/AmountFormatterTest.kt
@@ -79,6 +79,18 @@ class AmountFormatterTest {
     }
 
     @Test
+    fun formatFiatShowsExactlyOneCent() {
+        // 50 sats at $20k/BTC = $0.01 — the smallest displayable amount.
+        assertEquals("$0.01", formatter.formatFiat(amountSats = 50, btcPrice = 20_000.0, currencyCode = "USD"))
+    }
+
+    @Test
+    fun formatFiatHidesSubCentAmounts() {
+        // 49 sats at $20k/BTC = $0.0098 — sub-cent conversions are never shown.
+        assertNull(formatter.formatFiat(amountSats = 49, btcPrice = 20_000.0, currencyCode = "USD"))
+    }
+
+    @Test
     fun usdUsesBareLeadingDollarSymbolRegardlessOfDeviceLocale() {
         val germanFormatter = AmountFormatter(Locale.GERMANY)
 

--- a/ios/CashuWallet/Core/AmountFormatter.swift
+++ b/ios/CashuWallet/Core/AmountFormatter.swift
@@ -31,10 +31,13 @@ enum AmountFormatter {
     }
 
     /// Converts sats at the supplied BTC price and formats the selected fiat
-    /// currency. A missing/non-positive price produces no conversion.
+    /// currency. A missing/non-positive price produces no conversion, and
+    /// neither does a sub-cent result — dust would render as a misleading
+    /// "$0.00", so anything under one cent is hidden instead.
     static func fiat(sats: UInt64, btcPrice: Double?, currencyCode: String) -> String? {
         guard let btcPrice, btcPrice > 0 else { return nil }
         let value = Double(sats) / 100_000_000.0 * btcPrice
+        guard value >= 0.01 else { return nil }
         return fiat(value, currencyCode: currencyCode)
     }
 

--- a/ios/CashuWallet/Core/PriceService.swift
+++ b/ios/CashuWallet/Core/PriceService.swift
@@ -132,19 +132,11 @@ class PriceService: ObservableObject {
         return UInt64(sats)
     }
     
-    /// Format satoshis as selected fiat currency string.
-    func formatSatsAsFiat(_ sats: UInt64) -> String {
-        AmountFormatter.fiat(satsToFiat(sats), currencyCode: currencyCode)
-    }
-
-    /// Backward-compatible wrapper used by existing views
-    func satsToUSD(_ sats: UInt64) -> Double {
-        satsToFiat(sats)
-    }
-
-    /// Backward-compatible wrapper used by existing views
-    func formatSatsAsUSD(_ sats: UInt64) -> String {
-        formatSatsAsFiat(sats)
+    /// Format satoshis as selected fiat currency string. Nil when no price is
+    /// loaded or the amount converts to under one cent (sub-cent fiat is never
+    /// displayed).
+    func formatSatsAsFiat(_ sats: UInt64) -> String? {
+        AmountFormatter.fiat(sats: sats, btcPrice: btcPriceUSD, currencyCode: currencyCode)
     }
     
     /// Start auto-refresh timer

--- a/ios/CashuWallet/Core/Services/TokenService.swift
+++ b/ios/CashuWallet/Core/Services/TokenService.swift
@@ -79,17 +79,20 @@ class TokenService: ObservableObject {
         let localP2PKSigningKeys = SettingsManager.shared.allP2PKSigningKeyHexes().map { SecretKey(hex: $0) }
 
         // Create SendOptions
-        // includeFee: true — the token carries the recipient's redeem fee on top
-        // of `amount`, so receiving it credits the full amount and the fee we
-        // return below is the sender's real cost. Matches CDK's pay_request
-        // (see estimateCashuPaymentFee). With false, sending 755 produced a
-        // 755 token that redeemed to 754 while the send screen showed "no fee".
+        // includeFee: false — the token carries exactly `amount`; the redeem
+        // fee is the recipient's cost and their wallet shows it (see
+        // ReceiveTokenDetailView's fee preview). Crucially this lets Send Max
+        // move the whole balance: all proofs go out as-is, no swap, no fee —
+        // also on fee-charging mints. The fee we return below is only the
+        // sender-side change-swap fee (zero for a max send). Payment requests
+        // stay includeFee: true — there the requester must net the asked
+        // amount (see estimateCashuPaymentFee).
         let sendOptions = SendOptions(
             memo: sendMemo,
             conditions: spendingConditions,
             amountSplitTarget: SplitTarget.none,
             sendKind: SendKind.onlineExact,
-            includeFee: true,
+            includeFee: false,
             useP2bk: false,
             maxProofs: nil,
             metadata: [:],

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -329,8 +329,9 @@ struct MainWalletView: View {
                     .font(.body)
                     .foregroundStyle(.secondary)
                     .transition(.opacity)
-            } else if settings.showFiatBalance && priceService.btcPriceUSD > 0 {
-                Text(priceService.formatSatsAsFiat(walletManager.balance))
+            } else if settings.showFiatBalance,
+                      let fiatBalance = priceService.formatSatsAsFiat(walletManager.balance) {
+                Text(fiatBalance)
             } else if let secondary = display.secondary {
                 Text(secondary)
                     .font(.body)

--- a/ios/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/ios/CashuWallet/Views/Mints/MintDetailView.swift
@@ -205,8 +205,8 @@ struct MintDetailView: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(AmountFormatter.sats(mint.balance, useBitcoinSymbol: settings.useBitcoinSymbol))
                     .monospacedDigit()
-                if showFiat {
-                    Text(priceService.formatSatsAsFiat(mint.balance))
+                if showFiat, let fiatBalance = priceService.formatSatsAsFiat(mint.balance) {
+                    Text(fiatBalance)
                         .font(.caption)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)

--- a/ios/CashuWallet/Views/Send/Components/CurrencyAmountDisplay.swift
+++ b/ios/CashuWallet/Views/Send/Components/CurrencyAmountDisplay.swift
@@ -20,8 +20,18 @@ struct CurrencyAmountDisplay: View {
     @ObservedObject private var priceService = PriceService.shared
     @ObservedObject private var settings = SettingsManager.shared
 
+    /// Display-mode fiat string; nil when no price is loaded or the amount
+    /// converts to under one cent (sub-cent fiat is never displayed).
+    private var displayFiat: String? {
+        priceService.formatSatsAsFiat(sats)
+    }
+
     private var fiatAvailable: Bool {
-        priceService.btcPriceUSD > 0
+        // Entry mode only needs a live price — the primary unit and flip pill
+        // must stay put while the user types through small values. Display
+        // mode also drops fiat for sub-cent amounts.
+        if entryRaw != nil { return priceService.btcPriceUSD > 0 }
+        return displayFiat != nil
     }
 
     private var effectivePrimary: AmountDisplayPrimary {
@@ -40,7 +50,7 @@ struct CurrencyAmountDisplay: View {
             )
         }
         switch effectivePrimary {
-        case .fiat: return priceService.formatSatsAsFiat(sats)
+        case .fiat: return displayFiat ?? AmountFormatter.sats(sats, useBitcoinSymbol: settings.useBitcoinSymbol)
         case .sats: return AmountFormatter.sats(sats, useBitcoinSymbol: settings.useBitcoinSymbol)
         }
     }
@@ -48,7 +58,10 @@ struct CurrencyAmountDisplay: View {
     private var secondaryText: String {
         switch effectivePrimary {
         case .fiat: return AmountFormatter.sats(sats, useBitcoinSymbol: settings.useBitcoinSymbol)
-        case .sats: return priceService.formatSatsAsFiat(sats)
+        case .sats:
+            // Entry mode keeps the raw conversion (even "$0.00") so the pill
+            // doesn't blink in and out while typing through small values.
+            return displayFiat ?? AmountFormatter.fiat(priceService.satsToFiat(sats), currencyCode: priceService.currencyCode)
         }
     }
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -686,8 +686,13 @@ struct SendView: View {
                     // Detail rows on canvas with hairline dividers — same
                     // pattern as the Lightning Invoice screen.
                     VStack(spacing: 0) {
-                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText)
-                        canvasDivider
+                        // Sender's send fee — zero unless the send needed a
+                        // change swap. The receiver's redeem fee is shown on
+                        // their side, so a "0 sat" row here only misleads.
+                        if tokenFee > 0 {
+                            detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText)
+                            canvasDivider
+                        }
                         detailRow(icon: "banknote", label: "Unit", value: generatedTokenUnit.uppercased())
                         // Fiat conversion is only meaningful for sats; a non-sat
                         // account unit has no BTC-price equivalent.
@@ -742,8 +747,10 @@ struct SendView: View {
             : CurrencyAmount(value: generatedAmount, currency: generatedUnitCurrency).formatted()
         var rows: [PaymentStatusView.DetailRow] = [
             .init(icon: "bitcoinsign", label: "Amount", value: amountText),
-            .init(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText),
         ]
+        if tokenFee > 0 {
+            rows.append(.init(icon: "arrow.up.arrow.down", label: "Fee", value: generatedFeeText))
+        }
         if let mintURL = generatedTokenMintURL {
             rows.append(.init(
                 icon: "bitcoinsign.bank.building",

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -15,6 +15,9 @@ struct SendView: View {
     @State private var errorMessage: String?
     @State private var errorSeverity: ErrorSeverity = .error
     @State private var errorShowsMintAction = false
+    // Optional second line under the error notice (e.g. the change-fee hint);
+    // overrides the generic insufficient-balance detail when set.
+    @State private var errorDetail: String?
     @State private var showMintPicker = false
     @State private var selectedSendMint: MintInfo?
 
@@ -225,7 +228,7 @@ struct SendView: View {
                     } else if let error = errorMessage {
                         sendInputNotice(
                             message: error,
-                            detail: errorShowsMintAction ? insufficientBalanceDetail : nil,
+                            detail: errorDetail ?? (errorShowsMintAction ? insufficientBalanceDetail : nil),
                             severity: errorSeverity
                         )
                     }
@@ -420,12 +423,29 @@ struct SendView: View {
 
     private func useMax(mint: MintInfo) {
         HapticFeedback.impact(.light)
+        // The gross balance is always sendable: sends don't include fees
+        // (TokenService includeFee: false), and a full-balance send matches
+        // the proof set exactly — no swap, no fee, also on fee-charging mints.
+        fillAmount(baseUnits: effectiveSendBalance)
+    }
+
+    /// Writes a base-unit amount into the keypad string in the current entry
+    /// mode. Fiat entry is coarser than sats, so the cents round-trip can land
+    /// above the target — which would leave a Send Max fill unsendable — and
+    /// gets trimmed a cent at a time until it fits.
+    private func fillAmount(baseUnits: UInt64) {
         if isSatSend {
             // Balance is sats; express it in the current entry unit so the keypad
             // string keeps its meaning.
-            amountString = AmountFormatter.entryConverted(raw: String(mint.balance), from: .sats, to: entryUnit)
+            amountString = AmountFormatter.entryConverted(raw: String(baseUnits), from: .sats, to: entryUnit)
+            guard entryUnit == .fiat else { return }
+            var cents = AmountFormatter.entryBaseUnits(raw: amountString, decimals: 2)
+            while cents > 0, AmountFormatter.entrySats(raw: amountString, unit: .fiat) > baseUnits {
+                cents -= 1
+                amountString = AmountFormatter.entryString(baseUnits: cents, decimals: 2)
+            }
         } else {
-            amountString = AmountFormatter.entryString(baseUnits: effectiveSendBalance, decimals: sendUnitDecimals)
+            amountString = AmountFormatter.entryString(baseUnits: baseUnits, decimals: sendUnitDecimals)
         }
     }
 
@@ -774,10 +794,11 @@ struct SendView: View {
         return "You have \(sendBalanceText) in \(mint.name)."
     }
 
-    private func presentError(_ message: String, severity: ErrorSeverity = .error, showsMintAction: Bool = false) {
+    private func presentError(_ message: String, severity: ErrorSeverity = .error, showsMintAction: Bool = false, detail: String? = nil) {
         errorMessage = message
         errorSeverity = severity
         errorShowsMintAction = showsMintAction
+        errorDetail = detail
     }
 
     private func extractMintHost(_ url: String) -> String {
@@ -820,11 +841,23 @@ struct SendView: View {
                 HapticFeedback.notification(.success)
             } catch {
                 let walletMessage = error.walletMessage
-                presentError(
-                    walletMessage.text,
-                    severity: walletMessage.severity,
-                    showsMintAction: error.isInsufficientBalanceError
-                )
+                if error.isInsufficientBalanceError, amount <= effectiveSendBalance {
+                    // The balance covers the amount, but the swap that makes
+                    // change for it carries a fee the remainder can't absorb —
+                    // the plain "Not enough balance." reads as a wallet bug when
+                    // the user typed exactly what the screen says they hold.
+                    presentError(
+                        "Not enough balance to cover the mint fee.",
+                        severity: .caution,
+                        detail: "The mint charges a fee to make change for this amount. Try Send Max."
+                    )
+                } else {
+                    presentError(
+                        walletMessage.text,
+                        severity: walletMessage.severity,
+                        showsMintAction: error.isInsufficientBalanceError
+                    )
+                }
                 HapticFeedback.notification(.error)
             }
             isGenerating = false

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -694,13 +694,13 @@ struct SendView: View {
                             canvasDivider
                         }
                         detailRow(icon: "banknote", label: "Unit", value: generatedTokenUnit.uppercased())
-                        // Fiat conversion is only meaningful for sats; a non-sat
-                        // account unit has no BTC-price equivalent.
-                        if generatedIsSat {
+                        // Fiat conversion is only meaningful for sats, only when
+                        // the user opted into fiat balances, and only for amounts
+                        // worth at least a cent — matches Android's gating.
+                        if generatedIsSat, settings.showFiatBalance,
+                           let fiatValue = priceService.formatSatsAsFiat(generatedAmount) {
                             canvasDivider
-                            detailRow(icon: "banknote", label: "Fiat",
-                                      value: priceService.btcPriceUSD > 0
-                                          ? priceService.formatSatsAsFiat(generatedAmount) : "—")
+                            detailRow(icon: "banknote", label: "Fiat", value: fiatValue)
                         }
                         if let mintURL = generatedTokenMintURL {
                             canvasDivider


### PR DESCRIPTION
> **Stacked on #169** — only the last commit (`1949776`) is new here. The first two commits are #169's; once it merges I'll rebase and this PR's diff collapses to the display commit alone.

Two display fixes, prompted by the same 10-sat token looking different on iOS vs Android:

## Hide fiat amounts under one cent (both platforms)

Fiat conversions worth less than $0.01 are never displayed — a 10-sat token no longer renders a misleading "$0.00"/"—" anywhere. The guard lives in the one formatter both platforms' fiat displays already flow through (`AmountFormatter.fiat(sats:btcPrice:currencyCode:)` on iOS, `formatFiat` on Android), so history rows, balance secondaries, and detail rows all inherit it with no per-screen changes. Display heroes fall back to sats exactly like the existing price-unavailable path.

Deliberate exception: the keypad entry screens keep the raw conversion in the flip pill so it doesn't blink in and out while typing through small values.

## Align the Pending Ecash fiat row (iOS)

iOS rendered a Fiat row unconditionally for sat tokens — with a "—" placeholder when no price was loaded — while Android gates the same row on the Show Fiat Balance setting plus a loaded price. iOS now uses Android's gating (setting on + price loaded + worth ≥ 1¢), and the "—" placeholder is gone. With default settings both platforms now show the same rows for the same token.

## Align the claim-watch status (Android)

Android polled the mint every 4s forever and flipped Pending → Checking only while each probe was in flight, so the status row flickered and the polling never stopped. iOS keeps the spinner up for the whole watch session with 5s → 15s backoff and rests at "Pending" after 10 checks. Android now mirrors that exactly — "Checking…" means actively watching, "Pending" means the same thing on both platforms, and rate-limited mints stop getting hit indefinitely.

## Align the Copy button (Android)

The Pending Ecash Copy button used the default inverted-ink primary fill (white in dark mode / black in light) and scrolled with the content. It now uses `neutralActionButtonColors()` — the same theme-adapting gray tonal fill as the transaction detail's Copy action — and is pinned below a weighted scroll region, mirroring iOS's non-prominent glass capsule sitting outside the ScrollView.

## Gray bottom CTAs by default + standard bottom margin (Android)

iOS renders every bottom CTA as the gray non-prominent glass capsule, with exactly one inverted-ink exception (`.glassButton(prominent: true)` on the Receive Ecash commit). Android's `PrimaryButton` defaulted to inverted ink, so ~20 CTAs diverged. The default fill is now `neutralActionButtonColors()`, with the Receive Ecash "Receive" button opting back into inverted ink to mirror iOS. The shared `NumberPadFooter` (and the Pending Ecash Copy footer) also gains the app-wide 16dp bottom margin above the gesture inset — keypad CTAs previously sat flush against the raw navigation-bar inset, below both the app's own convention and iOS's `.padding(.bottom, 16)`.

## Tests

New formatter unit tests on both platforms covering the 1-cent boundary (50 sats @ $20k = $0.01 shows; 49 sats hides) and the missing-price case. Full iOS simulator suite and Android unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
