### PR TITLE
Replace Send/Receive method-button glass with filled sheet-action circles

### DIFF
--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -504,17 +504,22 @@ right tool for the job.
   Typography and padding match `FullWidthCapsuleButtonStyle` exactly
   (`.body.weight(.semibold)`, `.padding(.vertical, 18)`) so it reads as one
   family.
-- **Send-method row (carve-out) — round glass icon buttons.** The Send chooser
-  (`UnifiedSendView`) offers its "ways to send" — Scan · Ecash · Tap — as a
-  centered row of **circular** Liquid Glass icon buttons, each a monochrome SF
-  Symbol over a one-word `.caption.weight(.medium)` label on the canvas. On
-  iOS 26 each circle uses Apple's native `.buttonStyle(.glass)` +
-  `.buttonBorderShape(.circle)` inside a `GlassEffectContainer`; iOS 18–25 falls
-  back to a `.quaternary` circle with `PressableButtonStyle`. This is a
-  deliberate, bounded expansion of the surface vocabulary beyond the full-width
-  capsule — justified because here the SF Symbol *is* the affordance (icon-only,
-  no text on the surface) and it echoes the circular glass button the home row
-  itself once carried (see Capsule + Circle + Capsule, above).
+- **Send/Receive-method row (carve-out) — round filled icon buttons.** The Send
+  and Receive sheets offer their "ways to send/receive" — Scan · Ecash · Tap /
+  Scan · Ecash · Bitcoin — as a centered row of **circular** icon buttons
+  (`CircularGlassIconButton`): a 72pt `.quaternary` circle, a monochrome
+  `.title` SF Symbol, 40pt row gaps, and a one-word `.caption.weight(.medium)`
+  label below, with `PressableButtonStyle` press feedback. The metrics mirror
+  Android's `CircularMethodButton` (72dp circle · 32dp icon · 40dp gap) for
+  cross-platform parity. This is Apple's sheet-action-circle
+  pattern (Maps, Find My, Wallet) — deliberately **not** Liquid Glass: the row
+  scrolls with the sheet's content, and the content layer gets no glass. Glass
+  here would sit on the sheet's own glass background (glass can't sample
+  glass) and turn near-invisible under the system Clear appearance; the
+  semantic fill renders identically under Clear and Tinted and adapts to
+  Increase Contrast. Same surface on all OS versions. The carve-out beyond the
+  full-width capsule stays justified because the SF Symbol *is* the affordance
+  (icon-only, no text on the surface).
 - **Press feedback — `PressableButtonStyle`**: 0.97 scale on press down
   (`.snappy(0.09)`), spring back on release (`.snappy(0.18)`). Apply only
   where the glass style doesn't already carry feedback (the chooser

