### PR TITLE
Fix blank iOS History on fresh wallets; unify empty states across platforms

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
@@ -36,7 +36,6 @@ import com.cashu.me.ui.theme.CashuTheme
 // iOS renders the glyph hierarchically at 0.62 opacity; dim the tint the same
 // amount so the icon sits behind the text instead of competing with it.
 private const val EmptyStateIconAlpha = 0.62f
-private const val EmptyStateActionWidthFraction = 0.7f
 
 /**
  * Size variants mirroring iOS NativeEmptyState.Style. Dimensions are the iOS
@@ -164,9 +163,12 @@ fun EmptyState(
             PrimaryButton(
                 text = actionLabel,
                 onClick = onAction,
-                // Deliberately narrower than a full-width CTA: the empty-state
-                // action is an invitation, not the screen's primary commit.
-                modifier = Modifier.fillMaxWidth(EmptyStateActionWidthFraction),
+                // Full width at 32dp side margins (16dp component padding +
+                // 16dp here) — iOS renders every primary CTA as a full-width
+                // capsule inset 32pt, including this one.
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = CashuTheme.spacing.comfortable),
             )
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
@@ -27,18 +27,32 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.CashuTheme
 
-// Matches iOS NativeEmptyState's 56pt glyph (component-level, not on the
-// spacing scale).
-private val EmptyStateIconSize = 56.dp
 // iOS renders the glyph hierarchically at 0.62 opacity; dim the tint the same
 // amount so the icon sits behind the text instead of competing with it.
 private const val EmptyStateIconAlpha = 0.62f
 private const val EmptyStateActionWidthFraction = 0.7f
+
+/**
+ * Size variants mirroring iOS NativeEmptyState.Style. Dimensions are the iOS
+ * point values, deliberately off the spacing scale. (iOS also has a smaller
+ * `.compact`; add it here when an Android call site needs one.)
+ */
+enum class EmptyStateSize(
+    internal val iconSize: Dp,
+    internal val iconGap: Dp,
+) {
+    /** Full-tab empty trays (Home, History): 56dp glyph, title2-scale text. */
+    FullScreen(iconSize = 56.dp, iconGap = 12.dp),
+
+    /** Content-fit hosts like the Send sheet: 42dp glyph, headline-scale text. */
+    Section(iconSize = 42.dp, iconGap = 10.dp),
+}
 // iOS NativeEmptyState entrance: opacity 0→1, scale 0.96→1, rise from 8pt.
 private const val EntranceInitialScale = 0.96f
 private val EntranceRise = 8.dp
@@ -54,6 +68,8 @@ private const val EntranceDamping = 0.82f
  * @param fillHeight when true (default), expands to fill the parent and
  *   centers its content — home/history empty trays. Set false for wrap-content
  *   hosts like a content-fit Send bottom sheet.
