### PR TITLE
Simplify wallet activity on Home and History

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/HomeActivity.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/HomeActivity.kt
@@ -1,0 +1,18 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.WalletTransaction
+
+/**
+ * Home is a compact settled-ledger view, not an operational queue. Generated
+ * receive artifacts and every non-completed state remain available in History.
+ */
+internal fun recentCompletedTransactions(
+    transactions: List<WalletTransaction>,
+    limit: Int,
+): List<WalletTransaction> = transactions
+    .asSequence()
+    .filter { it.status == TransactionStatus.Completed }
+    .sortedByDescending { it.dateEpochMillis }
+    .take(limit.coerceAtLeast(0))
+    .toList()

--- a/android/app/src/main/java/com/cashu/me/Core/PendingMintQuoteTransactions.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PendingMintQuoteTransactions.kt
@@ -32,6 +32,14 @@ internal fun pendingMintQuoteTransactions(
         if (amount <= 0) return@mapNotNull null
 
         val timestamp = timestamps.getOrPut(quote.id) { nowEpochMillis }
+        // A paid-but-unissued quote stays Pending even past expiry: the invoice
+        // settled, and NUT-04 lets the wallet mint it after the invoice expires.
+        val isPaid = quote.state == MintQuoteState.Paid ||
+            quote.state == MintQuoteState.Issued ||
+            quote.amountPaid > 0
+        val isUnpaidBolt11 = quote.paymentMethod == PaymentMethodKind.Bolt11 && !isPaid
+        val expiry = quote.expiryEpochSeconds ?: 0
+        val isExpiredUnpaidInvoice = isUnpaidBolt11 && expiry > 0 && nowEpochMillis / 1000 > expiry
         WalletTransaction(
             id = quote.id,
             amount = amount,
@@ -42,15 +50,17 @@ internal fun pendingMintQuoteTransactions(
                 TransactionKind.Lightning
             },
             dateEpochMillis = timestamp,
-            status = if (quote.state == MintQuoteState.Issued || quote.amountIssued >= amount) {
-                TransactionStatus.Completed
-            } else {
-                TransactionStatus.Pending
+            status = when {
+                quote.state == MintQuoteState.Issued || quote.amountIssued >= amount ->
+                    TransactionStatus.Completed
+                isExpiredUnpaidInvoice -> TransactionStatus.Expired
+                else -> TransactionStatus.Pending
             },
             mintUrl = mintUrl,
             invoice = quote.request,
             quoteId = quote.id,
             unit = quote.unit,
+            isUnpaidInvoice = isUnpaidBolt11,
         )
     }
 

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -17,10 +17,11 @@ object TransactionDisplay {
     // Kind-first, capitalized kind, lowercase verb — single source of truth for
     // rows AND the detail title, so a row and the sheet it opens read identically.
     fun title(transaction: WalletTransaction): String = when (transaction.kind) {
-        TransactionKind.Lightning -> if (transaction.type == TransactionType.Incoming) {
-            "Lightning received"
-        } else {
-            "Lightning paid"
+        TransactionKind.Lightning -> when {
+            transaction.type != TransactionType.Incoming -> "Lightning paid"
+            // Nothing has been received while the invoice awaits payment.
+            transaction.isUnpaidInvoice -> "Lightning invoice"
+            else -> "Lightning received"
         }
         TransactionKind.Onchain -> if (transaction.type == TransactionType.Incoming) {
             "Bitcoin received"
@@ -43,6 +44,7 @@ object TransactionDisplay {
         }
         TransactionStatus.Pending -> "Pending"
         TransactionStatus.Failed -> "Failed"
+        TransactionStatus.Expired -> "Expired"
     }
 
     fun qrContent(transaction: WalletTransaction): String? =

--- a/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
@@ -31,7 +31,7 @@ data class CashuRequest(
     val displayTitle: String
         get() = when (quoteKind?.lowercase()) {
             "bolt12" -> "Reusable Invoice"
-            "bolt11" -> if (receivedPayments.isEmpty()) "Lightning Invoice" else "Lightning received"
+            "bolt11" -> if (receivedPayments.isEmpty()) "Lightning invoice" else "Lightning received"
             "onchain" -> if (receivedPayments.isEmpty()) "Bitcoin Address" else "Bitcoin received"
             else -> "Cashu Request"
         }

--- a/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
@@ -22,9 +22,15 @@ data class WalletTransaction(
     val isPendingToken: Boolean = false,
     val quoteId: String? = null,
     val cashuRequestId: String? = null,
+    /** BOLT11 mint quote still awaiting payment — titles the row "Lightning invoice". */
+    val isUnpaidInvoice: Boolean = false,
 ) {
     val displayStatusText: String
         get() = if (status == TransactionStatus.Pending) statusNote ?: status.displayText else status.displayText
+
+    /** Quiet Pending rule: expired never credited the balance, so it keeps the bare muted amount. */
+    val isUnsettled: Boolean
+        get() = status == TransactionStatus.Pending || status == TransactionStatus.Expired
 }
 
 @Serializable
@@ -51,12 +57,14 @@ enum class TransactionKind {
 enum class TransactionStatus {
     Pending,
     Completed,
-    Failed;
+    Failed,
+    Expired;
 
     val displayText: String
         get() = when (this) {
             Pending -> "Pending"
             Completed -> "Completed"
             Failed -> "Failed"
+            Expired -> "Expired"
         }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
@@ -77,8 +77,8 @@ fun requestRowDisplay(
 }
 
 /**
- * Cashu Request timeline row, paired with [TransactionRow] in History and Home
- * Recent. A request is structurally an incoming-ecash event in waiting, so the
+ * Cashu Request timeline row, paired with [TransactionRow] in History. A
+ * request is structurally an incoming-ecash event in waiting, so the
  * leading icon is the same muted down-arrow. Amount states mirror iOS
  * CashuRequestAmountColumn: fixed+waiting → bare muted amount; received →
  * "+amount" in primary; any-amount+waiting → no trailing element (caller passes
@@ -127,9 +127,9 @@ fun CashuRequestRow(
                 Text(
                     text = if (received) "+$primaryAmountText" else primaryAmountText,
                     style = MaterialTheme.typography.bodyLarge.withMonoDigits(),
-                    fontWeight = FontWeight.SemiBold,
+                    fontWeight = FontWeight.Medium,
                     color = if (received) {
-                        MaterialTheme.colorScheme.onSurface
+                        CashuTheme.colors.received
                     } else {
                         MaterialTheme.colorScheme.onSurfaceVariant
                     },
@@ -138,7 +138,8 @@ fun CashuRequestRow(
             if (secondaryAmountText != null) {
                 Text(
                     text = secondaryAmountText,
-                    style = MaterialTheme.typography.bodySmall.withMonoDigits(),
+                    style = MaterialTheme.typography.bodyMedium.withMonoDigits(),
+                    fontWeight = FontWeight.Normal,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }

--- a/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
@@ -45,8 +45,8 @@ data class TransactionRowModel(
 /**
  * Canonical timeline row. Leading muted directional arrow (direction is the
  * arrow's orientation, never colour); kind is named in the title. The amount is
- * a two-state ledger signal: bare + muted while pending, signed + primary once
- * settled (One Green Rule / Quiet Pending — no badge, no spinner, no green).
+ * the ledger signal: received is green with a plus, sent is primary with no
+ * sign, and pending/expired is muted with no sign.
  */
 @Composable
 fun TransactionRow(
@@ -56,18 +56,14 @@ fun TransactionRow(
 ) {
     val tx = model.transaction
     val incoming = tx.type == TransactionType.Incoming
-    val pending = tx.status == TransactionStatus.Pending
-    val amountColor = if (pending) {
-        MaterialTheme.colorScheme.onSurfaceVariant
-    } else {
-        MaterialTheme.colorScheme.onSurface
+    val unsettled = tx.isUnsettled
+    val amountColor = when {
+        unsettled -> MaterialTheme.colorScheme.onSurfaceVariant
+        incoming -> CashuTheme.colors.received
+        else -> MaterialTheme.colorScheme.onSurface
     }
-    val amountText = if (pending) {
-        model.primaryAmount
-    } else {
-        "${if (incoming) "+" else "−"}${model.primaryAmount}"
-    }
-    val semanticAmount = if (pending) model.primaryAmount else "${if (incoming) "+" else "-"}${model.primaryAmount}"
+    val amountText = if (!unsettled && incoming) "+${model.primaryAmount}" else model.primaryAmount
+    val semanticAmount = amountText
     val semanticParts = listOfNotNull(
         model.title,
         if (incoming) "Incoming" else "Outgoing",
@@ -108,13 +104,14 @@ fun TransactionRow(
             Text(
                 text = amountText,
                 style = MaterialTheme.typography.bodyLarge.withMonoDigits(),
-                fontWeight = FontWeight.SemiBold,
+                fontWeight = FontWeight.Medium,
                 color = amountColor,
             )
             if (model.secondaryAmount != null) {
                 Text(
                     text = model.secondaryAmount,
-                    style = MaterialTheme.typography.bodySmall.withMonoDigits(),
+                    style = MaterialTheme.typography.bodyMedium.withMonoDigits(),
+                    fontWeight = FontWeight.Normal,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -82,7 +82,6 @@ import com.cashu.me.Core.displayText
 import com.cashu.me.Models.CashuRequest
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.WalletTransaction
-import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuRequestRow
 import com.cashu.me.ui.components.requestRowDisplay
 import com.cashu.me.ui.components.CashuSearchBar
@@ -340,7 +339,6 @@ fun HistoryScreen(
                                         )
                                     }
                                 }
-                                if (item != section.items.last()) CanvasDivider()
                                 }
                             }
                         }

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -72,7 +72,6 @@ import com.cashu.me.Core.recentCompletedTransactions
 import com.cashu.me.Models.WalletTransaction
 import com.cashu.me.ui.components.BalanceDisplay
 import com.cashu.me.ui.components.BalanceHeroHeight
-import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.EmptyState
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.MintChip
@@ -311,7 +310,6 @@ fun HomeScreen(
                                 ),
                                 onClick = { onOpenTransaction(tx) },
                             )
-                            if (tx != recentTransactions.last()) CanvasDivider()
                         }
                     }
                     item("view-all") {

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -60,7 +60,6 @@ import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountDisplayText
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.displayMintUnitAmount
-import com.cashu.me.Core.CashuRequestStore
 import com.cashu.me.Core.HomeBalance
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
@@ -69,13 +68,11 @@ import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.displayText
-import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Core.recentCompletedTransactions
 import com.cashu.me.Models.WalletTransaction
 import com.cashu.me.ui.components.BalanceDisplay
 import com.cashu.me.ui.components.BalanceHeroHeight
 import com.cashu.me.ui.components.CanvasDivider
-import com.cashu.me.ui.components.CashuRequestRow
-import com.cashu.me.ui.components.requestRowDisplay
 import com.cashu.me.ui.components.EmptyState
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.MintChip
@@ -99,11 +96,9 @@ fun HomeScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
     priceService: PriceService,
-    cashuRequestStore: CashuRequestStore,
     onOpenMints: () -> Unit,
     onOpenHistory: () -> Unit,
     onOpenTransaction: (WalletTransaction) -> Unit,
-    onOpenCashuRequest: (CashuRequest) -> Unit,
     onReceive: () -> Unit,
     onSend: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -113,7 +108,6 @@ fun HomeScreen(
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
     val priceState by priceService.state.collectAsState()
-    val requestState by cashuRequestStore.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
     var refreshing by remember { mutableStateOf(false) }
@@ -129,10 +123,8 @@ fun HomeScreen(
         )
     }
 
-    // Unified timeline: merge transactions + Cashu Requests, dedup claim-tx ids,
-    // sort by date descending, cap at RECENT_LIMIT.
-    val recentItems = remember(walletState.transactions, requestState.requests) {
-        unifiedRecent(walletState.transactions, requestState.requests, RECENT_LIMIT)
+    val recentTransactions = remember(walletState.transactions) {
+        recentCompletedTransactions(walletState.transactions, RECENT_LIMIT)
     }
 
     // Received-delta beat (iOS MainWalletView "payment-received celebration"):
@@ -273,11 +265,11 @@ fun HomeScreen(
                 ),
             ) {
                 item("section-header") {
-                    if (recentItems.isNotEmpty()) {
+                    if (recentTransactions.isNotEmpty()) {
                         SectionHeader(text = "Recent")
                     }
                 }
-                if (recentItems.isEmpty()) {
+                if (recentTransactions.isEmpty()) {
                     item("empty") {
                         val hasMints = walletState.mints.isNotEmpty()
                         // iOS: a single quiet tray empty state, centered in the region
@@ -296,54 +288,30 @@ fun HomeScreen(
                         )
                     }
                 } else {
-                    items(recentItems, key = { it.key }) { item ->
+                    items(recentTransactions, key = { it.id }) { tx ->
                         // Spring-animated placement when the timeline reshuffles
-                        // (new payment lands, request claimed) — History parity.
+                        // as completed payments land — History parity.
                         Column(modifier = Modifier.animateItem()) {
-                            when (item) {
-                                is HomeRecentItem.Tx -> {
-                                    val tx = item.transaction
-                                    val amountDisplay = formatter.displayMintUnitAmount(
-                                        amount = tx.amount,
-                                        unit = tx.unit,
-                                        preferredPrimary = settings.amountDisplayPrimary,
-                                        showFiat = settings.showFiatBalance,
-                                        btcPrice = priceState.btcPrice,
-                                        currencyCode = settings.bitcoinPriceCurrency,
-                                        useBitcoinSymbol = settings.useBitcoinSymbol,
-                                    )
-                                    TransactionRow(
-                                        model = TransactionRowModel(
-                                            transaction = tx,
-                                            title = TransactionDisplay.title(tx),
-                                            timestamp = formatRelativeTimestamp(tx.dateEpochMillis),
-                                            primaryAmount = amountDisplay.primary,
-                                            secondaryAmount = amountDisplay.secondary,
-                                        ),
-                                        onClick = { onOpenTransaction(tx) },
-                                    )
-                                }
-                                is HomeRecentItem.Req -> {
-                                    val req = item.request
-                                    val amountDisplay = requestRowDisplay(
-                                        request = req,
-                                        formatter = formatter,
-                                        preferredPrimary = settings.amountDisplayPrimary,
-                                        showFiat = settings.showFiatBalance,
-                                        btcPrice = priceState.btcPrice,
-                                        currencyCode = settings.bitcoinPriceCurrency,
-                                        useBitcoinSymbol = settings.useBitcoinSymbol,
-                                    )
-                                    CashuRequestRow(
-                                        request = req,
-                                        timestamp = formatRelativeTimestamp(req.createdAtEpochMillis),
-                                        primaryAmountText = amountDisplay?.primary,
-                                        secondaryAmountText = amountDisplay?.secondary,
-                                        onClick = { onOpenCashuRequest(req) },
-                                    )
-                                }
-                            }
-                            if (item != recentItems.last()) CanvasDivider()
+                            val amountDisplay = formatter.displayMintUnitAmount(
+                                amount = tx.amount,
+                                unit = tx.unit,
+                                preferredPrimary = settings.amountDisplayPrimary,
+                                showFiat = settings.showFiatBalance,
+                                btcPrice = priceState.btcPrice,
+                                currencyCode = settings.bitcoinPriceCurrency,
+                                useBitcoinSymbol = settings.useBitcoinSymbol,
+                            )
+                            TransactionRow(
+                                model = TransactionRowModel(
+                                    transaction = tx,
+                                    title = TransactionDisplay.title(tx),
+                                    timestamp = formatRelativeTimestamp(tx.dateEpochMillis),
+                                    primaryAmount = amountDisplay.primary,
+                                    secondaryAmount = amountDisplay.secondary,
+                                ),
+                                onClick = { onOpenTransaction(tx) },
+                            )
+                            if (tx != recentTransactions.last()) CanvasDivider()
                         }
                     }
                     item("view-all") {
@@ -597,40 +565,4 @@ private fun ActionDuet(
             colors = actionColors,
         )
     }
-}
-
-/** Unified Home/History timeline item. Mirrors iOS HistoryItem enum. */
-internal sealed interface HomeRecentItem {
-    val date: Long
-    val key: String
-    data class Tx(val transaction: WalletTransaction) : HomeRecentItem {
-        override val date: Long get() = transaction.dateEpochMillis
-        override val key: String get() = "tx:${transaction.id}"
-    }
-    data class Req(val request: CashuRequest) : HomeRecentItem {
-        override val date: Long get() = request.createdAtEpochMillis
-        override val key: String get() = "req:${request.id}"
-    }
-}
-
-/**
- * Merge transactions + Cashu Requests, suppress transactions that are already
- * claim-attached to a request (so the request is the single representation),
- * sort by date desc, return up to [limit].
- */
-internal fun unifiedRecent(
-    transactions: List<WalletTransaction>,
-    requests: List<CashuRequest>,
-    limit: Int,
-): List<HomeRecentItem> {
-    val claimedTxIds = buildSet {
-        requests.forEach { req ->
-            req.receivedPayments.forEach { add(it.transactionId) }
-        }
-    }
-    val txItems = transactions
-        .filterNot { it.id in claimedTxIds }
-        .map { HomeRecentItem.Tx(it) as HomeRecentItem }
-    val reqItems = requests.map { HomeRecentItem.Req(it) as HomeRecentItem }
-    return (txItems + reqItems).sortedByDescending { it.date }.take(limit)
 }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -276,14 +276,10 @@ private fun NavGraphBuilder.tabDestinations(
             walletManager = container.walletManager,
             settingsManager = container.settingsManager,
             priceService = container.priceService,
-            cashuRequestStore = container.cashuRequestStore,
             onOpenMints = { navController.navigateToTab(TopTab.Mints) },
             onOpenHistory = { navController.navigateToTab(TopTab.History) },
             onOpenTransaction = { tx ->
                 navController.navigate(transactionDetailRouteFor(tx.id))
-            },
-            onOpenCashuRequest = { req ->
-                navController.navigate(cashuRequestDetailRouteFor(req.id))
             },
             // Receive goes straight to the unified surface — no chooser (iOS
             // parity). Bitcoin is now a button inside that sheet, not a chooser row.

--- a/android/app/src/test/java/com/cashu/me/Core/HistoryFiltersTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/HistoryFiltersTest.kt
@@ -16,7 +16,8 @@ class HistoryFiltersTest {
         val pending = transaction("pending", TransactionStatus.Pending)
         val completed = transaction("completed", TransactionStatus.Completed)
         val failed = transaction("failed", TransactionStatus.Failed)
-        val transactions = listOf(pending, completed, failed)
+        val expired = transaction("expired", TransactionStatus.Expired)
+        val transactions = listOf(pending, completed, failed, expired)
 
         assertEquals(transactions, filterTransactions(transactions, HistoryFilter.All))
         assertEquals(listOf(pending), filterTransactions(transactions, HistoryFilter.Pending))

--- a/android/app/src/test/java/com/cashu/me/Core/HomeActivityTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/HomeActivityTest.kt
@@ -1,0 +1,54 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HomeActivityTest {
+    @Test
+    fun showsOnlyLatestCompletedSentAndReceivedTransactions() {
+        val transactions = listOf(
+            transaction("received-via-request", TransactionStatus.Completed, 20, TransactionType.Incoming)
+                .copy(cashuRequestId = "request"),
+            transaction("pending-request", TransactionStatus.Pending, 50),
+            transaction("failed", TransactionStatus.Failed, 40),
+            transaction("sent", TransactionStatus.Completed, 30),
+            transaction("expired", TransactionStatus.Expired, 60),
+        )
+
+        val recent = recentCompletedTransactions(transactions, limit = 5)
+
+        assertEquals(listOf("sent", "received-via-request"), recent.map { it.id })
+    }
+
+    @Test
+    fun appliesTheRecentLimitAfterFilteringAndSorting() {
+        val transactions = listOf(
+            transaction("old", TransactionStatus.Completed, 10),
+            transaction("new", TransactionStatus.Completed, 30),
+            transaction("middle", TransactionStatus.Completed, 20),
+        )
+
+        assertEquals(
+            listOf("new", "middle"),
+            recentCompletedTransactions(transactions, limit = 2).map { it.id },
+        )
+    }
+
+    private fun transaction(
+        id: String,
+        status: TransactionStatus,
+        dateEpochMillis: Long,
+        type: TransactionType = TransactionType.Outgoing,
+    ) = WalletTransaction(
+        id = id,
+        amount = 1,
+        type = type,
+        kind = TransactionKind.Ecash,
+        dateEpochMillis = dateEpochMillis,
+        status = status,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/Core/PendingMintQuoteTransactionsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PendingMintQuoteTransactionsTest.kt
@@ -32,6 +32,7 @@ class PendingMintQuoteTransactionsTest {
         assertEquals(TransactionType.Incoming, row.type)
         assertEquals(TransactionKind.Lightning, row.kind)
         assertEquals(TransactionStatus.Pending, row.status)
+        assertTrue(row.isUnpaidInvoice)
         assertEquals("lnbc1quote", row.invoice)
         assertEquals("usd", row.unit)
         assertEquals(1_700_000_000_000L, row.dateEpochMillis)
@@ -66,6 +67,43 @@ class PendingMintQuoteTransactionsTest {
 
         assertEquals(42L, rows.single().amount)
         assertEquals(TransactionStatus.Completed, rows.single().status)
+        assertFalse(rows.single().isUnpaidInvoice)
+    }
+
+    @Test
+    fun expiresUnpaidBolt11InvoicesPastExpiry() {
+        val nowMillis = 1_700_000_000_000L
+        val nowSeconds = nowMillis / 1000
+
+        fun rowFor(quote: MintQuoteInfo) = pendingMintQuoteTransactions(
+            quotes = listOf(quote),
+            trackedMintUrls = setOf(MintUrl),
+            completedQuoteIds = emptySet(),
+            timestamps = mutableMapOf(),
+            nowEpochMillis = nowMillis,
+        ).single()
+
+        val expired = rowFor(quote(expiryEpochSeconds = nowSeconds - 1))
+        assertEquals(TransactionStatus.Expired, expired.status)
+        assertTrue(expired.isUnpaidInvoice)
+
+        val live = rowFor(quote(expiryEpochSeconds = nowSeconds + 60))
+        assertEquals(TransactionStatus.Pending, live.status)
+        assertTrue(live.isUnpaidInvoice)
+
+        // Paid before expiry stays mintable (NUT-04): Pending, titled as received.
+        val paid = rowFor(quote(state = MintQuoteState.Paid, amountPaid = 10, expiryEpochSeconds = nowSeconds - 1))
+        assertEquals(TransactionStatus.Pending, paid.status)
+        assertFalse(paid.isUnpaidInvoice)
+
+        // No expiry recorded (null or 0 sentinel) means the invoice never expires.
+        assertEquals(TransactionStatus.Pending, rowFor(quote(expiryEpochSeconds = null)).status)
+        assertEquals(TransactionStatus.Pending, rowFor(quote(expiryEpochSeconds = 0)).status)
+
+        // Only the BOLT11 rail expires; addresses stay fundable.
+        val onchain = rowFor(quote(method = PaymentMethodKind.Onchain, expiryEpochSeconds = nowSeconds - 1))
+        assertEquals(TransactionStatus.Pending, onchain.status)
+        assertFalse(onchain.isUnpaidInvoice)
     }
 
     @Test
@@ -129,13 +167,14 @@ class PendingMintQuoteTransactionsTest {
         amountPaid: Long = 0,
         amountIssued: Long = 0,
         unit: String = "sat",
+        expiryEpochSeconds: Long? = null,
     ) = MintQuoteInfo(
         id = id,
         request = "lnbc1quote",
         amount = amount,
         paymentMethod = method,
         state = state,
-        expiryEpochSeconds = null,
+        expiryEpochSeconds = expiryEpochSeconds,
         mintUrl = MintUrl,
         amountPaid = amountPaid,
         amountIssued = amountIssued,

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -33,6 +33,32 @@ class TransactionDisplayTest {
     }
 
     @Test
+    fun unpaidInvoiceTitlesAsInvoiceUntilPaid() {
+        val unpaid = transaction(
+            kind = TransactionKind.Lightning,
+            type = TransactionType.Incoming,
+            invoice = "lnbc1test",
+        ).copy(status = TransactionStatus.Pending, isUnpaidInvoice = true)
+
+        assertEquals("Lightning invoice", TransactionDisplay.title(unpaid))
+        assertEquals("Lightning received", TransactionDisplay.title(unpaid.copy(isUnpaidInvoice = false)))
+    }
+
+    @Test
+    fun expiredInvoiceRetiresQrAndReadsExpired() {
+        val expired = transaction(
+            kind = TransactionKind.Lightning,
+            type = TransactionType.Incoming,
+            invoice = "lnbc1test",
+        ).copy(status = TransactionStatus.Expired, isUnpaidInvoice = true)
+
+        assertEquals("Lightning invoice", TransactionDisplay.title(expired))
+        assertEquals("Expired", TransactionDisplay.statusText(expired))
+        assertTrue(!TransactionDisplay.showsQr(expired))
+        assertEquals(null, TransactionDisplay.copyableContent(expired))
+    }
+
+    @Test
     fun settledArtifactsAreNotScannableButEcashKeepsCopyReceipt() {
         val settledEcash = transaction(
             kind = TransactionKind.Ecash,

--- a/android/app/src/test/java/com/cashu/me/Models/CashuRequestDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Models/CashuRequestDisplayTest.kt
@@ -20,7 +20,7 @@ class CashuRequestDisplayTest {
         val bolt12 = CashuRequest(encoded = "lno1", quoteKind = "bolt12")
         val onchain = CashuRequest(encoded = "bc1q", quoteKind = "onchain")
 
-        assertEquals("Lightning Invoice", bolt11.displayTitle)
+        assertEquals("Lightning invoice", bolt11.displayTitle)
         assertEquals("Reusable Invoice", bolt12.displayTitle)
         assertEquals("Bitcoin Address", onchain.displayTitle)
         assertFalse(bolt11.isEcashRequest)

--- a/docs/android/UX_SPEC.md
+++ b/docs/android/UX_SPEC.md
@@ -23,8 +23,8 @@ Cashu Wallet is a **system utility**, not a crypto dashboard. The bar is set by 
 | **Quiet Pending Rule** | Pending state = clock icon + low-alpha orange tint, never a saturated pill. |
 | **Tabular Figure Rule** | All balances/amounts/fees use a monospaced-digit `FontFeatureSetting` and animate digits independently (`Modifier.animateContentSize` + `AnimatedContent` with `numericContentTransform`). |
 | **System-Style Rule** | All text uses `MaterialTheme.typography.*` slots so it scales with system font size. No hardcoded `sp` outside the theme file. |
-| **Flat-By-Default Rule** | No elevation on rows, cards, buttons. Depth from M3 tonal surfaces and 0.5dp dividers only. **One exception:** transient success toast (a floating M3 surface). |
-| **CanvasDivider Rule** | List rows on canvas screens are separated by a single 0.5dp `HorizontalDivider` with 28dp leading inset — never card stacks. |
+| **Flat-By-Default Rule** | No elevation on rows, cards, buttons. Depth comes from M3 tonal surfaces and deliberate spacing. **One exception:** transient success toast (a floating M3 surface). |
+| **CanvasDivider Rule** | Use a 0.5dp `HorizontalDivider` with 28dp leading inset where a detail screen needs explicit separation. Home and History activity rows omit dividers and rely on spacing. |
 | **Share-At-Top Rule** | When a screen shows a shareable QR (invoice, request, token, transaction), `Share` lives in the `TopAppBar` actions, never in the footer button stack. |
 | **Singular Button Rule** | Primary AND secondary CTAs both use `FilledTonalButton`. No `OutlinedButton`, no inverted-fill. Hierarchy via copy and disabled state. The single most-prominent action per screen (e.g. "Create Wallet") may use `Button` (filled). |
 | **Iconless-CTA Rule** | Primary CTAs (Copy, Send, Receive, Continue, New Request) are text-only. No leading icons. |
@@ -94,7 +94,7 @@ Top-to-bottom inside the pinned region:
 
 - **Notification toast** (top inset) — if `walletManager.lastNotification` non-null. Floating M3 surface with leading icon, message, and dismiss `IconButton`. Auto-dismiss after 5s. Toast carries the only allowed shadow in the app.
 - **"Recent activity" section header** — `labelMedium`, uppercase, letter-spaced, `onSurfaceVariant`. **Padding: 16dp top, 8dp bottom** (carve-out from the original 28dp top spec — matches iOS rhythm where `HistoryView` and `SettingsView` section headers both use 16pt top). Rendered via the shared `SectionHeader` component for consistency across Home, History, Settings, and Mints.
-- **Up to 5 completed transaction rows** — the latest settled sent/received payments, including payments received through reusable requests or offers. Generated receive artifacts and pending, failed, or expired transactions stay in History. Same anatomy as History rows (see §4.2). `CanvasDivider` between, none after last.
+- **Up to 5 completed transaction rows** — the latest settled sent/received payments, including payments received through reusable requests or offers. Generated receive artifacts and pending, failed, or expired transactions stay in History. Same anatomy as History rows (see §4.2). Rows use spacing only, with no separators.
 - **"View all activity" `TextButton`** — bottom of section, navigates to History tab.
 
 **Empty state**: if no mints, replace the activity section with `EmptyState(icon = Icons.Outlined.AccountBalance, title = "Add a mint to get started", supporting = "Mints custody your ecash. Go to the Mints tab to add one.", actionLabel = "Add mint", onAction = …)`. If mints exist but no transactions, show `EmptyState(icon = Icons.Outlined.History, title = "No transactions yet", supporting = "Your activity will show up here.")`.
@@ -162,7 +162,7 @@ Pushed top-level destination from the History tab. `CenterAlignedTopAppBar(title
 - Completed outgoing: `onSurface`, unsigned. Direction is already carried by the title and arrow.
 - Failed: `onSurface`.
 
-**Divider:** `HorizontalDivider(thickness = 0.5.dp, color = outlineVariant)`, 28dp leading inset. None after the last row in a section.
+**Divider:** none. Transaction and request rows use spacing and section grouping instead of horizontal rules.
 
 **Entrance:** first 8 rows on initial render animate in with 35ms stagger, 6dp y-offset → 0, fade in. Subsequent loads/filters re-render snappily without stagger.
 

--- a/docs/android/UX_SPEC.md
+++ b/docs/android/UX_SPEC.md
@@ -94,7 +94,7 @@ Top-to-bottom inside the pinned region:
 
 - **Notification toast** (top inset) — if `walletManager.lastNotification` non-null. Floating M3 surface with leading icon, message, and dismiss `IconButton`. Auto-dismiss after 5s. Toast carries the only allowed shadow in the app.
 - **"Recent activity" section header** — `labelMedium`, uppercase, letter-spaced, `onSurfaceVariant`. **Padding: 16dp top, 8dp bottom** (carve-out from the original 28dp top spec — matches iOS rhythm where `HistoryView` and `SettingsView` section headers both use 16pt top). Rendered via the shared `SectionHeader` component for consistency across Home, History, Settings, and Mints.
-- **Up to 5 transaction rows** — same anatomy as History rows (see §4.2). `CanvasDivider` between, none after last.
+- **Up to 5 completed transaction rows** — the latest settled sent/received payments, including payments received through reusable requests or offers. Generated receive artifacts and pending, failed, or expired transactions stay in History. Same anatomy as History rows (see §4.2). `CanvasDivider` between, none after last.
 - **"View all activity" `TextButton`** — bottom of section, navigates to History tab.
 
 **Empty state**: if no mints, replace the activity section with `EmptyState(icon = Icons.Outlined.AccountBalance, title = "Add a mint to get started", supporting = "Mints custody your ecash. Go to the Mints tab to add one.", actionLabel = "Add mint", onAction = …)`. If mints exist but no transactions, show `EmptyState(icon = Icons.Outlined.History, title = "No transactions yet", supporting = "Your activity will show up here.")`.
@@ -146,10 +146,10 @@ Pushed top-level destination from the History tab. `CenterAlignedTopAppBar(title
 | Slot | Contents |
 |------|---------|
 | Leading (40dp) | Method icon (Ecash custom glyph / `Icons.Filled.Bolt` for Lightning / `Icons.Outlined.CurrencyBitcoin` for on-chain) **with a bottom-trailing 16dp status badge** on a `surface`-colored circle. Badge swaps via `AnimatedContent` w/ fade-through (~280ms). |
-| Title (top) | `bodyLarge`, e.g. "Lightning received", "Bitcoin sent", "Sent ecash". |
+| Title (top) | `bodyLarge`, e.g. "Lightning received", "Bitcoin sent", "Sent ecash". *(2026-07-21: a BOLT11 mint quote still awaiting payment titles as "Lightning invoice" — `WalletTransaction.isUnpaidInvoice` via `TransactionDisplay.title()` — flipping to "Lightning received" only once paid. An unpaid invoice past its quote expiry keeps that title with status **Expired**: excluded from the Pending filter, QR/Copy/Share retired in detail, amount stays bare + muted.)* |
 | Subtitle (bottom) | `bodySmall`, `onSurfaceVariant`, relative timestamp ("2 hr ago"). |
-| Trailing top | Amount: `bodyLarge` semibold, monospaced digits, prefix `+`/`−`. Color rules below. |
-| Trailing bottom | Fiat sub-amount: `bodySmall`, `onSurfaceVariant`, monospaced. Only if `showFiatBalance && btcPriceUsd > 0`. |
+| Trailing top | Amount: `bodyLarge` medium, monospaced digits. Completed incoming gets `+`; outgoing is unsigned. Color rules below. |
+| Trailing bottom | Converted sub-amount: `bodyMedium` regular, `onSurfaceVariant`, monospaced. Only if `showFiatBalance && btcPriceUsd > 0`. The neighboring size and weight keep both currencies inside one amount block. |
 
 **Status badge colors:**
 - Pending: `Icons.Outlined.Schedule` (clock), `pending-orange`, pulsing alpha animation.
@@ -158,7 +158,8 @@ Pushed top-level destination from the History tab. `CenterAlignedTopAppBar(title
 
 **Amount color:**
 - Pending: `onSurfaceVariant`.
-- Completed: `received-green` (both directions — "money landed is money landed", per iOS).
+- Completed incoming: `received-green`, prefixed with `+`.
+- Completed outgoing: `onSurface`, unsigned. Direction is already carried by the title and arrow.
 - Failed: `onSurface`.
 
 **Divider:** `HorizontalDivider(thickness = 0.5.dp, color = outlineVariant)`, 28dp leading inset. None after the last row in a section.

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -162,8 +162,9 @@ What this system explicitly rejects, pulled verbatim from docs/product/PRODUCT.m
 - One sans family: San Francisco at native iOS text styles. No display pairings,
   no custom fonts, no fluid clamps.
 - Liquid Glass on iOS 26+ for primary interactive surfaces. Quiet fallbacks below.
-- Hairline `CanvasDivider` (0.5pt at `Color(.separator)`) as the single-canvas
-  separator. No card stacks, no nested containers.
+- Hairline `CanvasDivider` (0.5pt at `Color(.separator)`) where a single-canvas
+  detail needs separation. Home and History activity rows use spacing alone.
+  No card stacks, no nested containers.
 - Motion is exponential ease-out, in the 180–350ms range. Seven named animations
   carry the full vocabulary: row stagger, badge symbol-replace, chooser cascade,
   press feedback, sheet cross-fade (in-sheet flow swap), payment-received
@@ -555,7 +556,8 @@ The canonical list pattern. Defined in
   amount alone (the `arrow.triangle.2.circlepath` refresh button was removed
   2026-06-01). Manual re-check is History pull-to-refresh
   (`syncPendingMintQuotes()` + `checkAllPendingTokens()`).
-- **Separator**: `CanvasDivider()` with the default 28pt leading inset.
+- **Separator**: none. Home and History activity rows flow on the canvas with
+  spacing and section grouping carrying the rhythm.
 - **Entrance**: none — rows appear in place. *(Retired 2026-07-06.)* The list
   once staggered its first eight rows in on appearance, but the History tab is
   swapped for `Color.clear` when unselected (`MainTabView.tabContent`, a
@@ -746,9 +748,10 @@ moment — and it is still a system glyph at a system color.
 
 ### Named Rules
 
-**The CanvasDivider Rule.** Single-canvas screens (History, Lightning Invoice
-detail) use `CanvasDivider` between rows. Raw `Divider()` is legacy. There are
-no card stacks; rows sit directly on the canvas, separated only by the hairline.
+**The CanvasDivider Rule.** Single-canvas detail screens such as Lightning
+Invoice detail use `CanvasDivider` between rows. Raw `Divider()` is legacy.
+There are no card stacks. Home and History transaction activity are an explicit
+carve-out: their rows flow without hairlines, separated by spacing and grouping.
 
 *Carve-out (Settings, 2026-06-28):* the Settings screen and its detail
 subscreens drop hairlines entirely — rows flow on the bare canvas, separated by
@@ -954,8 +957,8 @@ curve or a delight beat):*
 - **Do** branch with `if #available(iOS 26.0, *)` for Liquid Glass and provide
   a quiet `.thinMaterial` or `.quaternary` fallback. Never ship a Liquid Glass
   surface that breaks on iOS 18.
-- **Do** use `CanvasDivider()` between rows on single-canvas screens. The
-  default 28pt leading inset already aligns to the icon column.
+- **Do** use `CanvasDivider()` when a single-canvas detail needs explicit row
+  separation. Home and History transaction activity intentionally omit it.
 - **Do** name iOS text styles (`.body`, `.largeTitle`, `.caption`) so Dynamic
   Type scales for free. Pair balance/amount text with `.minimumScaleFactor(0.5)`
   and `.lineLimit(1)` so AX5 doesn't truncate a money value.

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -112,7 +112,7 @@ components:
     rounded: "circle"
     iconSymbol: "arrow.down (incoming) / arrow.up (outgoing)"
     iconSize: "16px"
-    note: "Leading 36x36 history-row glyph (TransactionIcon). Pure directional arrow, always muted; direction is the arrow's orientation, never colour. The amount carries settled/pending state via .primary / .secondary — never green (One Green Rule). Carve-out: supersedes the prior kind-glyph + corner directional badge model."
+    note: "Leading 36x36 history-row glyph (TransactionIcon). Pure directional arrow, always muted; direction is the arrow's orientation, never colour. The primary amount carries state: green +amount for completed incoming, unsigned .primary for completed outgoing, .secondary for pending/expired. Carve-out: supersedes the prior kind-glyph + corner directional badge model."
   row-inspector-editable:
     backgroundColor: "transparent"
     textColor: "{colors.primary-text}"
@@ -207,18 +207,17 @@ opacity for foreground (icon, status text) and at low opacity (10–18%) when us
 as a tinted background.
 
 - **Confirmed Green** (`Color.green`, ≈ `#34C759` / `#30D158`): green is the
-  receiver's reward, but **no longer on a ledger amount** — *as of 2026-06-01
-  in-row amount green is retired* (see the amended One Green Rule; transaction
-  and Cashu Request row amounts are `.primary` when settled, `.secondary` when
-  pending). Green lives in **off-row / detail-surface success states**: the
+  receiver's reward. A completed incoming transaction or received Cashu Request
+  uses green for its primary `+amount`; outgoing amounts remain `.primary`, and
+  pending/expired amounts remain `.secondary`. Green also lives in
+  **off-row / detail-surface success states**: the
   default-mint indicator dot; the `checkmark.seal.fill` "N payments received"
   status and `checkmark.circle.fill` toast inside `CashuRequestDetailView`; the
   64pt `checkmark.circle.fill` success icon on `PaymentStatusView`; and the same
   64pt completed check on the transaction detail sheet (`TransactionDetailView`).
-  *As of 2026-07-05 the home received-delta beat is no longer green* (see the One
-  Green Rule). **Nothing on a list row is green.** The leading directional arrow
-  is always `.secondary` regardless of direction or state — green belongs to
-  receipt-confirmation surfaces, not the ledger line.
+  *As of 2026-07-05 the home received-delta beat is no longer green.* The leading
+  directional arrow is always `.secondary` regardless of direction or state;
+  only the received primary amount turns green on a ledger row.
 - **Pending Orange** (`Color.orange`, ≈ `#FF9500` / `#FF9F0A`): foreground for the
   "Waiting for payment…" clock on a Cashu Request and the amber
   `exclamationmark.triangle.fill` caution on `PaymentStatusView`. It does **not**
@@ -246,20 +245,18 @@ as a tinted background.
 `Color(.separator)`) or one of three state hues at a stated opacity. There is no
 fourth case.
 
-**The One Green Rule.** *Amended 2026-06-01: in-row amount green is retired —
-amounts are never green.* A transaction row's amount is now a **two-state
-ledger signal**: `.secondary` while `transaction.status == .pending`, `.primary`
-once settled (both directions, both kinds — incoming, outgoing, ecash,
-Lightning, on-chain). A received Cashu Request renders `.primary` too. The
-shared `TransactionAmountColumn` (`ios/CashuWallet/Views/Components/`) is the
-canonical implementation: `amountColor` is exactly
-`transaction.status == .pending ? .secondary : .primary`; do not re-derive the
-color elsewhere. *Rationale for the carve-out:* mixing green/white/gray amounts
-at mixed weights read as noisy rather than calm; a single white-settles /
-gray-pends language is more aligned with the "System Utility" North Star, and
-direction is already carried by the leading arrow + the `+`/`−` prefix.
-Green now survives in **one off-row place only**, which is not a
-transaction-row amount:
+**The One Green Rule.** *Amended 2026-07-21:* within a ledger row, green belongs
+only to the primary amount of completed incoming money: green `+amount` for an
+incoming transaction or received Cashu Request. A completed outgoing amount is
+unsigned `.primary`; pending and expired amounts are unsigned `.secondary`.
+The title, timestamp, leading arrow, and converted sub-amount never turn green.
+The shared `TransactionAmountColumn` is the canonical implementation; do not
+re-derive the sign or color elsewhere. Direction for outgoing rows is already
+carried by the title and upward arrow, so a minus sign adds noise without new
+information.
+
+Outside ledger rows, confirmed green also appears in deliberate success and
+selection states, including:
 1. The **default-mint indicator dot** — a small green dot on a mint's icon
    (Mints list `MintsListView`, mint profile `MintDetailView`) marking the
    user's selected default mint. A *selection* marker (same axis as "Set as
@@ -293,7 +290,11 @@ directional-arrow-on-a-circle hero and the small green "✓ Received" badge are 
 State also rides an explicit **`Status` row** — the first detail row, monochrome
 value (the hero glyph already carries the colour): completed → **Claimed** (ecash)
 / **Paid** (lightning) / **Confirmed** (on-chain); pending → **Pending**; failed →
-**Failed**. A **`Date` row** follows. Remaining rows are conditional essentials —
+**Failed**; expired → **Expired** *(added 2026-07-21: an unpaid BOLT11 invoice
+past its quote expiry — the QR/Share/Copy retire with it and the hero stays
+empty like a pending no-QR row; no red X, since nothing failed, the invoice
+simply lapsed. A quote paid before expiry stays **Pending** even past expiry —
+NUT-04 lets it be minted afterwards)*. A **`Date` row** follows. Remaining rows are conditional essentials —
 **Fee** when `> 0`, **Mint** always; the **Unit** row and the settled **Request**
 row stay dropped (`unitLabel` is always BTC/SAT; the live request is the QR/Copy).
 On-chain keeps **Address** / **Transaction ID** and its address QR. The **Type**
@@ -324,29 +325,24 @@ The muted-orange pending language survives only off the list, on the
 sheet's pending state is now a monochrome "Pending" `Status` row — no orange,
 2026-07-05(c).) Never a full-saturation pill, never a loud "PENDING" wordmark.
 
-*Amended 2026-06-27: the leading `+`/`−` sign is itself a settled-ledger
-signal. A pending row — either direction — renders a **bare, unsigned** amount;
-the sign appears only on settlement, together with the `.primary` colour. This
-unifies the transaction column (`TransactionAmountColumn`, used by BOLT11 /
-Lightning / ecash) with the waiting Cashu Request / Reusable Invoice
-(`CashuRequestAmountColumn`), which already showed a bare amount until paid — so
-a pending incoming BOLT11 invoice no longer shows `+21` while a waiting BOLT12
-offer shows `21`.*
+*Amended 2026-07-21: only a completed incoming row uses a sign: green `+amount`.
+Completed outgoing rows are unsigned and `.primary`; their title and upward arrow
+already carry direction. Pending and expired rows are also unsigned and muted.
+Cashu Request / Reusable Invoice rows follow the same rule: waiting is bare and
+muted, received is green with `+`.*
 
-*Amended 2026-06-27: the leading `+`/`−` sign is itself a settled-ledger
-signal. A pending row — either direction — renders a **bare, unsigned** amount;
-the sign appears only on settlement, together with the `.primary` colour. This
-unifies the transaction column (`TransactionAmountColumn`, used by BOLT11 /
-Lightning / ecash) with the waiting Cashu Request / Reusable Invoice
-(`CashuRequestAmountColumn`), which already showed a bare amount until paid — so
-a pending incoming BOLT11 invoice no longer shows `+21` while a waiting BOLT12
-offer shows `21`.*
+*Amended 2026-07-21: **expired** rows (`isUnsettled` = pending or expired) keep
+the same bare, muted amount — an expired invoice never credited the balance, so
+it must not read as settled.*
 
 **The Fiat Sub-Amount Rule.** When
-`settings.showFiatBalance && priceService.btcPriceUSD > 0`, any row that
-renders a sats amount also renders the fiat equivalent directly below it in
-`.caption / .secondary / .monospacedDigit()` — supplementary text, never a
-peer. Cashu Request "any amount" rows (no fixed expected total) render no
+`settings.showFiatBalance && priceService.btcPriceUSD > 0`, any sat-unit row
+renders its configured primary amount with the converted value below it in
+`.system(.subheadline, design: .rounded).weight(.regular) / .secondary /
+.monospacedDigit()`. The primary value is the neighboring
+`.system(.body, design: .rounded).weight(.medium)`: enough hierarchy to preserve
+the configured primary currency without making the conversion read like tiny
+metadata. Cashu Request "any amount" rows (no fixed expected total) render no
 trailing element and therefore no fiat. Fiat re-renders silently on price
 ticks; no `.contentTransition`. Same gate as the hero balance fiat line, so
 turning fiat off in Settings clears the entire app uniformly.
@@ -544,13 +540,17 @@ The canonical list pattern. Defined in
   (Models.swift), reused by the History/Home rows **and** the transaction detail
   nav title, so a row and the sheet it opens always read identically. *(2026-06-01:
   was verb-first lowercase "Received ecash"; unified to kind-first.)*
+  *(2026-07-21: a BOLT11 mint quote still awaiting payment titles as
+  **"Lightning invoice"** — `isUnpaidInvoice` — flipping to "Lightning received"
+  only once the invoice is paid. "Received" must never assert money that hasn't
+  arrived; this also covers the expired state, which keeps the invoice title.
+  Mirrors the request-row precedent `CashuRequest.displayTitle`.)*
 - **Timestamp**: `.caption`, `Color.secondary`, immediately under the title.
   Formatted with `RelativeDateTimeFormatter(.abbreviated)` ("2 hr ago", "3 d ago").
-- **Trailing amount**: `.system(.body, design: .rounded).weight(.semibold)
-  .monospacedDigit()`, `.contentTransition(.numericText(value:))`, prefixed
-  with `+` or `−`. Two-state colour: pending → `Color.secondary`, everything
-  settled → `.primary` (both directions, both kinds; never green — see the
-  amended One Green Rule).
+- **Trailing amount**: `.system(.body, design: .rounded).weight(.medium)
+  .monospacedDigit()`, `.contentTransition(.numericText(value:))`. Completed
+  incoming → green `+amount`; completed outgoing → unsigned `.primary`; pending
+  or expired → unsigned `.secondary`.
 - **Pending indicator**: none on the row. Pending is the muted `.secondary`
   amount alone (the `arrow.triangle.2.circlepath` refresh button was removed
   2026-06-01). Manual re-check is History pull-to-refresh
@@ -584,13 +584,14 @@ section. Defined in `HistoryView.swift` → `cashuRequestRow(request:, staggerIn
   `.secondary` — matches transaction rows exactly. The payment count
   ("3 payments received") is no longer surfaced on the row; it lives in
   `CashuRequestDetailView`.
-- **Trailing amount** (all `.semibold`, matching every other amount):
+- **Trailing amount** (`.body` medium primary with a `.subheadline` regular
+  conversion, matching every other amount):
   - Fixed-amount + waiting: `amount` in `.secondary`, no indicator — the muted
     amount alone signals waiting (the target is visible while pending).
-  - Fixed-amount + received: `+amount` in `.primary`, monospaced digit,
+  - Fixed-amount + received: `+amount` in `.green`, monospaced digit,
     `.contentTransition(.numericText(value:))`. Cumulative for multi-payment.
   - Any-amount + waiting: no trailing element at all.
-  - Any-amount + received: `+\(totalReceived)` in `.primary`, cumulative.
+  - Any-amount + received: `+\(totalReceived)` in `.green`, cumulative.
 - **Duplicate suppression**: when a payment lands, `WalletManager
   .receiveCashuRequestPayment` diffs the mint's incoming transaction ids
   before/after the receive, identifies the new CDK tx id, and stores it on
@@ -667,12 +668,12 @@ camera scanner only.
 The signature surface of the NUT-18 receive flow.
 `ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift`. The view runs in two
 contexts: as the receive-flow face inside a `.medium`/`.large` sheet from
-`ReceiveEcashView`, or — from History/Home — presented as its **own bottom
+`ReceiveEcashView`, or — from History — presented as its **own bottom
 `.sheet`** (wrapped in a `NavigationStack` at the call site for its toolbar).
 **Detail surfaces are always bottom sheets, never pushed** — tapping any
-history/recent item (transaction *or* Cashu Request) slides up the same way, so
-the two never diverge into a push vs. sheet split. The same content scales to
-both contexts.
+History item or completed Home transaction slides up the same way, so the two
+never diverge into a push vs. sheet split. The same content scales to both
+contexts.
 
 - **QR**: 280×280 `QRCodeView(content:, showControls: false, staticOnly: true)`
   on a `Color.white` `RoundedRectangle(cornerRadius: 20)` with 16pt padding.
@@ -692,7 +693,7 @@ both contexts.
     on-screen request (the `.cashuTokenReceived` notification carries the
     `requestId`). In the **receive flow** (watching a fresh request, `onClose`
     set) it dwells ~1.2s then the sheet auto-dismisses — mirroring the Lightning
-    invoice. When **inspecting** an existing request from History/Home it holds
+    invoice. When **inspecting** an existing request from History it holds
     2.5s then reverts to the persistent count (no dismiss).
   - Received (persistent) → `checkmark.seal.fill` + "N payments received",
     `Color.green`. Quiet — no symbol effect, no animation.

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -1159,7 +1159,7 @@
 				CODE_SIGN_ENTITLEMENTS = CashuWallet/CashuWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = D7AHD3GLH6;
+				DEVELOPMENT_TEAM = JQ4WB222T4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CashuWallet/Info.plist;
@@ -1182,7 +1182,7 @@
 					"-framework",
 					SystemConfiguration,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.cashu.me;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cashu.me.xyz;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -1198,7 +1198,7 @@
 				CODE_SIGN_ENTITLEMENTS = CashuWallet/CashuWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = D7AHD3GLH6;
+				DEVELOPMENT_TEAM = JQ4WB222T4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CashuWallet/Info.plist;
@@ -1221,7 +1221,7 @@
 					"-framework",
 					SystemConfiguration,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.cashu.me;
+				PRODUCT_BUNDLE_IDENTIFIER = com.cashu.me.xyz;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/ios/CashuWallet/Core/Services/TransactionService.swift
+++ b/ios/CashuWallet/Core/Services/TransactionService.swift
@@ -526,8 +526,17 @@ class TransactionService: ObservableObject {
             let timestamp = timestamps[quote.id] ?? Date().timeIntervalSince1970
             timestamps[quote.id] = timestamp
             let createdAt = Date(timeIntervalSince1970: timestamp)
+            // A paid-but-unissued quote stays Pending even past expiry: the
+            // invoice settled, and NUT-04 lets the wallet mint it afterwards.
+            let isPaid = quote.state == .paid || quote.state == .issued || quote.amountPaid.value > 0
+            let isUnpaidBolt11 = paymentMethod == .bolt11 && !isPaid
+            let isExpiredUnpaidInvoice = isUnpaidBolt11
+                && quote.expiry > 0
+                && Date().timeIntervalSince1970 > Double(quote.expiry)
             let status: WalletTransaction.TransactionStatus =
-                quote.state == .issued || quote.amountIssued.value >= amount ? .completed : .pending
+                quote.state == .issued || quote.amountIssued.value >= amount ? .completed
+                : isExpiredUnpaidInvoice ? .expired
+                : .pending
 
             var storedPaymentProof = getPreimage(quoteId: quote.id)
             var statusNote: String?
@@ -566,6 +575,7 @@ class TransactionService: ObservableObject {
                 quoteId: quote.id
             )
             transaction.unit = PaymentRequestDecoder.unitDescription(quote.unit)
+            transaction.isUnpaidInvoice = isUnpaidBolt11
             transactions.append(transaction)
         }
 

--- a/ios/CashuWallet/Models/Requests/CashuRequest.swift
+++ b/ios/CashuWallet/Models/Requests/CashuRequest.swift
@@ -118,7 +118,7 @@ struct CashuRequest: Codable, Identifiable, Hashable {
         case .bolt12:
             return "Reusable Invoice"
         case .bolt11:
-            return receivedPayments.isEmpty ? "Lightning Invoice" : "Lightning received"
+            return receivedPayments.isEmpty ? "Lightning invoice" : "Lightning received"
         case .onchain:
             return receivedPayments.isEmpty ? "Bitcoin Address" : "Bitcoin received"
         }

--- a/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
+++ b/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
@@ -46,6 +46,16 @@ struct WalletTransaction: Identifiable {
     /// (a reusable BOLT12 offer, a BOLT11 invoice, an on-chain address).
     var quoteId: String? = nil
 
+    /// BOLT11 mint quote still awaiting payment — titles the row
+    /// "Lightning invoice" until the invoice settles.
+    var isUnpaidInvoice: Bool = false
+
+    /// The Quiet Pending treatment (bare, muted amount) covers expired too:
+    /// an expired invoice never credited the balance.
+    var isUnsettled: Bool {
+        status == .pending || status == .expired
+    }
+
     var displayStatusText: String {
         if status == .pending {
             return statusNote ?? status.displayText
@@ -60,6 +70,8 @@ struct WalletTransaction: Identifiable {
     /// transaction detail nav title.
     var displayTitle: String {
         if isPendingReceiveToken { return "Ecash to claim" }
+        // Nothing has been received while the invoice awaits payment.
+        if isUnpaidInvoice { return "Lightning invoice" }
         switch (kind, type) {
         case (.ecash,     .incoming): return "Ecash received"
         case (.ecash,     .outgoing): return "Ecash sent"
@@ -101,14 +113,31 @@ struct WalletTransaction: Identifiable {
         case pending
         case completed
         case failed
-        
+        case expired
+
         var displayText: String {
             switch self {
             case .pending: return "Pending"
             case .completed: return "Completed"
             case .failed: return "Failed"
+            case .expired: return "Expired"
             }
         }
+    }
+}
+
+/// Home is a compact settled-ledger view, not an operational queue. Generated
+/// receive artifacts and every non-completed state remain available in History.
+enum HomeActivity {
+    static func recentTransactions(
+        from transactions: [WalletTransaction],
+        limit: Int
+    ) -> [WalletTransaction] {
+        transactions
+            .filter { $0.status == .completed }
+            .sorted { $0.date > $1.date }
+            .prefix(max(0, limit))
+            .map { $0 }
     }
 }
 

--- a/ios/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
+++ b/ios/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
@@ -1,10 +1,11 @@
 import SwiftUI
 
-// Shared trailing region for Cashu Request rows on Home and History.
-// - Received: .primary +amount + fiat sub-line (settled reads white).
+// Shared trailing region for Cashu Request rows in History.
+// - Received: green +amount + muted converted sub-line.
 // - Waiting (fixed amount): muted amount + fiat, no indicator (gray = waiting).
 // - Waiting (any amount, no fixed expected total): no trailing element.
-// All amounts share the .semibold weight. See DESIGN.md —
+// Primary and secondary values use neighboring type sizes and weights so they
+// read as one amount block. See DESIGN.md —
 // The Amount Column Rule, The One Green Rule, The Fiat Sub-Amount Rule.
 struct CashuRequestAmountColumn: View {
     let request: CashuRequest
@@ -20,9 +21,9 @@ struct CashuRequestAmountColumn: View {
             let display = amountDisplay(receivedAmount)
             VStack(alignment: .trailing, spacing: 2) {
                 Text("+\(display.primary)")
-                    .font(.system(.body, design: .rounded).weight(.semibold))
+                    .font(.system(.body, design: .rounded).weight(.medium))
                     .monospacedDigit()
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(.green)
                     .lineLimit(1)
                     // No `.minimumScaleFactor` — it collides with `.numericText`
                     // (short amounts collapse toward 50%).
@@ -30,7 +31,7 @@ struct CashuRequestAmountColumn: View {
 
                 if let secondary = display.secondary {
                     Text(secondary)
-                        .font(.caption)
+                        .font(.system(.subheadline, design: .rounded).weight(.regular))
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }
@@ -39,14 +40,14 @@ struct CashuRequestAmountColumn: View {
             let display = amountDisplay(amount)
             VStack(alignment: .trailing, spacing: 2) {
                 Text(display.primary)
-                    .font(.system(.body, design: .rounded).weight(.semibold))
+                    .font(.system(.body, design: .rounded).weight(.medium))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 
                 if let secondary = display.secondary {
                     Text(secondary)
-                        .font(.caption)
+                        .font(.system(.subheadline, design: .rounded).weight(.regular))
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
                 }

--- a/ios/CashuWallet/Views/Components/TransactionAmountColumn.swift
+++ b/ios/CashuWallet/Views/Components/TransactionAmountColumn.swift
@@ -1,11 +1,12 @@
 import SwiftUI
 
 // Shared trailing region for transaction rows on Home and History.
-// Renders the amount VStack(sats, optional fiat) — trailing-aligned.
-// Amount color is a two-state ledger signal: .primary = settled,
-// .secondary = pending. No row badge; pending is conveyed by the muted
-// amount alone, and re-check lives on History pull-to-refresh. See
-// DESIGN.md — The One Green Rule, The Quiet Pending Rule,
+// Renders the configured primary amount plus its optional conversion —
+// trailing-aligned.
+// Amount styling is the ledger signal: received = green with a plus, sent =
+// primary with no sign, pending/expired = muted with no sign. No row badge;
+// re-check lives on History pull-to-refresh. See DESIGN.md — The Received
+// Amount Rule, The Quiet Pending Rule,
 // The Fiat Sub-Amount Rule.
 struct TransactionAmountColumn: View {
     let transaction: WalletTransaction
@@ -16,7 +17,7 @@ struct TransactionAmountColumn: View {
     var body: some View {
         VStack(alignment: .trailing, spacing: 2) {
             Text(formattedAmount)
-                .font(.system(.body, design: .rounded).weight(.semibold))
+                .font(.system(.body, design: .rounded).weight(.medium))
                 .monospacedDigit()
                 .foregroundStyle(amountColor)
                 .lineLimit(1)
@@ -28,30 +29,26 @@ struct TransactionAmountColumn: View {
 
             if let secondaryAmount {
                 Text(secondaryAmount)
-                    .font(.caption)
+                    .font(.system(.subheadline, design: .rounded).weight(.regular))
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
             }
         }
     }
 
-    // Two-state ledger: pending reads muted, everything settled reads
-    // .primary. Amounts are never green (see The One Green Rule).
+    // Received value is the only green element in the row. Sent value stays
+    // primary; unsettled (pending or expired) stays muted.
     private var amountColor: Color {
-        transaction.status == .pending ? .secondary : .primary
+        if transaction.isUnsettled { return .secondary }
+        return transaction.type == .incoming ? .green : .primary
     }
 
-    // The +/− sign is a *settled-ledger* signal: a pending receive hasn't
-    // credited the balance and a pending send hasn't debited it, so neither
-    // wears a sign until it settles — matching the waiting Cashu Request /
-    // Reusable Invoice, which shows a bare amount until paid. The sign and the
-    // `.primary` colour arrive together on settlement. See DESIGN.md — The
-    // Quiet Pending Rule.
+    // Only a settled receipt gets a sign. Sent, pending, and expired rows stay
+    // unsigned; direction remains explicit in the title and arrow.
     private var formattedAmount: String {
         let value = nativeAmount
-        guard transaction.status != .pending else { return value }
-        let prefix = transaction.type == .incoming ? "+" : "−"
-        return "\(prefix)\(value)"
+        guard !transaction.isUnsettled, transaction.type == .incoming else { return value }
+        return "+\(value)"
     }
 
     private var isSatUnit: Bool {

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -244,7 +244,7 @@ struct HistoryView: View {
             // UISearchController/refresh-control plumbing so pull-to-refresh
             // stays stable while search is presented. Section headers stay as
             // plain rows (not `Section` headers) to keep them non-pinned, and
-            // native separators are hidden in favor of our CanvasDivider.
+            // native separators are hidden so activity rows flow on the canvas.
             List {
                 ForEach(sectionsWithOffsets, id: \.group.title) { entry in
                     sectionHeader(entry.group.title)
@@ -256,10 +256,6 @@ struct HistoryView: View {
                         let globalIndex = entry.startIndex + index
                         VStack(spacing: 0) {
                             row(for: item)
-
-                            if index < entry.group.items.count - 1 {
-                                CanvasDivider()
-                            }
                         }
                         .id(item.id)
                         .onAppear {

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -569,7 +569,7 @@ struct HistoryView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .pending ? transaction.displayStatusText.lowercased() : "completed"), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint("Opens transaction details")
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if transaction.isPendingReceiveToken {
@@ -615,9 +615,8 @@ struct HistoryView: View {
                 currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
             ).formatted()
         }
-        guard transaction.status != .pending else { return value }
-        let prefix = transaction.type == .incoming ? "+" : "−"
-        return "\(prefix)\(value)"
+        guard !transaction.isUnsettled else { return value }
+        return transaction.type == .incoming ? "+\(value)" : value
     }
 
     private static let shortTimeFormatter: DateFormatter = {

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -222,10 +222,11 @@ struct TransactionDetailView: View {
         }
     }
 
-    /// True when the hero renders nothing (a no-QR transaction still pending), so
-    /// the amount gets top breathing room instead of butting against the nav bar.
+    /// True when the hero renders nothing (a no-QR transaction still pending, or
+    /// an expired invoice — deliberately quiet, no glyph), so the amount gets top
+    /// breathing room instead of butting against the nav bar.
     private var heroSlotIsEmpty: Bool {
-        !showsQR && transaction.status == .pending
+        !showsQR && transaction.isUnsettled
     }
 
     /// The lifecycle word for the Status row. Direction/rail come from the nav
@@ -240,6 +241,7 @@ struct TransactionDetailView: View {
             }
         case .pending: return "Pending"
         case .failed:  return "Failed"
+        case .expired: return "Expired"
         }
     }
 
@@ -249,6 +251,7 @@ struct TransactionDetailView: View {
         case .completed: return "checkmark.circle"
         case .pending:   return "clock"
         case .failed:    return "xmark.circle"
+        case .expired:   return "clock.badge.xmark"
         }
     }
 

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -11,7 +11,6 @@ struct MainWalletView: View {
     @EnvironmentObject var navigationManager: NavigationManager
     @ObservedObject var settings = SettingsManager.shared
     @ObservedObject var priceService = PriceService.shared
-    @ObservedObject private var requestStore = CashuRequestStore.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @State private var activeSheet: WalletSheet?
@@ -23,10 +22,6 @@ struct MainWalletView: View {
     @State private var receiveEcashDetent: PresentationDetent = .medium
     @State private var contactlessCoordinator = ContactlessPaymentCoordinator()
     @State private var selectedTransaction: WalletTransaction?
-    /// Unclaimed incoming token being claimed (rows open the claim flow
-    /// directly — one Receive tap, no intermediate detail sheet).
-    @State private var claimReceiveToken: PendingReceiveToken?
-    @State private var selectedRequest: CashuRequest?
     @State private var topInsetHeight: CGFloat = 0
     /// Last-viewed home balance unit, persisted so the wallet reopens on it.
     /// Clamped back to "sat" whenever that unit no longer carries a balance.
@@ -126,25 +121,6 @@ struct MainWalletView: View {
                 TransactionDetailView(transaction: transaction)
                     .environmentObject(walletManager)
                     .canvasSheetBackground()
-            }
-            // Claim flow for an unclaimed incoming token. `item:` captures the
-            // pending token at presentation, so the content stays stable while
-            // the claim removes it from the store (a live lookup here would go
-            // nil mid-flow and blank the screen).
-            .fullScreenCover(item: $claimReceiveToken) { pending in
-                ReceiveTokenDetailView(
-                    tokenString: pending.token,
-                    onComplete: { claimReceiveToken = nil },
-                    claim: { try await walletManager.claimPendingReceiveToken(pending) }
-                )
-                .environmentObject(walletManager)
-            }
-            .sheet(item: $selectedRequest) { request in
-                NavigationStack {
-                    CashuRequestDetailView(request: request)
-                        .environmentObject(walletManager)
-                }
-                .canvasSheetBackground()
             }
             .task { await walletManager.loadTransactions() }
         }
@@ -549,12 +525,12 @@ struct MainWalletView: View {
         }
     }
 
-    private func recentList(_ items: [HomeItem]) -> some View {
+    private func recentList(_ items: [WalletTransaction]) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Recent")
 
             ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                row(for: item)
+                transactionRow(transaction: item)
 
                 if index < items.count - 1 {
                     CanvasDivider()
@@ -589,49 +565,13 @@ struct MainWalletView: View {
             .padding(.bottom, 14)
     }
 
-    // MARK: - Recent items pipeline (mirrors HistoryView, capped at 5)
+    // MARK: - Recent completed payments
 
-    private enum HomeItem: Identifiable {
-        case transaction(WalletTransaction)
-        case request(CashuRequest)
-
-        var id: String {
-            switch self {
-            case .transaction(let t): return "tx-\(t.id)"
-            case .request(let r):     return "req-\(r.id)"
-            }
-        }
-
-        var date: Date {
-            switch self {
-            case .transaction(let t): return t.date
-            case .request(let r):     return r.createdAt
-            }
-        }
-    }
-
-    /// Suppress transactions that are already represented by a Cashu Request
-    /// row, then merge requests + transactions, sort desc, cap.
-    private var recentItems: [HomeItem] {
-        let claimedTxIds = Set(requestStore.requests.flatMap { $0.receivedPayments.map(\.transactionId) })
-        let txItems: [HomeItem] = walletManager.transactions
-            .filter { !claimedTxIds.contains($0.id) }
-            .map(HomeItem.transaction)
-        let reqItems: [HomeItem] = requestStore.requests.map(HomeItem.request)
-        return (txItems + reqItems)
-            .sorted { $0.date > $1.date }
-            .prefix(recentRowCap)
-            .map { $0 }
-    }
-
-    @ViewBuilder
-    private func row(for item: HomeItem) -> some View {
-        switch item {
-        case .transaction(let tx):
-            transactionRow(transaction: tx)
-        case .request(let req):
-            cashuRequestRow(request: req)
-        }
+    private var recentItems: [WalletTransaction] {
+        HomeActivity.recentTransactions(
+            from: walletManager.transactions,
+            limit: recentRowCap
+        )
     }
 
     // MARK: - Transaction row (slimmer than HistoryView's variant)
@@ -639,14 +579,7 @@ struct MainWalletView: View {
     private func transactionRow(transaction: WalletTransaction) -> some View {
         Button {
             HapticFeedback.selection()
-            // Unclaimed incoming ecash goes straight to the claim flow — one
-            // Receive tap, no intermediate detail sheet.
-            if transaction.isPendingReceiveToken,
-               let pending = walletManager.pendingReceiveTokens.first(where: { $0.tokenId == transaction.id }) {
-                claimReceiveToken = pending
-            } else {
-                selectedTransaction = transaction
-            }
+            selectedTransaction = transaction
         } label: {
             HStack(spacing: 14) {
                 rowIcon(for: transaction)
@@ -672,7 +605,7 @@ struct MainWalletView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .pending ? "pending" : "completed"), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint("Opens transaction details")
     }
 
@@ -695,56 +628,8 @@ struct MainWalletView: View {
                 currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
             ).formatted()
         }
-        guard transaction.status != .pending else { return value }
-        let prefix = transaction.type == .incoming ? "+" : "−"
-        return "\(prefix)\(value)"
-    }
-
-    // MARK: - Cashu Request row
-
-    private func cashuRequestRow(request: CashuRequest) -> some View {
-        let isReceived = !request.receivedPayments.isEmpty
-        return Button {
-            HapticFeedback.selection()
-            selectedRequest = request
-        } label: {
-            HStack(spacing: 14) {
-                TransactionIcon(direction: .incoming)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(request.displayTitle)
-                        .font(.body.weight(.medium))
-                        .lineLimit(1)
-
-                    Text(formatRelativeDate(request.createdAt))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer(minLength: 8)
-
-                CashuRequestAmountColumn(
-                    request: request,
-                    received: isReceived,
-                    receivedAmount: totalReceived(for: request)
-                )
-            }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 16)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(request.displayTitle), \(isReceived ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))")
-        .accessibilityHint("Opens request details")
-    }
-
-    private func totalReceived(for request: CashuRequest) -> UInt64 {
-        let ids = Set(request.receivedPayments.map(\.transactionId))
-        guard !ids.isEmpty else { return 0 }
-        return walletManager.transactions
-            .filter { ids.contains($0.id) }
-            .reduce(UInt64(0)) { $0 + $1.amount }
+        guard !transaction.isUnsettled else { return value }
+        return transaction.type == .incoming ? "+\(value)" : value
     }
 
     // MARK: - Relative date

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -529,12 +529,8 @@ struct MainWalletView: View {
         VStack(alignment: .leading, spacing: 0) {
             sectionHeader("Recent")
 
-            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+            ForEach(items) { item in
                 transactionRow(transaction: item)
-
-                if index < items.count - 1 {
-                    CanvasDivider()
-                }
             }
 
             Button(action: onViewAllHistory) {

--- a/ios/CashuWalletTests/TransactionServiceTests.swift
+++ b/ios/CashuWalletTests/TransactionServiceTests.swift
@@ -15,6 +15,51 @@ final class TransactionServiceTests: XCTestCase {
         )
     }
 
+    func testHomeActivityShowsOnlyLatestCompletedTransactions() {
+        let now = Date()
+        var completedIncoming = transaction(
+            id: "received-via-request",
+            status: .completed,
+            date: now.addingTimeInterval(-10),
+            type: .incoming
+        )
+        completedIncoming.cashuRequestId = "request"
+        let completedOutgoing = transaction(
+            id: "sent",
+            status: .completed,
+            date: now
+        )
+        let pending = transaction(
+            id: "pending-request",
+            status: .pending,
+            date: now.addingTimeInterval(10)
+        )
+        let failed = transaction(
+            id: "failed",
+            status: .failed,
+            date: now.addingTimeInterval(20)
+        )
+        let expired = transaction(
+            id: "expired",
+            status: .expired,
+            date: now.addingTimeInterval(30)
+        )
+
+        let recent = HomeActivity.recentTransactions(
+            from: [completedIncoming, pending, failed, completedOutgoing, expired],
+            limit: 5
+        )
+
+        XCTAssertEqual(recent.map(\.id), ["sent", "received-via-request"])
+        XCTAssertEqual(
+            HomeActivity.recentTransactions(
+                from: [completedIncoming, completedOutgoing],
+                limit: 1
+            ).map(\.id),
+            ["sent"]
+        )
+    }
+
     // MARK: - Saved token (txId ↔ encoded token)
 
     func testGetTokenNilByDefault() {
@@ -261,7 +306,71 @@ final class TransactionServiceTests: XCTestCase {
         )
     }
 
+    // MARK: - Unpaid / expired invoice display
+
+    func testUnpaidInvoiceTitlesAsInvoiceUntilPaid() {
+        var transaction = WalletTransaction(
+            id: "quote",
+            amount: 500,
+            type: .incoming,
+            kind: .lightning,
+            date: Date(),
+            memo: nil,
+            status: .pending
+        )
+        transaction.isUnpaidInvoice = true
+
+        XCTAssertEqual(transaction.displayTitle, "Lightning invoice")
+
+        transaction.isUnpaidInvoice = false
+        XCTAssertEqual(transaction.displayTitle, "Lightning received")
+    }
+
+    func testExpiredStatusDisplayAndQuietPending() {
+        var transaction = WalletTransaction(
+            id: "quote",
+            amount: 500,
+            type: .incoming,
+            kind: .lightning,
+            date: Date(),
+            memo: nil,
+            status: .expired
+        )
+        transaction.isUnpaidInvoice = true
+
+        XCTAssertEqual(transaction.status.displayText, "Expired")
+        XCTAssertEqual(transaction.displayStatusText, "Expired")
+        XCTAssertEqual(transaction.displayTitle, "Lightning invoice")
+        XCTAssertTrue(transaction.isUnsettled)
+        XCTAssertFalse(WalletTransaction(
+            id: "settled",
+            amount: 500,
+            type: .incoming,
+            kind: .lightning,
+            date: Date(),
+            memo: nil,
+            status: .completed
+        ).isUnsettled)
+    }
+
     // MARK: - Helpers
+
+    private func transaction(
+        id: String,
+        status: WalletTransaction.TransactionStatus,
+        date: Date,
+        type: WalletTransaction.TransactionType = .outgoing
+    ) -> WalletTransaction {
+        WalletTransaction(
+            id: id,
+            amount: 1,
+            type: type,
+            kind: .ecash,
+            date: date,
+            memo: nil,
+            status: status
+        )
+    }
 
     private func pendingToken(id: String, amount: UInt64) -> PendingToken {
         PendingToken(


### PR DESCRIPTION
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/4e6e5829-b310-4092-91f0-bc948ad2231a" />

## Summary

- keep Home focused on the five latest completed sent and received payments while generated and pending activity remains available in History
- default History to All and clarify transaction/request titles and status handling across iOS and Android
- align amount hierarchy and direction styling: incoming is green with a plus, outgoing is unsigned and primary, and pending/expired remains muted
- remove horizontal separators from Home and History activity rows and update the platform design specs
- add and update coverage for Home filtering, pending Lightning invoices, and transaction display behavior

## Verification

- ./gradlew :app:compileDebugKotlin
- xcodebuild build -quiet -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
- git diff --check upstream/main...HEAD

No simulator or emulator was launched.