--- a/ios/CashuWallet/Views/Components/PressableButtonStyle.swift
+++ b/ios/CashuWallet/Views/Components/PressableButtonStyle.swift
@@ -19,11 +19,10 @@ struct PressableButtonStyle: ButtonStyle {
 
 /// One round glass icon button with a one-word caption on the canvas below it —
 /// the shared "method" button used by both the Send and Receive sheets
-/// (Scan · Ecash · Tap / Scan · Ecash · Bitcoin). On iOS 26, the configurable
-/// native glass button style retains the system-owned inset and interaction,
-/// while a subtle adaptive tint keeps it distinct from the sheet's own glass
-/// without turning three peer actions into prominent filled controls. iOS 18–25
-/// falls back to a `.quaternary` circle. Wrap a row in a
+/// (Scan · Ecash · Tap / Scan · Ecash · Bitcoin). On iOS 26 this is the plain
+/// system `.glass` button style — untinted, matching the home Receive/Send
+/// pills and the input field's glass — with the system-owned inset and
+/// interaction. iOS 18–25 falls back to a `.quaternary` circle. Wrap a row in a
 /// `GlassEffectContainer(spacing:)` on iOS 26 so the adjacent circular glass
 /// surfaces sample light consistently (glass can't sample other glass).
 struct CircularGlassIconButton: View {
@@ -41,7 +40,7 @@ struct CircularGlassIconButton: View {
                         .foregroundStyle(.primary)
                         .frame(width: 64, height: 64)
                 }
-                .buttonStyle(.glass(.regular.tint(Color.primary.opacity(0.15))))
+                .buttonStyle(.glass)
                 .buttonBorderShape(.circle)
             } else {
                 Button(action: action) {

--- a/ios/CashuWallet/Views/Components/PressableButtonStyle.swift
+++ b/ios/CashuWallet/Views/Components/PressableButtonStyle.swift
@@ -17,14 +17,17 @@ struct PressableButtonStyle: ButtonStyle {
 
 // MARK: - Circular glass method button
 
-/// One round glass icon button with a one-word caption on the canvas below it —
-/// the shared "method" button used by both the Send and Receive sheets
-/// (Scan · Ecash · Tap / Scan · Ecash · Bitcoin). On iOS 26 this is the plain
-/// system `.glass` button style — untinted, matching the home Receive/Send
-/// pills and the input field's glass — with the system-owned inset and
-/// interaction. iOS 18–25 falls back to a `.quaternary` circle. Wrap a row in a
-/// `GlassEffectContainer(spacing:)` on iOS 26 so the adjacent circular glass
-/// surfaces sample light consistently (glass can't sample other glass).
+/// One round icon button with a one-word caption below it — the shared "method"
+/// button used by both the Send and Receive sheets (Scan · Ecash · Tap /
+/// Scan · Ecash · Bitcoin). Apple's sheet-action-circle pattern (Maps, Find My,
+/// Wallet): a monochrome symbol on a `.quaternary` fill. These buttons scroll
+/// with the sheet's content, and the content layer gets no Liquid Glass —
+/// glass sitting on the sheet's own glass background can't sample it and turns
+/// invisible under the system Clear appearance. The semantic fill adapts to
+/// light/dark and Increase Contrast, and renders identically under the Clear
+/// and Tinted system glass settings. Metrics mirror Android's
+/// `CircularMethodButton` (72dp circle · 32dp icon · 40dp row gap) so the
+/// Send/Receive sheets match across platforms.
 struct CircularGlassIconButton: View {
     let icon: String
     let label: String
@@ -33,25 +36,14 @@ struct CircularGlassIconButton: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            if #available(iOS 26, *) {
-                Button(action: action) {
-                    Image(systemName: icon)
-                        .font(.title2)
-                        .foregroundStyle(.primary)
-                        .frame(width: 64, height: 64)
-                }
-                .buttonStyle(.glass)
-                .buttonBorderShape(.circle)
-            } else {
-                Button(action: action) {
-                    Image(systemName: icon)
-                        .font(.title2)
-                        .foregroundStyle(.primary)
-                        .frame(width: 64, height: 64)
-                        .background(.quaternary, in: Circle())
-                }
-                .buttonStyle(PressableButtonStyle())
+            Button(action: action) {
+                Image(systemName: icon)
+                    .font(.title)
+                    .foregroundStyle(.primary)
+                    .frame(width: 72, height: 72)
+                    .background(.quaternary, in: Circle())
             }
+            .buttonStyle(PressableButtonStyle())
 
             Text(label)
                 .font(.caption.weight(.medium))

--- a/ios/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveView.swift
@@ -294,11 +294,10 @@ struct UnifiedReceiveView: View {
 
     // MARK: Receive-method buttons
 
-    /// The primary "ways to receive" — a centered row of round Liquid Glass icon
-    /// buttons wrapped in a `GlassEffectContainer` on iOS 26 so adjacent circular
-    /// glass surfaces sample light consistently (same technique as Send).
+    /// The primary "ways to receive" — a centered row of round filled icon
+    /// buttons (Apple's sheet-action-circle pattern; same component as Send).
     private var receiveMethodRow: some View {
-        let row = HStack(spacing: 28) {
+        HStack(spacing: 40) {
             CircularGlassIconButton(icon: "qrcode.viewfinder", label: "Scan",
                                     a11y: "Scan QR code") {
                 HapticFeedback.selection()
@@ -316,14 +315,6 @@ struct UnifiedReceiveView: View {
                 route = .lightning
             }
             .accessibilityIdentifier("wallet-flow-receiveLightning")
-        }
-
-        return Group {
-            if #available(iOS 26, *) {
-                GlassEffectContainer(spacing: 28) { row }
-            } else {
-                row
-            }
         }
         .frame(maxWidth: .infinity)   // center the group on the leading-aligned canvas
     }

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1364,12 +1364,10 @@ struct UnifiedSendView: View {
 
     // MARK: Send-method buttons
 
-    /// The primary "ways to send" as a centered row of round Liquid Glass icon
-    /// buttons. The `HStack` is wrapped in a `GlassEffectContainer` on iOS 26 so
-    /// the adjacent circular glass surfaces sample light consistently (glass
-    /// can't sample other glass) — same technique as the home Receive/Send row.
+    /// The primary "ways to send" as a centered row of round filled icon
+    /// buttons (Apple's sheet-action-circle pattern; same component as Receive).
     private var sendMethodRow: some View {
-        let row = HStack(spacing: 28) {
+        HStack(spacing: 40) {
             sendMethodButton(icon: "qrcode.viewfinder", label: "Scan",
                              a11y: "Scan QR code", action: openScanner)
 
@@ -1387,18 +1385,10 @@ struct UnifiedSendView: View {
                 }
             }
         }
-
-        return Group {
-            if #available(iOS 26, *) {
-                GlassEffectContainer(spacing: 28) { row }
-            } else {
-                row
-            }
-        }
         .frame(maxWidth: .infinity)   // center the group on the leading-aligned canvas
     }
 
-    /// One round glass icon button with a one-word caption on the canvas below it.
+    /// One round filled icon button with a one-word caption on the canvas below it.
     /// Delegates to the shared `CircularGlassIconButton` so the Send and Receive
     /// sheets stay pixel-identical.
     private func sendMethodButton(


### PR DESCRIPTION
## What
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/a60e50d5-87a7-453d-ad20-fcfc2b0c498d" />

Before: Left
After: Right


The Send sheet's Scan · Ecash · Tap buttons and the Receive sheet's Scan · Ecash · Bitcoin buttons become monochrome SF Symbols on **72pt `.quaternary` filled circles** with 40pt gaps — Apple's sheet-action-circle pattern (Maps, Find My, Wallet) — on every OS version. The iOS 26 Liquid Glass branch in `CircularGlassIconButton` is deleted along with the now-dead `GlassEffectContainer` wrappers in both sheets; the former pre-iOS-26 fallback is now the single code path. DESIGN.md records the pattern and metrics.

This PR originally swapped the buttons' hand-tuned glass tint for plain `.buttonStyle(.glass)` (5a19b00). On-device testing showed the deeper problem, and the second commit (894602b) supersedes that approach — see below.

## Why

**Untinted glass was nearly invisible under the system Clear appearance.** With Settings → Display & Brightness → Liquid Glass set to Clear, in dark mode, the `.glass` circles all but vanished. Regular glass has almost no intrinsic surface — its visibility comes from refracting content behind it plus a system frost that Clear strips away. Behind these buttons there is nothing to refract: a glass sheet over a pure-black canvas.

**These buttons were glass in the content layer, which Apple avoids.** They scroll with the sheet's content, and the guidance is no Liquid Glass in the content layer — glass is for chrome floating above scrollable content. Worse, they sat on the sheet's own glass background, and glass can't sample other glass. Apple's own sheets render this exact element as a filled gray circle, not glass.

**The semantic fill is deterministic.** `.quaternary` renders identically under Clear and Tinted, adapts to light/dark and Increase Contrast, and needs no per-mode tuning — the original sin of the hand-tuned tint this PR started by removing.

**72pt/40pt is exact Android parity.** Android's `CircularMethodButton` deliberately ships 72dp circles, 32dp icons, 40dp gaps. The old iOS glass rendering happened to measure ~87pt only because the style padded an already-64pt frame — an accident Android's sizing had been visually tuned against. iOS now matches Android's numbers (112pt center-to-center on both) and keeps roughly the familiar footprint.

## Verification

Built and driven on an iPhone 17 Pro (iOS 26.2) simulator: Receive and Send sheets checked in dark and light mode — circles clearly visible in both, row fits the self-measuring compact detent, press feedback intact. The fill is opaque, so the Clear/Tinted system setting cannot affect it by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)