+ * @param size glyph/text scale; [EmptyStateSize.Section] matches the smaller
+ *   iOS `.section` style used inside sheets.
  */
 @Composable
 fun EmptyState(
@@ -64,6 +80,7 @@ fun EmptyState(
     actionLabel: String? = null,
     onAction: (() -> Unit)? = null,
     fillHeight: Boolean = true,
+    size: EmptyStateSize = EmptyStateSize.FullScreen,
 ) {
     val reduceMotion = rememberReducedMotion()
     var appeared by remember { mutableStateOf(false) }
@@ -104,17 +121,25 @@ fun EmptyState(
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = EmptyStateIconAlpha),
             modifier = Modifier
-                .size(EmptyStateIconSize)
+                .size(size.iconSize)
                 .graphicsLayer {
                     scaleX = iconBounce
                     scaleY = iconBounce
                 },
         )
-        Spacer(Modifier.height(CashuTheme.spacing.default))
+        Spacer(Modifier.height(size.iconGap))
         Text(
             text = title,
-            // iOS title2 semibold (22pt); titleLarge is 22sp but ships Normal.
-            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+            // iOS title2/headline semibold; the M3 roles ship lighter weights.
+            style = when (size) {
+                EmptyStateSize.FullScreen ->
+                    MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold)
+                EmptyStateSize.Section ->
+                    MaterialTheme.typography.titleMedium.copy(
+                        fontWeight = FontWeight.SemiBold,
+                        letterSpacing = 0.sp,
+                    )
+            },
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
@@ -122,9 +147,14 @@ fun EmptyState(
             Spacer(Modifier.height(CashuTheme.spacing.micro))
             Text(
                 text = supporting,
-                // iOS body (17pt) with SF's near-zero tracking; bodyLarge's
-                // default 0.5sp letter spacing reads looser than the iOS twin.
-                style = MaterialTheme.typography.bodyLarge.copy(letterSpacing = 0.sp),
+                // iOS body/subheadline with SF's near-zero tracking; the M3
+                // roles' default letter spacing reads looser than the iOS twin.
+                style = when (size) {
+                    EmptyStateSize.FullScreen ->
+                        MaterialTheme.typography.bodyLarge.copy(letterSpacing = 0.sp)
+                    EmptyStateSize.Section ->
+                        MaterialTheme.typography.bodyMedium.copy(letterSpacing = 0.sp)
+                },
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )

--- a/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/EmptyState.kt
@@ -25,13 +25,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.CashuTheme
 
-// M3 empty-state icon is 48dp (component-level, not on the spacing scale).
-private val EmptyStateIconSize = 48.dp
+// Matches iOS NativeEmptyState's 56pt glyph (component-level, not on the
+// spacing scale).
+private val EmptyStateIconSize = 56.dp
+// iOS renders the glyph hierarchically at 0.62 opacity; dim the tint the same
+// amount so the icon sits behind the text instead of competing with it.
+private const val EmptyStateIconAlpha = 0.62f
 private const val EmptyStateActionWidthFraction = 0.7f
 // iOS NativeEmptyState entrance: opacity 0→1, scale 0.96→1, rise from 8pt.
 private const val EntranceInitialScale = 0.96f
@@ -96,7 +102,7 @@ fun EmptyState(
         Icon(
             imageVector = icon,
             contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = EmptyStateIconAlpha),
             modifier = Modifier
                 .size(EmptyStateIconSize)
                 .graphicsLayer {
@@ -104,18 +110,21 @@ fun EmptyState(
                     scaleY = iconBounce
                 },
         )
-        Spacer(Modifier.height(CashuTheme.spacing.comfortable))
+        Spacer(Modifier.height(CashuTheme.spacing.default))
         Text(
             text = title,
-            style = MaterialTheme.typography.titleMedium,
+            // iOS title2 semibold (22pt); titleLarge is 22sp but ships Normal.
+            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
         if (supporting != null) {
-            Spacer(Modifier.height(CashuTheme.spacing.snug))
+            Spacer(Modifier.height(CashuTheme.spacing.micro))
             Text(
                 text = supporting,
-                style = MaterialTheme.typography.bodyMedium,
+                // iOS body (17pt) with SF's near-zero tracking; bodyLarge's
+                // default 0.5sp letter spacing reads looser than the iOS twin.
+                style = MaterialTheme.typography.bodyLarge.copy(letterSpacing = 0.sp),
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -1,13 +1,7 @@
 package com.cashu.me.ui.history
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Box
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.VisibilityThreshold
 import androidx.compose.animation.core.spring
@@ -21,7 +15,6 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -58,16 +51,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountFormatter
@@ -94,7 +84,6 @@ import com.cashu.me.ui.components.TransactionRow
 import com.cashu.me.ui.components.TransactionRowModel
 import com.cashu.me.ui.components.formatRelativeTimestamp
 import com.cashu.me.ui.theme.CashuTheme
-import com.cashu.me.ui.theme.rememberReducedMotion
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -393,57 +382,17 @@ private fun HistoryEmptyState(
         )
         else -> Triple(
             Icons.Outlined.History,
-            "No activity yet",
+            "No Activity Yet",
             "Your first payment will show up here.",
         )
     }
-    // Pulse the empty-state glyph (resting state under reduce-motion).
-    val reducedMotion = rememberReducedMotion()
-    val transition = rememberInfiniteTransition(label = "empty-pulse")
-    val pulseAlpha by transition.animateFloat(
-        initialValue = 0.4f,
-        targetValue = 1f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1200),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = "empty-pulse-alpha",
-    )
-    Box(
+    EmptyState(
+        icon = icon,
+        title = title,
+        supporting = supporting,
         modifier = modifier,
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
-        ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .size(HISTORY_EMPTY_ICON_SIZE)
-                    .alpha(if (icon == Icons.Outlined.History && !reducedMotion) pulseAlpha else 1f),
-            )
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            if (supporting != null) {
-                Text(
-                    text = supporting,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-    }
+    )
 }
-
-// Smaller-than-48dp on purpose: this is an inline empty-state glyph inside an
-// already-spaced column, not the standalone EmptyState component.
-private val HISTORY_EMPTY_ICON_SIZE = 40.dp
 
 /** Unified History timeline item. Mirrors iOS HistoryItem enum. */
 internal sealed interface HistoryItem {

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.ArrowCircleDown
 import androidx.compose.material.icons.outlined.Cancel
 import androidx.compose.material.icons.outlined.Nfc
 import androidx.compose.material.icons.outlined.Payments
@@ -77,6 +78,7 @@ import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.EmptyState
+import com.cashu.me.ui.components.EmptyStateSize
 import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
@@ -618,12 +620,15 @@ private fun InputFace(
         !hasBalance -> {
             // Compact (no fillMaxHeight) so the sheet hugs this empty state.
             EmptyState(
-                icon = Icons.Outlined.Payments,
+                // Circled down arrow — same glyph and .section scale as the
+                // iOS zero-balance Send sheet.
+                icon = Icons.Outlined.ArrowCircleDown,
                 title = "Nothing to send yet",
                 supporting = "Receive some ecash before you can send.",
                 actionLabel = "Receive",
                 onAction = onReceive,
                 fillHeight = false,
+                size = EmptyStateSize.Section,
                 modifier = Modifier
                     .padding(vertical = CashuTheme.spacing.section)
                     .navigationBarsPadding(),

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -74,16 +74,17 @@ struct HistoryView: View {
         NavigationStack {
             Group {
                 if filteredItems.isEmpty {
-                    // Don't show the "No History Yet" empty state until the first
-                    // load finishes: on the very first tab visit the transaction
-                    // service is empty (still loading), and rendering the animated
-                    // empty state here made it swoop in for a beat before the list
-                    // arrived. A brief blank canvas during the (fast, local) load
-                    // reads as nothing happening — then the list or the real empty
-                    // state settles in place. Later visits already have cached data,
-                    // so this branch isn't taken.
+                    // Don't show the empty state until the first load finishes:
+                    // rendering it during the (fast, local) initial load made it
+                    // swoop in for a beat before a populated list arrived. The
+                    // pre-load branch must be a placeholder view, not nothing —
+                    // an empty Group detaches every modifier below, including
+                    // the .task that performs the initial load, deadlocking a
+                    // fresh wallet on a blank screen.
                     if didInitialLoad {
                         emptyStateView
+                    } else {
+                        Color.clear
                     }
                 } else {
                     historyList
@@ -473,9 +474,9 @@ struct HistoryView: View {
             // copy so the two screens read as deliberate siblings, not
             // accidental duplicates.
             NativeEmptyState(
-                title: "No History Yet",
+                title: "No Activity Yet",
                 systemImage: "clock.arrow.circlepath",
-                description: "Your payments will appear here."
+                description: "Your first payment will show up here."
             )
         }
     }

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -20,6 +20,17 @@ final class MainTabUITests: UITestBase {
             screen("history-screen").waitForExistence(timeout: 10),
             "History view should appear"
         )
+        // The screen container exists even when its content fails to mount
+        // (the identifier is on the NavigationStack), so also assert rendered
+        // content: a fresh wallet must show the title and the empty state.
+        XCTAssertTrue(
+            app.navigationBars["History"].waitForExistence(timeout: 5),
+            "History title should render on an empty wallet"
+        )
+        XCTAssertTrue(
+            app.staticTexts["No Activity Yet"].waitForExistence(timeout: 5),
+            "Fresh wallet should show the History empty state"
+        )
 
         tapTab("Mints")
         XCTAssertTrue(


### PR DESCRIPTION
## Summary
<img width="2400" height="1350" alt="image" src="https://github.com/user-attachments/assets/d3065f27-da7f-45bf-9cda-04f9d31f8f6f" />
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/7ab1b423-e2f9-4230-b65d-dc583b513611" />


**iOS — blank History tab on a brand-new wallet.** With zero transactions, the History screen rendered nothing at all: no title, no toolbar, no empty state. The pre-load gate (`if didInitialLoad { emptyStateView }`) had no else branch, so the content `Group` resolved empty — detaching every modifier hanging off it, including the `.task` that runs the initial load and sets `didInitialLoad`. The screen deadlocked blank forever. The gate now renders a `Color.clear` placeholder during the load, and the empty-state copy matches Android ("No Activity Yet" / "Your first payment will show up here.").

**Android — empty states aligned with iOS.** The shared `EmptyState` is restyled to `NativeEmptyState`'s metrics: 56dp glyph dimmed to 0.62 alpha, 22sp semibold title, 16sp zero-tracking supporting text, tighter 12/4dp gaps. History drops its inline variant (and the infinite glyph pulse) and delegates to the shared component, gaining the same entrance settle + bounce as Home.

**Android — Send zero-balance sheet parity.** The cash glyph becomes `ArrowCircleDown` (iOS `arrow.down.circle`), rendered at a new `EmptyStateSize.Section` scale (42dp glyph, headline-scale text) mirroring the smaller iOS `.section` style used in that sheet.

**Empty-state action buttons are full-width CTAs.** The bespoke 0.7-fraction pill matched neither M3 convention nor iOS's full-width capsule; actions now fill the width at 32dp side margins.

## Test plan

- iOS: `MainTabUITests` extended to assert the History nav title and empty state actually render on a fresh wallet — the old check passed even while the screen was blank (the identifier sits on the `NavigationStack`). Suite passes on iPhone 17 Pro simulator.
- Android: `assembleDebug` clean; emulator-verified Home, History, and Send empty states against iOS reference screenshots in dark and light themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)