### PR TITLE
Polish Android NFC send and receive flows

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Views/Send/ContactlessPayContentComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Views/Send/ContactlessPayContentComposeTest.kt
@@ -1,0 +1,84 @@
+package com.cashu.me.Views.Send
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ContactlessPayContentComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun disabledNfcExposesSettingsAction() {
+        var settingsClicks = 0
+
+        compose.setCashuContent {
+            Box(Modifier.width(360.dp)) {
+                ContactlessPayContent(
+                    availability = ContactlessAvailability.Disabled,
+                    status = "",
+                    error = null,
+                    isProcessing = false,
+                    paymentComplete = false,
+                    lastPaymentAmount = null,
+                    onOpenNfcSettings = { settingsClicks += 1 },
+                )
+            }
+        }
+
+        compose.onNodeWithText("NFC is disabled in system settings.").assertIsDisplayed()
+        compose.onNodeWithText("Open NFC settings").performClick()
+        compose.runOnIdle {
+            assertEquals(1, settingsClicks)
+        }
+    }
+
+    @Test
+    fun processingStateRendersAtLargeFontWithoutRedundantActions() {
+        compose.setCashuContent(fontScale = 2f) {
+            Box(
+                Modifier
+                    .width(280.dp)
+                    .testTag("contactlessLargeFont"),
+            ) {
+                ContactlessPayContent(
+                    availability = ContactlessAvailability.Ready,
+                    status = "Writing payment...",
+                    error = null,
+                    isProcessing = true,
+                    paymentComplete = false,
+                    lastPaymentAmount = null,
+                    onOpenNfcSettings = {},
+                )
+            }
+        }
+
+        compose.onNodeWithText("Contactless").assertIsDisplayed()
+        compose.onNodeWithText("Writing payment...").assertIsDisplayed()
+        compose.onNodeWithText("Close").assertDoesNotExist()
+        compose.onNodeWithText("Reset").assertDoesNotExist()
+        compose.onNodeWithTag("contactlessLargeFont").captureToImage().assertNonEmpty()
+    }
+
+    private fun ImageBitmap.assertNonEmpty() {
+        assertTrue(width > 0)
+        assertTrue(height > 0)
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/navigation/BackNavigationComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/navigation/BackNavigationComposeTest.kt
@@ -33,12 +33,10 @@ class BackNavigationComposeTest {
             "shell:receive-detail" to shellBackAction(
                 receiveDetailVisible = true,
                 scannerVisible = true,
-                contactlessVisible = true,
             )!!.name,
             "shell:scanner" to shellBackAction(
                 receiveDetailVisible = false,
                 scannerVisible = true,
-                contactlessVisible = true,
             )!!.name,
             "onboarding:restore-progress-working" to onboardingBackAction(
                 OnboardingBackState.RestoreProgress,

--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/CashuRequestSuccessTerminalComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/CashuRequestSuccessTerminalComposeTest.kt
@@ -1,0 +1,43 @@
+package com.cashu.me.ui.receive
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CashuRequestSuccessTerminalComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun receiptUsesSharedTerminalAndWaitsForDone() {
+        var done = false
+
+        compose.setCashuContent {
+            CashuRequestSuccessTerminal(
+                amountLabel = "19 sat",
+                mintName = "Minibits mint",
+                onDone = { done = true },
+            )
+        }
+
+        compose.onNodeWithContentDescription("Success").assertIsDisplayed()
+        compose.onNodeWithText("Payment received").assertIsDisplayed()
+        compose.onNodeWithText("Amount").assertIsDisplayed()
+        compose.onNodeWithText("19 sat").assertIsDisplayed()
+        compose.onNodeWithText("Mint").assertIsDisplayed()
+        compose.onNodeWithText("Minibits mint").assertIsDisplayed()
+
+        compose.runOnIdle { assertTrue(!done) }
+        compose.onNodeWithText("Done").performClick()
+        compose.runOnIdle { assertTrue(done) }
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/nfc/NfcReceiveIndicatorComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/nfc/NfcReceiveIndicatorComposeTest.kt
@@ -1,0 +1,114 @@
+package com.cashu.me.ui.receive.nfc
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Core.NfcReceive.NfcReceiveState
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NfcReceiveIndicatorComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun missingAmountSurfaceHugsContentAndIsCentered() {
+        val message = "Set an amount to receive by tap."
+
+        compose.setCashuContent {
+            Box(Modifier.width(360.dp)) {
+                NfcReceiveIndicatorContent(
+                    state = NfcReceiveState(
+                        phase = NfcReceivePhase.NeedsAmount,
+                        message = message,
+                    ),
+                    modifier = Modifier.testTag("nfcIndicator"),
+                )
+            }
+        }
+
+        compose.onNodeWithText(message).assertIsDisplayed()
+        assertSurfaceHugsContentAndIsCentered()
+        assertNoLegacyNavigationCopy()
+    }
+
+    @Test
+    fun readySurfaceHugsContentAndIsCentered() {
+        val message = "Ask the sender to hold their phone near yours."
+
+        compose.setCashuContent {
+            Box(Modifier.width(360.dp)) {
+                NfcReceiveIndicatorContent(
+                    state = NfcReceiveState(phase = NfcReceivePhase.Waiting),
+                    modifier = Modifier.testTag("nfcIndicator"),
+                )
+            }
+        }
+
+        compose.onNodeWithText(message).assertIsDisplayed()
+        assertSurfaceHugsContentAndIsCentered()
+        assertNoLegacyNavigationCopy()
+    }
+
+    @Test
+    fun readySurfaceStaysWithinBoundsAtLargeFont() {
+        val message = "Ask the sender to hold their phone near yours."
+
+        compose.setCashuContent(fontScale = 2f) {
+            Box(Modifier.width(280.dp)) {
+                NfcReceiveIndicatorContent(
+                    state = NfcReceiveState(phase = NfcReceivePhase.Waiting),
+                    modifier = Modifier.testTag("nfcIndicator"),
+                )
+            }
+        }
+
+        compose.onNodeWithText(message).assertIsDisplayed()
+        val indicatorBounds = compose.onNodeWithTag("nfcIndicator")
+            .fetchSemanticsNode().boundsInRoot
+        val surfaceBounds = compose.onNodeWithTag("nfcReceiveIndicatorSurface")
+            .fetchSemanticsNode().boundsInRoot
+
+        assertTrue(surfaceBounds.left >= indicatorBounds.left)
+        assertTrue(surfaceBounds.right <= indicatorBounds.right)
+        compose.onNodeWithTag("nfcIndicator").captureToImage().assertNonEmpty()
+    }
+
+    private fun assertSurfaceHugsContentAndIsCentered() {
+        val indicatorBounds = compose.onNodeWithTag("nfcIndicator")
+            .fetchSemanticsNode().boundsInRoot
+        val surfaceBounds = compose.onNodeWithTag("nfcReceiveIndicatorSurface")
+            .fetchSemanticsNode().boundsInRoot
+
+        assertTrue(surfaceBounds.width < indicatorBounds.width)
+        assertEquals(indicatorBounds.center.x, surfaceBounds.center.x, 1f)
+    }
+
+    private fun assertNoLegacyNavigationCopy() {
+        compose.onAllNodesWithText("Tap", substring = true).assertCountEquals(0)
+        compose.onAllNodesWithText("→", substring = true).assertCountEquals(0)
+        compose.onAllNodesWithText("->", substring = true).assertCountEquals(0)
+    }
+
+    private fun ImageBitmap.assertNonEmpty() {
+        assertTrue(width > 0)
+        assertTrue(height > 0)
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/nfc/NfcReceiveSuccessTransitionComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/nfc/NfcReceiveSuccessTransitionComposeTest.kt
@@ -1,0 +1,53 @@
+package com.cashu.me.ui.receive.nfc
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Core.NfcReceive.NfcReceiveState
+import com.cashu.me.ui.setCashuContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NfcReceiveSuccessTransitionComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun processingMorphsDirectlyIntoTheSharedReceipt() {
+        var state by mutableStateOf(NfcReceiveState(NfcReceivePhase.Redeeming))
+
+        compose.setCashuContent {
+            NfcReceiveOverlayContent(
+                state = state,
+                successAmountLabel = "19 sat",
+                successMintName = "Minibits mint",
+                onSuccessDone = {},
+                onRetry = {},
+            )
+        }
+
+        compose.onNodeWithText("Securing ecash").assertIsDisplayed()
+        compose.runOnIdle {
+            state = NfcReceiveState(
+                phase = NfcReceivePhase.Success,
+                amount = 19,
+                settlementMint = "https://mint.example",
+            )
+        }
+        compose.waitForIdle()
+
+        compose.onNodeWithContentDescription("Success").assertIsDisplayed()
+        compose.onNodeWithText("Payment received").assertIsDisplayed()
+        compose.onNodeWithText("19 sat").assertIsDisplayed()
+        compose.onNodeWithText("Minibits mint").assertIsDisplayed()
+        compose.onNodeWithText("Done").assertIsDisplayed()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveCoordinator.kt
@@ -99,7 +99,7 @@ class NfcReceiveCoordinator(
             armed = false
             mutableState.value = NfcReceiveState(
                 NfcReceivePhase.NeedsAmount,
-                "Add an amount to enable Tap to receive.",
+                "Set an amount to receive by tap.",
             )
             return
         }
@@ -147,7 +147,7 @@ class NfcReceiveCoordinator(
         val adapter = NfcAdapter.getDefaultAdapter(appContext)
         return when {
             adapter == null || !manager.hasSystemFeature(PackageManager.FEATURE_NFC_HOST_CARD_EMULATION) ->
-                NfcReceiveState(NfcReceivePhase.Unavailable, "Tap to receive is not available on this device.")
+                NfcReceiveState(NfcReceivePhase.Unavailable, "Receiving by tap isn't available on this device.")
             !adapter.isEnabled -> NfcReceiveState(NfcReceivePhase.Disabled, "Turn on NFC to receive by tap.")
             else -> NfcReceiveState(NfcReceivePhase.Inactive)
         }

--- a/android/app/src/main/java/com/cashu/me/Views/Send/ContactlessPayView.kt
+++ b/android/app/src/main/java/com/cashu/me/Views/Send/ContactlessPayView.kt
@@ -3,30 +3,49 @@ package com.cashu.me.Views.Send
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.Ndef
+import android.provider.Settings
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Nfc
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -34,30 +53,94 @@ import com.cashu.me.Core.Services.NFCPaymentInput
 import com.cashu.me.Core.Services.NFCPaymentService
 import com.cashu.me.Core.Services.NFCReaderDelegate
 import com.cashu.me.Core.WalletManager
-import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.PrimaryButton
+
+/**
+ * Android has no system-owned NFC reader sheet, so reader mode is presented in
+ * a native Material 3 modal bottom sheet. The host owns dismissal animation and
+ * prevents accidental swipe/back dismissal while a tag is being read or written.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ContactlessPaySheet(
+    walletManager: WalletManager,
+    onDismissed: () -> Unit,
+    onLightningRequest: (String) -> Unit,
+) {
+    val dismissLocked = remember { mutableStateOf(false) }
+    val confirmValueChange = remember {
+        { value: SheetValue -> value != SheetValue.Hidden || !dismissLocked.value }
+    }
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        confirmValueChange = confirmValueChange,
+    )
+    val scope = rememberCoroutineScope()
+    var closing by remember { mutableStateOf(false) }
+
+    fun hideThen(action: () -> Unit) {
+        if (closing) return
+        closing = true
+        // Deliberate navigation is allowed to end the session even if the tag
+        // callback has not yet delivered its final idle-state recomposition.
+        dismissLocked.value = false
+        scope.launch { sheetState.hide() }.invokeOnCompletion { action() }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = {
+            if (!dismissLocked.value && !closing) {
+                closing = true
+                onDismissed()
+            }
+        },
+        sheetState = sheetState,
+    ) {
+        ContactlessPayView(
+            walletManager = walletManager,
+            onLightningRequest = { invoice ->
+                hideThen { onLightningRequest(invoice) }
+            },
+            onDismissLockChanged = { dismissLocked.value = it },
+        )
+    }
+}
 
 @Composable
 fun ContactlessPayView(
     walletManager: WalletManager,
-    contentPadding: PaddingValues = PaddingValues(),
-    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
     onLightningRequest: (String) -> Unit,
+    onDismissLockChanged: (Boolean) -> Unit = {},
 ) {
     val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
     val activity = remember(context) { context.findActivity() }
     val adapter = remember(context) { NfcAdapter.getDefaultAdapter(context) }
     val scope = rememberCoroutineScope()
     val service = remember(walletManager) { NFCPaymentService(walletManager) }
+    val currentDismissLockChanged by rememberUpdatedState(onDismissLockChanged)
+    var nfcEnabled by remember(adapter) { mutableStateOf(adapter?.isEnabled == true) }
     var status by remember { mutableStateOf("Hold the phone near an NFC payment tag.") }
     var error by remember { mutableStateOf<String?>(null) }
     var isProcessing by remember { mutableStateOf(false) }
     var paymentComplete by remember { mutableStateOf(false) }
     var lastPaymentAmount by remember { mutableStateOf<Long?>(null) }
 
-    DisposableEffect(activity, adapter, service) {
-        if (activity != null && adapter?.isEnabled == true) {
+    DisposableEffect(lifecycleOwner, adapter) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                nfcEnabled = adapter?.isEnabled == true
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    DisposableEffect(activity, adapter, service, nfcEnabled) {
+        if (activity != null && adapter != null && nfcEnabled) {
             val flags = (
                 NfcAdapter.FLAG_READER_NFC_A or
                     NfcAdapter.FLAG_READER_NFC_B or
@@ -71,6 +154,7 @@ fun ContactlessPayView(
                     scope.launch {
                         if (isProcessing) return@launch
                         isProcessing = true
+                        currentDismissLockChanged(true)
                         paymentComplete = false
                         lastPaymentAmount = null
                         error = null
@@ -100,6 +184,7 @@ fun ContactlessPayView(
                             status = "Ready to scan again."
                         }
                         isProcessing = false
+                        currentDismissLockChanged(false)
                     }
                 },
                 flags,
@@ -110,45 +195,106 @@ fun ContactlessPayView(
             if (activity != null && adapter != null) {
                 runCatching { adapter.disableReaderMode(activity) }
             }
+            currentDismissLockChanged(false)
         }
     }
 
+    ContactlessPayContent(
+        availability = when {
+            adapter == null -> ContactlessAvailability.Unavailable
+            !nfcEnabled -> ContactlessAvailability.Disabled
+            else -> ContactlessAvailability.Ready
+        },
+        status = status,
+        error = error,
+        isProcessing = isProcessing,
+        paymentComplete = paymentComplete,
+        lastPaymentAmount = lastPaymentAmount,
+        modifier = modifier,
+        onOpenNfcSettings = { context.openNfcSettings() },
+    )
+}
+
+internal enum class ContactlessAvailability { Unavailable, Disabled, Ready }
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun ContactlessPayContent(
+    availability: ContactlessAvailability,
+    status: String,
+    error: String?,
+    isProcessing: Boolean,
+    paymentComplete: Boolean,
+    lastPaymentAmount: Long?,
+    onOpenNfcSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(contentPadding)
-            .padding(24.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("contactlessSheetContent")
+            .padding(horizontal = 24.dp)
+            .padding(bottom = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Text("Contactless", style = MaterialTheme.typography.headlineSmall)
-        if (adapter == null) {
-            InlineNotice(text = "NFC is not available on this device.")
-        } else if (!adapter.isEnabled) {
-            InlineNotice(text = "NFC is disabled in system settings.")
-        } else {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (isProcessing) {
-                    LoadingIndicator()
-                }
-                Text(status, color = MaterialTheme.colorScheme.secondary)
+        Text(
+            text = "Contactless",
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Surface(
+            modifier = Modifier.size(80.dp),
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Outlined.Nfc,
+                    contentDescription = null,
+                    modifier = Modifier.size(40.dp),
+                    tint = MaterialTheme.colorScheme.onSurface,
+                )
             }
         }
+
+        when (availability) {
+            ContactlessAvailability.Unavailable ->
+                InlineNotice(text = "NFC is not available on this device.")
+            ContactlessAvailability.Disabled ->
+                InlineNotice(text = "NFC is disabled in system settings.")
+            ContactlessAvailability.Ready ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (isProcessing) {
+                        LoadingIndicator(modifier = Modifier.size(24.dp))
+                    }
+                    Text(
+                        text = status,
+                        modifier = Modifier.padding(start = if (isProcessing) 8.dp else 0.dp),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+        }
+
         if (paymentComplete) {
             Text("Payment sent!", style = MaterialTheme.typography.titleMedium)
-            lastPaymentAmount?.let { Text("$it sat", style = MaterialTheme.typography.headlineSmall) }
+            lastPaymentAmount?.let {
+                Text("$it sat", style = MaterialTheme.typography.headlineSmall)
+            }
         }
         error?.let { InlineNotice(text = it) }
-        PrimaryButton("Close", onClick = onClose)
-        GhostButton(
-            text = if (paymentComplete) "Pay again" else "Reset",
-            enabled = !isProcessing,
-            onClick = {
-                error = null
-                paymentComplete = false
-                lastPaymentAmount = null
-                status = "Hold the phone near an NFC payment tag."
-            },
-        )
+
+        when (availability) {
+            ContactlessAvailability.Disabled ->
+                PrimaryButton("Open NFC settings", onClick = onOpenNfcSettings)
+            ContactlessAvailability.Unavailable,
+            ContactlessAvailability.Ready -> Unit
+        }
     }
 }
 
@@ -183,3 +329,8 @@ private tailrec fun Context.findActivity(): Activity? =
         is ContextWrapper -> baseContext.findActivity()
         else -> null
     }
+
+private fun Context.openNfcSettings() {
+    runCatching { startActivity(Intent(Settings.ACTION_NFC_SETTINGS)) }
+        .recoverCatching { startActivity(Intent(Settings.ACTION_WIRELESS_SETTINGS)) }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/BackNavigationPolicy.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/BackNavigationPolicy.kt
@@ -3,18 +3,15 @@ package com.cashu.me.ui.navigation
 enum class ShellBackAction {
     CloseReceiveDetail,
     CloseScanner,
-    CloseContactless,
 }
 
 fun shellBackAction(
     receiveDetailVisible: Boolean,
     scannerVisible: Boolean,
-    contactlessVisible: Boolean,
 ): ShellBackAction? =
     when {
         receiveDetailVisible -> ShellBackAction.CloseReceiveDetail
         scannerVisible -> ShellBackAction.CloseScanner
-        contactlessVisible -> ShellBackAction.CloseContactless
         else -> null
     }
 

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -131,7 +131,6 @@ fun CashuNavHost(
                 cashuRequestStore = container.cashuRequestStore,
                 nfcReceiveCoordinator = container.nfcReceiveCoordinator,
                 requestId = requestId,
-                isReceiveFlow = entry.arguments?.getBoolean("fresh") == true,
                 onClose = { navController.popBackStack() },
                 snackbarHostState = container.snackbarHostState,
             )
@@ -248,9 +247,9 @@ internal fun transactionDetailRouteFor(transactionId: String): String {
     return Routes.TRANSACTION_DETAIL.replace("{transactionId}", encoded)
 }
 
-internal fun cashuRequestDetailRouteFor(requestId: String, fresh: Boolean = false): String {
+internal fun cashuRequestDetailRouteFor(requestId: String): String {
     val encoded = URLEncoder.encode(requestId, StandardCharsets.UTF_8.name())
-    return "request/$encoded?fresh=$fresh"
+    return "request/$encoded?fresh=false"
 }
 
 private fun NavGraphBuilder.tabDestinations(

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/Routes.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/Routes.kt
@@ -19,8 +19,8 @@ object Routes {
     // With arguments
     const val MINT_DETAIL = "mints/{mintUrl}"
     const val TRANSACTION_DETAIL = "history/transaction/{transactionId}"
-    // `fresh` = opened straight after creating the request (actively waiting),
-    // vs. from history. Only the fresh context takes over full-screen on payment.
+    // Keep the legacy `fresh` query in the route pattern so restored back stacks
+    // from earlier builds continue to resolve. Success behavior is now uniform.
     const val CASHU_REQUEST_DETAIL = "request/{requestId}?fresh={fresh}"
 
     // Wallet settings and sub-screens

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -123,7 +124,8 @@ fun CashuRequestDetailScreen(
     var unitPickerOpen by remember { mutableStateOf(false) }
     var regenerateError by remember { mutableStateOf<String?>(null) }
     val offerNfcReceive = request?.shouldOfferNfcReceive() == true
-    val nfcTransferActive = offerNfcReceive && nfcState.phase.isNfcTransferActive()
+    val keepNfcSessionMounted = shouldKeepNfcSessionMounted(offerNfcReceive, nfcState.phase)
+    val nfcTransferActive = keepNfcSessionMounted && nfcState.phase.isNfcTransferActive()
 
     // Re-signs the same NUT-18 request in place (same id/history entry) — used
     // by the Mint sheet, the Amount sheet's Done, and "New Request" (called
@@ -205,7 +207,7 @@ fun CashuRequestDetailScreen(
     // Existing payments form the baseline, so revisiting history stays inline.
     val successPayment = request?.receivedPayments
         ?.firstOrNull { it.transactionId == successPaymentId }
-    if (request != null && successPayment != null) {
+    if (request != null && successPayment != null && nfcState.phase != NfcReceivePhase.Success) {
         val isSatRequest = request.unit.equals("sat", ignoreCase = true)
         val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
         val amountLabel = successPayment.amount.takeIf { it > 0L }?.let {
@@ -282,7 +284,7 @@ fun CashuRequestDetailScreen(
             return@Scaffold
         }
 
-        if (offerNfcReceive) {
+        if (keepNfcSessionMounted) {
             NfcReceiveLifecycle(
                 coordinator = nfcReceiveCoordinator,
                 request = request,
@@ -477,10 +479,46 @@ fun CashuRequestDetailScreen(
         }
     }
 
-    if (offerNfcReceive) {
-        NfcReceiveOverlay(coordinator = nfcReceiveCoordinator)
+    if (keepNfcSessionMounted) {
+        val nfcSuccessAmountLabel = request?.let { currentRequest ->
+            nfcState.amount?.takeIf { it > 0L }?.let { amount ->
+                if (currentRequest.unit.equals("sat", ignoreCase = true)) {
+                    formatter.formatWalletSats(amount, settings.useBitcoinSymbol)
+                } else {
+                    CurrencyAmount(
+                        amount,
+                        CurrencyRegistry.currencyForMintUnit(currentRequest.unit),
+                    ).formatted()
+                }
+            }
+        }
+        val nfcSuccessMintName = nfcState.settlementMint?.let { url ->
+            walletState.mints.firstOrNull { it.url == url }?.name ?: url
+        }
+        NfcReceiveOverlay(
+            coordinator = nfcReceiveCoordinator,
+            successAmountLabel = nfcSuccessAmountLabel,
+            successMintName = nfcSuccessMintName,
+            onSuccessDone = {
+                nfcReceiveCoordinator.deactivate()
+                onClose()
+            },
+        )
     }
 }
+
+internal fun shouldKeepNfcSessionMounted(
+    offerNfcReceive: Boolean,
+    phase: NfcReceivePhase,
+): Boolean = offerNfcReceive || phase in setOf(
+    NfcReceivePhase.Connected,
+    NfcReceivePhase.Receiving,
+    NfcReceivePhase.Validating,
+    NfcReceivePhase.Redeeming,
+    NfcReceivePhase.Converting,
+    NfcReceivePhase.Success,
+    NfcReceivePhase.Failure,
+)
 
 private fun NfcReceivePhase.isNfcTransferActive(): Boolean = this in setOf(
     NfcReceivePhase.Connected,
@@ -607,24 +645,32 @@ internal fun CashuRequestSuccessTerminal(
         title = "Payment received",
         onDone = onDone,
         rows = {
-            if (amountLabel != null) {
-                InspectorRow(
-                    label = "Amount",
-                    value = amountLabel,
-                    leadingIcon = Icons.Outlined.Payments,
-                    valueMonospaced = true,
-                )
-            }
-            if (mintName != null) {
-                if (amountLabel != null) CanvasDivider(leadingInset = 16.dp)
-                InspectorRow(
-                    label = "Mint",
-                    value = mintName,
-                    leadingIcon = Icons.Outlined.AccountBalance,
-                )
-            }
+            CashuRequestReceiptRows(amountLabel = amountLabel, mintName = mintName)
         },
     )
+}
+
+@Composable
+internal fun ColumnScope.CashuRequestReceiptRows(
+    amountLabel: String?,
+    mintName: String?,
+) {
+    if (amountLabel != null) {
+        InspectorRow(
+            label = "Amount",
+            value = amountLabel,
+            leadingIcon = Icons.Outlined.Payments,
+            valueMonospaced = true,
+        )
+    }
+    if (mintName != null) {
+        if (amountLabel != null) CanvasDivider(leadingInset = 16.dp)
+        InspectorRow(
+            label = "Mint",
+            value = mintName,
+            leadingIcon = Icons.Outlined.AccountBalance,
+        )
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -1,16 +1,10 @@
 package com.cashu.me.ui.receive
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.scaleIn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +45,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,6 +71,7 @@ import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Models.CashuRequestPayment
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
@@ -110,10 +106,6 @@ fun CashuRequestDetailScreen(
     nfcReceiveCoordinator: NfcReceiveCoordinator,
     requestId: String,
     onClose: () -> Unit,
-    // True when opened straight after creating the request (actively waiting).
-    // Only then does the first payment take over full-screen (iOS parity);
-    // from history the screen stays inline/persistent (reusable, multi-payment).
-    isReceiveFlow: Boolean = false,
     snackbarHostState: SnackbarHostState? = null,
 ) {
     val storeState by cashuRequestStore.state.collectAsState()
@@ -195,41 +187,47 @@ fun CashuRequestDetailScreen(
         }
     }
 
-    // Track payment count changes for celebration animation.
     val paymentCount = request?.receivedPayments?.size ?: 0
-    var previousCount by remember(requestId) { mutableStateOf(paymentCount) }
-    var celebrate by remember { mutableStateOf(false) }
-    // Fresh receive-flow only: the first payment arms a single-fire full-screen
-    // takeover (iOS `didAutoComplete`). History views never set this.
-    var didComplete by remember(requestId) { mutableStateOf(false) }
-    LaunchedEffect(paymentCount) {
-        if (paymentCount > previousCount && previousCount >= 0) {
-            if (isReceiveFlow) didComplete = true
-            celebrate = true
-            delay(2500)
-            celebrate = false
+    var observedPaymentIds by rememberSaveable(requestId) {
+        mutableStateOf(request?.receivedPayments?.map { it.transactionId })
+    }
+    var successPaymentId by rememberSaveable(requestId) { mutableStateOf<String?>(null) }
+    LaunchedEffect(requestId, request?.receivedPayments) {
+        val currentPayments = request?.receivedPayments ?: return@LaunchedEffect
+        newestUnseenPayment(observedPaymentIds, currentPayments)?.let { payment ->
+            successPaymentId = payment.transactionId
         }
-        previousCount = paymentCount
+        observedPaymentIds = currentPayments.map { it.transactionId }
     }
 
-    // Fresh + paid → replace the whole screen with the shared success terminal,
-    // auto-dismissing after a brief dwell (no Done button, matching Receive
-    // Lightning). Reusable/history requests never reach here.
-    if (isReceiveFlow && didComplete && request != null) {
+    // A payment that lands while this request is open always gets the shared
+    // full-screen receipt, regardless of whether it arrived via NFC or Nostr.
+    // Existing payments form the baseline, so revisiting history stays inline.
+    val successPayment = request?.receivedPayments
+        ?.firstOrNull { it.transactionId == successPaymentId }
+    if (request != null && successPayment != null) {
         val isSatRequest = request.unit.equals("sat", ignoreCase = true)
         val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
-        val receivedAmount = request.amount?.takeIf { it > 0L } ?: request.totalReceived.takeIf { it > 0L }
-        val amountLabel = receivedAmount?.let {
+        val amountLabel = successPayment.amount.takeIf { it > 0L }?.let {
             if (isSatRequest) formatter.formatWalletSats(it, settings.useBitcoinSymbol)
             else CurrencyAmount(it, requestCurrency).formatted()
         }
-        val mintName = request.mints.firstOrNull()?.let { url ->
+        val transactionMintUrl = walletState.transactions
+            .firstOrNull { it.id == successPayment.transactionId }
+            ?.mintUrl
+        val creditedMintUrl = transactionMintUrl
+            ?: nfcState.settlementMint.takeIf { nfcState.phase == NfcReceivePhase.Success }
+            ?: request.mints.singleOrNull()
+        val mintName = creditedMintUrl?.let { url ->
             walletState.mints.firstOrNull { it.url == url }?.name ?: url
-        } ?: "Any mint"
+        }
         CashuRequestSuccessTerminal(
             amountLabel = amountLabel,
             mintName = mintName,
-            onDone = onClose,
+            onDone = {
+                nfcReceiveCoordinator.deactivate()
+                onClose()
+            },
         )
         return
     }
@@ -340,7 +338,6 @@ fun CashuRequestDetailScreen(
                 StatusBlock(
                     received = request.receivedPayments.isNotEmpty(),
                     paymentCount = paymentCount,
-                    celebrate = celebrate,
                 )
 
                 Column(modifier = Modifier.fillMaxWidth()) {
@@ -494,39 +491,20 @@ private fun NfcReceivePhase.isNfcTransferActive(): Boolean = this in setOf(
 )
 
 @Composable
-private fun StatusBlock(received: Boolean, paymentCount: Int, celebrate: Boolean) {
+private fun StatusBlock(received: Boolean, paymentCount: Int) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
     ) {
         if (received) {
-            // Live celebration grows in gently (0.9 → 1, the one delight beat);
-            // the persistent N-payments state is quiet — no animation.
-            AnimatedVisibility(
-                visible = true,
-                enter = if (celebrate) {
-                    scaleIn(
-                        animationSpec = spring(dampingRatio = 0.7f, stiffness = Spring.StiffnessMediumLow),
-                        initialScale = 0.9f,
-                    ) + fadeIn()
-                } else {
-                    fadeIn()
-                },
-                exit = fadeOut(),
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.CheckCircle,
-                    contentDescription = null,
-                    tint = CashuTheme.colors.received,
-                    modifier = Modifier.size(CashuTheme.spacing.loose),
-                )
-            }
+            Icon(
+                imageVector = Icons.Outlined.CheckCircle,
+                contentDescription = null,
+                tint = CashuTheme.colors.received,
+                modifier = Modifier.size(CashuTheme.spacing.loose),
+            )
             Text(
-                text = when {
-                    celebrate -> "Payment received!"
-                    paymentCount == 1 -> "1 payment received"
-                    else -> "$paymentCount payments received"
-                },
+                text = if (paymentCount == 1) "1 payment received" else "$paymentCount payments received",
                 style = MaterialTheme.typography.titleMedium,
                 color = CashuTheme.colors.received,
             )
@@ -617,23 +595,17 @@ private fun CashuRequestAmountEditSheet(
     }
 }
 
-/** Full-screen shared success terminal for a fresh request's first payment
- *  (iOS `CashuRequestDetailView.paymentSuccessView`). Auto-dismisses after a
- *  brief dwell — no Done button, mirroring Receive Lightning. */
+/** Full-screen shared receipt for a payment that lands while the request is open. */
 @Composable
-private fun CashuRequestSuccessTerminal(
+internal fun CashuRequestSuccessTerminal(
     amountLabel: String?,
     mintName: String?,
     onDone: () -> Unit,
 ) {
-    LaunchedEffect(Unit) {
-        delay(1800)
-        onDone()
-    }
     PaymentStatusScreen(
         phase = PaymentStatusPhase.Success,
-        title = "Payment Received!",
-        onDone = null,
+        title = "Payment received",
+        onDone = onDone,
         rows = {
             if (amountLabel != null) {
                 InspectorRow(
@@ -653,4 +625,16 @@ private fun CashuRequestSuccessTerminal(
             }
         },
     )
+}
+
+/**
+ * Returns the newest payment that was not present in the last observed snapshot.
+ * A null snapshot means the request has just opened, so its payments establish
+ * the baseline and must not replay an old success terminal.
+ */
+internal fun newestUnseenPayment(
+    observedPaymentIds: Collection<String>?,
+    currentPayments: List<CashuRequestPayment>,
+): CashuRequestPayment? = observedPaymentIds?.let { observed ->
+    currentPayments.lastOrNull { it.transactionId !in observed }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -9,14 +9,19 @@ import android.nfc.cardemulation.CardEmulation
 import android.os.Build
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.togetherWith
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.background
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -43,6 +48,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
@@ -51,11 +57,18 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.cashu.me.Core.NfcReceive.CashuNfcHostApduService
 import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
 import com.cashu.me.Core.NfcReceive.NfcReceivePhase
+import com.cashu.me.Core.NfcReceive.NfcReceiveState
 import com.cashu.me.Models.CashuRequest
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
 import com.cashu.me.ui.components.SpinnerRing
 import com.cashu.me.ui.theme.CashuTheme
+import com.cashu.me.ui.theme.rememberReducedMotion
+
+private const val NfcIndicatorResizeMillis = 220
+private const val NfcIndicatorFadeOutMillis = 90
+private const val NfcIndicatorFadeInMillis = 150
+private const val NfcIndicatorFadeInDelayMillis = 60
 
 @Composable
 fun NfcReceiveLifecycle(
@@ -106,6 +119,12 @@ fun NfcReceiveLifecycle(
 @Composable
 fun NfcReceiveIndicator(coordinator: NfcReceiveCoordinator, modifier: Modifier = Modifier) {
     val state by coordinator.state.collectAsState()
+    NfcReceiveIndicatorContent(state = state, modifier = modifier)
+}
+
+@Composable
+internal fun NfcReceiveIndicatorContent(state: NfcReceiveState, modifier: Modifier = Modifier) {
+    val reducedMotion = rememberReducedMotion()
     val active = state.phase in setOf(
         NfcReceivePhase.Waiting,
         NfcReceivePhase.Connected,
@@ -119,35 +138,80 @@ fun NfcReceiveIndicator(coordinator: NfcReceiveCoordinator, modifier: Modifier =
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
         label = "nfc-indicator-color",
     )
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .animateContentSize(animationSpec = spring(stiffness = Spring.StiffnessMediumLow))
-            .background(indicatorColor, MaterialTheme.shapes.small)
-            .padding(horizontal = CashuTheme.spacing.default, vertical = CashuTheme.spacing.default),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
     ) {
-        Icon(
-            imageVector = Icons.Outlined.Nfc,
-            contentDescription = null,
-            tint = if (active) CashuTheme.colors.pending else MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(18.dp),
-        )
-        AnimatedContent(
-            targetState = state.phase to (state.message ?: if (active) "Another wallet can use Send → Tap" else "Open this request with NFC enabled"),
-            transitionSpec = {
-                fadeIn(spring(stiffness = Spring.StiffnessMedium)) togetherWith
-                    fadeOut(spring(stiffness = Spring.StiffnessMedium))
+        Surface(
+            modifier = if (reducedMotion) {
+                Modifier.testTag("nfcReceiveIndicatorSurface")
+            } else {
+                Modifier
+                    .testTag("nfcReceiveIndicatorSurface")
+                    .animateContentSize(
+                        animationSpec = tween(
+                            durationMillis = NfcIndicatorResizeMillis,
+                            easing = FastOutSlowInEasing,
+                        ),
+                        alignment = Alignment.Center,
+                    )
             },
-            label = "nfc-indicator-content",
-            modifier = Modifier.weight(1f),
-        ) { (_, line) ->
-            Text(
-                text = line,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            shape = MaterialTheme.shapes.small,
+            color = indicatorColor,
+        ) {
+            Row(
+                modifier = Modifier
+                    .testTag("nfcReceiveIndicatorContent")
+                    .padding(
+                        horizontal = CashuTheme.spacing.default,
+                        vertical = CashuTheme.spacing.snug,
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Nfc,
+                    contentDescription = null,
+                    tint = if (active) CashuTheme.colors.pending else MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(18.dp),
+                )
+                AnimatedContent(
+                    targetState = state.phase to (state.message ?: if (active) {
+                        "Ask the sender to hold their phone near yours."
+                    } else {
+                        "Open this request with NFC enabled."
+                    }),
+                    transitionSpec = {
+                        if (reducedMotion) {
+                            (EnterTransition.None togetherWith ExitTransition.None).using(null)
+                        } else {
+                            (
+                                fadeIn(
+                                    tween(
+                                        durationMillis = NfcIndicatorFadeInMillis,
+                                        delayMillis = NfcIndicatorFadeInDelayMillis,
+                                        easing = LinearOutSlowInEasing,
+                                    ),
+                                ) togetherWith fadeOut(
+                                    tween(
+                                        durationMillis = NfcIndicatorFadeOutMillis,
+                                        easing = FastOutLinearInEasing,
+                                    ),
+                                )
+                            ).using(null)
+                        }
+                    },
+                    contentAlignment = Alignment.Center,
+                    label = "nfc-indicator-content",
+                ) { (_, line) ->
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -225,7 +225,6 @@ fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
         NfcReceivePhase.Validating,
         NfcReceivePhase.Redeeming,
         NfcReceivePhase.Converting,
-        NfcReceivePhase.Success,
         NfcReceivePhase.Failure,
     )
     val haptics = LocalHapticFeedback.current
@@ -241,12 +240,6 @@ fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
     ) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
             when (state.phase) {
-                NfcReceivePhase.Success -> PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Success,
-                    title = "Payment received",
-                    detail = state.amount?.let { "$it sat added to your wallet" } ?: "Ecash added to your wallet",
-                    onDone = coordinator::clearResult,
-                )
                 NfcReceivePhase.Failure -> PaymentStatusScreen(
                     phase = PaymentStatusPhase.Failure,
                     title = "Payment failed",

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -62,6 +62,7 @@ import com.cashu.me.Models.CashuRequest
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
 import com.cashu.me.ui.components.SpinnerRing
+import com.cashu.me.ui.receive.CashuRequestReceiptRows
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.rememberReducedMotion
 
@@ -79,7 +80,21 @@ fun NfcReceiveLifecycle(
     val context = LocalContext.current
     val activity = context.findActivity()
     val lifecycle = LocalLifecycleOwner.current.lifecycle
-    DisposableEffect(activity, lifecycle, coordinator, request, settlementMintUrl) {
+    // Payment history is updated immediately before the coordinator publishes
+    // Success. Key the HCE session only to signed-request fields so that update
+    // cannot dispose the processing overlay and expose the QR screen for a frame.
+    DisposableEffect(
+        activity,
+        lifecycle,
+        coordinator,
+        request.id,
+        request.encoded,
+        request.amount,
+        request.unit,
+        request.mints,
+        request.memo,
+        settlementMintUrl,
+    ) {
         val adapter = NfcAdapter.getDefaultAdapter(context)
         val component = ComponentName(context, CashuNfcHostApduService::class.java)
         fun resume() {
@@ -217,7 +232,12 @@ internal fun NfcReceiveIndicatorContent(state: NfcReceiveState, modifier: Modifi
 }
 
 @Composable
-fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
+fun NfcReceiveOverlay(
+    coordinator: NfcReceiveCoordinator,
+    successAmountLabel: String?,
+    successMintName: String?,
+    onSuccessDone: () -> Unit,
+) {
     val state by coordinator.state.collectAsState()
     val visible = state.phase in setOf(
         NfcReceivePhase.Connected,
@@ -225,6 +245,7 @@ fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
         NfcReceivePhase.Validating,
         NfcReceivePhase.Redeeming,
         NfcReceivePhase.Converting,
+        NfcReceivePhase.Success,
         NfcReceivePhase.Failure,
     )
     val haptics = LocalHapticFeedback.current
@@ -239,26 +260,65 @@ fun NfcReceiveOverlay(coordinator: NfcReceiveCoordinator) {
         exit = fadeOut(spring(stiffness = Spring.StiffnessMedium)),
     ) {
         Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-            when (state.phase) {
-                NfcReceivePhase.Failure -> PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Failure,
-                    title = "Payment failed",
-                    detail = state.message ?: "The payment could not be received.",
-                    doneLabel = "Try again",
-                    onDone = coordinator::clearResult,
-                )
-                NfcReceivePhase.Validating, NfcReceivePhase.Redeeming, NfcReceivePhase.Converting -> PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Processing,
-                    title = when (state.phase) {
+            NfcReceiveOverlayContent(
+                state = state,
+                successAmountLabel = successAmountLabel,
+                successMintName = successMintName,
+                onSuccessDone = onSuccessDone,
+                onRetry = coordinator::clearResult,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun NfcReceiveOverlayContent(
+    state: NfcReceiveState,
+    successAmountLabel: String?,
+    successMintName: String?,
+    onSuccessDone: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    when (state.phase) {
+        NfcReceivePhase.Failure -> PaymentStatusScreen(
+            phase = PaymentStatusPhase.Failure,
+            title = "Payment failed",
+            detail = state.message ?: "The payment could not be received.",
+            doneLabel = "Try again",
+            onDone = onRetry,
+        )
+        NfcReceivePhase.Validating,
+        NfcReceivePhase.Redeeming,
+        NfcReceivePhase.Converting,
+        NfcReceivePhase.Success,
+        -> {
+            val succeeded = state.phase == NfcReceivePhase.Success
+            PaymentStatusScreen(
+                phase = if (succeeded) PaymentStatusPhase.Success else PaymentStatusPhase.Processing,
+                title = if (succeeded) {
+                    "Payment received"
+                } else {
+                    when (state.phase) {
                         NfcReceivePhase.Validating -> "Checking payment"
                         NfcReceivePhase.Redeeming -> "Securing ecash"
                         else -> "Moving to your default mint"
-                    },
-                    detail = "Transfer complete — you can move the phones apart.",
-                )
-                else -> NfcTransferScreen()
-            }
+                    }
+                },
+                detail = if (succeeded) null else "Transfer complete — you can move the phones apart.",
+                onDone = onSuccessDone.takeIf { succeeded },
+                rows = if (succeeded) {
+                    {
+                        CashuRequestReceiptRows(
+                            amountLabel = successAmountLabel,
+                            mintName = successMintName,
+                        )
+                    }
+                } else {
+                    null
+                },
+            )
         }
+        else -> NfcTransferScreen()
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -356,9 +356,7 @@ private fun AuthenticatedShell(container: AppContainer) {
                 cashuRequestStore = container.cashuRequestStore,
                 onOpenRequest = { id ->
                     close()
-                    // Fresh (just-created, actively waiting) → arms the full-screen
-                    // takeover on the first payment; history entries pass fresh=false.
-                    navController.navigate(cashuRequestDetailRouteFor(id, fresh = true))
+                    navController.navigate(cashuRequestDetailRouteFor(id))
                 },
                 onClose = close,
                 // Universal scanner (Send parity): auto-routes whatever it reads.

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -42,7 +42,7 @@ import com.cashu.me.Core.PaymentRequestDecodeResult
 import com.cashu.me.Core.PaymentRequestDecoder
 import com.cashu.me.Core.TokenParser
 import com.cashu.me.Views.Components.ScannerView
-import com.cashu.me.Views.Send.ContactlessPayView
+import com.cashu.me.Views.Send.ContactlessPaySheet
 import com.cashu.me.ui.onboarding.OnboardingScreen
 import com.cashu.me.ui.navigation.Routes
 import com.cashu.me.ui.navigation.TopTab
@@ -188,6 +188,7 @@ private fun AuthenticatedShell(container: AppContainer) {
     // The active money flow, hosted in a modal bottom sheet (iOS WalletFlow sheets).
     var activeFlow by remember { mutableStateOf<WalletFlow?>(null) }
     var flowDismissLocked by remember { mutableStateOf(false) }
+    var openContactlessAfterFlowDismiss by remember { mutableStateOf(false) }
     var pendingReceiveScan by remember { mutableStateOf<String?>(null) }
     var pendingSendScan by remember { mutableStateOf<String?>(null) }
     var pendingMintScan by remember { mutableStateOf<String?>(null) }
@@ -259,21 +260,6 @@ private fun AuthenticatedShell(container: AppContainer) {
             navController = navController,
         )
         AnimatedVisibility(
-            visible = showContactless,
-            enter = overlayEnter,
-            exit = overlayExit,
-        ) {
-            ContactlessPayView(
-                walletManager = container.walletManager,
-                onClose = { showContactless = false },
-                onLightningRequest = { invoice ->
-                    pendingSendScan = invoice
-                    showContactless = false
-                    activeFlow = WalletFlow.Send
-                },
-            )
-        }
-        AnimatedVisibility(
             visible = activeScannerTarget != null,
             enter = overlayEnter,
             exit = overlayExit,
@@ -330,17 +316,15 @@ private fun AuthenticatedShell(container: AppContainer) {
         // instead of popping the NavHost — or exiting the app — underneath it.
         // Declared after WalletScaffold so this callback registers last on the
         // OnBackPressedDispatcher and takes precedence over NavHost back handling
-        // while an overlay is visible. Receive detail renders above the scanner,
-        // which renders above Contactless — dismissal order matches. (Flow
-        // sheets live in their own window and handle back themselves.)
-        BackHandler(enabled = !appLockState.isLocked && (receiveTokenDetail != null || activeScannerTarget != null || showContactless)) {
-            when (shellBackAction(receiveTokenDetail != null, activeScannerTarget != null, showContactless)) {
+        // while an overlay is visible. Receive detail renders above the scanner.
+        // Modal sheets live in their own windows and handle back themselves.
+        BackHandler(enabled = !appLockState.isLocked && (receiveTokenDetail != null || activeScannerTarget != null)) {
+            when (shellBackAction(receiveTokenDetail != null, activeScannerTarget != null)) {
                 com.cashu.me.ui.navigation.ShellBackAction.CloseReceiveDetail -> {
                     // Never abandon a redeem in flight.
                     if (!receiveDetailDismissLocked) receiveTokenDetail = null
                 }
                 com.cashu.me.ui.navigation.ShellBackAction.CloseScanner -> scannerTarget = null
-                com.cashu.me.ui.navigation.ShellBackAction.CloseContactless -> showContactless = false
                 null -> Unit
             }
         }
@@ -355,7 +339,13 @@ private fun AuthenticatedShell(container: AppContainer) {
     WalletFlowSheetHost(
         flow = activeFlow,
         dismissLocked = flowDismissLocked,
-        onDismissed = { activeFlow = null },
+        onDismissed = {
+            activeFlow = null
+            if (openContactlessAfterFlowDismiss) {
+                openContactlessAfterFlowDismiss = false
+                showContactless = true
+            }
+        },
         snackbarHostState = container.snackbarHostState,
     ) { flow, close ->
         when (flow) {
@@ -412,8 +402,10 @@ private fun AuthenticatedShell(container: AppContainer) {
                     scannerTarget = ScannerTarget.Auto
                 },
                 onContactless = {
+                    // Android has no system NFC sheet. Let Send finish its hide
+                    // animation before mounting the fresh Material NFC sheet.
+                    openContactlessAfterFlowDismiss = true
                     close()
-                    showContactless = true
                 },
                 onSendEcash = { activeFlow = WalletFlow.SendEcash },
                 onOpenReceiveToken = { token ->
@@ -442,6 +434,18 @@ private fun AuthenticatedShell(container: AppContainer) {
                 onDismissLockChanged = { flowDismissLocked = it },
             )
         }
+    }
+
+    if (showContactless) {
+        ContactlessPaySheet(
+            walletManager = container.walletManager,
+            onDismissed = { showContactless = false },
+            onLightningRequest = { invoice ->
+                showContactless = false
+                pendingSendScan = invoice
+                activeFlow = WalletFlow.Send
+            },
+        )
     }
 }
 

--- a/android/app/src/test/java/com/cashu/me/ui/navigation/BackNavigationPolicyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/navigation/BackNavigationPolicyTest.kt
@@ -9,17 +9,13 @@ class BackNavigationPolicyTest {
     fun shellBackPrioritizesTopmostOverlay() {
         assertEquals(
             ShellBackAction.CloseReceiveDetail,
-            shellBackAction(receiveDetailVisible = true, scannerVisible = true, contactlessVisible = true),
+            shellBackAction(receiveDetailVisible = true, scannerVisible = true),
         )
         assertEquals(
             ShellBackAction.CloseScanner,
-            shellBackAction(receiveDetailVisible = false, scannerVisible = true, contactlessVisible = true),
+            shellBackAction(receiveDetailVisible = false, scannerVisible = true),
         )
-        assertEquals(
-            ShellBackAction.CloseContactless,
-            shellBackAction(receiveDetailVisible = false, scannerVisible = false, contactlessVisible = true),
-        )
-        assertNull(shellBackAction(receiveDetailVisible = false, scannerVisible = false, contactlessVisible = false))
+        assertNull(shellBackAction(receiveDetailVisible = false, scannerVisible = false))
     }
 
     @Test

--- a/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
@@ -1,0 +1,64 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Models.CashuRequestPayment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CashuRequestPaymentObservationTest {
+    @Test
+    fun `existing payments establish baseline without replaying success`() {
+        assertNull(newestUnseenPayment(null, listOf(payment("existing"))))
+    }
+
+    @Test
+    fun `new payment is returned after baseline`() {
+        val received = newestUnseenPayment(
+            observedPaymentIds = listOf("existing"),
+            currentPayments = listOf(payment("existing"), payment("new", amount = 19)),
+        )
+
+        assertEquals("new", received?.transactionId)
+        assertEquals(19L, received?.amount)
+    }
+
+    @Test
+    fun `first payment is returned after an empty request baseline`() {
+        val received = newestUnseenPayment(
+            observedPaymentIds = emptyList(),
+            currentPayments = listOf(payment("first", amount = 19)),
+        )
+
+        assertEquals("first", received?.transactionId)
+    }
+
+    @Test
+    fun `unchanged payment snapshot does not replay success`() {
+        assertNull(
+            newestUnseenPayment(
+                observedPaymentIds = listOf("existing"),
+                currentPayments = listOf(payment("existing")),
+            ),
+        )
+    }
+
+    @Test
+    fun `newest unseen payment wins when updates arrive together`() {
+        val received = newestUnseenPayment(
+            observedPaymentIds = listOf("existing"),
+            currentPayments = listOf(
+                payment("existing"),
+                payment("new-1"),
+                payment("new-2"),
+            ),
+        )
+
+        assertEquals("new-2", received?.transactionId)
+    }
+
+    private fun payment(id: String, amount: Long = 1) = CashuRequestPayment(
+        transactionId = id,
+        amount = amount,
+        receivedAtEpochMillis = 1,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
@@ -1,8 +1,11 @@
 package com.cashu.me.ui.receive
 
+import com.cashu.me.Core.NfcReceive.NfcReceivePhase
 import com.cashu.me.Models.CashuRequestPayment
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CashuRequestPaymentObservationTest {
@@ -54,6 +57,14 @@ class CashuRequestPaymentObservationTest {
         )
 
         assertEquals("new-2", received?.transactionId)
+    }
+
+    @Test
+    fun `NFC session stays mounted while payment record and success state hand off`() {
+        assertTrue(shouldKeepNfcSessionMounted(false, NfcReceivePhase.Redeeming))
+        assertTrue(shouldKeepNfcSessionMounted(false, NfcReceivePhase.Success))
+        assertFalse(shouldKeepNfcSessionMounted(false, NfcReceivePhase.Inactive))
+        assertTrue(shouldKeepNfcSessionMounted(true, NfcReceivePhase.Waiting))
     }
 
     private fun payment(id: String, amount: Long = 1) = CashuRequestPayment(


### PR DESCRIPTION
## Summary
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/ce441c92-cda4-4888-9fb3-3910585c267e" />
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/c99a7076-6e8a-4d60-8ca2-2f173dd5a2da" />

- present Android contactless payments in a native Material 3 modal sheet with guarded dismissal, lifecycle-aware NFC state, and a path to NFC settings
- make Cashu Request NFC guidance content-hugging and centered with clearer sentence-case copy
- replace competing size springs with a center-anchored container morph and subtle fade-through, including reduced-motion support
- route newly received Cashu Request payments from NFC or Nostr through the shared full-screen receipt with the actual credited amount, resolved mint, and explicit Done action
- preserve the quiet inline payment summary when revisiting an already-paid request from History
- add Compose and unit coverage for the contactless sheet, NFC receive indicator, receipt terminal, and one-shot payment observation

## Testing
- ./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin :app:testDebugUnitTest
- ./gradlew :app:assembleDebug
- manual verification on a Pixel 7a running Android 16, including reopening an already-paid history request without replaying success