### PR TITLE
On-chain receive/history parity + picker-sheet polish

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -11,6 +11,9 @@ import com.cashu.me.Core.Protocols.CurrencyRegistry
 data class TransactionDetailField(
     val label: String,
     val value: String,
+    // Full untruncated payload for tap-to-copy rows (the display `value` may be
+    // middle-truncated); null = row is not copyable.
+    val copyValue: String? = null,
 )
 
 object TransactionDisplay {
@@ -53,7 +56,8 @@ object TransactionDisplay {
      * shareable only for an unclaimed outgoing send; an incoming pending token
      * is money to claim, not a payment code. One-shot Lightning invoices retire
      * after settlement, reusable BOLT12 offers stay live, and on-chain addresses
-     * remain fundable after a payment and therefore always keep their QR.
+     * retire once the deposit is minted — a confirmed receive is a historical
+     * receipt (checkmark hero), not a payment code to re-present.
      */
     fun showsQr(transaction: WalletTransaction): Boolean = when (transaction.kind) {
         TransactionKind.Ecash ->
@@ -64,7 +68,8 @@ object TransactionDisplay {
             transaction.invoice != null &&
                 (transaction.status == TransactionStatus.Pending ||
                     transaction.invoice.startsWith("lno", ignoreCase = true))
-        TransactionKind.Onchain -> transaction.invoice != null
+        TransactionKind.Onchain ->
+            transaction.invoice != null && transaction.status == TransactionStatus.Pending
     }
 
     /**
@@ -95,12 +100,25 @@ object TransactionDisplay {
             if (transaction.fee > 0) add(TransactionDetailField("Fee", formatNativeAmount(transaction.fee, transaction.unit)))
             transaction.mintUrl?.let { add(TransactionDetailField("Mint", mintHost(it))) }
             if (transaction.kind == TransactionKind.Onchain) {
-                transaction.invoice?.let { add(TransactionDetailField("Address", it)) }
-                transaction.preimage?.let { add(TransactionDetailField("Transaction ID", it)) }
+                // Address/txid are reference blobs — show the decoder's standard
+                // 8…6 short form; tap-to-copy carries the full value.
+                transaction.invoice?.let {
+                    add(TransactionDetailField("Address", middleTruncated(it), copyValue = it))
+                }
+                transaction.preimage?.let {
+                    add(TransactionDetailField("Transaction ID", middleTruncated(it), copyValue = it))
+                }
             } else {
-                transaction.preimage?.let { add(TransactionDetailField("Payment Proof", it)) }
+                transaction.preimage?.let {
+                    add(TransactionDetailField("Payment Proof", it, copyValue = it))
+                }
             }
         }
+
+    /** `prefix(8)…suffix(6)` middle-truncation, the decoder's convention for
+     *  opaque destination blobs; short strings pass through untouched. */
+    private fun middleTruncated(value: String): String =
+        if (value.length > 16) "${value.take(8)}…${value.takeLast(6)}" else value
 
     private fun formatNativeAmount(amount: Long, unit: String): String =
         if (unit.equals("sat", ignoreCase = true)) {

--- a/android/app/src/main/java/com/cashu/me/ui/components/ExplorerLinkRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/ExplorerLinkRow.kt
@@ -1,0 +1,74 @@
+package com.cashu.me.ui.components
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.cashu.me.ui.theme.CashuTheme
+
+// Inline link glyph next to the "View in block explorer" label.
+private val EXPLORER_GLYPH_SIZE = 18.dp
+
+/**
+ * Whole-row tappable external link to a block explorer — shared by the
+ * transaction detail and on-chain receive screens. iOS parity:
+ * `ReceiveLightningView.explorerLinkRow`.
+ */
+@Composable
+fun ExplorerLinkRow(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    label: String = "View in block explorer",
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(
+                horizontal = CashuTheme.spacing.comfortable,
+                vertical = CashuTheme.spacing.snug,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(EXPLORER_GLYPH_SIZE),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(EXPLORER_GLYPH_SIZE),
+        )
+    }
+}
+
+internal fun Context.openInBrowser(url: String) {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    startActivity(intent)
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
@@ -32,7 +32,8 @@ private val InspectorEditHintSize = 16.dp
 /**
  * Two-column metadata row used inside Cashu Request / Transaction Detail inspector
  * groups. Optional leading icon, optional pencil affordance for editable rows
- * (which trigger a sub-sheet on tap).
+ * (which trigger a sub-sheet on tap), optional quiet trailing affordance for
+ * other tappable rows (e.g. tap-to-copy: ContentCopy → green Check).
  *
  * @param loading skeleton fill-in (iOS `.redacted(.placeholder)` on confirm fee
  *   rows): while true a quiet placeholder bar holds the value slot, then the
@@ -46,11 +47,13 @@ fun InspectorRow(
     leadingIcon: ImageVector? = null,
     editable: Boolean = false,
     onClick: (() -> Unit)? = null,
+    trailingIcon: ImageVector? = null,
+    trailingIconTint: Color? = null,
     valueMonospaced: Boolean = false,
     valueColor: Color? = null,
     loading: Boolean = false,
 ) {
-    val rowMod = if (onClick != null && editable) {
+    val rowMod = if (onClick != null) {
         modifier.fillMaxWidth().clickable(onClick = onClick)
     } else {
         modifier.fillMaxWidth()
@@ -97,6 +100,13 @@ fun InspectorRow(
                 imageVector = Icons.Outlined.Edit,
                 contentDescription = "Edit $label",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(InspectorEditHintSize),
+            )
+        } else if (trailingIcon != null) {
+            Icon(
+                imageVector = trailingIcon,
+                contentDescription = null,
+                tint = trailingIconTint ?: MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.size(InspectorEditHintSize),
             )
         }

--- a/android/app/src/main/java/com/cashu/me/ui/components/MintPickerSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/MintPickerSheet.kt
@@ -65,14 +65,7 @@ fun MintPickerSheet(
                 .padding(horizontal = CashuTheme.spacing.comfortable)
                 .navigationBarsPadding(),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(
-                    horizontal = CashuTheme.spacing.snug,
-                    vertical = CashuTheme.spacing.default,
-                ),
-            )
+            FlowSheetTitle(title = title)
             if (allowAnyMint) {
                 MintPickerAnyRow(
                     selected = activeMintUrl == null,

--- a/android/app/src/main/java/com/cashu/me/ui/components/UnitPickerSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/UnitPickerSheet.kt
@@ -49,14 +49,7 @@ fun UnitPickerSheet(
                 .padding(horizontal = CashuTheme.spacing.comfortable)
                 .navigationBarsPadding(),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(
-                    horizontal = CashuTheme.spacing.snug,
-                    vertical = CashuTheme.spacing.default,
-                ),
-            )
+            FlowSheetTitle(title = title)
             units.forEach { unit ->
                 val code = unit.uppercase()
                 val displayName = CurrencyRegistry.currencyForMintUnit(unit).displayName

--- a/android/app/src/main/java/com/cashu/me/ui/components/WaitingForPaymentRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/WaitingForPaymentRow.kt
@@ -1,0 +1,61 @@
+package com.cashu.me.ui.components
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import com.cashu.me.ui.theme.CashuTheme
+import com.cashu.me.ui.theme.rememberReducedMotion
+
+/**
+ * Pulsing orange clock + neutral status text for a pending payment — shared by
+ * the receive rails and the Cashu Request detail screen. iOS parity:
+ * `ReceiveLightningView.statusBadge` pending branch.
+ */
+@Composable
+fun WaitingForPaymentRow(text: String = "Waiting for payment…") {
+    val reducedMotion = rememberReducedMotion()
+    val transition = rememberInfiniteTransition(label = "waiting-pulse")
+    val alpha by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = 0.4f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1100),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "waiting-pulse-alpha",
+    )
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    ) {
+        Box(modifier = Modifier.alpha(if (reducedMotion) 1f else alpha)) {
+            Icon(
+                imageVector = Icons.Outlined.Schedule,
+                contentDescription = null,
+                tint = CashuTheme.colors.pending,
+                modifier = Modifier.size(CashuTheme.spacing.loose),
+            )
+        }
+        Text(
+            text = text,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -1,8 +1,5 @@
 package com.cashu.me.ui.history
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -14,10 +11,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.OpenInNew
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -58,11 +56,13 @@ import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.DetailActionFooter
 import com.cashu.me.ui.components.EmptyState
+import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.components.neutralActionButtonColors
+import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withMonoDigits
@@ -89,6 +89,15 @@ fun TransactionDetailScreen(
         if (copied) {
             delay(2000)
             copied = false
+        }
+    }
+    // Tap-to-copy inspector rows (Address / Transaction ID / Payment Proof):
+    // which row last copied, for the ContentCopy → green Check swap.
+    var copiedFieldLabel by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(copiedFieldLabel) {
+        if (copiedFieldLabel != null) {
+            delay(3000)
+            copiedFieldLabel = null
         }
     }
 
@@ -190,24 +199,40 @@ fun TransactionDetailScreen(
                 Column(modifier = Modifier.fillMaxWidth()) {
                     val fields = remember(transaction) { TransactionDisplay.detailFields(transaction) }
                     fields.forEachIndexed { index, field ->
+                        val fieldCopied = copiedFieldLabel == field.label
                         InspectorRow(
                             label = field.label,
                             value = field.value,
                             valueMonospaced = field.value.length > 24 ||
                                 field.label in MonospacedLabels,
+                            onClick = field.copyValue?.let { full ->
+                                {
+                                    // No app snackbar: Android 13+ shows the system
+                                    // clipboard bubble, so the row's check swap is
+                                    // the only in-app confirmation.
+                                    clipboard.setText(AnnotatedString(full))
+                                    copiedFieldLabel = field.label
+                                }
+                            },
+                            trailingIcon = field.copyValue?.let {
+                                if (fieldCopied) Icons.Outlined.Check else Icons.Outlined.ContentCopy
+                            },
+                            trailingIconTint = if (fieldCopied) CashuTheme.colors.received else null,
                         )
                         if (index != fields.lastIndex) CanvasDivider(leadingInset = 16.dp)
+                    }
+                    // Explorer link joins the detail rows (iOS parity), not the
+                    // pinned footer — it's reference material, not an action.
+                    if (explorerUrl != null) {
+                        if (fields.isNotEmpty()) CanvasDivider(leadingInset = 16.dp)
+                        ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
                     }
                 }
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
             }
 
-            if (explorerUrl != null || hasPrimaryAction) {
+            if (hasPrimaryAction) {
                 DetailActionFooter {
-                    if (explorerUrl != null) {
-                        ExplorerLinkRow(url = explorerUrl, onOpen = { context.openInBrowser(it) })
-                        if (hasPrimaryAction) Spacer(Modifier.height(CashuTheme.spacing.snug))
-                    }
                     if (pendingReceiveToken != null && onClaimReceiveToken != null) {
                         PrimaryButton(
                             text = "Receive",
@@ -231,9 +256,6 @@ fun TransactionDetailScreen(
         }
     }
 }
-
-// Inline link glyph next to the "View in block explorer" label.
-private val EXPLORER_GLYPH_SIZE = 18.dp
 
 // Historical success gets a more generous 96dp hero; failure stays restrained.
 private val COMPLETED_HERO_GLYPH_SIZE = 96.dp
@@ -268,39 +290,6 @@ private fun HeroAmount(
     )
 }
 
-@Composable
-private fun ExplorerLinkRow(url: String, onOpen: (String) -> Unit) {
-    androidx.compose.foundation.layout.Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = CashuTheme.spacing.comfortable,
-                vertical = CashuTheme.spacing.snug,
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-    ) {
-        Icon(
-            imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(EXPLORER_GLYPH_SIZE),
-        )
-        Text(
-            text = "View in block explorer",
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.weight(1f),
-        )
-        IconButton(onClick = { onOpen(url) }) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-                contentDescription = "Open",
-            )
-        }
-    }
-}
-
 private fun WalletTransaction.explorerUrl(): String? {
     if (kind != TransactionKind.Onchain) return null
     return preimage?.let {
@@ -308,11 +297,4 @@ private fun WalletTransaction.explorerUrl(): String? {
     } ?: invoice?.let {
         OnchainExplorer.addressWebUrl(address = it, mintUrl = mintUrl)
     }
-}
-
-private fun Context.openInBrowser(url: String) {
-    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    }
-    startActivity(intent)
 }

--- a/android/app/src/main/java/com/cashu/me/ui/mints/AddMintSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/AddMintSheet.kt
@@ -34,6 +34,7 @@ import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.mintUrlCandidates
 import com.cashu.me.Core.normalizeUserMintUrl
 import com.cashu.me.ui.components.CashuTextField
+import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.PrimaryButton
@@ -106,12 +107,7 @@ fun AddMintSheet(
                 .padding(bottom = CashuTheme.spacing.comfortable),
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
         ) {
-            Text(
-                text = "Add Mint",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(vertical = CashuTheme.spacing.snug),
-            )
+            FlowSheetTitle(title = "Add Mint")
 
             CashuTextField(
                 value = url,

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -1,18 +1,12 @@
 package com.cashu.me.ui.receive
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -33,7 +27,6 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.CurrencyExchange
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.Payments
-import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.Icon
@@ -54,7 +47,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -92,9 +84,9 @@ import com.cashu.me.ui.components.SecondaryButton
 import com.cashu.me.ui.components.SheetHeader
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.components.UnitPickerSheet
+import com.cashu.me.ui.components.WaitingForPaymentRow
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.theme.CashuTheme
-import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.withMonoDigits
 import com.cashu.me.ui.receive.nfc.NfcReceiveIndicator
 import com.cashu.me.ui.receive.nfc.NfcReceiveLifecycle
@@ -495,11 +487,11 @@ private fun NfcReceivePhase.isNfcTransferActive(): Boolean = this in setOf(
 
 @Composable
 private fun StatusBlock(received: Boolean, paymentCount: Int, celebrate: Boolean) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-    ) {
-        if (received) {
+    if (received) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+        ) {
             // Live celebration grows in gently (0.9 → 1, the one delight beat);
             // the persistent N-payments state is quiet — no animation.
             AnimatedVisibility(
@@ -530,32 +522,9 @@ private fun StatusBlock(received: Boolean, paymentCount: Int, celebrate: Boolean
                 style = MaterialTheme.typography.titleMedium,
                 color = CashuTheme.colors.received,
             )
-        } else {
-            val reducedMotion = rememberReducedMotion()
-            val transition = rememberInfiniteTransition(label = "waiting-pulse")
-            val alpha by transition.animateFloat(
-                initialValue = 1f,
-                targetValue = 0.4f,
-                animationSpec = infiniteRepeatable(
-                    animation = tween(1100),
-                    repeatMode = RepeatMode.Reverse,
-                ),
-                label = "waiting-pulse-alpha",
-            )
-            Box(modifier = Modifier.alpha(if (reducedMotion) 1f else alpha)) {
-                Icon(
-                    imageVector = Icons.Outlined.Schedule,
-                    contentDescription = null,
-                    tint = CashuTheme.colors.pending,
-                    modifier = Modifier.size(CashuTheme.spacing.loose),
-                )
-            }
-            Text(
-                text = "Waiting for payment…",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
         }
+    } else {
+        WaitingForPaymentRow()
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -86,6 +86,7 @@ import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.ExplorerLinkRow
+import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.components.IconSwap
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InspectorRow
@@ -1154,14 +1155,7 @@ private fun ReceiveMethodPickerSheet(
                 .padding(horizontal = CashuTheme.spacing.comfortable)
                 .navigationBarsPadding(),
         ) {
-            Text(
-                text = "Receive with",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(
-                    horizontal = CashuTheme.spacing.snug,
-                    vertical = CashuTheme.spacing.default,
-                ),
-            )
+            FlowSheetTitle(title = "Receive with")
             methods.forEach { kind ->
                 Row(
                     modifier = Modifier

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -2,15 +2,9 @@ package com.cashu.me.ui.receive
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.Crossfade
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -37,8 +31,8 @@ import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Repeat
-import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material.icons.outlined.UnfoldMore
 import androidx.compose.material3.DropdownMenu
@@ -60,7 +54,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -77,6 +70,8 @@ import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.CashuRequestStore
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
+import com.cashu.me.Core.OnchainExplorer
+import com.cashu.me.Core.OnchainPaymentObservation
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
@@ -90,6 +85,7 @@ import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
+import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.IconSwap
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InspectorRow
@@ -103,11 +99,13 @@ import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SheetHeader
 import com.cashu.me.ui.components.TwoFaceScreen
 import com.cashu.me.ui.components.UnitPickerSheet
+import com.cashu.me.ui.components.WaitingForPaymentRow
+import com.cashu.me.ui.components.neutralActionButtonColors
+import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.theme.CapsuleShape
 import com.cashu.me.ui.theme.CashuTheme
-import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.withMonoDigits
 
 private sealed interface ReceiveLnFace {
@@ -139,6 +137,11 @@ fun ReceiveLightningScreen(
     // When a payment lands the whole screen crossfades to the shared full-screen
     // success terminal (iOS parity — no inline "Paid" row, no Done button).
     var successInfo by remember { mutableStateOf<ReceiveSuccessInfo?>(null) }
+    // On-chain quotes abandoned via "Use new address": a payment may already be
+    // racing toward the old address, so keep checking them for the life of the
+    // sheet (mint-status checks only — no extra explorer polling). Set
+    // semantics dedupe repeated presses.
+    var abandonedOnchainQuoteIds by remember { mutableStateOf(setOf<String>()) }
     var selectedReceiveUnit by remember { mutableStateOf<String?>(null) }
     var unitPickerOpen by remember { mutableStateOf(false) }
     var mintPickerOpen by remember { mutableStateOf(false) }
@@ -237,6 +240,24 @@ fun ReceiveLightningScreen(
     }
 
     /**
+     * Fresh deposit address from the overflow menu (BOLT12 "new invoice"
+     * parity). Remembers the outgoing quote first — a payment may already be
+     * racing toward it (screen-scoped watcher keeps checking it). The header
+     * can't see the Display block's live quote; the face quote is safe here
+     * because an Issued quote can't still be on screen (the success terminal
+     * takes over).
+     */
+    fun createNewOnchainAddress() {
+        val quote = (face as? ReceiveLnFace.Display)?.quote
+        if (quote != null && quote.paymentMethod == PaymentMethodKind.Onchain &&
+            quote.state != MintQuoteState.Issued && !quote.isExpired
+        ) {
+            abandonedOnchainQuoteIds = abandonedOnchainQuoteIds + quote.id
+        }
+        createMintRequest(PaymentMethodKind.Onchain, amountless = true)
+    }
+
+    /**
      * Re-mints the reusable BOLT12 offer at a new amount (iOS
      * `setReusableOfferAmount`). null / 0 → amountless (reuse existing offer);
      * positive → a fresh fixed-amount offer.
@@ -292,6 +313,50 @@ fun ReceiveLightningScreen(
         face = ReceiveLnFace.Input
     }
 
+    // Abandoned-quote watcher: every quote-keyed monitor re-keys to the
+    // replacement after "Use new address", so this screen-scoped loop is what
+    // keeps checking the old address(es). refreshPendingMintQuote returns
+    // whether tokens were actually minted — on-chain quotes can sit Pending
+    // until a mint attempt succeeds, so the Boolean (not the quote state) is
+    // the reliable signal. Keyed on isNotEmpty so the first pass runs
+    // immediately after the first tap (a quote already paid at tap time mints
+    // on the first tick). Dies with the sheet; the global pending-quote sweep
+    // remains the fallback after that.
+    LaunchedEffect(abandonedOnchainQuoteIds.isNotEmpty()) {
+        while (abandonedOnchainQuoteIds.isNotEmpty() && successInfo == null) {
+            for (quoteId in abandonedOnchainQuoteIds) {
+                val info = runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull()
+                // Drop quotes that expired before the mint saw any deposit; a
+                // funded-but-expired quote keeps being checked.
+                if (info != null && info.isExpired &&
+                    info.state == MintQuoteState.Unpaid &&
+                    (info.amount ?: 0L) == 0L && info.amountPaid == 0L
+                ) {
+                    abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
+                    continue
+                }
+                val minted = runCatching { walletManager.refreshPendingMintQuote(quoteId) }
+                    .getOrDefault(false)
+                if (!minted) continue
+                abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
+                // Refetch for the credited amount (on-chain always mints sat).
+                val refreshed = runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull() ?: info
+                val paidAmount = refreshed?.amount
+                    ?: refreshed?.amountIssued?.takeIf { it > 0 }
+                    ?: refreshed?.amountPaid?.takeIf { it > 0 }
+                successInfo = ReceiveSuccessInfo(
+                    amountLabel = paidAmount?.let {
+                        formatter.formatWalletSats(it, settings.useBitcoinSymbol)
+                    },
+                    mintName = walletState.mints.firstOrNull { it.url == refreshed?.mintUrl }?.name
+                        ?: walletState.activeMint?.name,
+                )
+                return@LaunchedEffect // terminal owns the sheet now
+            }
+            delay(30_000)
+        }
+    }
+
     // The paid terminal replaces the whole sheet body (header + faces), fading
     // in over the QR the way iOS swaps `body` to the success view.
     Crossfade(targetState = successInfo, label = "receive-ln-terminal") { terminal ->
@@ -325,10 +390,15 @@ fun ReceiveLightningScreen(
             actions = {
                 val current = face
                 if (current is ReceiveLnFace.Display) {
-                    if (current.quote.paymentMethod == PaymentMethodKind.Bolt12) {
-                        // Overflow menu keeps share + new-invoice secondary —
+                    val menuMethod = current.quote.paymentMethod
+                    if (menuMethod == PaymentMethodKind.Bolt12 ||
+                        menuMethod == PaymentMethodKind.Onchain
+                    ) {
+                        // Overflow menu keeps share + new-artifact secondary —
                         // quieter than a prominent Share / New pair (iOS still
-                        // uses ShareLink; Android folds both into ⋮).
+                        // uses ShareLink; Android folds both into ⋮). On-chain
+                        // mirrors BOLT12 with a fresh deposit address.
+                        val isOnchainMenu = menuMethod == PaymentMethodKind.Onchain
                         IconButton(onClick = { displayActionsOpen = true }) {
                             ToolbarIcon(Icons.Filled.MoreVert, contentDescription = "More options")
                         }
@@ -346,23 +416,34 @@ fun ReceiveLightningScreen(
                                     displayActionsOpen = false
                                     context.shareText(
                                         current.quote.request,
-                                        subject = "Reusable Invoice",
+                                        subject = if (isOnchainMenu) "Bitcoin Address" else "Reusable Invoice",
                                     )
                                 },
                             )
                             DropdownMenuItem(
                                 text = {
                                     Text(
-                                        if (creating) "Creating…" else "New reusable invoice",
+                                        when {
+                                            creating -> "Creating…"
+                                            isOnchainMenu -> "New address"
+                                            else -> "New reusable invoice"
+                                        },
                                     )
                                 },
                                 leadingIcon = {
-                                    Icon(Icons.Outlined.Repeat, contentDescription = null)
+                                    Icon(
+                                        if (isOnchainMenu) Icons.Outlined.Refresh else Icons.Outlined.Repeat,
+                                        contentDescription = null,
+                                    )
                                 },
                                 enabled = !creating,
                                 onClick = {
                                     displayActionsOpen = false
-                                    createNewReusableInvoice()
+                                    if (isOnchainMenu) {
+                                        createNewOnchainAddress()
+                                    } else {
+                                        createNewReusableInvoice()
+                                    }
                                 },
                             )
                         }
@@ -440,9 +521,8 @@ fun ReceiveLightningScreen(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
-            forward = { initial, target ->
-                initial is ReceiveLnFace.Input && target is ReceiveLnFace.Display
-            },
+            // Display → Display (fresh on-chain address) also slides forward.
+            forward = { _, target -> target is ReceiveLnFace.Display },
             label = "receive-lightning-face",
         ) { current ->
             when (current) {
@@ -496,6 +576,42 @@ fun ReceiveLightningScreen(
                             runCatching { walletManager.pollMintQuote(current.quote.id) }
                                 .getOrNull()
                                 ?.let { liveQuote = it }
+                        }
+                    }
+                    // On-chain: watch the address on the block explorer so the
+                    // status line can report mempool/confirmation progress before
+                    // the mint credits the deposit, and nudge a mint attempt while
+                    // the quote is still un-issued (iOS refreshOnchainObservation
+                    // + mintQuoteIfReady parity). 30s cadence matches iOS and is
+                    // polite to the third-party explorer API.
+                    var onchainObservation by remember(current.quote.id) {
+                        mutableStateOf<OnchainPaymentObservation?>(null)
+                    }
+                    val quoteCreatedAtMillis = remember(current.quote.id) { System.currentTimeMillis() }
+                    LaunchedEffect(current.quote.id) {
+                        if (current.quote.paymentMethod != PaymentMethodKind.Onchain) return@LaunchedEffect
+                        while (true) {
+                            val quote = liveQuote
+                            // CDK reports the deposited amount on the quote once the
+                            // mint sees the payment; observing before that would
+                            // match any dust against an expectedAmount of zero.
+                            val expectedAmount = quote.amount ?: 0L
+                            val unissued = quote.state != MintQuoteState.Paid &&
+                                quote.state != MintQuoteState.Issued
+                            if (unissued && expectedAmount > 0) {
+                                onchainObservation = OnchainExplorer.observePayment(
+                                    address = quote.request,
+                                    mintUrl = quote.mintUrl ?: activeMint?.url,
+                                    expectedAmount = expectedAmount,
+                                    createdAfterEpochMillis = quoteCreatedAtMillis,
+                                )
+                                // Mint on the wallet's app-lifetime scope so a
+                                // dismissal never cancels a mint mid-flight.
+                                walletManager.launch {
+                                    runCatching { walletManager.refreshPendingMintQuote(quote.id) }
+                                }
+                            }
+                            delay(30_000)
                         }
                     }
                     val amountLabel = liveQuote.amount?.let {
@@ -555,6 +671,23 @@ fun ReceiveLightningScreen(
                             )
                         }
                     }
+                    val isOnchain = liveQuote.paymentMethod == PaymentMethodKind.Onchain
+                    val observation = onchainObservation
+                    val explorerUrl = if (isOnchain) {
+                        val explorerMintUrl = liveQuote.mintUrl ?: activeMint?.url
+                        observation?.txid?.let {
+                            OnchainExplorer.transactionWebUrl(
+                                txid = it,
+                                address = liveQuote.request,
+                                mintUrl = explorerMintUrl,
+                            )
+                        } ?: OnchainExplorer.addressWebUrl(
+                            address = liveQuote.request,
+                            mintUrl = explorerMintUrl,
+                        )
+                    } else {
+                        null
+                    }
                     DisplayFace(
                         quote = liveQuote,
                         amountLabel = amountLabel.takeUnless {
@@ -566,6 +699,16 @@ fun ReceiveLightningScreen(
                             .firstOrNull { it.quoteId == liveQuote.id }
                             ?.createdAtEpochMillis,
                         errorText = errorText,
+                        pendingStatusText = when {
+                            !isOnchain -> "Waiting for payment…"
+                            observation != null -> "${observation.statusText}. Trying to mint…"
+                            else -> "Waiting for on-chain payment…"
+                        },
+                        explorerLabel = if (observation == null) {
+                            "View address in block explorer"
+                        } else {
+                            "View transaction in block explorer"
+                        },
                         onCopy = { clipboard.setText(AnnotatedString(liveQuote.request)) },
                         onEditReusableAmount = if (
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12
@@ -574,6 +717,7 @@ fun ReceiveLightningScreen(
                         } else {
                             null
                         },
+                        onOpenExplorer = explorerUrl?.let { url -> { context.openInBrowser(url) } },
                     )
                 }
             }
@@ -798,8 +942,11 @@ private fun DisplayFace(
     mintName: String?,
     createdAtEpochMillis: Long?,
     errorText: String?,
+    pendingStatusText: String,
+    explorerLabel: String,
     onCopy: () -> Unit,
     onEditReusableAmount: (() -> Unit)?,
+    onOpenExplorer: (() -> Unit)?,
 ) {
     var copied by remember { mutableStateOf(false) }
     LaunchedEffect(copied) {
@@ -838,7 +985,7 @@ private fun DisplayFace(
                     receivedAmountLabel = receivedAmountLabel,
                 )
             } else {
-                WaitingForPaymentRow()
+                WaitingForPaymentRow(text = pendingStatusText)
             }
             errorText?.let { InlineNotice(text = it) }
             if (!isReusable) {
@@ -881,61 +1028,40 @@ private fun DisplayFace(
                         )
                     }
                 }
-            } else if (mintName != null) {
-                InspectorRow(
-                    label = "Mint",
-                    value = mintName,
-                    leadingIcon = Icons.Outlined.AccountBalance,
-                )
+            } else if (mintName != null || onOpenExplorer != null) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    if (mintName != null) {
+                        InspectorRow(
+                            label = "Mint",
+                            value = mintName,
+                            leadingIcon = Icons.Outlined.AccountBalance,
+                        )
+                    }
+                    if (onOpenExplorer != null) {
+                        if (mintName != null) {
+                            CanvasDivider(leadingInset = 16.dp)
+                        }
+                        ExplorerLinkRow(label = explorerLabel, onClick = onOpenExplorer)
+                    }
+                }
             }
         }
         Column(
             modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
         ) {
+            // Copy is a secondary convenience, not a primary action — quiet
+            // neutral tonal fill (iOS gray .glassButton() parity on every rail).
             PrimaryButton(
                 text = if (copied) "Copied" else quote.paymentMethod.copyActionTitle,
                 onClick = {
                     onCopy()
                     copied = true
                 },
+                colors = neutralActionButtonColors(),
             )
         }
         Spacer(Modifier.navigationBarsPadding())
-    }
-}
-
-/** Pulsing clock + "Waiting for payment…" for one-shot invoices. */
-@Composable
-private fun WaitingForPaymentRow() {
-    val reducedMotion = rememberReducedMotion()
-    val transition = rememberInfiniteTransition(label = "waiting-pulse")
-    val alpha by transition.animateFloat(
-        initialValue = 1f,
-        targetValue = 0.4f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1100),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "waiting-pulse-alpha",
-    )
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-    ) {
-        Box(modifier = Modifier.alpha(if (reducedMotion) 1f else alpha)) {
-            Icon(
-                imageVector = Icons.Outlined.Schedule,
-                contentDescription = null,
-                tint = CashuTheme.colors.pending,
-                modifier = Modifier.size(CashuTheme.spacing.loose),
-            )
-        }
-        Text(
-            text = "Waiting for payment…",
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -147,6 +147,7 @@ fun ReceiveLightningScreen(
     var mintPickerOpen by remember { mutableStateOf(false) }
     var reusableAmountPickerOpen by remember { mutableStateOf(false) }
     var displayActionsOpen by remember { mutableStateOf(false) }
+    var methodPickerOpen by remember { mutableStateOf(false) }
 
     val activeMint = walletState.activeMint
     val supportedMethods = activeMint?.supportedMintMethods?.ifEmpty { listOf(PaymentMethodKind.Bolt11) }
@@ -456,10 +457,9 @@ fun ReceiveLightningScreen(
                     }
                 } else if (current is ReceiveLnFace.Input) {
                     // Method picker rides the header (iOS parity): an icon
-                    // opening a menu, shown only when >1 method exists.
+                    // opening a bottom sheet, shown only when >1 method exists.
                     if (supportedMethods.size > 1) {
-                        var methodMenuOpen by remember { mutableStateOf(false) }
-                        IconButton(onClick = { methodMenuOpen = true }) {
+                        IconButton(onClick = { methodPickerOpen = true }) {
                             // Animated glyph replacement on method switch
                             // (iOS .contentTransition(.symbolEffect(.replace))).
                             IconSwap(
@@ -467,41 +467,6 @@ fun ReceiveLightningScreen(
                                 contentDescription = "Receive method: ${method.friendlyTitle}, ${method.friendlyDescriptor}",
                                 iconSize = CashuTheme.iconSizes.toolbar,
                             )
-                        }
-                        DropdownMenu(
-                            expanded = methodMenuOpen,
-                            onDismissRequest = { methodMenuOpen = false },
-                            shape = MaterialTheme.shapes.large,
-                        ) {
-                            supportedMethods.forEach { kind ->
-                                DropdownMenuItem(
-                                    text = {
-                                        // Title + one-line descriptor (iOS friendlyTitle /
-                                        // friendlyDescriptor parity). Material3 MenuItem
-                                        // only takes a single text composable, so both
-                                        // lines live here.
-                                        Column {
-                                            Text(
-                                                text = kind.friendlyTitle,
-                                                style = MaterialTheme.typography.bodyLarge,
-                                            )
-                                            Text(
-                                                text = kind.friendlyDescriptor,
-                                                style = MaterialTheme.typography.bodySmall,
-                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            )
-                                        }
-                                    },
-                                    leadingIcon = { Icon(kind.menuIcon, contentDescription = null) },
-                                    trailingIcon = if (kind == method) {
-                                        { Icon(Icons.Filled.Check, contentDescription = "Selected") }
-                                    } else null,
-                                    onClick = {
-                                        methodMenuOpen = false
-                                        applyMethodOption(kind)
-                                    },
-                                )
-                            }
                         }
                     }
                     if (showsUnitSelector) {
@@ -751,6 +716,18 @@ fun ReceiveLightningScreen(
                 unitPickerOpen = false
             },
             onDismiss = { unitPickerOpen = false },
+        )
+    }
+
+    if (methodPickerOpen) {
+        ReceiveMethodPickerSheet(
+            methods = supportedMethods,
+            selectedMethod = method,
+            onSelect = { kind ->
+                methodPickerOpen = false
+                applyMethodOption(kind)
+            },
+            onDismiss = { methodPickerOpen = false },
         )
     }
 
@@ -1151,6 +1128,81 @@ private fun ReusableAmountEditSheet(
                     onDone(UnitAmountEntry.baseUnits(amount, decimals).takeIf { it > 0 })
                 },
             )
+        }
+    }
+}
+
+/** Receive-method chooser bottom sheet (iOS `MethodPickerSheet` / "Receive
+ *  with" parity) — replaces the old toolbar dropdown for mints that support
+ *  more than one receive rail. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReceiveMethodPickerSheet(
+    methods: List<PaymentMethodKind>,
+    selectedMethod: PaymentMethodKind,
+    onSelect: (PaymentMethodKind) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = CashuTheme.spacing.comfortable)
+                .navigationBarsPadding(),
+        ) {
+            Text(
+                text = "Receive with",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(
+                    horizontal = CashuTheme.spacing.snug,
+                    vertical = CashuTheme.spacing.default,
+                ),
+            )
+            methods.forEach { kind ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSelect(kind) }
+                        .padding(
+                            horizontal = CashuTheme.spacing.snug,
+                            vertical = CashuTheme.spacing.default,
+                        ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+                ) {
+                    Icon(
+                        imageVector = kind.menuIcon,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(CashuTheme.spacing.loose),
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = kind.friendlyTitle,
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium,
+                        )
+                        Text(
+                            text = kind.friendlyDescriptor,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    if (kind == selectedMethod) {
+                        Icon(
+                            imageVector = Icons.Filled.Check,
+                            contentDescription = "Selected",
+                            tint = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.size(CashuTheme.spacing.loose),
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(CashuTheme.spacing.snug))
         }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/CurrencyPickerSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/CurrencyPickerSheet.kt
@@ -36,6 +36,7 @@ import java.util.Locale
 import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.ui.components.CanvasDivider
+import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withMonoDigits
 
@@ -64,14 +65,7 @@ fun CurrencyPickerSheet(
         sheetState = sheetState,
     ) {
         Column(modifier = Modifier.navigationBarsPadding()) {
-            Text(
-                text = "Currency",
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(
-                    horizontal = CashuTheme.spacing.section,
-                    vertical = CashuTheme.spacing.default,
-                ),
-            )
+            FlowSheetTitle(title = "Currency")
             LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
                 item("off") {
                     CurrencyRow(

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.2.1"
+agp = "9.3.0"
 kotlin = "2.2.21"
 coreKtx = "1.18.0"
 splashscreen = "1.0.1"

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -8,6 +8,9 @@ struct TransactionDetailView: View {
 
     @State private var copyButtonText = "Copy"
     @State private var showShareSheet = false
+    /// Label of the row whose value was just copied — drives the doc.on.doc →
+    /// green checkmark swap on tap-to-copy rows (Address / Transaction ID / …).
+    @State private var copiedRowLabel: String?
 
     /// Returns the content to display as a QR code.
     private var qrContent: String? {
@@ -51,8 +54,10 @@ struct TransactionDetailView: View {
             guard transaction.invoice != nil else { return false }
             return transaction.status == .pending || isReusableOffer
         case .onchain:
-            // An on-chain address stays fundable, so its QR is left as-is.
-            return transaction.invoice != nil
+            // The address is only worth re-presenting while the deposit is
+            // still awaited; once confirmed this is a historical receipt like
+            // a settled invoice — checkmark hero, no QR.
+            return transaction.invoice != nil && transaction.status == .pending
         }
     }
 
@@ -115,20 +120,22 @@ struct TransactionDetailView: View {
                         // Status + Date. Type is omitted — the nav title names it.
                         VStack(spacing: 0) {
                             ForEach(Array(detailRows.enumerated()), id: \.offset) { index, row in
-                                detailRow(icon: row.icon, label: row.label, value: row.value)
+                                if let copyValue = row.copyValue {
+                                    copyableRow(icon: row.icon, label: row.label, value: row.value, copyValue: copyValue)
+                                } else {
+                                    detailRow(icon: row.icon, label: row.label, value: row.value)
+                                }
                                 if index < detailRows.count - 1 { canvasDivider }
+                            }
+                            if let explorerURL = onchainExplorerURL {
+                                canvasDivider
+                                explorerLinkRow(label: "View in block explorer", url: explorerURL)
                             }
                         }
                         .padding(.top, 8)
                         .padding(.horizontal, 4)
                     }
                     .padding(.horizontal)
-                }
-
-                if let explorerURL = onchainExplorerURL {
-                    Link("View in block explorer", destination: explorerURL)
-                        .textLinkButton()
-                        .padding(.vertical, 12)
                 }
 
                 // Single primary action — Copy. Appears for an actionable
@@ -256,30 +263,32 @@ struct TransactionDetailView: View {
     /// correct as later rows drop out. Unit is gone (`unitLabel` is always BTC/SAT);
     /// the settled Request string is gone (its live form is the QR/Copy). On-chain
     /// keeps Address / Transaction ID (still actionable).
-    private var detailRows: [(icon: String, label: String, value: String)] {
-        var rows: [(icon: String, label: String, value: String)] = [
-            (statusFieldIcon, "Status", statusFieldValue),
-            ("calendar", "Date", transaction.date.formatted(date: .abbreviated, time: .shortened)),
+    private var detailRows: [(icon: String, label: String, value: String, copyValue: String?)] {
+        var rows: [(icon: String, label: String, value: String, copyValue: String?)] = [
+            (statusFieldIcon, "Status", statusFieldValue, nil),
+            ("calendar", "Date", transaction.date.formatted(date: .abbreviated, time: .shortened), nil),
         ]
         if transaction.fee > 0 {
-            rows.append(("arrow.up.arrow.down", "Fee", formattedNativeFee))
+            rows.append(("arrow.up.arrow.down", "Fee", formattedNativeFee, nil))
         }
         if transaction.kind == .onchain {
             if let mintUrl = transaction.mintUrl {
-                rows.append(("bitcoinsign.bank.building", "Mint", extractMintHost(mintUrl)))
+                rows.append(("bitcoinsign.bank.building", "Mint", extractMintHost(mintUrl), nil))
             }
+            // Address/txid are reference blobs — show the decoder's standard
+            // 8…6 short form; tap-to-copy carries the full value.
             if let request = transaction.invoice {
-                rows.append(("qrcode", "Address", request))
+                rows.append(("qrcode", "Address", PaymentRequestDecoder.middleTruncated(request), request))
             }
             if let preimage = transaction.preimage {
-                rows.append(("checkmark.seal", "Transaction ID", preimage))
+                rows.append(("checkmark.seal", "Transaction ID", PaymentRequestDecoder.middleTruncated(preimage), preimage))
             }
         } else {
             if let mintUrl = transaction.mintUrl {
-                rows.append(("bitcoinsign.bank.building", "Mint", extractMintHost(mintUrl)))
+                rows.append(("bitcoinsign.bank.building", "Mint", extractMintHost(mintUrl), nil))
             }
             if let preimage = transaction.preimage {
-                rows.append(("key", "Payment Proof", preimage))
+                rows.append(("key", "Payment Proof", preimage, preimage))
             }
         }
         return rows
@@ -319,6 +328,69 @@ struct TransactionDetailView: View {
         .font(.subheadline)
         .padding(.horizontal, 4)
         .padding(.vertical, 14)
+    }
+
+    /// Same shape as `detailRow` but tap-to-copy: copies the FULL value (the
+    /// display may be middle-truncated) with a success haptic and a fleeting
+    /// doc.on.doc → green checkmark swap — the app's copy-feedback convention
+    /// (iOS has no native toast). Deliberately no `.textSelection`: it would
+    /// fight the tap gesture, and the row itself is the copy affordance.
+    private func copyableRow(icon: String, label: String, value: String, copyValue: String) -> some View {
+        let isCopied = copiedRowLabel == label
+        return Button {
+            UIPasteboard.general.string = copyValue
+            HapticFeedback.notification(.success)
+            copiedRowLabel = label
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                if copiedRowLabel == label { copiedRowLabel = nil }
+            }
+        } label: {
+            HStack {
+                Label(label, systemImage: icon)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(value)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                    .font(.footnote)
+                    .foregroundStyle(isCopied ? AnyShapeStyle(.green) : AnyShapeStyle(.tertiary))
+                    .padding(.leading, 4)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .animation(.snappy(duration: 0.18), value: copiedRowLabel)
+        .accessibilityLabel(isCopied ? "\(label) copied" : label)
+        .accessibilityHint("Copies the \(label.lowercased()) to clipboard")
+    }
+
+    /// Same shape as `detailRow` but opens an external URL, with the trailing
+    /// arrow-up-right glyph settings uses for outbound links — the on-chain
+    /// block explorer row (matches the receive screen's row).
+    private func explorerLinkRow(label: String, url: URL) -> some View {
+        Link(destination: url) {
+            HStack {
+                Label(label, systemImage: "safari")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
+        .accessibilityHint("Opens the block explorer in your browser")
     }
 
     private var canvasDivider: some View {

--- a/ios/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestMintPickerSheet.swift
@@ -57,11 +57,6 @@ struct CashuRequestMintPickerSheet: View {
             .listStyle(.plain)
             .navigationTitle("Mint")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
-                }
-            }
         }
     }
 
@@ -148,14 +143,6 @@ struct CashuRequestUnitPickerSheet: View {
             .listStyle(.plain)
             .navigationTitle("Unit")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
-                }
-            }
         }
     }
 

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -169,7 +169,6 @@ struct ReceiveLightningView: View {
             .sheet(isPresented: $showMintPicker) {
                 MintSelectorSheet(selectedMint: $walletManager.activeMint)
                     .environmentObject(walletManager)
-                    .presentationDetents([.medium])
             }
             .sheet(isPresented: $showMethodPicker) {
                 MethodPickerSheet(
@@ -177,7 +176,6 @@ struct ReceiveLightningView: View {
                     options: availableMethodOptions,
                     onSelect: { applyMethodOption($0) }
                 )
-                .presentationDetents([.medium])
             }
             .sheet(isPresented: $showUnitPicker) {
                 UnitSelectorSheet(
@@ -185,7 +183,6 @@ struct ReceiveLightningView: View {
                     selectedUnit: effectiveUnit,
                     onSelect: selectReceiveUnit
                 )
-                .presentationDetents([.medium])
             }
             .onAppear {
                 syncSelectedMethodWithActiveMint()

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -30,6 +30,11 @@ struct ReceiveLightningView: View {
     @State private var onchainObservation: OnchainPaymentObservation?
     @State private var quoteCreatedAt: Date?
     @State private var monitoredQuoteId: String?
+    /// On-chain quotes abandoned via "Use new address" — a payment may already
+    /// be racing toward the old address, so keep checking them for the life of
+    /// the sheet (Android parity). Mint-status checks only; no explorer polling.
+    @State private var abandonedOnchainQuoteIds: [String] = []
+    @State private var abandonedQuoteTask: Task<Void, Never>?
 
     // Multi-unit mint: the user's explicit unit pick for this receive (nil = the
     // mint's default mintable unit), plus the picker flag.
@@ -78,23 +83,37 @@ struct ReceiveLightningView: View {
 
                 if let quote = mintQuote, !isPaid {
                     ToolbarItem(placement: .topBarTrailing) {
-                        if quote.paymentMethod == .bolt12 {
+                        if quote.paymentMethod == .bolt12 || quote.paymentMethod == .onchain {
                             // Overflow menu keeps Share + New quieter than a
                             // dedicated share glyph + second bottom CTA
-                            // (Android ⋮ parity).
+                            // (Android ⋮ parity). On-chain mirrors BOLT12's
+                            // "new artifact" item with a fresh address.
                             Menu {
                                 ShareLink(item: quote.request) {
                                     Label("Share", systemImage: "square.and.arrow.up")
                                 }
-                                Button {
-                                    createNewAmountlessOffer(unit: quote.unit)
-                                } label: {
-                                    Label(
-                                        isCreatingRequest ? "Creating…" : "New reusable invoice",
-                                        systemImage: "arrow.2.squarepath"
-                                    )
+                                if quote.paymentMethod == .bolt12 {
+                                    Button {
+                                        createNewAmountlessOffer(unit: quote.unit)
+                                    } label: {
+                                        Label(
+                                            isCreatingRequest ? "Creating…" : "New reusable invoice",
+                                            systemImage: "arrow.2.squarepath"
+                                        )
+                                    }
+                                    .disabled(isCreatingRequest)
+                                } else {
+                                    Button {
+                                        trackAbandonedOnchainQuote()
+                                        createRequest(method: .onchain, amountless: false, forceNew: true)
+                                    } label: {
+                                        Label(
+                                            isCreatingRequest ? "Creating…" : "New address",
+                                            systemImage: "arrow.clockwise"
+                                        )
+                                    }
+                                    .disabled(isCreatingRequest)
                                 }
-                                .disabled(isCreatingRequest)
                             } label: {
                                 Image(systemName: "ellipsis")
                                     .toolbarIconTapTarget()
@@ -196,6 +215,8 @@ struct ReceiveLightningView: View {
                 quoteStatusTask = nil
                 expiryTimer = nil
                 monitoredQuoteId = nil
+                abandonedQuoteTask?.cancel()
+                abandonedQuoteTask = nil
             }
         }
         .accessibilityIdentifier("receive-lightning-screen")
@@ -654,23 +675,27 @@ struct ReceiveLightningView: View {
                         .foregroundStyle(expiryTimeRemaining < 60 ? Color.red : Color.primary.opacity(0.5))
                     }
 
-                    if let mint = walletManager.activeMint {
-                        detailRow(
-                            icon: "bitcoinsign.bank.building",
-                            label: "Mint",
-                            value: extractMintHost(mint.url)
-                        )
+                    if walletManager.activeMint != nil || blockExplorerURL(for: quote) != nil {
+                        VStack(spacing: 0) {
+                            if let mint = walletManager.activeMint {
+                                detailRow(
+                                    icon: "bitcoinsign.bank.building",
+                                    label: "Mint",
+                                    value: extractMintHost(mint.url)
+                                )
+                            }
+                            if let explorerURL = blockExplorerURL(for: quote) {
+                                if walletManager.activeMint != nil {
+                                    canvasDivider
+                                }
+                                explorerLinkRow(label: blockExplorerLabel(for: quote), url: explorerURL)
+                            }
+                        }
                         .padding(.top, 8)
                         .padding(.horizontal, 4)
                     }
                 }
                 .padding(.horizontal)
-            }
-
-            if let explorerURL = blockExplorerURL(for: quote) {
-                Link(blockExplorerLabel(for: quote), destination: explorerURL)
-                    .font(.subheadline.weight(.medium))
-                    .padding(.vertical, 12)
             }
 
             Button(action: { copyRequest(quote.request) }) {
@@ -719,17 +744,11 @@ struct ReceiveLightningView: View {
                         .accessibilityLabel("Request amount: \(amount) \(quote.unit)")
                 }
             } else {
+                // "New address" lives in the toolbar overflow menu (BOLT12
+                // parity); this slot only shows progress while it generates.
                 if isCreatingRequest {
                     ProgressView()
                         .tint(.secondary)
-                } else if quote.paymentMethod == .onchain {
-                    Button { createRequest(method: .onchain, amountless: false, forceNew: true) } label: {
-                        Label("Use new address", systemImage: "arrow.clockwise")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                    }
-                    .accessibilityLabel("Use new address")
-                    .accessibilityHint("Generates a fresh deposit address and replaces the current QR code")
                 }
             }
         }
@@ -778,6 +797,29 @@ struct ReceiveLightningView: View {
         }
         .buttonStyle(.plain)
         .accessibilityHint("Edits the \(label.lowercased())")
+    }
+
+    /// Same shape as `detailRow` but opens an external URL, with the trailing
+    /// arrow-up-right glyph settings uses for outbound links — used for the
+    /// on-chain block explorer row.
+    private func explorerLinkRow(label: String, url: URL) -> some View {
+        Link(destination: url) {
+            HStack {
+                Label(label, systemImage: "safari")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
+        .accessibilityHint("Opens the block explorer in your browser")
     }
 
     private var canvasDivider: some View {
@@ -839,11 +881,11 @@ struct ReceiveLightningView: View {
                 HStack(spacing: 6) {
                     Image(systemName: "clock")
                         .symbolEffect(.pulse, options: .repeating, isActive: !reduceMotion)
+                        .foregroundStyle(.orange)
                         .accessibilityHidden(true)
                     Text(pendingStatusText)
                 }
                 .font(.subheadline)
-                .foregroundStyle(.orange)
                 .transition(.opacity)
             }
         }
@@ -1183,6 +1225,77 @@ struct ReceiveLightningView: View {
                 expiryTimer?.invalidate()
                 quoteStatusTask?.cancel()
             }
+        }
+    }
+
+    /// "Use new address" re-keys every monitor to the replacement quote
+    /// (`createRequest` resets `monitoredQuoteId` and cancels
+    /// `quoteStatusTask`); this keeps the outgoing address on a 30s
+    /// mint-status check so a payment already in flight still lands with the
+    /// full success screen. Multiple presses accrue; ids are deduped.
+    private func trackAbandonedOnchainQuote() {
+        guard let quote = mintQuote,
+              quote.paymentMethod == .onchain,
+              quote.state != .issued,
+              !quote.isExpired,
+              !abandonedOnchainQuoteIds.contains(quote.id) else { return }
+        abandonedOnchainQuoteIds.append(quote.id)
+        startAbandonedQuoteWatcher()
+    }
+
+    private func startAbandonedQuoteWatcher() {
+        guard abandonedQuoteTask == nil else { return }
+        abandonedQuoteTask = Task { @MainActor in
+            while !Task.isCancelled && !isPaid && !abandonedOnchainQuoteIds.isEmpty {
+                await checkAbandonedOnchainQuotes()
+                try? await Task.sleep(nanoseconds: 30_000_000_000)
+            }
+            abandonedQuoteTask = nil
+        }
+    }
+
+    @MainActor
+    private func checkAbandonedOnchainQuotes() async {
+        for quoteId in abandonedOnchainQuoteIds {
+            guard !isPaid, !Task.isCancelled else { return }
+            guard let info = try? await walletManager.checkMintQuote(quoteId: quoteId) else { continue }
+            // Drop quotes that expired before the mint saw any deposit; a
+            // funded-but-expired quote keeps being probed.
+            if info.isExpired, info.state == .pending, (info.amount ?? 0) == 0 {
+                abandonedOnchainQuoteIds.removeAll { $0 == quoteId }
+                continue
+            }
+            // On-chain quotes sit .pending until a mint attempt succeeds — the
+            // mint call is the probe (mintQuoteIfReady parity; not-yet-funded
+            // failures are expected and swallowed).
+            var mintedAmount: UInt64?
+            do {
+                mintedAmount = try await walletManager.mintTokens(quoteId: quoteId)
+            } catch {
+                guard isAlreadyIssuedMintError(error) else { continue }
+            }
+            abandonedOnchainQuoteIds.removeAll { $0 == quoteId }
+            // Stop the live quote's monitoring BEFORE swapping `mintQuote`, so
+            // the display view's onChange can't restart polling mid-swap; then
+            // reuse the standard success path.
+            quoteStatusTask?.cancel()
+            monitoredQuoteId = nil
+            expiryTimer?.invalidate()
+            let refreshed = (try? await walletManager.checkMintQuote(quoteId: quoteId)) ?? info
+            // `receiveSuccessRows` and the home toast need a non-nil amount;
+            // fall back to the freshly minted amount if the quote lacks one.
+            mintQuote = refreshed.amount != nil ? refreshed : MintQuoteInfo(
+                id: refreshed.id,
+                request: refreshed.request,
+                amount: mintedAmount,
+                paymentMethod: .onchain,
+                state: .issued,
+                expiry: refreshed.expiry,
+                createdAt: refreshed.createdAt,
+                unit: refreshed.unit
+            )
+            await completeReceivedQuote(mintInBackground: false)
+            return
         }
     }
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -3714,14 +3714,6 @@ struct UnitSelectorSheet: View {
             .scrollBounceBehavior(.basedOnSize)
             .navigationTitle("Select Unit")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "xmark")
-                    }
-                    .accessibilityLabel("Close")
-                }
-            }
         }
         .presentationDetents([.height(detentHeight)])
         .presentationDragIndicator(.visible)
@@ -3798,11 +3790,6 @@ struct MintSelectorSheet: View {
         }
         .navigationTitle("Select Mint")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-                SheetCloseButton()
-            }
-        }
         .presentationDetents([.height(detentHeight)])
         .presentationDragIndicator(.visible)
     }
@@ -4039,11 +4026,6 @@ struct AddMintToPaySheet: View {
             .scrollBounceBehavior(.basedOnSize)
             .navigationTitle("Add a mint to pay")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
-                }
-            }
         }
         .presentationDetents([.height(detentHeight)])
         .presentationDragIndicator(.visible)
@@ -4109,9 +4091,10 @@ struct AddMintToPaySheet: View {
 /// instead of stretching to `.medium` — same technique as `AddMintToPaySheet`.
 struct MethodPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
-    /// The live option, for the accent glyph + VoiceOver `.isSelected`. Read-only:
-    /// the parent owns the (method, isAmountless) state this maps to, so the
-    /// parent can react to a pick with side effects (e.g. auto-create) race-free.
+    /// The live option, for the trailing checkmark + VoiceOver `.isSelected`.
+    /// Read-only: the parent owns the (method, isAmountless) state this maps
+    /// to, so the parent can react to a pick with side effects (e.g.
+    /// auto-create) race-free.
     let selectedOption: ReceiveMethodOption
     let options: [ReceiveMethodOption]
     var onSelect: (ReceiveMethodOption) -> Void
@@ -4135,6 +4118,8 @@ struct MethodPickerSheet: View {
                     ForEach(options) { option in
                         Button(action: { select(option) }) {
                             HStack(spacing: 12) {
+                                optionIcon(for: option)
+
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text(option.friendlyTitle)
                                         .font(.body.weight(.medium))
@@ -4145,12 +4130,10 @@ struct MethodPickerSheet: View {
 
                                 Spacer()
 
-                                // Glyph teaches the nav-bar mapping and carries selection:
-                                // accent when chosen, muted otherwise. The row's
-                                // `.isSelected` trait conveys state to VoiceOver.
-                                Image(systemName: option.navSymbol)
-                                    .foregroundStyle(selectedOption == option ? Color.accentColor : .secondary)
-                                    .accessibilityHidden(true)
+                                if selectedOption == option {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(Color.accentColor)
+                                }
                             }
                             .padding(.horizontal, 20)
                             .padding(.vertical, 12)
@@ -4171,11 +4154,6 @@ struct MethodPickerSheet: View {
             .scrollBounceBehavior(.basedOnSize)
             .navigationTitle("Receive with")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
-                }
-            }
         }
         .presentationDetents([.height(detentHeight)])
         .presentationDragIndicator(.visible)
@@ -4187,6 +4165,14 @@ struct MethodPickerSheet: View {
         }
         onSelect(option)   // parent mutates state + may auto-create
         dismiss()
+    }
+
+    private func optionIcon(for option: ReceiveMethodOption) -> some View {
+        Image(systemName: option.navSymbol)
+            .font(.title3.weight(.medium))
+            .foregroundStyle(.secondary)
+            .frame(width: 24)
+            .accessibilityHidden(true)
     }
 }
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -132,7 +132,6 @@ struct SendView: View {
                     onSelect: selectSendMint
                 )
                     .environmentObject(walletManager)
-                    .presentationDetents([.medium])
             }
             .sheet(isPresented: $showUnitPicker) {
                 UnitSelectorSheet(
@@ -140,7 +139,6 @@ struct SendView: View {
                     selectedUnit: effectiveSendUnit,
                     onSelect: selectSendUnit
                 )
-                .presentationDetents([.medium])
             }
             .sheet(isPresented: $showShareSheet) {
                 if let token = generatedToken {
@@ -2106,7 +2104,6 @@ struct UnifiedSendView: View {
                 }
             )
             .environmentObject(walletManager)
-            .presentationDetents([.medium])
         case .cashuRequest:
             MintSelectorSheet(
                 selectedMint: $selectedMint,
@@ -2119,7 +2116,6 @@ struct UnifiedSendView: View {
                 }
             )
             .environmentObject(walletManager)
-            .presentationDetents([.medium])
         case nil:
             EmptyView()
         }
@@ -2884,7 +2880,6 @@ struct MeltView: View {
                     onSelect: selectMeltMint
                 )
                     .environmentObject(walletManager)
-                    .presentationDetents([.medium])
             }
             .onAppear {
                 syncMeltModeWithAvailableMints()
@@ -3666,34 +3661,57 @@ struct UnitSelectorSheet: View {
     let selectedUnit: String
     let onSelect: (String) -> Void
 
+    /// Measured height of the rows, driving a content-fit detent so the sheet
+    /// hugs its units instead of stretching to `.medium`. Mirrors `AddMintToPaySheet`.
+    @State private var rowsHeight: CGFloat = 0
+
+    /// Fixed sheet chrome around the measured rows: drag indicator + inline nav
+    /// bar + a little bottom breathing room.
+    private static let navChrome: CGFloat = 96
+
+    private var detentHeight: CGFloat {
+        let rows = rowsHeight > 0 ? rowsHeight : CGFloat(units.count) * 68
+        return rows + Self.navChrome
+    }
+
     var body: some View {
         NavigationStack {
-            List(units, id: \.self) { unit in
-                Button(action: { select(unit) }) {
-                    HStack(spacing: 12) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(unit.uppercased())
-                                .font(.body.weight(.medium))
-                            if let subtitle = unitSubtitle(unit) {
-                                Text(subtitle)
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(units, id: \.self) { unit in
+                        Button(action: { select(unit) }) {
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(unit.uppercased())
+                                        .font(.body.weight(.medium))
+                                    if let subtitle = unitSubtitle(unit) {
+                                        Text(subtitle)
+                                            .font(.subheadline)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                }
+
+                                Spacer()
+
+                                if unit == selectedUnit {
+                                    Image(systemName: "checkmark")
+                                        .foregroundStyle(Color.accentColor)
+                                }
                             }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 12)
+                            .contentShape(Rectangle())
                         }
-
-                        Spacer()
-
-                        if unit == selectedUnit {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(Color.accentColor)
-                        }
+                        .buttonStyle(.plain)
                     }
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .listRowSeparator(.hidden)
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { newHeight in
+                    rowsHeight = newHeight
+                }
             }
-            .listStyle(.plain)
+            .scrollBounceBehavior(.basedOnSize)
             .navigationTitle("Select Unit")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -3705,6 +3723,8 @@ struct UnitSelectorSheet: View {
                 }
             }
         }
+        .presentationDetents([.height(detentHeight)])
+        .presentationDragIndicator(.visible)
     }
 
     private func select(_ unit: String) {
@@ -3729,6 +3749,28 @@ struct MintSelectorSheet: View {
     private let paymentMethod: PaymentMethodKind?
     private let minimumAmount: UInt64?
     private let onSelect: ((MintInfo) -> Void)?
+
+    /// Measured height of the mint rows, driving a content-fit detent so the
+    /// sheet hugs its mints instead of stretching to `.medium`. Mirrors
+    /// `AddMintToPaySheet`. Only applies to `mintListView` — the empty states
+    /// below use a fixed compact height instead, since they're static
+    /// messages, not a list to measure.
+    @State private var rowsHeight: CGFloat = 0
+
+    /// Fixed sheet chrome around the measured rows: drag indicator + inline nav
+    /// bar + a little bottom breathing room.
+    private static let navChrome: CGFloat = 96
+
+    /// Fixed height for the empty / no-compatible-mints messages.
+    private static let compactStateHeight: CGFloat = 320
+
+    private var detentHeight: CGFloat {
+        guard sourceMints.isEmpty == false, displayMints.isEmpty == false else {
+            return Self.compactStateHeight
+        }
+        let rows = rowsHeight > 0 ? rowsHeight : CGFloat(displayMints.count) * 68
+        return rows + Self.navChrome
+    }
 
     init(
         selectedMint: Binding<MintInfo?>,
@@ -3761,6 +3803,8 @@ struct MintSelectorSheet: View {
                 SheetCloseButton()
             }
         }
+        .presentationDetents([.height(detentHeight)])
+        .presentationDragIndicator(.visible)
     }
 
     private var emptyStateView: some View {
@@ -3813,41 +3857,53 @@ struct MintSelectorSheet: View {
     }
 
     private var mintListView: some View {
-        List(displayMints) { mint in
-            Button(action: { selectMint(mint) }) {
-                HStack(spacing: 12) {
-                    mintIcon(for: mint)
-                        .overlay(alignment: .bottomTrailing) {
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(displayMints) { mint in
+                    Button(action: { selectMint(mint) }) {
+                        HStack(spacing: 12) {
+                            mintIcon(for: mint)
+                                .overlay(alignment: .bottomTrailing) {
+                                    if selectedMint?.id == mint.id {
+                                        Circle()
+                                            .fill(.green)
+                                            .frame(width: 12, height: 12)
+                                            .overlay(
+                                                Circle().stroke(Color(.systemBackground), lineWidth: 2)
+                                            )
+                                            .offset(x: 2, y: 2)
+                                    }
+                                }
+
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(mint.name)
+                                    .font(.body.weight(.medium))
+                                Text(mintSubtitle(for: mint))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+
                             if selectedMint?.id == mint.id {
-                                Circle()
-                                    .fill(.green)
-                                    .frame(width: 12, height: 12)
-                                    .overlay(
-                                        Circle().stroke(Color(.systemBackground), lineWidth: 2)
-                                    )
-                                    .offset(x: 2, y: 2)
+                                Image(systemName: "checkmark")
+                                    .foregroundStyle(Color.accentColor)
                             }
                         }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(mint.name)
-                            .font(.body.weight(.medium))
-                        Text(mintSubtitle(for: mint))
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .contentShape(Rectangle())
                     }
-
-                    Spacer()
-
-                    if selectedMint?.id == mint.id {
-                        Image(systemName: "checkmark")
-                            .foregroundStyle(Color.accentColor)
-                    }
+                    .buttonStyle(.plain)
                 }
             }
-            .listRowSeparator(.hidden)
+            .onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                rowsHeight = newHeight
+            }
         }
-        .listStyle(.plain)
+        .scrollBounceBehavior(.basedOnSize)
     }
 
     private func mintSubtitle(for mint: MintInfo) -> String {
@@ -4047,9 +4103,10 @@ struct AddMintToPaySheet: View {
 
 // MARK: - Method Picker Sheet
 
-/// Medium-detent picker for choosing a receive/send rail. Mirrors
+/// Content-fit picker for choosing a receive/send rail. Mirrors
 /// `MintSelectorSheet`: plain rows with a friendly title + descriptor and a
-/// trailing checkmark, dismiss-on-select. Detent is applied by the caller.
+/// trailing checkmark, dismiss-on-select. Sizes itself to its (2-4) rows
+/// instead of stretching to `.medium` — same technique as `AddMintToPaySheet`.
 struct MethodPickerSheet: View {
     @Environment(\.dismiss) private var dismiss
     /// The live option, for the accent glyph + VoiceOver `.isSelected`. Read-only:
@@ -4059,37 +4116,59 @@ struct MethodPickerSheet: View {
     let options: [ReceiveMethodOption]
     var onSelect: (ReceiveMethodOption) -> Void
 
+    /// Measured height of the option rows, driving a content-fit detent.
+    @State private var rowsHeight: CGFloat = 0
+
+    /// Fixed sheet chrome around the measured rows: drag indicator + inline nav
+    /// bar + a little bottom breathing room.
+    private static let navChrome: CGFloat = 96
+
+    private var detentHeight: CGFloat {
+        let rows = rowsHeight > 0 ? rowsHeight : CGFloat(options.count) * 68
+        return rows + Self.navChrome
+    }
+
     var body: some View {
         NavigationStack {
-            List(options) { option in
-                Button(action: { select(option) }) {
-                    HStack(spacing: 12) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(option.friendlyTitle)
-                                .font(.body.weight(.medium))
-                            Text(option.friendlyDescriptor)
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
+            ScrollView {
+                VStack(spacing: 0) {
+                    ForEach(options) { option in
+                        Button(action: { select(option) }) {
+                            HStack(spacing: 12) {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(option.friendlyTitle)
+                                        .font(.body.weight(.medium))
+                                    Text(option.friendlyDescriptor)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer()
+
+                                // Glyph teaches the nav-bar mapping and carries selection:
+                                // accent when chosen, muted otherwise. The row's
+                                // `.isSelected` trait conveys state to VoiceOver.
+                                Image(systemName: option.navSymbol)
+                                    .foregroundStyle(selectedOption == option ? Color.accentColor : .secondary)
+                                    .accessibilityHidden(true)
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 12)
+                            .contentShape(Rectangle())
                         }
-
-                        Spacer()
-
-                        // Glyph teaches the nav-bar mapping and carries selection:
-                        // accent when chosen, muted otherwise. The row's
-                        // `.isSelected` trait conveys state to VoiceOver.
-                        Image(systemName: option.navSymbol)
-                            .foregroundStyle(selectedOption == option ? Color.accentColor : .secondary)
-                            .accessibilityHidden(true)
+                        .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(option.friendlyTitle). \(option.friendlyDescriptor)")
+                        .accessibilityAddTraits(selectedOption == option ? .isSelected : [])
                     }
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .listRowSeparator(.hidden)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("\(option.friendlyTitle). \(option.friendlyDescriptor)")
-                .accessibilityAddTraits(selectedOption == option ? .isSelected : [])
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.height
+                } action: { newHeight in
+                    rowsHeight = newHeight
+                }
             }
-            .listStyle(.plain)
+            .scrollBounceBehavior(.basedOnSize)
             .navigationTitle("Receive with")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -4098,6 +4177,8 @@ struct MethodPickerSheet: View {
                 }
             }
         }
+        .presentationDetents([.height(detentHeight)])
+        .presentationDragIndicator(.visible)
     }
 
     private func select(_ option: ReceiveMethodOption) {

--- a/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
@@ -126,11 +126,6 @@ struct CurrencyPickerSheet: View {
             .navigationTitle("Currency")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.hidden, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    SheetCloseButton()
-                }
-            }
             .safeAreaInset(edge: .bottom) {
                 if settings.showFiatBalance {
                     priceFooter


### PR DESCRIPTION
## Summary
- Brings the Bitcoin address receive screen and on-chain transaction detail to full parity between iOS and Android: neutral waiting-status styling, block explorer as a tappable detail row, live mempool status updates on Android, shared green-checkmark success layout for confirmed on-chain transactions, and "New address" moved into the overflow menu (mirroring the BOLT12 pattern)
- iOS: content-fit bottom sheets for method/mint/unit pickers (sized to their content instead of a fixed `.medium` detent)
- Android: bottom sheet for the receive method picker, matching iOS
- iOS: picker-sheet close/icon conventions unified across the app (drag/scrim dismiss only, leading icon + trailing checkmark for selection)
- Android: picker-sheet titles centered via the shared `FlowSheetTitle` component
- Android: bump AGP to 9.3.0

## Test plan
- [ ] Verify Bitcoin address receive flow and confirmed on-chain transaction detail render identically on iOS and Android
- [ ] Verify mempool status updates live while waiting for an on-chain payment on Android
- [ ] Verify "New address" appears in the overflow menu and generates a fresh address
- [ ] Verify method/mint/unit picker sheets on iOS size to content and dismiss only via row tap/drag/scrim
- [ ] Verify Android picker sheet titles are centered and the receive method picker opens as a bottom sheet
- [ ] Confirm Android build succeeds with AGP 9.3.0