### PR TITLE
Add optional description to reusable BOLT12 offers

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -154,6 +154,7 @@ class FakeWalletGateway(
         method: PaymentMethodKind,
         mintUrl: String,
         unit: String,
+        description: String?,
     ): MintQuoteInfo {
         failIfRequested()
         val id = "mint-quote-${sequence.getAndIncrement()}"
@@ -170,6 +171,7 @@ class FakeWalletGateway(
             expiryEpochSeconds = System.currentTimeMillis() / 1000 + 3_600,
             mintUrl = normalize(mintUrl),
             unit = unit,
+            description = description.takeIf { method == PaymentMethodKind.Bolt12 },
         )
         mintQuotes[id] = MutableStateFlow(quote)
         return quote

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
@@ -1,11 +1,11 @@
 package com.cashu.me.ui.journeys
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onLast
-import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.cashu.me.Models.TransactionKind
 import com.cashu.me.Models.TransactionStatus
@@ -20,6 +20,7 @@ import com.cashu.me.test.fixtures.LaunchedFixture
 import com.cashu.me.ui.testing.UiTestTags
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,12 +52,23 @@ class HistoryDescriptionJourneyTest {
         assertEquals(description, fixture.container.walletManager.state.value.transactions.first { it.id == payment.id }.memo)
         assertEquals(21L, fixture.container.cashuRequestStore.request(request.id)?.totalReceived)
         fixture.scenario.recreate()
-        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").awaitText(description)
+        robot.awaitTag(UiTestTags.WalletScreen)
+        compose.onNodeWithText(description, useUnmergedTree = true).assertDoesNotExist()
+        compose.onNodeWithText("Outgoing coffee receipt", useUnmergedTree = true).assertDoesNotExist()
+        robot.tapText("History").awaitText("Reusable Invoice")
+        compose.onNodeWithText(description, useUnmergedTree = true).assertDoesNotExist()
+        compose.onNodeWithText("Outgoing coffee receipt", useUnmergedTree = true).assertDoesNotExist()
+        robot.tapDescription("Search history").typeIntoTag(UiTestTags.HistorySearch, "Coffee")
             .tapText("Reusable Invoice")
-        compose.onNodeWithText(description, useUnmergedTree = true).performScrollTo().assertIsDisplayed()
+        val descriptionText = compose.onNodeWithText(description, useUnmergedTree = true)
+        descriptionText.assertIsDisplayed()
+        val layouts = mutableListOf<TextLayoutResult>()
+        descriptionText.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(layouts) }
+        assertTrue("The entire description must fit on opening, without scrolling",
+            descriptionText.fetchSemanticsNode().boundsInRoot.height >= layouts.single().size.height - 1)
         robot.awaitText("Description").pressSystemBack()
-            .tapText("Outgoing coffee receipt")
-        compose.onAllNodesWithText("Outgoing coffee receipt", useUnmergedTree = true).onLast().performScrollTo().assertIsDisplayed()
+            .tapText("Lightning paid")
+        compose.onNodeWithText("Outgoing coffee receipt", useUnmergedTree = true).assertIsDisplayed()
         robot.awaitText("Description")
     }
 }

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
@@ -5,6 +5,10 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.cashu.me.Models.TransactionKind
@@ -60,12 +64,20 @@ class HistoryDescriptionJourneyTest {
         compose.onNodeWithText("Outgoing coffee receipt", useUnmergedTree = true).assertDoesNotExist()
         robot.tapDescription("Search history").typeIntoTag(UiTestTags.HistorySearch, "Coffee")
             .tapText("Reusable Invoice")
-        val descriptionText = compose.onNodeWithText(description, useUnmergedTree = true)
-        descriptionText.assertIsDisplayed()
+        val preview = compose.onNodeWithTag("payment-description-preview", useUnmergedTree = true)
+        preview.assertIsDisplayed()
+        robot.awaitText("Read more")
         val layouts = mutableListOf<TextLayoutResult>()
-        descriptionText.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(layouts) }
-        assertTrue("The entire description must fit on opening, without scrolling",
-            descriptionText.fetchSemanticsNode().boundsInRoot.height >= layouts.single().size.height - 1)
+        preview.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(layouts) }
+        assertTrue("The visible preview must fit without scrolling",
+            preview.fetchSemanticsNode().boundsInRoot.height >= layouts.single().size.height - 1)
+        val initialBounds = preview.fetchSemanticsNode().boundsInRoot
+        compose.onNodeWithText("Created", useUnmergedTree = true).performScrollTo().assertIsDisplayed()
+        assertEquals("The description stays at the bottom while details scroll",
+            initialBounds, preview.fetchSemanticsNode().boundsInRoot)
+        robot.tapText("Read more")
+        compose.onAllNodesWithText(description, useUnmergedTree = true).onLast().assertIsDisplayed()
+        robot.tapText("Done")
         robot.awaitText("Description").pressSystemBack()
             .tapText("Lightning paid")
         compose.onNodeWithText("Outgoing coffee receipt", useUnmergedTree = true).assertIsDisplayed()

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
@@ -1,0 +1,62 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onLast
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FakeWalletGateway
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Exercise the real history screens with deterministic settlement, without spending funds. */
+@RunWith(AndroidJUnit4::class)
+class HistoryDescriptionJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { launched?.close() }
+    private var launched: LaunchedFixture? = null
+    private val robot by lazy { WalletJourneyRobot(compose) }
+
+    @Test fun paidRequestAndOutgoingInvoiceKeepDescriptionsInHistoryAndDetails() {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val fixture = launched!!
+        robot.awaitTag(UiTestTags.WalletScreen)
+        val description = "Coffee tips 🌱 " + "Thank you for supporting the cafe. ".repeat(12) + "End of description."
+        val request = fixture.container.cashuRequestStore.upsertQuoteIntent(
+            quoteId = "history-quote", quoteKind = "bolt12", amount = null,
+            mints = listOf(FakeWalletGateway.TestMintUrl), memo = description, encoded = "lno1fixture",
+        )
+        val payment = WalletTransaction(id = "history-payment", amount = 21, type = TransactionType.Incoming,
+            kind = TransactionKind.Lightning, dateEpochMillis = System.currentTimeMillis(),
+            status = TransactionStatus.Completed, mintUrl = FakeWalletGateway.TestMintUrl, quoteId = "history-quote")
+        fixture.fakeGateway!!.addTransaction(payment)
+        fixture.fakeGateway!!.addTransaction(payment.copy(id = "history-outgoing", type = TransactionType.Outgoing,
+            quoteId = "melt-quote", memo = "Outgoing coffee receipt"))
+        runBlocking { fixture.container.walletManager.loadTransactions() }
+        assertEquals(description, fixture.container.walletManager.state.value.transactions.first { it.id == payment.id }.memo)
+        assertEquals(21L, fixture.container.cashuRequestStore.request(request.id)?.totalReceived)
+        fixture.scenario.recreate()
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").awaitText(description)
+            .tapText("Reusable Invoice")
+        compose.onNodeWithText(description, useUnmergedTree = true).performScrollTo().assertIsDisplayed()
+        robot.awaitText("Description").pressSystemBack()
+            .tapText("Outgoing coffee receipt")
+        compose.onAllNodesWithText("Outgoing coffee receipt", useUnmergedTree = true).onLast().performScrollTo().assertIsDisplayed()
+        robot.awaitText("Description")
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/HistoryDescriptionJourneyTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onLast
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.cashu.me.Models.TransactionKind
@@ -71,10 +70,10 @@ class HistoryDescriptionJourneyTest {
         preview.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { it(layouts) }
         assertTrue("The visible preview must fit without scrolling",
             preview.fetchSemanticsNode().boundsInRoot.height >= layouts.single().size.height - 1)
-        val initialBounds = preview.fetchSemanticsNode().boundsInRoot
-        compose.onNodeWithText("Created", useUnmergedTree = true).performScrollTo().assertIsDisplayed()
-        assertEquals("The description stays at the bottom while details scroll",
-            initialBounds, preview.fetchSemanticsNode().boundsInRoot)
+        val mintBounds = compose.onNodeWithText("Mint", useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+        val descriptionBounds = compose.onNodeWithText("Description", useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+        assertTrue("Description belongs immediately below Mint in the inspector",
+            descriptionBounds.top > mintBounds.bottom && descriptionBounds.top - mintBounds.bottom < 160)
         robot.tapText("Read more")
         compose.onAllNodesWithText(description, useUnmergedTree = true).onLast().assertIsDisplayed()
         robot.tapText("Done")

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LiveBolt12DescriptionJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LiveBolt12DescriptionJourneyTest.kt
@@ -1,0 +1,114 @@
+package com.cashu.me.ui.journeys
+
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import org.cashudevkit.decodeInvoice
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Opt-in, unfunded live-mint check. Creates offers only; never pays or mints tokens. */
+@RunWith(AndroidJUnit4::class)
+class LiveBolt12DescriptionJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { launched?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var launched: LaunchedFixture? = null
+
+    @Test
+    fun descriptionsAreEncodedAndSurviveReuseAndClearing() {
+        val args = InstrumentationRegistry.getArguments()
+        assumeTrue(args.getString("cashu.liveBolt12Descriptions") == "true")
+        val mintURL = requireNotNull(args.getString("cashu.nutshellMintUrl"))
+        launched = AppTestFixture.launch(FixtureMode.LiveSeededWithoutMint)
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("Mints").tapText("Add mint")
+            .typeIntoTag(UiTestTags.AddMintUrl, mintURL).pressSystemBack()
+            .tapTag(UiTestTags.AddMintSubmit)
+            .awaitTag(UiTestTags.mintRow(mintURL.trimEnd('/')), 30_000)
+        val mint = launched!!.container.walletManager.state.value.activeMint!!
+        assertTrue(mint.supportedMintMethods.orEmpty().contains(PaymentMethodKind.Bolt12))
+        assertTrue("Live mint must advertise description support", mint.supportsBolt12MintDescription)
+        robot.tapText("Wallet")
+        openOffer()
+        val plain = copiedOffer()
+        val defaultDescription = decodeInvoice(plain).description
+        assertNull(decodeInvoice(plain).amountMsat)
+
+        val description = "Coffee tips Thank you ☕"
+        editDescription("  Coffee tips\nThank you ☕  ")
+        val described = copiedOffer()
+        assertNotEquals(plain, described)
+        assertEquals(description, decodeInvoice(described).description)
+        assertNull(decodeInvoice(described).amountMsat)
+        robot.pressSystemBack()
+        openOffer()
+        assertEquals("Reopening must reuse the described offer", described, copiedOffer())
+
+        editDescription("Updated coffee note")
+        val edited = copiedOffer()
+        assertNotEquals(described, edited)
+        assertEquals("Updated coffee note", decodeInvoice(edited).description)
+
+        editDescription("   ")
+        val cleared = copiedOffer()
+        assertEquals("Clearing should reuse the original plain offer", plain, cleared)
+        assertEquals(defaultDescription, decodeInvoice(cleared).description)
+        robot.pressSystemBack()
+        openOffer()
+        assertEquals("Clearing must survive reopening", cleared, copiedOffer())
+
+        robot.tapText("Amount").tapDescription("2").tapDescription("1").tapText("Done")
+        compose.waitUntil(30_000) { launched!!.container.cashuRequestStore.state.value.currentRequest?.amount == 21L }
+        assertEquals(21_000uL, decodeInvoice(copiedOffer()).amountMsat)
+        editDescription("Fixed amount coffee")
+        val fixed = decodeInvoice(copiedOffer())
+        assertEquals("Fixed amount coffee", fixed.description)
+        assertEquals("Editing must preserve the fixed amount", 21_000uL, fixed.amountMsat)
+        editDescription("   ")
+        assertEquals(21_000uL, decodeInvoice(copiedOffer()).amountMsat)
+        assertEquals(defaultDescription, decodeInvoice(copiedOffer()).description)
+    }
+
+    private fun openOffer() {
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletReceive)
+            .tapText("Bitcoin")
+            .tapDescription("Receive method: Lightning invoice, One-time, instant")
+            .tapText("Reusable invoice")
+            .awaitText("Description", timeoutMillis = 30_000)
+    }
+
+    private fun editDescription(value: String) {
+        compose.onNodeWithText("Description", useUnmergedTree = true).performScrollTo()
+        robot.tapText("Description").replaceTextInTag("reusable-description-field", value)
+            .tapTag("reusable-description-save")
+            .assertTagDoesNotExist("reusable-description-field")
+        // A remint keeps the old QR visible until its replacement is ready.
+        robot.awaitText(value.trim().replace("\n", " ").ifEmpty { "None" }, timeoutMillis = 30_000)
+    }
+
+    private fun copiedOffer(): String {
+        robot.tapText("Copy invoice")
+        var copied = ""
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
+            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            copied = clipboard.primaryClip?.getItemAt(0)?.text.toString()
+        }
+        assertTrue("Copy must return a BOLT12 offer", copied.startsWith("lno1"))
+        return copied
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/OnboardingAsciiFieldLayoutComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/OnboardingAsciiFieldLayoutComposeTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
@@ -41,6 +42,18 @@ import org.junit.runner.RunWith
 class OnboardingAsciiFieldLayoutComposeTest {
     @get:Rule
     val compose = createComposeRule()
+
+    @Test
+    fun ambientFieldAllowsTheUiToBecomeIdle() {
+        compose.setCashuContent {
+            // No static-time override: when system motion is enabled, the
+            // production loop must honor the test clock's auto-advance policy.
+            AsciiField(modifier = Modifier.fillMaxSize())
+        }
+        compose.waitForIdle()
+        compose.onNodeWithTag(UiTestTags.OnboardingAsciiField, useUnmergedTree = true)
+            .assertIsDisplayed()
+    }
 
     private enum class Step { Welcome, RestoreMethod, RestoreInput }
 

--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReusableDescriptionEditSheetComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReusableDescriptionEditSheetComposeTest.kt
@@ -1,0 +1,63 @@
+package com.cashu.me.ui.receive
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReusableDescriptionEditSheetComposeTest {
+    @get:Rule val compose = createComposeRule()
+
+    @Test
+    fun savesTrimmedMultilineDescriptionWithKeyboardOpen() {
+        var saved: String? = null
+        compose.setCashuContent {
+            ReusableDescriptionEditSheet("Coffee tips", onDone = { saved = it }, onDismiss = {})
+        }
+        compose.onNodeWithTag("reusable-description-field")
+            .performTextReplacement("  Coffee tips\nThank you  ")
+        compose.onNodeWithTag("reusable-description-save").performScrollTo().assertIsDisplayed().performClick()
+        compose.runOnIdle { assertEquals("Coffee tips\nThank you", saved) }
+    }
+
+    @Test
+    fun clearingDescriptionSavesNil() {
+        var saved: String? = "old"
+        compose.setCashuContent {
+            ReusableDescriptionEditSheet("Coffee tips", onDone = { saved = it }, onDismiss = {})
+        }
+        compose.onNodeWithTag("reusable-description-field").performTextReplacement("   ")
+        compose.onNodeWithTag("reusable-description-save").performScrollTo().performClick()
+        compose.runOnIdle { assertNull(saved) }
+    }
+
+    @Test
+    fun capsLongDraftAndCanCloseWithoutSavingAtLargeFont() {
+        var saved = false
+        var dismissed = false
+        compose.setCashuContent(darkTheme = true, fontScale = 1.6f) {
+            ReusableDescriptionEditSheet(null, onDone = { saved = true }, onDismiss = { dismissed = true })
+        }
+        compose.onNodeWithTag("reusable-description-field").performTextReplacement("x".repeat(700))
+        compose.onNodeWithText("640 / 640").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithContentDescription("Close").performScrollTo().performClick()
+        compose.runOnIdle {
+            assertTrue(dismissed)
+            assertFalse(saved)
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkMintMethodMapping.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkMintMethodMapping.kt
@@ -18,6 +18,17 @@ internal fun CdkNuts.reportedMintMethods(): List<PaymentMethodKind> =
         .sortedBy { it.sortOrder }
 
 /**
+ * True when any NUT-04 bolt12 method advertises `description: true`. Null or
+ * false on every bolt12 method (or no bolt12 method at all) fails closed —
+ * the Receive Description row must not appear unless the mint said so.
+ */
+internal fun CdkNuts.reportsBolt12MintDescription(): Boolean =
+    nut04.methods.any {
+        it.method.toKnownPaymentMethodKind() == PaymentMethodKind.Bolt12 &&
+            it.description == true
+    }
+
+/**
  * NUT-05 melt rails exactly as reported, sat-only (pay-side non-sat is
  * deferred). Same reported-empty semantics as [reportedMintMethods].
  */

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -51,7 +51,7 @@ interface CdkWalletGateway {
      * never registers keysets/counters the user hasn't touched.
      */
     suspend fun unitBalanceIfExists(mintUrl: String, unit: String): Long?
-    suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, mintUrl: String, unit: String = "sat"): MintQuoteInfo
+    suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, mintUrl: String, unit: String = "sat", description: String? = null): MintQuoteInfo
     suspend fun checkMintQuote(quoteId: String): MintQuoteInfo
 
     /** Last durable local quote snapshot, without contacting the mint. */

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -285,14 +285,16 @@ class CdkWalletGatewayImpl : WalletGateway {
         runCatching { walletFor(mintUrl, cdkUnit(unit)).totalBalance().value.toLong() }.getOrNull()
     }
 
-    override suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, mintUrl: String, unit: String): MintQuoteInfo = cdkCall {
+    override suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, mintUrl: String, unit: String, description: String?): MintQuoteInfo = cdkCall {
         val cdkUnit = cdkUnit(unit)
         if (!unit.equals("sat", ignoreCase = true)) ensureWalletUnlocked(mintUrl, cdkUnit)
         val wallet = walletFor(mintUrl, cdkUnit)
         val quote = wallet.mintQuote(
             paymentMethod = cdkPaymentMethod(method),
             amount = amount?.toCdkAmount(),
-            description = null,
+            // Description is only threaded for BOLT12 offers (NUT-04 optional);
+            // mint support on other rails is uneven, so they keep nil.
+            description = description?.takeIf { method == PaymentMethodKind.Bolt12 },
             extra = if (method == PaymentMethodKind.Onchain) "{}" else null,
         )
         persistMintQuoteLocalMetadataIfNeeded(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -936,6 +936,7 @@ class CdkWalletGatewayImpl : WalletGateway {
             mintUnits = mintUnits,
             supportedMintMethods = mintMethods,
             supportedMeltMethods = meltMethods,
+            supportsBolt12MintDescription = nuts.reportsBolt12MintDescription(),
             contacts = contact.orEmpty().map { MintContact(method = it.method, info = it.info) },
             tosUrl = tosUrl,
             software = version?.let { MintSoftware(name = it.name, version = it.version) },

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
@@ -96,7 +96,10 @@ class CashuRequestStore(
                 amount = amount,
                 unit = unit,
                 mints = mints,
-                memo = memo?.takeIf { it.isNotBlank() },
+                // Quote-level metadata is immutable (BOLT12 offers can't change
+                // their description), so a null memo means "unknown here" and
+                // must not wipe the previously stored one.
+                memo = memo?.takeIf { it.isNotBlank() } ?: existing?.memo,
                 createdAtEpochMillis = existing?.createdAtEpochMillis ?: System.currentTimeMillis(),
                 quoteId = quoteId,
                 quoteKind = quoteKind,

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
@@ -101,6 +101,7 @@ class CashuRequestStore(
                 // must not wipe the previously stored one.
                 memo = memo?.takeIf { it.isNotBlank() } ?: existing?.memo,
                 createdAtEpochMillis = existing?.createdAtEpochMillis ?: System.currentTimeMillis(),
+                lastPresentedAtEpochMillis = existing?.lastPresentedAtEpochMillis,
                 quoteId = quoteId,
                 quoteKind = quoteKind,
                 receivedPayments = existing?.receivedPayments.orEmpty(),
@@ -126,6 +127,18 @@ class CashuRequestStore(
         }
         persist(updated, current.currentRequestId)
     }
+
+    /** Remember reuse separately from creation so clearing a memo survives reopening. */
+    fun markQuotePresented(quoteId: String) {
+        val request = mutableState.value.requests.firstOrNull { it.quoteId == quoteId } ?: return
+        upsert(request.copy(lastPresentedAtEpochMillis = System.currentTimeMillis()), makeCurrent = false)
+    }
+
+    fun lastPresentedAmountlessOffer(mintUrl: String, unit: String): CashuRequest? =
+        mutableState.value.requests.filter {
+            it.quoteKind == "bolt12" && it.amount == null && mintUrl in it.mints &&
+                it.unit.equals(unit, ignoreCase = true)
+        }.maxByOrNull { it.lastPresentedAtEpochMillis ?: it.createdAtEpochMillis }
 
     fun attachPaymentByQuoteId(quoteId: String, transactionId: String, amount: Long) {
         val request = mutableState.value.requests.firstOrNull { it.quoteId == quoteId } ?: return

--- a/android/app/src/main/java/com/cashu/me/Core/MintDiscoveryManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintDiscoveryManager.kt
@@ -312,6 +312,11 @@ internal object MintPreviewParser {
             mintUnits = mintUnits,
             supportedMintMethods = mintMethods,
             supportedMeltMethods = meltMethods,
+            supportsBolt12MintDescription = mintSettings.any { setting ->
+                PaymentMethodKind.fromRaw(setting["method"]?.jsonPrimitive?.contentOrNull) ==
+                    PaymentMethodKind.Bolt12 &&
+                    setting["description"]?.jsonPrimitive?.booleanOrNull == true
+            },
         )
     }.getOrNull()
 
@@ -373,6 +378,7 @@ private fun MintInfo.mergedWithPreview(preview: MintInfo): MintInfo = copy(
     mintUnits = preview.mintUnits,
     supportedMintMethods = preview.supportedMintMethods,
     supportedMeltMethods = preview.supportedMeltMethods,
+    supportsBolt12MintDescription = preview.supportsBolt12MintDescription,
     onchainMintConfirmations = preview.onchainMintConfirmations,
     lastUpdatedEpochMillis = preview.lastUpdatedEpochMillis,
 )

--- a/android/app/src/main/java/com/cashu/me/Core/MintDiscoveryManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintDiscoveryManager.kt
@@ -315,7 +315,8 @@ internal object MintPreviewParser {
             supportsBolt12MintDescription = mintSettings.any { setting ->
                 PaymentMethodKind.fromRaw(setting["method"]?.jsonPrimitive?.contentOrNull) ==
                     PaymentMethodKind.Bolt12 &&
-                    setting["description"]?.jsonPrimitive?.booleanOrNull == true
+                    (setting["options"]?.jsonObject?.get("description")
+                        ?: setting["description"])?.jsonPrimitive?.booleanOrNull == true
             },
         )
     }.getOrNull()

--- a/android/app/src/main/java/com/cashu/me/Core/MintQuoteDomain.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintQuoteDomain.kt
@@ -6,6 +6,15 @@ import com.cashu.me.Models.PaymentMethodKind
 
 internal const val LOCAL_NEVER_EXPIRES_EPOCH_SECONDS: Long = 253_402_300_799L
 
+/** CDK's payer-facing decoder replaces control characters (including newlines) with �. */
+internal fun normalizedOfferDescription(raw: String?): String? {
+    val cleaned = raw.orEmpty().filter { !it.isISOControl() || it.isWhitespace() }
+        .map { if (it.isWhitespace()) ' ' else it }.joinToString("")
+        .split(' ').filter(String::isNotEmpty).joinToString(" ").take(640)
+        .let { if (it.lastOrNull()?.isHighSurrogate() == true) it.dropLast(1) else it }
+    return cleaned.ifEmpty { null }
+}
+
 internal fun mintQuoteLocalStorageExpiry(
     expiryEpochSeconds: Long,
     paymentMethod: PaymentMethodKind,

--- a/android/app/src/main/java/com/cashu/me/Core/MintQuoteDomain.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintQuoteDomain.kt
@@ -43,17 +43,22 @@ internal fun mintQuoteStateForDomain(
 }
 
 /**
- * Finds the long-lived, amountless BOLT12 offer for one mint wallet. BOLT12
- * quotes remain in CDK's unissued list even after payments, so deliberately do
- * not filter by quote state here.
+ * Finds the long-lived, amountless BOLT12 offer for one mint wallet, matching
+ * the requested [description] exactly (null → only the plain, description-less
+ * offer). BOLT12 quotes remain in CDK's unissued list even after payments, so
+ * deliberately do not filter by quote state here. The description match keeps
+ * reuse unambiguous once several amountless offers exist (offers are
+ * immutable, so a changed description always mints a fresh one).
  */
 internal fun findExistingAmountlessBolt12Offer(
     quotes: List<MintQuoteInfo>,
     mintUrl: String,
     unit: String,
+    description: String? = null,
 ): MintQuoteInfo? = quotes.firstOrNull { quote ->
     quote.paymentMethod == PaymentMethodKind.Bolt12 &&
         quote.isAmountless &&
         quote.mintUrl == mintUrl &&
-        quote.unit.equals(unit, ignoreCase = true)
+        quote.unit.equals(unit, ignoreCase = true) &&
+        quote.description == description
 }

--- a/android/app/src/main/java/com/cashu/me/Core/PaymentRequestDecoder.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PaymentRequestDecoder.kt
@@ -77,6 +77,18 @@ object PaymentRequestParser {
 }
 
 object PaymentRequestDecoder {
+    /** Recover immutable descriptions from persisted invoices, including older history. */
+    fun description(raw: String?): String? {
+        if (raw.isNullOrBlank()) return null
+        LightningRequestParser.parseBolt12Offer(raw)?.let { return it.description?.takeIf(String::isNotBlank) }
+        return when (val decoded = decode(raw, includeCashuPaymentRequests = true)) {
+            is PaymentRequestDecodeResult.Bolt11 -> decoded.description
+            is PaymentRequestDecodeResult.Bolt12 -> decoded.description
+            is PaymentRequestDecodeResult.CashuPaymentRequest -> decoded.summary.description
+            else -> null
+        }?.takeIf(String::isNotBlank)
+    }
+
     private const val CREQ_A_PREFIX = "creqA"
 
     fun decode(

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/WalletServiceProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/WalletServiceProtocol.kt
@@ -21,7 +21,7 @@ interface WalletServiceProtocol {
     suspend fun removeMint(mint: MintInfo)
     suspend fun setActiveMint(mint: MintInfo)
     suspend fun restoreFromMint(url: String): RestoreMintResult
-    suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, unit: String = "sat"): MintQuoteInfo
+    suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, unit: String = "sat", description: String? = null): MintQuoteInfo
     suspend fun mintTokens(quoteId: String): Long
     suspend fun createMeltQuote(request: String, amountSats: Long? = null, preferredMintURL: String? = null): MeltQuoteInfo
     suspend fun meltTokens(quoteId: String, mintUrl: String? = null): MeltPaymentResult

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -101,7 +101,7 @@ object TransactionDisplay {
             add(TransactionDetailField("Date", formatDetailDate(transaction.dateEpochMillis)))
             if (transaction.fee > 0) add(TransactionDetailField("Fee", formatNativeAmount(transaction.fee, transaction.unit)))
             transaction.mintUrl?.let { add(TransactionDetailField("Mint", mintHost(it))) }
-            transaction.memo
+            transaction.displayDescription
                 ?.takeIf { it.isNotBlank() }
                 ?.let { add(TransactionDetailField("Memo", it)) }
             if (transaction.kind == TransactionKind.Onchain) {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -561,15 +561,19 @@ class WalletManager(
 
     override suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, unit: String, description: String?): MintQuoteInfo {
         val active = mutableState.value.activeMint ?: throw IllegalStateException("No active mint.")
+        val offerDescription = normalizedOfferDescription(description)
         return withLoadingResult {
-            gateway.createMintQuote(amount, method, active.url, unit, description).also {
+            gateway.createMintQuote(
+                amount, method, active.url, unit,
+                if (method == PaymentMethodKind.Bolt12) offerDescription else description,
+            ).also {
                 mintQuoteSyncService.rememberMintQuoteTimestamp(it.id)
             }.let { quote ->
                 // CDK drops the description from the returned quote (write-only),
                 // so re-attach it for callers that persist or display it (iOS
                 // `info.description` parity). Offers are immutable, so this
                 // matches what was embedded.
-                if (method == PaymentMethodKind.Bolt12) quote.copy(description = description) else quote
+                if (method == PaymentMethodKind.Bolt12) quote.copy(description = offerDescription) else quote
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -556,22 +556,47 @@ class WalletManager(
         return gateway.fetchMintInfo(normalized)
     }
 
-    override suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, unit: String): MintQuoteInfo {
+    override suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, unit: String, description: String?): MintQuoteInfo {
         val active = mutableState.value.activeMint ?: throw IllegalStateException("No active mint.")
         return withLoadingResult {
-            gateway.createMintQuote(amount, method, active.url, unit).also {
+            gateway.createMintQuote(amount, method, active.url, unit, description).also {
                 mintQuoteSyncService.rememberMintQuoteTimestamp(it.id)
+            }.let { quote ->
+                // CDK drops the description from the returned quote (write-only),
+                // so re-attach it for callers that persist or display it (iOS
+                // `info.description` parity). Offers are immutable, so this
+                // matches what was embedded.
+                if (method == PaymentMethodKind.Bolt12) quote.copy(description = description) else quote
             }
         }
     }
 
-    /** Returns the active mint's reusable amountless BOLT12 offer, if present. */
-    suspend fun existingAmountlessBolt12Offer(unit: String): MintQuoteInfo? {
+    /**
+     * Returns the active mint's reusable amountless BOLT12 offer matching
+     * [description] (null → the plain, description-less offer). CDK never
+     * returns the offer description, so the match joins quotes with the
+     * locally stored quote-intent memos keyed by quote id.
+     */
+    suspend fun existingAmountlessBolt12Offer(unit: String, description: String? = null): MintQuoteInfo? {
         val activeMint = mutableState.value.activeMint ?: return null
+        val memosByQuoteId = LinkedHashMap<String, String?>()
+        cashuRequestStore.state.value.requests.forEach { request ->
+            // First-wins matches offer immutability (iOS `uniquingKeysWith`
+            // parity) — a quote's memo is set once and never changes.
+            request.quoteId?.let { memosByQuoteId.putIfAbsent(it, request.memo) }
+        }
+        val quotes = gateway.listUnissuedMintQuotes().map { quote ->
+            if (quote.paymentMethod == PaymentMethodKind.Bolt12) {
+                quote.copy(description = memosByQuoteId[quote.id])
+            } else {
+                quote
+            }
+        }
         return findExistingAmountlessBolt12Offer(
-            quotes = gateway.listUnissuedMintQuotes(),
+            quotes = quotes,
             mintUrl = activeMint.url,
             unit = unit,
+            description = description,
         )
     }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -510,6 +510,9 @@ class WalletManager(
                 // value keeps the previously stored one.
                 supportedMintMethods = fetched.supportedMintMethods ?: mint.supportedMintMethods,
                 supportedMeltMethods = fetched.supportedMeltMethods ?: mint.supportedMeltMethods,
+                // Live NUT-04 advertisement is authoritative, including false
+                // (the mint dropped description support).
+                supportsBolt12MintDescription = fetched.supportsBolt12MintDescription,
                 lastUpdatedEpochMillis = System.currentTimeMillis(),
                 balance = mint.balance,
                 isActive = mint.isActive,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -7,6 +7,7 @@ import com.cashu.me.Models.TransactionKind
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
 import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.Models.restoringDescription
 
 internal data class WalletTransactionLoadResult(
     val transactions: List<WalletTransaction>,
@@ -76,12 +77,14 @@ internal class WalletTransactionLoader(
                 nowEpochMillis = System.currentTimeMillis(),
             ),
         )
+        val requests = walletStore.loadCashuRequests()
         val receiveTokenTransactions = pendingReceiveTokenTransactions(pendingReceiveTokens)
         // Row id spaces are disjoint by construction (saga-derived tx ids,
         // mint-issued quote ids, random pending-receive ids) and quote-backed
         // rows are skipped once CDK owns a transaction for the quote, so a
         // plain id dedupe is sufficient.
         val merged = (remoteWithTokens + pendingQuoteTransactions + receiveTokenTransactions)
+            .map { it.restoringDescription(requests) }
             .distinctBy { it.id }
             .sortedByDescending { it.dateEpochMillis }
         walletStore.saveTransactions(merged)

--- a/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
@@ -19,6 +19,10 @@ data class MintInfo(
     // (absent — hide the direction), non-empty = the reported methods.
     val supportedMintMethods: List<PaymentMethodKind>? = null,
     val supportedMeltMethods: List<PaymentMethodKind>? = null,
+    // NUT-04 bolt12 MintMethodSettings.description. Default false so records
+    // persisted before this landed, and mints that omit the field, fail closed
+    // (the Description row stays hidden until a live fetch advertises true).
+    val supportsBolt12MintDescription: Boolean = false,
     val onchainMintConfirmations: Int? = null,
     // NUT-06 self-reported metadata (contact / terms / software). Empty or null
     // when the mint did not report it — the UI never invents placeholders.

--- a/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
@@ -61,6 +61,10 @@ data class MintQuoteInfo(
     val updatedAtEpochSeconds: Long = 0,
     // Unit the quote mints into; poll/redeem must resolve the same-unit wallet.
     val unit: String = "sat",
+    // Payer-facing description embedded in a BOLT12 offer. CDK never returns it
+    // (write-only on mintQuote), so this is populated from local quote-intent
+    // metadata (CashuRequest.memo) — null everywhere else.
+    val description: String? = null,
 ) {
     val isExpired: Boolean
         get() = expiryEpochSeconds != null &&

--- a/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
@@ -19,6 +19,7 @@ data class CashuRequest(
     val mints: List<String> = emptyList(),
     val memo: String? = null,
     val createdAtEpochMillis: Long = System.currentTimeMillis(),
+    val lastPresentedAtEpochMillis: Long? = null,
     val quoteId: String? = null,
     val quoteKind: String? = null,
     val receivedPayments: List<CashuRequestPayment> = emptyList(),

--- a/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
@@ -2,6 +2,7 @@ package com.cashu.me.Models
 
 import java.util.UUID
 import kotlinx.serialization.Serializable
+import com.cashu.me.Core.PaymentRequestDecoder
 
 @Serializable
 data class CashuRequestPayment(
@@ -25,6 +26,9 @@ data class CashuRequest(
     val receivedPayments: List<CashuRequestPayment> = emptyList(),
     val receivedPaymentIds: List<String> = emptyList(),
 ) {
+    val displayDescription: String?
+        get() = memo?.takeIf(String::isNotBlank) ?: PaymentRequestDecoder.description(encoded)
+
     val totalReceived: Long get() = receivedPayments.sumOf { it.amount }
 
     val isEcashRequest: Boolean get() = quoteKind == null

--- a/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Models
 
 import kotlinx.serialization.Serializable
+import com.cashu.me.Core.PaymentRequestDecoder
 
 @Serializable
 data class WalletTransaction(
@@ -33,6 +34,9 @@ data class WalletTransaction(
     /** BOLT11 mint quote still awaiting payment — titles the row "Lightning invoice". */
     val isUnpaidInvoice: Boolean = false,
 ) {
+    val displayDescription: String?
+        get() = memo?.takeIf(String::isNotBlank) ?: PaymentRequestDecoder.description(invoice)
+
     val displayStatusText: String
         get() = if (status == TransactionStatus.Pending) statusNote ?: status.displayText else status.displayText
 
@@ -106,3 +110,14 @@ internal fun List<WalletTransaction>.liveDetail(
 ): WalletTransaction? =
     firstOrNull { it.id == openId }
         ?: firstOrNull { it.quoteId != null && it.quoteId == openQuoteId }
+
+/** CDK may omit a mint transaction's memo and request after settlement. */
+internal fun WalletTransaction.restoringDescription(requests: List<CashuRequest>): WalletTransaction {
+    val description = displayDescription ?: requests.firstOrNull { request ->
+        type == TransactionType.Incoming && unit.equals(request.unit, ignoreCase = true) &&
+            (request.receivedPayments.any { it.transactionId == id } || cashuRequestId == request.id ||
+                (quoteId != null && quoteId == request.quoteId &&
+                    request.mints.any { it.trimEnd('/') == mintUrl?.trimEnd('/') }))
+    }?.displayDescription
+    return if (description == memo) this else copy(memo = description)
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import com.cashu.me.Core.AmountDisplayText
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.displayMintUnitAmount
@@ -114,6 +115,15 @@ fun CashuRequestRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
+            request.displayDescription?.let { description ->
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
             Text(
                 text = timestamp,
                 style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import com.cashu.me.Core.AmountDisplayText
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.displayMintUnitAmount
@@ -115,15 +114,6 @@ fun CashuRequestRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
-            request.displayDescription?.let { description ->
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
             Text(
                 text = timestamp,
                 style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
@@ -1,5 +1,6 @@
 package com.cashu.me.ui.components
 
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -133,3 +134,20 @@ fun InspectorRow(
     }
 }
 
+
+/** Prose needs the full inspector width and must remain readable without truncation. */
+@Composable
+fun DescriptionDetailRow(description: String, label: String = "Description") {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(
+            horizontal = CashuTheme.spacing.comfortable,
+            vertical = CashuTheme.spacing.default,
+        ),
+        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    ) {
+        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        SelectionContainer {
+            Text(description, style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
@@ -1,6 +1,6 @@
 package com.cashu.me.ui.components
 
-import androidx.compose.foundation.text.selection.SelectionContainer
+import android.content.res.Configuration
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -9,16 +9,27 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -135,9 +146,15 @@ fun InspectorRow(
 }
 
 
-/** Prose needs the full inspector width and must remain readable without truncation. */
+/** A bounded, non-scrolling footer keeps descriptions visible on small screens. */
 @Composable
 fun DescriptionDetailRow(description: String, label: String = "Description") {
+    var overflowing by remember(description) { mutableStateOf(false) }
+    var showFullDescription by remember(description) { mutableStateOf(false) }
+    val configuration = LocalConfiguration.current
+    val previewLines = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE ||
+        configuration.fontScale > 1.3f) 1 else 3
+
     Column(
         modifier = Modifier.fillMaxWidth().padding(
             horizontal = CashuTheme.spacing.comfortable,
@@ -145,9 +162,36 @@ fun DescriptionDetailRow(description: String, label: String = "Description") {
         ),
         verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
     ) {
-        Text(label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        SelectionContainer {
-            Text(description, style = MaterialTheme.typography.bodyLarge)
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            if (overflowing) {
+                TextButton(onClick = { showFullDescription = true }) { Text("Read more") }
+            }
         }
+        SelectionContainer {
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = previewLines,
+                overflow = TextOverflow.Ellipsis,
+                onTextLayout = { overflowing = it.hasVisualOverflow },
+                modifier = Modifier.testTag("payment-description-preview"),
+            )
+        }
+    }
+    if (showFullDescription) {
+        AlertDialog(
+            onDismissRequest = { showFullDescription = false },
+            title = { Text(label) },
+            text = {
+                SelectionContainer {
+                    Text(description, modifier = Modifier.verticalScroll(rememberScrollState()))
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showFullDescription = false }) { Text("Done") }
+            },
+        )
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
@@ -146,13 +146,13 @@ fun InspectorRow(
 }
 
 
-/** A bounded, non-scrolling footer keeps descriptions visible on small screens. */
+/** Prose belongs to the inspector, with a native reader for longer descriptions. */
 @Composable
 fun DescriptionDetailRow(description: String, label: String = "Description") {
     var overflowing by remember(description) { mutableStateOf(false) }
     var showFullDescription by remember(description) { mutableStateOf(false) }
     val configuration = LocalConfiguration.current
-    val previewLines = if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE ||
+    val previewLines = if (LocalCompactPaymentDetails.current || configuration.orientation == Configuration.ORIENTATION_LANDSCAPE ||
         configuration.fontScale > 1.3f) 1 else 3
 
     Column(

--- a/android/app/src/main/java/com/cashu/me/ui/components/PaymentDetailContent.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/PaymentDetailContent.kt
@@ -1,0 +1,58 @@
+package com.cashu.me.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.cashu.me.ui.theme.CashuTheme
+
+internal val LocalCompactPaymentDetails = compositionLocalOf { false }
+
+/** Fits the QR around the actual receipt text, with scrolling for oversized content. */
+@Composable
+fun PaymentDetailContent(
+    modifier: Modifier = Modifier,
+    hero: @Composable (Dp) -> Unit,
+    details: @Composable ColumnScope.() -> Unit,
+) {
+    var detailsHeight by remember { mutableIntStateOf(0) }
+    val density = LocalDensity.current
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val compact = maxHeight < 600.dp
+        val qrSize = minOf(280.dp, maxWidth - 64.dp,
+            maxHeight - with(density) { detailsHeight.toDp() } - 64.dp).coerceAtLeast(120.dp)
+        Column(
+            modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())
+                .padding(horizontal = CashuTheme.spacing.comfortable, vertical = CashuTheme.spacing.snug),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+        ) {
+            hero(qrSize)
+            CompositionLocalProvider(LocalCompactPaymentDetails provides compact) {
+                Column(
+                    modifier = Modifier.fillMaxWidth().onSizeChanged { detailsHeight = it.height },
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                    content = details,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
@@ -75,7 +74,6 @@ fun TransactionRow(
         tx.displayStatusText,
         semanticAmount,
         model.secondaryAmount,
-        tx.displayDescription,
         model.timestamp,
     )
     Row(
@@ -104,15 +102,6 @@ fun TransactionRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
-            tx.displayDescription?.let { description ->
-                Text(
-                    text = description,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
             Text(
                 text = model.timestamp,
                 style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
@@ -74,6 +75,7 @@ fun TransactionRow(
         tx.displayStatusText,
         semanticAmount,
         model.secondaryAmount,
+        tx.displayDescription,
         model.timestamp,
     )
     Row(
@@ -102,6 +104,15 @@ fun TransactionRow(
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
+            tx.displayDescription?.let { description ->
+                Text(
+                    text = description,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
             Text(
                 text = model.timestamp,
                 style = MaterialTheme.typography.bodySmall,

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -316,6 +316,7 @@ fun HistoryScreen(
                                                 secondaryAmount = amountDisplay.secondary,
                                             ),
                                             onClick = {
+                                                keyboardController?.hide()
                                                 val pending = walletState.pendingReceiveTokens
                                                     .firstOrNull { it.tokenId == tx.id }
                                                 if (tx.isPendingReceiveToken && pending != null) {
@@ -354,7 +355,10 @@ fun HistoryScreen(
                                             timestamp = formatRelativeTimestamp(item.request.createdAtEpochMillis),
                                             primaryAmountText = amountDisplay?.primary,
                                             secondaryAmountText = amountDisplay?.secondary,
-                                            onClick = { onOpenCashuRequest(item.request) },
+                                            onClick = {
+                                                keyboardController?.hide()
+                                                onOpenCashuRequest(item.request)
+                                            },
                                             onLongClick = { requestPendingDelete = item.request },
                                         )
                                     }

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -507,12 +507,12 @@ internal fun unifiedFiltered(
                 val tx = item.transaction
                 TransactionDisplay.title(tx).contains(query, ignoreCase = true) ||
                     tx.amount.toString().contains(query) ||
-                    tx.memo?.contains(query, ignoreCase = true) == true
+                    tx.displayDescription?.contains(query, ignoreCase = true) == true
             }
             is HistoryItem.Req -> {
                 item.request.displayTitle.contains(query, ignoreCase = true) ||
                     (item.request.amount?.toString()?.contains(query) == true) ||
-                    item.request.memo?.contains(query, ignoreCase = true) == true
+                    item.request.displayDescription?.contains(query, ignoreCase = true) == true
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -40,6 +41,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -70,6 +72,7 @@ import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.LocalConfirmationToastController
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
+import com.cashu.me.ui.components.PaymentDetailContent
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SecondaryButton
 import com.cashu.me.ui.components.SheetHeader
@@ -151,7 +154,13 @@ fun TransactionReceiptSheet(
     val copyableContent = TransactionDisplay.copyableContent(current)
     val title = TransactionDisplay.title(current)
     val description = current.displayDescription
-    val fields = remember(current) { TransactionDisplay.detailFields(current).filterNot { it.label == "Memo" } }
+    val fields = remember(current, walletState.mints) {
+        TransactionDisplay.detailFields(current).filterNot { it.label == "Memo" }.map { field ->
+            if (field.label == "Mint") {
+                field.copy(value = walletState.mints.firstOrNull { it.url == current.mintUrl }?.name ?: field.value)
+            } else field
+        }
+    }
     val explorerUrl = remember(current) { current.explorerUrl() }
     val pendingReceiveToken = current.token?.takeIf {
         current.isPendingReceiveToken &&
@@ -162,6 +171,171 @@ fun TransactionReceiptSheet(
         automaticChecksEnabled = settings.checkSentTokens,
         transaction = current,
     )
+
+    val hero: @Composable (Dp) -> Unit = { qrSize ->
+        when {
+            showsQr && qrContent != null -> QrCard(
+                content = qrContent,
+                size = qrSize,
+                staticOnly = current.kind != TransactionKind.Ecash,
+                shareSubject = title,
+                confirmationMessage =
+                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+            )
+            current.status == TransactionStatus.Completed -> Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = "Completed",
+                tint = CashuTheme.colors.onReceivedContainer,
+                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
+            )
+            current.status == TransactionStatus.Failed -> Icon(
+                imageVector = Icons.Filled.Cancel,
+                contentDescription = "Failed",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(FAILED_GLYPH_SIZE),
+            )
+            else -> Unit
+        }
+    }
+    val details: @Composable () -> Unit = {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.section),
+        ) {
+            HeroAmount(
+                transaction = current,
+                formatter = formatter,
+                preferredPrimary = settings.homeBalancePrimary,
+                useBitcoinSymbol = settings.useBitcoinSymbol,
+                showFiat = settings.showFiatBalance,
+                btcPrice = priceState.btcPrice,
+                currencyCode = priceState.currencyCode,
+                compact = showsQr,
+            )
+
+            Column(modifier = Modifier.fillMaxWidth()) {
+                fields.forEach { field ->
+                    InspectorRow(
+                        label = field.label,
+                        modifier = Modifier.heightIn(min = 48.dp),
+                        value = field.value,
+                        valueMonospaced = field.value.length > 24 ||
+                            field.label in MonospacedLabels,
+                        onClick = field.copyValue?.let { full ->
+                            {
+                                scope.launch {
+                                    clipboard.setClipEntry(
+                                        ClipEntry(ClipData.newPlainText(field.label, full)),
+                                    )
+                                    confirmationToastController?.show(
+                                        copyConfirmationMessage(field.label),
+                                    )
+                                }
+                            }
+                        },
+                        trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
+                    )
+                    if (field.label == "Mint" && description != null) {
+                        DescriptionDetailRow(description)
+                    }
+                }
+                if (fields.none { it.label == "Mint" } && description != null) {
+                    DescriptionDetailRow(description)
+                }
+                // Explorer link joins the detail rows (iOS parity) —
+                // it's reference material, not an action.
+                if (explorerUrl != null) {
+                    ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
+                }
+            }
+
+            if (offersManualClaimCheck) {
+                when (val outcome = manualCheckResult) {
+                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                        text = "Status checked",
+                        detail = "This token has not been claimed yet.",
+                        severity = NoticeSeverity.Info,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                        },
+                    )
+                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                        text = "Couldn't check status",
+                        detail = outcome.message.text,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                        },
+                        severity = NoticeSeverity.Caution,
+                    )
+                    PendingTokenClaimCheckResult.Claimed, null -> Unit
+                }
+            }
+        }
+    }
+    val actions: @Composable () -> Unit = {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+        ) {
+            if (pendingReceiveToken != null && onClaimReceiveToken != null) {
+                PrimaryButton(
+                    text = "Receive",
+                    onClick = { onClaimReceiveToken(pendingReceiveToken) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            } else {
+                if (copyableContent != null) {
+                        SecondaryButton(
+                        text = "Copy",
+                        onClick = {
+                            scope.launch {
+                                clipboard.setClipEntry(
+                                    ClipEntry(ClipData.newPlainText(title, copyableContent)),
+                                )
+                                confirmationToastController?.show(
+                                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                )
+                            }
+                        },
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                        },
+                    )
+                }
+                if (offersManualClaimCheck) {
+                    PrimaryButton(
+                        text = if (checkingClaim) "Checking…" else "Check Status",
+                        onClick = {
+                            checkingClaim = true
+                            manualCheckResult = null
+                            scope.launch {
+                                try {
+                                    manualCheckResult = runPendingTokenClaimCheck {
+                                        walletManager.checkPendingTokenStatus(current)
+                                    }
+                                } finally {
+                                    checkingClaim = false
+                                }
+                            }
+                        },
+                        loading = checkingClaim,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .testTag(UiTestTags.HistoryCheckTokenStatus)
+                            .semantics {
+                                contentDescription = if (checkingClaim) {
+                                    "Checking claim status"
+                                } else {
+                                    "Check Status"
+                                }
+                                liveRegion = LiveRegionMode.Polite
+                            },
+                    )
+                }
+            }
+
+        }
+    }
 
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -174,182 +348,35 @@ fun TransactionReceiptSheet(
                 .testTag(UiTestTags.TransactionReceiptSheet),
         ) {
             CompactSheetContent {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                ) {
-                    SheetHeader(title = title)
-
-                    Column(
-                        modifier = Modifier.weight(1f, fill = false)
-                            .verticalScroll(rememberScrollState()),
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = CashuTheme.spacing.comfortable),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-                        ) {
-                            // Hero state slot: live request → QR; completed → 64dp green
-                            // check; failed → 64dp red X; pending with no QR → no glyph.
-                            // State detail lives in the monochrome Status row below.
-                            when {
-                                showsQr && qrContent != null -> QrCard(
-                                    content = qrContent,
-                                    staticOnly = current.kind != TransactionKind.Ecash,
-                                    shareSubject = title,
-                                    confirmationMessage =
-                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                )
-                                current.status == TransactionStatus.Completed -> Icon(
-                                    imageVector = Icons.Filled.CheckCircle,
-                                    contentDescription = "Completed",
-                                    tint = CashuTheme.colors.onReceivedContainer,
-                                    modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
-                                )
-                                current.status == TransactionStatus.Failed -> Icon(
-                                    imageVector = Icons.Filled.Cancel,
-                                    contentDescription = "Failed",
-                                    tint = MaterialTheme.colorScheme.error,
-                                    modifier = Modifier.size(FAILED_GLYPH_SIZE),
-                                )
-                                else -> Unit
-                            }
-
-                            HeroAmount(
-                                transaction = current,
-                                formatter = formatter,
-                                preferredPrimary = settings.homeBalancePrimary,
-                                useBitcoinSymbol = settings.useBitcoinSymbol,
-                                showFiat = settings.showFiatBalance,
-                                btcPrice = priceState.btcPrice,
-                                currencyCode = priceState.currencyCode,
-                                compact = showsQr,
-                            )
-
-                            Column(modifier = Modifier.fillMaxWidth()) {
-                                fields.forEach { field ->
-                                    InspectorRow(
-                                        label = field.label,
-                                        value = field.value,
-                                        valueMonospaced = field.value.length > 24 ||
-                                            field.label in MonospacedLabels,
-                                        onClick = field.copyValue?.let { full ->
-                                            {
-                                                scope.launch {
-                                                    clipboard.setClipEntry(
-                                                        ClipEntry(ClipData.newPlainText(field.label, full)),
-                                                    )
-                                                    confirmationToastController?.show(
-                                                        copyConfirmationMessage(field.label),
-                                                    )
-                                                }
-                                            }
-                                        },
-                                        trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
-                                    )
-                                }
-                                // Explorer link joins the detail rows (iOS parity) —
-                                // it's reference material, not an action.
-                                if (explorerUrl != null) {
-                                    ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
-                                }
-                            }
-
-                            if (offersManualClaimCheck) {
-                                when (val outcome = manualCheckResult) {
-                                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
-                                        text = "Status checked",
-                                        detail = "This token has not been claimed yet.",
-                                        severity = NoticeSeverity.Info,
-                                        modifier = Modifier.semantics {
-                                            liveRegion = LiveRegionMode.Polite
-                                        },
-                                    )
-                                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
-                                        text = "Couldn't check status",
-                                        detail = outcome.message.text,
-                                        modifier = Modifier.semantics {
-                                            liveRegion = LiveRegionMode.Polite
-                                        },
-                                        severity = NoticeSeverity.Caution,
-                                    )
-                                    PendingTokenClaimCheckResult.Claimed, null -> Unit
-                                }
-                            }
+                if (showsQr && description != null) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        SheetHeader(title = title)
+                        PaymentDetailContent(
+                            modifier = Modifier.weight(1f, fill = false),
+                            hero = hero,
+                        ) { details() }
+                        Column(modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable)) {
+                            actions()
                         }
-                    }
-
-                    if (description != null) {
-                        DescriptionDetailRow(description)
-                    }
-
-                    Column(
-                        modifier = Modifier.fillMaxWidth()
-                            .padding(horizontal = CashuTheme.spacing.comfortable),
-                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-                    ) {
-                        if (pendingReceiveToken != null && onClaimReceiveToken != null) {
-                            Spacer(Modifier.height(CashuTheme.spacing.snug))
-                            PrimaryButton(
-                                text = "Receive",
-                                onClick = { onClaimReceiveToken(pendingReceiveToken) },
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        } else {
-                            if (copyableContent != null) {
-                                Spacer(Modifier.height(CashuTheme.spacing.snug))
-                                SecondaryButton(
-                                    text = "Copy",
-                                    onClick = {
-                                        scope.launch {
-                                            clipboard.setClipEntry(
-                                                ClipEntry(ClipData.newPlainText(title, copyableContent)),
-                                            )
-                                            confirmationToastController?.show(
-                                                "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                            )
-                                        }
-                                    },
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                )
-                            }
-                            if (offersManualClaimCheck) {
-                                PrimaryButton(
-                                    text = if (checkingClaim) "Checking…" else "Check Status",
-                                    onClick = {
-                                        checkingClaim = true
-                                        manualCheckResult = null
-                                        scope.launch {
-                                            try {
-                                                manualCheckResult = runPendingTokenClaimCheck {
-                                                    walletManager.checkPendingTokenStatus(current)
-                                                }
-                                            } finally {
-                                                checkingClaim = false
-                                            }
-                                        }
-                                    },
-                                    loading = checkingClaim,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .testTag(UiTestTags.HistoryCheckTokenStatus)
-                                        .semantics {
-                                            contentDescription = if (checkingClaim) {
-                                                "Checking claim status"
-                                            } else {
-                                                "Check Status"
-                                            }
-                                            liveRegion = LiveRegionMode.Polite
-                                        },
-                                )
-                            }
-                        }
-
                         Spacer(Modifier.height(CashuTheme.spacing.comfortable))
+                    }
+                } else {
+                    Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
+                        SheetHeader(title = title)
+                        Column(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = CashuTheme.spacing.comfortable)
+                                .padding(bottom = CashuTheme.spacing.comfortable),
+                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                            ) {
+                                hero(280.dp)
+                                details()
+                            }
+                            actions()
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -176,22 +176,24 @@ fun TransactionReceiptSheet(
             CompactSheetContent {
                 Column(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState()),
+                        .fillMaxWidth(),
                 ) {
                     SheetHeader(title = title)
 
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = CashuTheme.spacing.comfortable),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                        modifier = Modifier.weight(1f, fill = false)
+                            .verticalScroll(rememberScrollState()),
                     ) {
-                        // Hero state slot: live request → QR; completed → 64dp green
-                        // check; failed → 64dp red X; pending with no QR → no glyph.
-                        // State detail lives in the monochrome Status row below.
-                        if (!showsQr || description == null) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = CashuTheme.spacing.comfortable),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                        ) {
+                            // Hero state slot: live request → QR; completed → 64dp green
+                            // check; failed → 64dp red X; pending with no QR → no glyph.
+                            // State detail lives in the monochrome Status row below.
                             when {
                                 showsQr && qrContent != null -> QrCard(
                                     content = qrContent,
@@ -214,83 +216,80 @@ fun TransactionReceiptSheet(
                                 )
                                 else -> Unit
                             }
-                        }
 
-                        HeroAmount(
-                            transaction = current,
-                            formatter = formatter,
-                            preferredPrimary = settings.homeBalancePrimary,
-                            useBitcoinSymbol = settings.useBitcoinSymbol,
-                            showFiat = settings.showFiatBalance,
-                            btcPrice = priceState.btcPrice,
-                            currencyCode = priceState.currencyCode,
-                            compact = showsQr,
-                        )
+                            HeroAmount(
+                                transaction = current,
+                                formatter = formatter,
+                                preferredPrimary = settings.homeBalancePrimary,
+                                useBitcoinSymbol = settings.useBitcoinSymbol,
+                                showFiat = settings.showFiatBalance,
+                                btcPrice = priceState.btcPrice,
+                                currencyCode = priceState.currencyCode,
+                                compact = showsQr,
+                            )
 
-                        if (description != null) {
-                            DescriptionDetailRow(description)
-                            if (showsQr && qrContent != null) {
-                                QrCard(
-                                    content = qrContent,
-                                    staticOnly = current.kind != TransactionKind.Ecash,
-                                    shareSubject = title,
-                                    confirmationMessage =
-                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                )
-                            }
-                        }
-
-                        Column(modifier = Modifier.fillMaxWidth()) {
-                            fields.forEach { field ->
-                                InspectorRow(
-                                    label = field.label,
-                                    value = field.value,
-                                    valueMonospaced = field.value.length > 24 ||
-                                        field.label in MonospacedLabels,
-                                    onClick = field.copyValue?.let { full ->
-                                        {
-                                            scope.launch {
-                                                clipboard.setClipEntry(
-                                                    ClipEntry(ClipData.newPlainText(field.label, full)),
-                                                )
-                                                confirmationToastController?.show(
-                                                    copyConfirmationMessage(field.label),
-                                                )
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                fields.forEach { field ->
+                                    InspectorRow(
+                                        label = field.label,
+                                        value = field.value,
+                                        valueMonospaced = field.value.length > 24 ||
+                                            field.label in MonospacedLabels,
+                                        onClick = field.copyValue?.let { full ->
+                                            {
+                                                scope.launch {
+                                                    clipboard.setClipEntry(
+                                                        ClipEntry(ClipData.newPlainText(field.label, full)),
+                                                    )
+                                                    confirmationToastController?.show(
+                                                        copyConfirmationMessage(field.label),
+                                                    )
+                                                }
                                             }
-                                        }
-                                    },
-                                    trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
-                                )
+                                        },
+                                        trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
+                                    )
+                                }
+                                // Explorer link joins the detail rows (iOS parity) —
+                                // it's reference material, not an action.
+                                if (explorerUrl != null) {
+                                    ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
+                                }
                             }
-                            // Explorer link joins the detail rows (iOS parity) —
-                            // it's reference material, not an action.
-                            if (explorerUrl != null) {
-                                ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
+
+                            if (offersManualClaimCheck) {
+                                when (val outcome = manualCheckResult) {
+                                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                                        text = "Status checked",
+                                        detail = "This token has not been claimed yet.",
+                                        severity = NoticeSeverity.Info,
+                                        modifier = Modifier.semantics {
+                                            liveRegion = LiveRegionMode.Polite
+                                        },
+                                    )
+                                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                                        text = "Couldn't check status",
+                                        detail = outcome.message.text,
+                                        modifier = Modifier.semantics {
+                                            liveRegion = LiveRegionMode.Polite
+                                        },
+                                        severity = NoticeSeverity.Caution,
+                                    )
+                                    PendingTokenClaimCheckResult.Claimed, null -> Unit
+                                }
                             }
                         }
+                    }
 
-                        if (offersManualClaimCheck) {
-                            when (val outcome = manualCheckResult) {
-                                PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
-                                    text = "Status checked",
-                                    detail = "This token has not been claimed yet.",
-                                    severity = NoticeSeverity.Info,
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                )
-                                is PendingTokenClaimCheckResult.Failed -> InlineNotice(
-                                    text = "Couldn't check status",
-                                    detail = outcome.message.text,
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                    severity = NoticeSeverity.Caution,
-                                )
-                                PendingTokenClaimCheckResult.Claimed, null -> Unit
-                            }
-                        }
+                    if (description != null) {
+                        DescriptionDetailRow(description)
+                    }
 
+                    Column(
+                        modifier = Modifier.fillMaxWidth()
+                            .padding(horizontal = CashuTheme.spacing.comfortable),
+                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+                    ) {
                         if (pendingReceiveToken != null && onClaimReceiveToken != null) {
                             Spacer(Modifier.height(CashuTheme.spacing.snug))
                             PrimaryButton(

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -4,8 +4,9 @@ import android.content.ClipData
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -63,6 +64,7 @@ import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.AmountHero
 import com.cashu.me.ui.components.CompactSheetContent
 import com.cashu.me.ui.components.ExplorerLinkRow
+import com.cashu.me.ui.components.DescriptionDetailRow
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.LocalConfirmationToastController
@@ -181,179 +183,162 @@ fun TransactionReceiptSheet(
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = CashuTheme.spacing.comfortable)
-                            .padding(bottom = CashuTheme.spacing.comfortable),
+                            .padding(horizontal = CashuTheme.spacing.comfortable),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.section),
+                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
                     ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-                        ) {
-                            // Hero state slot: live request → QR; completed → 64dp green
-                            // check; failed → 64dp red X; pending with no QR → no glyph.
-                            // State detail lives in the monochrome Status row below.
-                            when {
-                                showsQr && qrContent != null -> QrCard(
-                                    content = qrContent,
-                                    staticOnly = current.kind != TransactionKind.Ecash,
-                                    shareSubject = title,
-                                    confirmationMessage =
-                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                )
-                                current.status == TransactionStatus.Completed -> Icon(
-                                    imageVector = Icons.Filled.CheckCircle,
-                                    contentDescription = "Completed",
-                                    tint = CashuTheme.colors.onReceivedContainer,
-                                    modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
-                                )
-                                current.status == TransactionStatus.Failed -> Icon(
-                                    imageVector = Icons.Filled.Cancel,
-                                    contentDescription = "Failed",
-                                    tint = MaterialTheme.colorScheme.error,
-                                    modifier = Modifier.size(FAILED_GLYPH_SIZE),
-                                )
-                                else -> Unit
-                            }
-
-                            HeroAmount(
-                                transaction = current,
-                                formatter = formatter,
-                                preferredPrimary = settings.homeBalancePrimary,
-                                useBitcoinSymbol = settings.useBitcoinSymbol,
-                                showFiat = settings.showFiatBalance,
-                                btcPrice = priceState.btcPrice,
-                                currencyCode = priceState.currencyCode,
-                                compact = showsQr,
+                        // Hero state slot: live request → QR; completed → 64dp green
+                        // check; failed → 64dp red X; pending with no QR → no glyph.
+                        // State detail lives in the monochrome Status row below.
+                        when {
+                            showsQr && qrContent != null -> QrCard(
+                                content = qrContent,
+                                staticOnly = current.kind != TransactionKind.Ecash,
+                                shareSubject = title,
+                                confirmationMessage =
+                                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
                             )
+                            current.status == TransactionStatus.Completed -> Icon(
+                                imageVector = Icons.Filled.CheckCircle,
+                                contentDescription = "Completed",
+                                tint = CashuTheme.colors.onReceivedContainer,
+                                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
+                            )
+                            current.status == TransactionStatus.Failed -> Icon(
+                                imageVector = Icons.Filled.Cancel,
+                                contentDescription = "Failed",
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(FAILED_GLYPH_SIZE),
+                            )
+                            else -> Unit
                         }
 
-                        // The last row's 12dp inset + this gap leaves 24dp before actions.
-                        Column(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
-                        ) {
-                            Column(modifier = Modifier.fillMaxWidth()) {
-                                fields.forEach { field ->
-                                    InspectorRow(
-                                        label = field.label,
-                                        modifier = Modifier.heightIn(min = 48.dp),
-                                        value = field.value,
-                                        valueMonospaced = field.value.length > 24 ||
-                                            field.label in MonospacedLabels,
-                                        onClick = field.copyValue?.let { full ->
-                                            {
-                                                scope.launch {
-                                                    clipboard.setClipEntry(
-                                                        ClipEntry(ClipData.newPlainText(field.label, full)),
-                                                    )
-                                                    confirmationToastController?.show(
-                                                        copyConfirmationMessage(field.label),
-                                                    )
-                                                }
+                        HeroAmount(
+                            transaction = current,
+                            formatter = formatter,
+                            preferredPrimary = settings.homeBalancePrimary,
+                            useBitcoinSymbol = settings.useBitcoinSymbol,
+                            showFiat = settings.showFiatBalance,
+                            btcPrice = priceState.btcPrice,
+                            currencyCode = priceState.currencyCode,
+                            compact = showsQr,
+                        )
+
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            fields.forEach { field ->
+                                if (field.label == "Memo") {
+                                    DescriptionDetailRow(field.value)
+                                    return@forEach
+                                }
+                                InspectorRow(
+                                    label = field.label,
+                                    value = field.value,
+                                    valueMonospaced = field.value.length > 24 ||
+                                        field.label in MonospacedLabels,
+                                    onClick = field.copyValue?.let { full ->
+                                        {
+                                            scope.launch {
+                                                clipboard.setClipEntry(
+                                                    ClipEntry(ClipData.newPlainText(field.label, full)),
+                                                )
+                                                confirmationToastController?.show(
+                                                    copyConfirmationMessage(field.label),
+                                                )
                                             }
-                                        },
-                                        trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
-                                    )
-                                }
-                                // Explorer link joins the detail rows (iOS parity) —
-                                // it's reference material, not an action.
-                                if (explorerUrl != null) {
-                                    ExplorerLinkRow(
-                                        onClick = { context.openInBrowser(explorerUrl) },
-                                        modifier = Modifier.heightIn(min = 48.dp),
-                                    )
-                                }
-                            }
-
-                            if (offersManualClaimCheck) {
-                                when (val outcome = manualCheckResult) {
-                                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
-                                        text = "Status checked",
-                                        detail = "This token has not been claimed yet.",
-                                        severity = NoticeSeverity.Info,
-                                        modifier = Modifier.semantics {
-                                            liveRegion = LiveRegionMode.Polite
-                                        },
-                                    )
-                                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
-                                        text = "Couldn't check status",
-                                        detail = outcome.message.text,
-                                        modifier = Modifier.semantics {
-                                            liveRegion = LiveRegionMode.Polite
-                                        },
-                                        severity = NoticeSeverity.Caution,
-                                    )
-                                    PendingTokenClaimCheckResult.Claimed, null -> Unit
-                                }
-                            }
-
-                            if ((pendingReceiveToken != null && onClaimReceiveToken != null) ||
-                                copyableContent != null || offersManualClaimCheck
-                            ) {
-                                Column(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
-                                ) {
-                                    if (pendingReceiveToken != null && onClaimReceiveToken != null) {
-                                        PrimaryButton(
-                                            text = "Receive",
-                                            onClick = { onClaimReceiveToken(pendingReceiveToken) },
-                                            modifier = Modifier.fillMaxWidth(),
-                                        )
-                                    } else {
-                                        if (copyableContent != null) {
-                                            SecondaryButton(
-                                                text = "Copy",
-                                                onClick = {
-                                                    scope.launch {
-                                                        clipboard.setClipEntry(
-                                                            ClipEntry(ClipData.newPlainText(title, copyableContent)),
-                                                        )
-                                                        confirmationToastController?.show(
-                                                            "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                                        )
-                                                    }
-                                                },
-                                                modifier = Modifier.semantics {
-                                                    liveRegion = LiveRegionMode.Polite
-                                                },
-                                            )
                                         }
-                                        if (offersManualClaimCheck) {
-                                            PrimaryButton(
-                                                text = if (checkingClaim) "Checking…" else "Check Status",
-                                                onClick = {
-                                                    checkingClaim = true
-                                                    manualCheckResult = null
-                                                    scope.launch {
-                                                        try {
-                                                            manualCheckResult = runPendingTokenClaimCheck {
-                                                                walletManager.checkPendingTokenStatus(current)
-                                                            }
-                                                        } finally {
-                                                            checkingClaim = false
-                                                        }
-                                                    }
-                                                },
-                                                loading = checkingClaim,
-                                                modifier = Modifier
-                                                    .fillMaxWidth()
-                                                    .testTag(UiTestTags.HistoryCheckTokenStatus)
-                                                    .semantics {
-                                                        contentDescription = if (checkingClaim) {
-                                                            "Checking claim status"
-                                                        } else {
-                                                            "Check Status"
-                                                        }
-                                                        liveRegion = LiveRegionMode.Polite
-                                                    },
-                                            )
-                                        }
-                                    }
-                                }
+                                    },
+                                    trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
+                                )
+                            }
+                            // Explorer link joins the detail rows (iOS parity) —
+                            // it's reference material, not an action.
+                            if (explorerUrl != null) {
+                                ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
                             }
                         }
+
+                        if (offersManualClaimCheck) {
+                            when (val outcome = manualCheckResult) {
+                                PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                                    text = "Status checked",
+                                    detail = "This token has not been claimed yet.",
+                                    severity = NoticeSeverity.Info,
+                                    modifier = Modifier.semantics {
+                                        liveRegion = LiveRegionMode.Polite
+                                    },
+                                )
+                                is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                                    text = "Couldn't check status",
+                                    detail = outcome.message.text,
+                                    modifier = Modifier.semantics {
+                                        liveRegion = LiveRegionMode.Polite
+                                    },
+                                    severity = NoticeSeverity.Caution,
+                                )
+                                PendingTokenClaimCheckResult.Claimed, null -> Unit
+                            }
+                        }
+
+                        if (pendingReceiveToken != null && onClaimReceiveToken != null) {
+                            Spacer(Modifier.height(CashuTheme.spacing.snug))
+                            PrimaryButton(
+                                text = "Receive",
+                                onClick = { onClaimReceiveToken(pendingReceiveToken) },
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        } else {
+                            if (copyableContent != null) {
+                                Spacer(Modifier.height(CashuTheme.spacing.snug))
+                                SecondaryButton(
+                                    text = "Copy",
+                                    onClick = {
+                                        scope.launch {
+                                            clipboard.setClipEntry(
+                                                ClipEntry(ClipData.newPlainText(title, copyableContent)),
+                                            )
+                                            confirmationToastController?.show(
+                                                "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                            )
+                                        }
+                                    },
+                                    modifier = Modifier.semantics {
+                                        liveRegion = LiveRegionMode.Polite
+                                    },
+                                )
+                            }
+                            if (offersManualClaimCheck) {
+                                PrimaryButton(
+                                    text = if (checkingClaim) "Checking…" else "Check Status",
+                                    onClick = {
+                                        checkingClaim = true
+                                        manualCheckResult = null
+                                        scope.launch {
+                                            try {
+                                                manualCheckResult = runPendingTokenClaimCheck {
+                                                    walletManager.checkPendingTokenStatus(current)
+                                                }
+                                            } finally {
+                                                checkingClaim = false
+                                            }
+                                        }
+                                    },
+                                    loading = checkingClaim,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag(UiTestTags.HistoryCheckTokenStatus)
+                                        .semantics {
+                                            contentDescription = if (checkingClaim) {
+                                                "Checking claim status"
+                                            } else {
+                                                "Check Status"
+                                            }
+                                            liveRegion = LiveRegionMode.Polite
+                                        },
+                                )
+                            }
+                        }
+
+                        Spacer(Modifier.height(CashuTheme.spacing.comfortable))
                     }
                 }
             }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -150,7 +150,8 @@ fun TransactionReceiptSheet(
     val qrContent = TransactionDisplay.qrContent(current)
     val copyableContent = TransactionDisplay.copyableContent(current)
     val title = TransactionDisplay.title(current)
-    val fields = remember(current) { TransactionDisplay.detailFields(current) }
+    val description = current.displayDescription
+    val fields = remember(current) { TransactionDisplay.detailFields(current).filterNot { it.label == "Memo" } }
     val explorerUrl = remember(current) { current.explorerUrl() }
     val pendingReceiveToken = current.token?.takeIf {
         current.isPendingReceiveToken &&
@@ -190,27 +191,29 @@ fun TransactionReceiptSheet(
                         // Hero state slot: live request → QR; completed → 64dp green
                         // check; failed → 64dp red X; pending with no QR → no glyph.
                         // State detail lives in the monochrome Status row below.
-                        when {
-                            showsQr && qrContent != null -> QrCard(
-                                content = qrContent,
-                                staticOnly = current.kind != TransactionKind.Ecash,
-                                shareSubject = title,
-                                confirmationMessage =
-                                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                            )
-                            current.status == TransactionStatus.Completed -> Icon(
-                                imageVector = Icons.Filled.CheckCircle,
-                                contentDescription = "Completed",
-                                tint = CashuTheme.colors.onReceivedContainer,
-                                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
-                            )
-                            current.status == TransactionStatus.Failed -> Icon(
-                                imageVector = Icons.Filled.Cancel,
-                                contentDescription = "Failed",
-                                tint = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.size(FAILED_GLYPH_SIZE),
-                            )
-                            else -> Unit
+                        if (!showsQr || description == null) {
+                            when {
+                                showsQr && qrContent != null -> QrCard(
+                                    content = qrContent,
+                                    staticOnly = current.kind != TransactionKind.Ecash,
+                                    shareSubject = title,
+                                    confirmationMessage =
+                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                )
+                                current.status == TransactionStatus.Completed -> Icon(
+                                    imageVector = Icons.Filled.CheckCircle,
+                                    contentDescription = "Completed",
+                                    tint = CashuTheme.colors.onReceivedContainer,
+                                    modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
+                                )
+                                current.status == TransactionStatus.Failed -> Icon(
+                                    imageVector = Icons.Filled.Cancel,
+                                    contentDescription = "Failed",
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(FAILED_GLYPH_SIZE),
+                                )
+                                else -> Unit
+                            }
                         }
 
                         HeroAmount(
@@ -224,12 +227,21 @@ fun TransactionReceiptSheet(
                             compact = showsQr,
                         )
 
+                        if (description != null) {
+                            DescriptionDetailRow(description)
+                            if (showsQr && qrContent != null) {
+                                QrCard(
+                                    content = qrContent,
+                                    staticOnly = current.kind != TransactionKind.Ecash,
+                                    shareSubject = title,
+                                    confirmationMessage =
+                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                )
+                            }
+                        }
+
                         Column(modifier = Modifier.fillMaxWidth()) {
                             fields.forEach { field ->
-                                if (field.label == "Memo") {
-                                    DescriptionDetailRow(field.value)
-                                    return@forEach
-                                }
                                 InspectorRow(
                                     label = field.label,
                                     value = field.value,

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
@@ -11,6 +11,7 @@ import android.os.PowerManager
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.withInfiniteAnimationFrameNanos
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -28,7 +29,6 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.BlendMode
@@ -442,8 +442,8 @@ internal object AsciiFieldWarp {
 }
 
 /** Mutable finger state, read by the frame loop. Deliberately not Compose
- * state: the 30fps [withFrameNanos] tick already repaints, so mutations here
- * surface on the next frame without invalidating the composition per touch
+ * state: the 30fps [withInfiniteAnimationFrameNanos] tick already repaints, so
+ * mutations surface on the next frame without invalidating composition per touch
  * event. Mirrors iOS `AsciiFieldWarpTouch`. */
 internal class AsciiFieldWarpTouch {
     enum class Phase { Idle, Pressed, Released }
@@ -966,8 +966,8 @@ internal fun AsciiField(
     // The single decision point for every play/pause input, mirroring the
     // web's sync(): Reduce Motion / battery saver / staticTime paint one
     // still frame; leaving the step pair or opening the concept sheet stops
-    // the clockwork. Backgrounding pauses for free — withFrameNanos simply
-    // stops being serviced while the choreographer is idle.
+    // the clockwork. Backgrounding pauses for free — the frame clock stops
+    // being serviced while the choreographer is idle.
     val clockRuns = staticTime == null && !reducedMotion && !powerSave && active
 
     // Wall-clock zero. Time is always derived from the monotonic clock —
@@ -994,7 +994,10 @@ internal fun AsciiField(
             // skip: alternate frames on a 120 Hz panel would still be 60fps.
             var lastDrawNanos = 0L
             while (true) {
-                withFrameNanos { nanos ->
+                // Mark the ambient loop as infinite so Compose's test policy
+                // can stop it while advancing to idle. A raw frame loop keeps
+                // the recomposer busy forever on the onboarding welcome screen.
+                withInfiniteAnimationFrameNanos { nanos ->
                     val capNanos = if (interacting.value) 16_000_000L else 33_000_000L
                     if (nanos - lastDrawNanos >= capNanos) {
                         lastDrawNanos = nanos

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -74,6 +74,7 @@ import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InlineNoticeHost
 import com.cashu.me.ui.components.LocalConfirmationToastController
+import com.cashu.me.ui.components.DescriptionDetailRow
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.MintPickerSheet
 import com.cashu.me.ui.components.NumberPadFooter
@@ -384,6 +385,7 @@ fun CashuRequestDetailScreen(
                             label = "Created",
                             value = formatDate(request.createdAtEpochMillis),
                         )
+                        request.displayDescription?.let { DescriptionDetailRow(it) }
                         if (request.totalReceived > 0L) {
                             InspectorRow(
                                 label = "Total received",

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -81,6 +81,7 @@ import com.cashu.me.ui.components.NumberPadFooter
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
+import com.cashu.me.ui.components.PaymentDetailContent
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SecondaryButton
 import com.cashu.me.ui.components.SheetHeader
@@ -297,23 +298,18 @@ fun CashuRequestDetailScreen(
                     .fillMaxSize()
                     .padding(padding),
             ) {
-                Column(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(horizontal = CashuTheme.spacing.comfortable),
-                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                PaymentDetailContent(
+                    modifier = Modifier.weight(1f),
+                    hero = { qrSize ->
+                        QrCard(
+                            content = request.encoded,
+                            size = qrSize,
+                            shareSubject = request.displayTitle,
+                            staticOnly = true,
+                            confirmationMessage = "Copied payment request",
+                        )
+                    },
                 ) {
-                    Spacer(Modifier.height(CashuTheme.spacing.snug))
-                    QrCard(
-                        content = request.encoded,
-                        shareSubject = request.displayTitle,
-                        staticOnly = true,
-                        confirmationMessage = "Copied Cashu request",
-                    )
-
                     // Request amounts render in the request's own unit.
                     val isSatRequest = request.unit.equals("sat", ignoreCase = true)
                     val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
@@ -366,21 +362,26 @@ fun CashuRequestDetailScreen(
                             editable = requestEditable,
                             onClick = { mintPickerOpen = true },
                         )
-                        InspectorRow(
-                            label = "Amount",
-                            value = request.amount?.let {
-                                if (isSatRequest) "$it sat" else formatRequestAmount(it)
-                            } ?: "Any",
-                            valueMonospaced = true,
-                            editable = requestEditable,
-                            onClick = { amountPickerOpen = true },
-                        )
-                        InspectorRow(
-                            label = "Unit",
-                            value = request.unit.uppercase(),
-                            editable = requestEditable && requestMint?.supportsMultipleMintUnits == true,
-                            onClick = { unitPickerOpen = true },
-                        )
+                        request.displayDescription?.let { DescriptionDetailRow(it) }
+                        if (request.isEcashRequest || request.amount == null) {
+                            InspectorRow(
+                                label = "Amount",
+                                value = request.amount?.let {
+                                    if (isSatRequest) "$it sat" else formatRequestAmount(it)
+                                } ?: "Any",
+                                valueMonospaced = true,
+                                editable = requestEditable,
+                                onClick = { amountPickerOpen = true },
+                            )
+                        }
+                        if (request.isEcashRequest) {
+                            InspectorRow(
+                                label = "Unit",
+                                value = request.unit.uppercase(),
+                                editable = requestEditable && requestMint?.supportsMultipleMintUnits == true,
+                                onClick = { unitPickerOpen = true },
+                            )
+                        }
                         InspectorRow(
                             label = "Created",
                             value = formatDate(request.createdAtEpochMillis),
@@ -392,6 +393,7 @@ fun CashuRequestDetailScreen(
                                 valueMonospaced = true,
                             )
                         }
+
                     }
 
                     InlineNoticeHost(
@@ -400,10 +402,7 @@ fun CashuRequestDetailScreen(
                         severity = NoticeSeverity.Error,
                     )
 
-                    Spacer(Modifier.height(CashuTheme.spacing.snug))
                 }
-
-                request.displayDescription?.let { DescriptionDetailRow(it) }
 
                 DetailActionFooter {
                     Row(

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -307,14 +307,12 @@ fun CashuRequestDetailScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Spacer(Modifier.height(CashuTheme.spacing.snug))
-                    if (request.displayDescription == null) {
-                        QrCard(
-                            content = request.encoded,
-                            shareSubject = request.displayTitle,
-                            staticOnly = true,
-                            confirmationMessage = "Copied Cashu request",
-                        )
-                    }
+                    QrCard(
+                        content = request.encoded,
+                        shareSubject = request.displayTitle,
+                        staticOnly = true,
+                        confirmationMessage = "Copied Cashu request",
+                    )
 
                     // Request amounts render in the request's own unit.
                     val isSatRequest = request.unit.equals("sat", ignoreCase = true)
@@ -332,16 +330,6 @@ fun CashuRequestDetailScreen(
                                 .copy(fontWeight = FontWeight.Bold)
                                 .withMonoDigits(),
                             modifier = Modifier.padding(vertical = 5.dp),
-                        )
-                    }
-
-                    request.displayDescription?.let { description ->
-                        DescriptionDetailRow(description)
-                        QrCard(
-                            content = request.encoded,
-                            shareSubject = request.displayTitle,
-                            staticOnly = true,
-                            confirmationMessage = "Copied Cashu request",
                         )
                     }
 
@@ -414,6 +402,8 @@ fun CashuRequestDetailScreen(
 
                     Spacer(Modifier.height(CashuTheme.spacing.snug))
                 }
+
+                request.displayDescription?.let { DescriptionDetailRow(it) }
 
                 DetailActionFooter {
                     Row(

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -307,12 +307,14 @@ fun CashuRequestDetailScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Spacer(Modifier.height(CashuTheme.spacing.snug))
-                    QrCard(
-                        content = request.encoded,
-                        shareSubject = request.displayTitle,
-                        staticOnly = true,
-                        confirmationMessage = "Copied Cashu request",
-                    )
+                    if (request.displayDescription == null) {
+                        QrCard(
+                            content = request.encoded,
+                            shareSubject = request.displayTitle,
+                            staticOnly = true,
+                            confirmationMessage = "Copied Cashu request",
+                        )
+                    }
 
                     // Request amounts render in the request's own unit.
                     val isSatRequest = request.unit.equals("sat", ignoreCase = true)
@@ -330,6 +332,16 @@ fun CashuRequestDetailScreen(
                                 .copy(fontWeight = FontWeight.Bold)
                                 .withMonoDigits(),
                             modifier = Modifier.padding(vertical = 5.dp),
+                        )
+                    }
+
+                    request.displayDescription?.let { description ->
+                        DescriptionDetailRow(description)
+                        QrCard(
+                            content = request.encoded,
+                            shareSubject = request.displayTitle,
+                            staticOnly = true,
+                            confirmationMessage = "Copied Cashu request",
                         )
                     }
 
@@ -385,7 +397,6 @@ fun CashuRequestDetailScreen(
                             label = "Created",
                             value = formatDate(request.createdAtEpochMillis),
                         )
-                        request.displayDescription?.let { DescriptionDetailRow(it) }
                         if (request.totalReceived > 0L) {
                             InspectorRow(
                                 label = "Total received",

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -224,6 +224,9 @@ fun ReceiveLightningScreen(
     val activeMint = walletState.activeMint
     val supportedMethods = activeMint?.supportedMintMethods?.ifEmpty { listOf(PaymentMethodKind.Bolt11) }
         ?: listOf(PaymentMethodKind.Bolt11)
+    // Fail closed: only mints that advertised NUT-04 bolt12 description=true
+    // get a Description row / description minting.
+    val mintSupportsBolt12Description = activeMint?.supportsBolt12MintDescription == true
 
     // Mint unit: NUT-04 mintable units only; on-chain always mints sat.
     val effectiveUnit = if (method == PaymentMethodKind.Onchain) {
@@ -244,12 +247,17 @@ fun ReceiveLightningScreen(
     val showsUnitSelector = activeMint?.supportsMultipleMintUnits == true &&
         method != PaymentMethodKind.Onchain
 
-    LaunchedEffect(activeMint?.url, cashuRequestState.requests) {
+    LaunchedEffect(activeMint?.url, cashuRequestState.requests, mintSupportsBolt12Description) {
         val mintUrl = activeMint?.url
         // Mint switch: drop the previous mint's description and re-restore.
         if (reusableOfferDescriptionLoadedFor != null && reusableOfferDescriptionLoadedFor != mintUrl) {
             reusableOfferDescription = null
             reusableOfferDescriptionLoadedFor = null
+        }
+        if (!mintSupportsBolt12Description) {
+            reusableOfferDescription = null
+            reusableOfferDescriptionLoadedFor = null
+            return@LaunchedEffect
         }
         if (reusableOfferDescriptionLoadedFor == null &&
             mintUrl != null &&
@@ -324,7 +332,10 @@ fun ReceiveLightningScreen(
                 // Offers are immutable: reuse only matches an offer carrying
                 // this exact description, so a changed description mints fresh.
                 val offerDescription = reusableOfferDescription
-                    .takeIf { requestMethod == PaymentMethodKind.Bolt12 }
+                    .takeIf {
+                        requestMethod == PaymentMethodKind.Bolt12 &&
+                            mintSupportsBolt12Description
+                    }
                 val quote = if (
                     requestMethod == PaymentMethodKind.Bolt12 &&
                     amountless &&
@@ -1014,7 +1025,8 @@ fun ReceiveLightningScreen(
                             null
                         },
                         onEditReusableDescription = if (
-                            liveQuote.paymentMethod == PaymentMethodKind.Bolt12
+                            liveQuote.paymentMethod == PaymentMethodKind.Bolt12 &&
+                            mintSupportsBolt12Description
                         ) {
                             { reusableDescriptionEditorOpen = true }
                         } else {
@@ -1117,7 +1129,10 @@ fun ReceiveLightningScreen(
         )
     }
 
-    if (reusableDescriptionEditorOpen && displayQuote?.paymentMethod == PaymentMethodKind.Bolt12) {
+    if (reusableDescriptionEditorOpen &&
+        displayQuote?.paymentMethod == PaymentMethodKind.Bolt12 &&
+        mintSupportsBolt12Description
+    ) {
         ReusableDescriptionEditSheet(
             initialDescription = cashuRequestState.requests
                 .firstOrNull { it.quoteId == displayQuote.id }?.memo
@@ -1362,16 +1377,18 @@ private fun DisplayFace(
                         editable = onEditReusableAmount != null,
                         onClick = onEditReusableAmount,
                     )
-                    // Payer-facing offer description (what the payer sees when
-                    // paying) — editable like the amount, re-mints on change.
-                    CanvasDivider(leadingInset = 16.dp)
-                    InspectorRow(
-                        label = "Description",
-                        value = descriptionLabel ?: "None",
-                        leadingIcon = Icons.Outlined.Notes,
-                        editable = onEditReusableDescription != null,
-                        onClick = onEditReusableDescription,
-                    )
+                    // Payer-facing offer description — only when the mint
+                    // advertised NUT-04 bolt12 MintMethodSettings.description.
+                    if (onEditReusableDescription != null) {
+                        CanvasDivider(leadingInset = 16.dp)
+                        InspectorRow(
+                            label = "Description",
+                            value = descriptionLabel ?: "None",
+                            leadingIcon = Icons.Outlined.Notes,
+                            editable = true,
+                            onClick = onEditReusableDescription,
+                        )
+                    }
                     if (createdAtEpochMillis != null) {
                         InspectorRow(
                             label = "Created",

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -107,7 +107,6 @@ import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
-import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.CompactSheetContent
 import com.cashu.me.ui.components.ExplorerLinkRow
@@ -124,6 +123,8 @@ import com.cashu.me.ui.components.NumberPadFooter
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
 import com.cashu.me.ui.components.PrimaryButton
+import com.cashu.me.ui.components.PaymentDetailContent
+import com.cashu.me.ui.components.DescriptionDetailRow
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SheetHeader
 import com.cashu.me.ui.components.TwoFaceScreen
@@ -977,9 +978,11 @@ fun ReceiveLightningScreen(
                                 MintQuoteSettlementState.Waiting
                             else -> null
                         },
-                        mintName = activeMint?.name,
-                        createdAtEpochMillis = quoteIntent?.createdAtEpochMillis,
-                        descriptionLabel = quoteIntent?.memo
+                        mintName = walletState.mints.firstOrNull { it.url == liveQuote.mintUrl }?.name
+                            ?: liveQuote.mintUrl?.let { android.net.Uri.parse(it).host }
+                            ?: activeMint?.name,
+                        createdAtEpochMillis = quoteIntent?.createdAtEpochMillis ?: quoteCreatedAtMillis,
+                        descriptionLabel = quoteIntent?.displayDescription
                             ?: liveQuote.description,
                         errorText = errorText,
                         amountPrimary = AmountDisplayPrimary.fromRaw(settings.amountDisplayPrimary),
@@ -1303,27 +1306,22 @@ private fun DisplayFace(
     val confirmationToastController = LocalConfirmationToastController.current
     val isReusable = quote.paymentMethod == PaymentMethodKind.Bolt12
     Column(modifier = Modifier.fillMaxSize()) {
-        // Scrolling content region; the copy CTA is pinned to the bottom (iOS
-        // parity — the QR is the focal element, actions sit below the fold).
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+        PaymentDetailContent(
+            modifier = Modifier.weight(1f),
+            hero = { qrSize ->
+                QrCard(
+                    content = quote.request,
+                    size = qrSize,
+                    shareSubject = "Payment request",
+                    staticOnly = true,
+                    confirmationMessage = if (quote.paymentMethod == PaymentMethodKind.Onchain) {
+                        "Copied Bitcoin address"
+                    } else {
+                        "Copied payment request"
+                    },
+                )
+            },
         ) {
-            Spacer(Modifier.height(CashuTheme.spacing.comfortable))
-            QrCard(
-                content = quote.request,
-                shareSubject = "Payment request",
-                staticOnly = true,
-                confirmationMessage = if (quote.paymentMethod == PaymentMethodKind.Onchain) {
-                    "Copied Bitcoin address"
-                } else {
-                    "Copied payment request"
-                },
-            )
             if (amountLabel != null) {
                 GeneratedInvoiceAmount(
                     amount = quote.amount ?: 0L,
@@ -1349,15 +1347,21 @@ private fun DisplayFace(
             if (!isReusable) {
                 ExpiryCaption(expirySeconds = quote.expiryEpochSeconds)
             }
-            if (isReusable) {
-                // Cashu-Request-style inspector group (iOS reusableOfferDisplayView).
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    if (mintName != null) {
-                        InspectorRow(
-                            label = "Mint",
-                            value = mintName,
-                        )
-                    }
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (mintName != null) {
+                    InspectorRow(label = "Mint", value = mintName)
+                }
+                if (isReusable && onEditReusableDescription != null) {
+                    InspectorRow(
+                        label = "Description",
+                        value = descriptionLabel ?: "None",
+                        editable = true,
+                        onClick = onEditReusableDescription,
+                    )
+                } else if (!descriptionLabel.isNullOrBlank()) {
+                    DescriptionDetailRow(descriptionLabel)
+                }
+                if (isReusable) {
                     InspectorRow(
                         label = "Amount",
                         value = amountLabel ?: "Any",
@@ -1365,42 +1369,16 @@ private fun DisplayFace(
                         editable = onEditReusableAmount != null,
                         onClick = onEditReusableAmount,
                     )
-                    // Payer-facing offer description — only when the mint
-                    // advertised NUT-04 bolt12 MintMethodSettings.description.
-                    if (onEditReusableDescription != null) {
-                        CanvasDivider(leadingInset = 16.dp)
-                        InspectorRow(
-                            label = "Description",
-                            value = descriptionLabel ?: "None",
-                            editable = true,
-                            onClick = onEditReusableDescription,
-                        )
-                    }
-                    if (createdAtEpochMillis != null) {
-                        InspectorRow(
-                            label = "Created",
-                            value = formatReusableCreatedAt(createdAtEpochMillis),
-                        )
-                    }
                     if (receivedAmountLabel != null) {
-                        InspectorRow(
-                            label = "Total received",
-                            value = receivedAmountLabel,
-                            valueMonospaced = true,
-                        )
+                        InspectorRow(label = "Total received", value = receivedAmountLabel,
+                            valueMonospaced = true)
                     }
                 }
-            } else if (mintName != null || onOpenExplorer != null) {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    if (mintName != null) {
-                        InspectorRow(
-                            label = "Mint",
-                            value = mintName,
-                        )
-                    }
-                    if (onOpenExplorer != null) {
-                        ExplorerLinkRow(label = explorerLabel, onClick = onOpenExplorer)
-                    }
+                if (createdAtEpochMillis != null) {
+                    InspectorRow(label = "Created", value = formatReusableCreatedAt(createdAtEpochMillis))
+                }
+                if (onOpenExplorer != null) {
+                    ExplorerLinkRow(label = explorerLabel, onClick = onOpenExplorer)
                 }
             }
         }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.IosShare
+import androidx.compose.material.icons.outlined.Notes
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Schedule
@@ -72,6 +73,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import java.text.DateFormat
 import java.util.Date
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
@@ -99,6 +101,8 @@ import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
+import com.cashu.me.ui.components.CanvasDivider
+import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.components.IconSwap
@@ -165,6 +169,9 @@ private fun receiveRequestFailureTitle(method: PaymentMethodKind): String = when
     PaymentMethodKind.Onchain -> "Couldn't Create Address"
 }
 
+/** Defensive cap for the payer-facing BOLT12 offer description. */
+private const val MAX_OFFER_DESCRIPTION_LENGTH = 640
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ReceiveLightningScreen(
@@ -200,6 +207,17 @@ fun ReceiveLightningScreen(
     var unitPickerOpen by remember { mutableStateOf(false) }
     var mintPickerOpen by remember { mutableStateOf(false) }
     var reusableAmountPickerOpen by remember { mutableStateOf(false) }
+    var reusableDescriptionEditorOpen by remember { mutableStateOf(false) }
+    // Description the next reusable BOLT12 offer is minted with. Initialized
+    // once per mint from the newest stored amountless offer intent so
+    // re-opening the screen reloads the described offer instead of minting a
+    // duplicate (CDK never returns offer descriptions — local memo is the
+    // only record). Keyed by mint url: a mint switch resets and re-restores.
+    var reusableOfferDescription by remember { mutableStateOf<String?>(null) }
+    var reusableOfferDescriptionLoadedFor by remember { mutableStateOf<String?>(null) }
+    // Quote creation is serialized through this handle — a new create cancels
+    // the in-flight one so the slowest job can't clobber the freshest offer.
+    var createJob by remember { mutableStateOf<Job?>(null) }
     var displayActionsOpen by remember { mutableStateOf(false) }
     var methodPickerOpen by remember { mutableStateOf(false) }
 
@@ -226,6 +244,32 @@ fun ReceiveLightningScreen(
     val showsUnitSelector = activeMint?.supportsMultipleMintUnits == true &&
         method != PaymentMethodKind.Onchain
 
+    LaunchedEffect(activeMint?.url, cashuRequestState.requests) {
+        val mintUrl = activeMint?.url
+        // Mint switch: drop the previous mint's description and re-restore.
+        if (reusableOfferDescriptionLoadedFor != null && reusableOfferDescriptionLoadedFor != mintUrl) {
+            reusableOfferDescription = null
+            reusableOfferDescriptionLoadedFor = null
+        }
+        if (reusableOfferDescriptionLoadedFor == null &&
+            mintUrl != null &&
+            cashuRequestState.requests.isNotEmpty()
+        ) {
+            reusableOfferDescription = cashuRequestState.requests
+                .filter { request ->
+                    request.quoteKind == "bolt12" &&
+                        // Only amountless reusable intents — a memo from a
+                        // one-off fixed quote must not leak into the reusable
+                        // offer on re-open.
+                        request.amount == null &&
+                        mintUrl in request.mints
+                }
+                .maxByOrNull { it.createdAtEpochMillis }
+                ?.memo
+            reusableOfferDescriptionLoadedFor = mintUrl
+        }
+    }
+
     fun persistReusableOffer(quote: MintQuoteInfo) {
         if (quote.paymentMethod != PaymentMethodKind.Bolt12) return
         cashuRequestStore.upsertQuoteIntent(
@@ -237,6 +281,9 @@ fun ReceiveLightningScreen(
             amount = quote.amount.takeUnless { quote.isAmountless },
             unit = quote.unit,
             mints = listOfNotNull(quote.mintUrl ?: activeMint?.url),
+            // An offer's description is immutable like the offer itself, so a
+            // null here means "unknown" and must not wipe the stored memo.
+            memo = quote.description,
             encoded = quote.request,
         )
     }
@@ -266,31 +313,42 @@ fun ReceiveLightningScreen(
         val requestAmount = if (amountless) null else explicit
         creating = true
         errorText = null
-        scope.launch {
+        createJob?.cancel()
+        createJob = scope.launch {
             try {
                 val requestUnit = if (requestMethod == PaymentMethodKind.Onchain) {
                     "sat"
                 } else {
                     amountEntryContext.quoteUnit
                 }
+                // Offers are immutable: reuse only matches an offer carrying
+                // this exact description, so a changed description mints fresh.
+                val offerDescription = reusableOfferDescription
+                    .takeIf { requestMethod == PaymentMethodKind.Bolt12 }
                 val quote = if (
                     requestMethod == PaymentMethodKind.Bolt12 &&
                     amountless &&
                     !forceNewReusableOffer
                 ) {
-                    walletManager.existingAmountlessBolt12Offer(unit = requestUnit)
-                        ?: walletManager.createMintQuote(
-                            amount = null,
-                            method = requestMethod,
-                            unit = requestUnit,
-                        )
+                    walletManager.existingAmountlessBolt12Offer(
+                        unit = requestUnit,
+                        description = offerDescription,
+                    ) ?: walletManager.createMintQuote(
+                        amount = null,
+                        method = requestMethod,
+                        unit = requestUnit,
+                        description = offerDescription,
+                    )
                 } else {
                     walletManager.createMintQuote(
                         amount = requestAmount,
                         method = requestMethod,
                         unit = requestUnit,
+                        description = offerDescription,
                     )
                 }
+                // createMintQuote (and the reuse path) already carry the
+                // description on the returned quote; no face-level copy.
                 face = ReceiveLnFace.Display(quote)
             } catch (t: Throwable) {
                 face = ReceiveLnFace.Failure(
@@ -367,6 +425,43 @@ fun ReceiveLightningScreen(
                 requestMethod = PaymentMethodKind.Bolt12,
                 amountless = false,
                 amountOverride = nextAmount,
+            )
+        }
+    }
+
+    /**
+     * Re-mints the reusable BOLT12 offer with a new payer-facing description
+     * (iOS `setReusableOfferDescription` parity). Blank → null (plain offer,
+     * reuse allowed); non-blank → a fresh offer, since offers are immutable.
+     * The current fixed amount, if any, is preserved.
+     */
+    fun setReusableOfferDescription(next: String?) {
+        method = PaymentMethodKind.Bolt12
+        errorText = null
+        // Strip control/bidi characters (kept payer-facing text clean for
+        // third-party wallets) and cap; an explicit user choice wins over the
+        // one-time restore.
+        reusableOfferDescription = next
+            ?.filter { !it.isISOControl() || it == '\n' }
+            ?.trim()
+            ?.take(MAX_OFFER_DESCRIPTION_LENGTH)
+            ?.ifEmpty { null }
+        reusableOfferDescriptionLoadedFor = activeMint?.url
+        val currentQuote = (face as? ReceiveLnFace.Display)?.quote
+        if (currentQuote != null &&
+            currentQuote.paymentMethod == PaymentMethodKind.Bolt12 &&
+            !currentQuote.isAmountless
+        ) {
+            // Preserve the displayed fixed amount via the same keypad/quote
+            // conversion as the Amount pencil. `UnitAmountEntry.entryString`
+            // would rebuild a mint-unit string and, on a sat quote with fiat
+            // primary, parse it as fiat — reminting the wrong amount.
+            setReusableOfferAmount(currentQuote.amount)
+        } else {
+            amount = ""
+            createMintRequest(
+                requestMethod = PaymentMethodKind.Bolt12,
+                amountless = true,
             )
         }
     }
@@ -860,6 +955,8 @@ fun ReceiveLightningScreen(
                     } else {
                         null
                     }
+                    val quoteIntent = cashuRequestState.requests
+                        .firstOrNull { it.quoteId == liveQuote.id }
                     DisplayFace(
                         quote = liveQuote,
                         amountLabel = amountLabel.takeUnless {
@@ -882,9 +979,9 @@ fun ReceiveLightningScreen(
                             else -> null
                         },
                         mintName = activeMint?.name,
-                        createdAtEpochMillis = cashuRequestState.requests
-                            .firstOrNull { it.quoteId == liveQuote.id }
-                            ?.createdAtEpochMillis,
+                        createdAtEpochMillis = quoteIntent?.createdAtEpochMillis,
+                        descriptionLabel = quoteIntent?.memo
+                            ?: liveQuote.description,
                         errorText = errorText,
                         amountPrimary = AmountDisplayPrimary.fromRaw(settings.amountDisplayPrimary),
                         onFlipAmountPrimary = {
@@ -913,6 +1010,13 @@ fun ReceiveLightningScreen(
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12
                         ) {
                             { reusableAmountPickerOpen = true }
+                        } else {
+                            null
+                        },
+                        onEditReusableDescription = if (
+                            liveQuote.paymentMethod == PaymentMethodKind.Bolt12
+                        ) {
+                            { reusableDescriptionEditorOpen = true }
                         } else {
                             null
                         },
@@ -1010,6 +1114,19 @@ fun ReceiveLightningScreen(
                 setReusableOfferAmount(next)
             },
             onDismiss = { reusableAmountPickerOpen = false },
+        )
+    }
+
+    if (reusableDescriptionEditorOpen && displayQuote?.paymentMethod == PaymentMethodKind.Bolt12) {
+        ReusableDescriptionEditSheet(
+            initialDescription = cashuRequestState.requests
+                .firstOrNull { it.quoteId == displayQuote.id }?.memo
+                ?: displayQuote.description,
+            onDone = { next ->
+                reusableDescriptionEditorOpen = false
+                setReusableOfferDescription(next)
+            },
+            onDismiss = { reusableDescriptionEditorOpen = false },
         )
     }
 }
@@ -1165,6 +1282,7 @@ private fun DisplayFace(
     settlementState: MintQuoteSettlementState?,
     mintName: String?,
     createdAtEpochMillis: Long?,
+    descriptionLabel: String?,
     errorText: String?,
     amountPrimary: AmountDisplayPrimary,
     onFlipAmountPrimary: (AmountDisplayPrimary) -> Unit,
@@ -1176,6 +1294,7 @@ private fun DisplayFace(
     onCopy: () -> Unit,
     onRetryPendingMint: () -> Unit,
     onEditReusableAmount: (() -> Unit)?,
+    onEditReusableDescription: (() -> Unit)?,
     onOpenExplorer: (() -> Unit)?,
 ) {
     val confirmationToastController = LocalConfirmationToastController.current
@@ -1242,6 +1361,16 @@ private fun DisplayFace(
                         valueMonospaced = amountLabel != null,
                         editable = onEditReusableAmount != null,
                         onClick = onEditReusableAmount,
+                    )
+                    // Payer-facing offer description (what the payer sees when
+                    // paying) — editable like the amount, re-mints on change.
+                    CanvasDivider(leadingInset = 16.dp)
+                    InspectorRow(
+                        label = "Description",
+                        value = descriptionLabel ?: "None",
+                        leadingIcon = Icons.Outlined.Notes,
+                        editable = onEditReusableDescription != null,
+                        onClick = onEditReusableDescription,
                     )
                     if (createdAtEpochMillis != null) {
                         InspectorRow(
@@ -1546,6 +1675,58 @@ private fun ReusableAmountEditSheet(
                             .takeIf { it > 0L },
                     )
                 },
+            )
+        }
+    }
+}
+
+/**
+ * Description edit sheet for a reusable BOLT12 offer (iOS
+ * `ReusableOfferDescriptionSheet` parity). The text is embedded in the offer
+ * payers receive. Seeded verbatim from the current offer's stored memo;
+ * never from profile or mint metadata. Empty →
+ * removes the description (plain offer).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ReusableDescriptionEditSheet(
+    initialDescription: String?,
+    onDone: (String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var description by remember { mutableStateOf(initialDescription.orEmpty()) }
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .imePadding()
+                .navigationBarsPadding()
+                .padding(horizontal = CashuTheme.spacing.comfortable),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+        ) {
+            SheetHeader(
+                title = "Description",
+                navigationIcon = Icons.Outlined.Close,
+                navigationContentDescription = "Close",
+                onNavigationClick = onDismiss,
+            )
+            CashuTextField(
+                value = description,
+                onValueChange = { description = it.take(MAX_OFFER_DESCRIPTION_LENGTH) },
+                label = "Description shown to the payer",
+                placeholder = "e.g. Coffee tips",
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 2,
+            )
+            PrimaryButton(
+                text = "Done",
+                onClick = { onDone(description.trim().ifEmpty { null }) },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -83,6 +83,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import com.cashu.me.Core.normalizedOfferDescription
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.CashuRequestStore
@@ -215,10 +216,10 @@ fun ReceiveLightningScreen(
     var reusableAmountPickerOpen by remember { mutableStateOf(false) }
     var reusableDescriptionEditorOpen by remember { mutableStateOf(false) }
     // Description the next reusable BOLT12 offer is minted with. Initialized
-    // once per mint from the newest stored amountless offer intent so
+    // once per mint/unit from the last presented amountless offer intent so
     // re-opening the screen reloads the described offer instead of minting a
     // duplicate (CDK never returns offer descriptions — local memo is the
-    // only record). Keyed by mint url: a mint switch resets and re-restores.
+    // only record). A mint or unit switch resets and re-restores.
     var reusableOfferDescription by remember { mutableStateOf<String?>(null) }
     var reusableOfferDescriptionLoadedFor by remember { mutableStateOf<String?>(null) }
     // Quote creation is serialized through this handle — a new create cancels
@@ -253,10 +254,9 @@ fun ReceiveLightningScreen(
     val showsUnitSelector = activeMint?.supportsMultipleMintUnits == true &&
         method != PaymentMethodKind.Onchain
 
-    LaunchedEffect(activeMint?.url, cashuRequestState.requests, mintSupportsBolt12Description) {
-        val mintUrl = activeMint?.url
-        // Mint switch: drop the previous mint's description and re-restore.
-        if (reusableOfferDescriptionLoadedFor != null && reusableOfferDescriptionLoadedFor != mintUrl) {
+    val descriptionContext = activeMint?.url?.let { "$it|$effectiveUnit" }
+    LaunchedEffect(descriptionContext, cashuRequestState.requests, mintSupportsBolt12Description) {
+        if (reusableOfferDescriptionLoadedFor != descriptionContext) {
             reusableOfferDescription = null
             reusableOfferDescriptionLoadedFor = null
         }
@@ -265,22 +265,10 @@ fun ReceiveLightningScreen(
             reusableOfferDescriptionLoadedFor = null
             return@LaunchedEffect
         }
-        if (reusableOfferDescriptionLoadedFor == null &&
-            mintUrl != null &&
-            cashuRequestState.requests.isNotEmpty()
-        ) {
-            reusableOfferDescription = cashuRequestState.requests
-                .filter { request ->
-                    request.quoteKind == "bolt12" &&
-                        // Only amountless reusable intents — a memo from a
-                        // one-off fixed quote must not leak into the reusable
-                        // offer on re-open.
-                        request.amount == null &&
-                        mintUrl in request.mints
-                }
-                .maxByOrNull { it.createdAtEpochMillis }
-                ?.memo
-            reusableOfferDescriptionLoadedFor = mintUrl
+        if (reusableOfferDescriptionLoadedFor == null && activeMint != null) {
+            reusableOfferDescription = cashuRequestStore
+                .lastPresentedAmountlessOffer(activeMint.url, effectiveUnit)?.memo
+            reusableOfferDescriptionLoadedFor = descriptionContext
         }
     }
 
@@ -300,6 +288,7 @@ fun ReceiveLightningScreen(
             memo = quote.description,
             encoded = quote.request,
         )
+        cashuRequestStore.markQuotePresented(quote.id)
     }
 
     fun createMintRequest(
@@ -455,15 +444,8 @@ fun ReceiveLightningScreen(
     fun setReusableOfferDescription(next: String?) {
         method = PaymentMethodKind.Bolt12
         errorText = null
-        // Strip control/bidi characters (kept payer-facing text clean for
-        // third-party wallets) and cap; an explicit user choice wins over the
-        // one-time restore.
-        reusableOfferDescription = next
-            ?.filter { !it.isISOControl() || it == '\n' }
-            ?.trim()
-            ?.take(MAX_OFFER_DESCRIPTION_LENGTH)
-            ?.ifEmpty { null }
-        reusableOfferDescriptionLoadedFor = activeMint?.url
+        reusableOfferDescription = normalizedOfferDescription(next)
+        reusableOfferDescriptionLoadedFor = descriptionContext
         val currentQuote = (face as? ReceiveLnFace.Display)?.quote
         if (currentQuote != null &&
             currentQuote.paymentMethod == PaymentMethodKind.Bolt12 &&

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.IosShare
-import androidx.compose.material.icons.outlined.Notes
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Schedule
@@ -1384,7 +1383,6 @@ private fun DisplayFace(
                         InspectorRow(
                             label = "Description",
                             value = descriptionLabel ?: "None",
-                            leadingIcon = Icons.Outlined.Notes,
                             editable = true,
                             onClick = onEditReusableDescription,
                         )

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material.icons.outlined.WarningAmber
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.CircularProgressIndicator
@@ -59,6 +60,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -102,6 +108,7 @@ import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuTextField
+import com.cashu.me.ui.components.CompactSheetContent
 import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.FlowSheetTitle
 import com.cashu.me.ui.components.IconSwap
@@ -1704,46 +1711,80 @@ private fun ReusableAmountEditSheet(
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ReusableDescriptionEditSheet(
+internal fun ReusableDescriptionEditSheet(
     initialDescription: String?,
     onDone: (String?) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var description by remember { mutableStateOf(initialDescription.orEmpty()) }
+    var description by rememberSaveable { mutableStateOf(initialDescription.orEmpty()) }
+    val focusRequester = remember { FocusRequester() }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         sheetState = sheetState,
+        containerColor = CashuTheme.colors.compactSheetContainer,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .imePadding()
-                .navigationBarsPadding()
-                .padding(horizontal = CashuTheme.spacing.comfortable),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-        ) {
-            SheetHeader(
-                title = "Description",
-                navigationIcon = Icons.Outlined.Close,
-                navigationContentDescription = "Close",
-                onNavigationClick = onDismiss,
-            )
-            CashuTextField(
-                value = description,
-                onValueChange = { description = it.take(MAX_OFFER_DESCRIPTION_LENGTH) },
-                label = "Description shown to the payer",
-                placeholder = "e.g. Coffee tips",
-                modifier = Modifier.fillMaxWidth(),
-                minLines = 2,
-            )
-            PrimaryButton(
-                text = "Done",
-                onClick = { onDone(description.trim().ifEmpty { null }) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+        CompactSheetContent {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .imePadding()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = CashuTheme.spacing.loose)
+                    .padding(bottom = CashuTheme.spacing.comfortable),
+            ) {
+                SheetHeader(
+                    title = "Description",
+                    navigationIcon = Icons.Outlined.Close,
+                    navigationContentDescription = "Close",
+                    onNavigationClick = onDismiss,
+                )
+                Text(
+                    text = "Add a note for anyone paying this invoice.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = CashuTheme.spacing.comfortable),
+                )
+                CashuTextField(
+                    value = description,
+                    onValueChange = { description = it.take(MAX_OFFER_DESCRIPTION_LENGTH) },
+                    label = "Description",
+                    placeholder = "e.g. Coffee tips",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                        .testTag("reusable-description-field"),
+                    keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Sentences),
+                    minLines = 3,
+                    maxLines = 5,
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = CashuTheme.spacing.snug, bottom = CashuTheme.spacing.section),
+                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+                ) {
+                    Text(
+                        text = "Leave blank to remove.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Text(
+                        text = "${description.length} / $MAX_OFFER_DESCRIPTION_LENGTH",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                PrimaryButton(
+                    text = "Save",
+                    onClick = { onDone(description.trim().ifEmpty { null }) },
+                    colors = ButtonDefaults.buttonColors(),
+                    modifier = Modifier.fillMaxWidth().testTag("reusable-description-save"),
+                )
+            }
         }
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
     }
 }
 

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
@@ -101,14 +101,69 @@ class CdkMintMethodMappingTest {
         assertTrue(nuts.reportedMeltMethods().isEmpty())
     }
 
-    private fun mintMethod(method: CdkPaymentMethod, unit: CdkCurrencyUnit) =
+    @Test
+    fun bolt12MintDescriptionFailsClosedUnlessAdvertisedTrue() {
+        assertEquals(
+            false,
+            nuts(nut04Methods = emptyList()).reportsBolt12MintDescription(),
+        )
+        assertEquals(
+            false,
+            nuts(
+                nut04Methods = listOf(
+                    mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat, description = null),
+                ),
+            ).reportsBolt12MintDescription(),
+        )
+        assertEquals(
+            false,
+            nuts(
+                nut04Methods = listOf(
+                    mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat, description = false),
+                ),
+            ).reportsBolt12MintDescription(),
+        )
+        assertEquals(
+            false,
+            nuts(
+                nut04Methods = listOf(
+                    mintMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Sat, description = true),
+                ),
+            ).reportsBolt12MintDescription(),
+        )
+        assertEquals(
+            true,
+            nuts(
+                nut04Methods = listOf(
+                    mintMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Sat, description = false),
+                    mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat, description = true),
+                ),
+            ).reportsBolt12MintDescription(),
+        )
+        // Any bolt12 unit advertising true is enough.
+        assertEquals(
+            true,
+            nuts(
+                nut04Methods = listOf(
+                    mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Usd, description = false),
+                    mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat, description = true),
+                ),
+            ).reportsBolt12MintDescription(),
+        )
+    }
+
+    private fun mintMethod(
+        method: CdkPaymentMethod,
+        unit: CdkCurrencyUnit,
+        description: Boolean? = null,
+    ) =
         CdkMintMethodSettings(
             method = method,
             unit = unit,
             methodName = null,
             minAmount = null,
             maxAmount = null,
-            description = null,
+            description = description,
         )
 
     private fun meltMethod(method: CdkPaymentMethod, unit: CdkCurrencyUnit) =

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestStoreTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestStoreTest.kt
@@ -12,6 +12,28 @@ import org.junit.Test
 
 class CashuRequestStoreTest {
     @Test
+    fun clearingDescriptionRestoresLastUsedOfferWithoutChangingHistory() {
+        val persistence = MemoryCashuRequestPersistence()
+        val store = CashuRequestStore(persistence)
+        val plain = CashuRequest(id = "plain", quoteId = "plain", quoteKind = "bolt12",
+            encoded = "lno-plain", mints = listOf("https://mint.example"), createdAtEpochMillis = 1)
+        store.upsert(plain)
+        store.upsert(plain.copy(id = "described", quoteId = "described", memo = "Coffee", createdAtEpochMillis = 2))
+        store.upsert(plain.copy(id = "other-unit", quoteId = "other-unit", unit = "usd", memo = "USD", createdAtEpochMillis = 3))
+        store.upsert(plain.copy(id = "fixed", quoteId = "fixed", amount = 21, memo = "Fixed", createdAtEpochMillis = 4))
+        assertEquals("described", store.lastPresentedAmountlessOffer("https://mint.example", "sat")?.id)
+        store.attachPaymentByQuoteId("plain", "payment", 21)
+        store.markQuotePresented("plain")
+        val reloaded = CashuRequestStore(persistence)
+        val restored = reloaded.lastPresentedAmountlessOffer("https://mint.example", "SAT")!!
+        assertNull(restored.memo)
+        assertEquals(plain.createdAtEpochMillis, restored.createdAtEpochMillis)
+        assertEquals(21L, restored.totalReceived)
+        assertEquals("other-unit", reloaded.lastPresentedAmountlessOffer("https://mint.example", "usd")?.id)
+        assertNull(reloaded.lastPresentedAmountlessOffer("https://other.example", "sat"))
+    }
+
+    @Test
     fun quoteIntentAttachmentUsesQuoteIdAndSuppressesDuplicatePayments() {
         val persistence = MemoryCashuRequestPersistence()
         val store = CashuRequestStore(persistence)

--- a/android/app/src/test/java/com/cashu/me/Core/HistoryDescriptionTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/HistoryDescriptionTest.kt
@@ -1,0 +1,73 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.CashuRequestPayment
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.Models.restoringDescription
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class HistoryDescriptionTest {
+    private val offer = "lno1pg95xmmxvejk2g8sn7xtz93pqfumuen7l8wthtz45p3ftn58pvrs9xlumvkuu2xet8egzkcklqtes"
+    private val description = "Coffee 🌱"
+    private val request = CashuRequest(
+        id = "request", encoded = offer, quoteId = "quote", quoteKind = "bolt12",
+        mints = listOf("https://mint.example"),
+    )
+    private fun payment(id: String = "payment", type: TransactionType = TransactionType.Incoming) = WalletTransaction(
+        id = id, amount = 21, type = type, kind = TransactionKind.Lightning,
+        dateEpochMillis = 1, status = TransactionStatus.Completed, quoteId = "quote",
+        mintUrl = "https://mint.example/",
+    )
+
+    @Test fun paidReusableRequestAndEveryReceiptKeepDescriptionAfterReload() {
+        val paid = request.copy(receivedPayments = listOf(
+            CashuRequestPayment("first", 21, 1), CashuRequestPayment("second", 42, 2),
+        ))
+        val reloaded = Json.decodeFromString<CashuRequest>(Json.encodeToString(paid))
+        assertEquals(description, reloaded.displayDescription)
+        for (id in listOf("first", "second")) {
+            val receipt = payment(id).restoringDescription(listOf(reloaded))
+            val restored = Json.decodeFromString<WalletTransaction>(Json.encodeToString(receipt))
+            assertEquals(description, restored.memo)
+            assertEquals(description, TransactionDisplay.detailFields(restored).single { it.label == "Memo" }.value)
+        }
+    }
+
+    @Test fun outgoingInvoiceRecoversDescriptionWithoutLocalRequest() {
+        val receipt = payment(type = TransactionType.Outgoing).copy(invoice = offer)
+            .restoringDescription(emptyList())
+        assertEquals(description, receipt.memo)
+        assertEquals(description, receipt.copy(status = TransactionStatus.Pending).displayDescription)
+    }
+
+    @Test fun quoteLinkDoesNotCopyMemoFromAnotherMintUnitOrDirection() {
+        for (receipt in listOf(payment().copy(mintUrl = "https://other.example"),
+            payment().copy(unit = "usd"), payment(type = TransactionType.Outgoing))) {
+            assertNull(receipt.restoringDescription(listOf(request)).memo)
+        }
+    }
+
+    @Test fun localMemoTakesPrecedenceAndEmptyDescriptionsStayHidden() {
+        assertEquals("Personal memo", payment().copy(memo = "Personal memo", invoice = offer).displayDescription)
+        assertNull(payment().copy(memo = " \n ").displayDescription)
+        assertNull(request.copy(encoded = "invalid", memo = " ").displayDescription)
+    }
+
+    @Test fun cashuRequestDescriptionSurvivesClaimedReceiptWithoutInvoice() {
+        val encoded = PaymentRequestBuilder.build(id = "cashu", amount = 21, unit = "sat",
+            mints = listOf("https://mint.example"), description = description,
+            nostrPubkeyHex = "1".repeat(64), relays = emptyList())
+        val cashu = CashuRequest(id = "cashu", encoded = encoded,
+            receivedPayments = listOf(CashuRequestPayment("payment", 21, 1)))
+        assertEquals(description, cashu.displayDescription)
+        assertEquals(description, payment().copy(kind = TransactionKind.Ecash, quoteId = null)
+            .restoringDescription(listOf(cashu)).memo)
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
@@ -118,6 +118,40 @@ class MintDiscoveryManagerTest {
         assertEquals(listOf("sat", "usd"), preview?.mintUnits)
         assertEquals(listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Bolt12), preview?.supportedMintMethods)
         assertEquals(listOf(PaymentMethodKind.Onchain), preview?.supportedMeltMethods)
+        assertEquals(false, preview?.supportsBolt12MintDescription)
+    }
+
+    @Test
+    fun parsesNut04Bolt12DescriptionAdvertisement() {
+        val advertised = MintPreviewParser.parse(
+            mintUrl = "https://mint.example.com",
+            jsonString = """
+                {
+                  "name":"Live Mint",
+                  "nuts":{
+                    "4":{"methods":[
+                      {"method":"bolt12","unit":"sat","description":true}
+                    ]}
+                  }
+                }
+            """.trimIndent(),
+        )
+        val omitted = MintPreviewParser.parse(
+            mintUrl = "https://mint.example.com",
+            jsonString = """
+                {
+                  "name":"Live Mint",
+                  "nuts":{
+                    "4":{"methods":[
+                      {"method":"bolt12","unit":"sat"}
+                    ]}
+                  }
+                }
+            """.trimIndent(),
+        )
+
+        assertEquals(true, advertised?.supportsBolt12MintDescription)
+        assertEquals(false, omitted?.supportsBolt12MintDescription)
     }
 
     @Test

--- a/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
@@ -130,7 +130,7 @@ class MintDiscoveryManagerTest {
                   "name":"Live Mint",
                   "nuts":{
                     "4":{"methods":[
-                      {"method":"bolt12","unit":"sat","description":true}
+                      {"method":"bolt12","unit":"sat","options":{"description":true}}
                     ]}
                   }
                 }

--- a/android/app/src/test/java/com/cashu/me/Core/MintInfoMethodsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintInfoMethodsTest.kt
@@ -13,6 +13,12 @@ import org.junit.Test
 class MintInfoMethodsTest {
 
     @Test
+    fun bolt12MintDescriptionDefaultsFalseOnUnfetchedRecords() {
+        val mint = MintInfo(url = "https://mint.example")
+        assertEquals(false, mint.supportsBolt12MintDescription)
+    }
+
+    @Test
     fun unknownRailsFallBackToBolt11CompatibilityDefault() {
         val mint = MintInfo(url = "https://mint.example")
 

--- a/android/app/src/test/java/com/cashu/me/Core/MintQuoteDomainTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintQuoteDomainTest.kt
@@ -36,6 +36,61 @@ class MintQuoteDomainTest {
     }
 
     @Test
+    fun reusableBolt12OfferReuseMatchesDescriptionExactly() {
+        val plain = MintQuoteInfo(
+            id = "plain",
+            request = "lno1plain",
+            amount = null,
+            paymentMethod = PaymentMethodKind.Bolt12,
+            state = MintQuoteState.Pending,
+            expiryEpochSeconds = null,
+            mintUrl = "https://mint.example",
+            unit = "sat",
+        )
+        val described = plain.copy(id = "described", description = "Coffee tips")
+        val quotes = listOf(plain, described)
+
+        // Nil description reuses only the plain offer.
+        assertEquals(
+            plain,
+            findExistingAmountlessBolt12Offer(
+                quotes = quotes,
+                mintUrl = "https://mint.example",
+                unit = "sat",
+                description = null,
+            ),
+        )
+        // A set description reuses only the offer carrying the same memo.
+        assertEquals(
+            described,
+            findExistingAmountlessBolt12Offer(
+                quotes = quotes,
+                mintUrl = "https://mint.example",
+                unit = "sat",
+                description = "Coffee tips",
+            ),
+        )
+        // A changed description matches nothing, so the caller mints fresh.
+        assertNull(
+            findExistingAmountlessBolt12Offer(
+                quotes = quotes,
+                mintUrl = "https://mint.example",
+                unit = "sat",
+                description = "Different memo",
+            ),
+        )
+        // A plain-offer lookup ignores described offers entirely.
+        assertNull(
+            findExistingAmountlessBolt12Offer(
+                quotes = listOf(described),
+                mintUrl = "https://mint.example",
+                unit = "sat",
+                description = null,
+            ),
+        )
+    }
+
+    @Test
     fun bolt12ZeroExpiryUsesLocalNeverExpiresSentinelForStorageAndIsHiddenForDisplay() {
         val stored = mintQuoteLocalStorageExpiry(0, PaymentMethodKind.Bolt12)
 

--- a/android/app/src/test/java/com/cashu/me/Core/MintQuoteDomainTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintQuoteDomainTest.kt
@@ -9,6 +9,15 @@ import org.junit.Test
 
 class MintQuoteDomainTest {
     @Test
+    fun normalizesDescriptionForPayerDisplay() {
+        assertEquals("Coffee tips Thank you ☕", normalizedOfferDescription("  Coffee tips\r\n\tThank you ☕  "))
+        assertEquals("Coffee", normalizedOfferDescription("Cof\u0000fee"))
+        assertNull(normalizedOfferDescription(" \r\n\t "))
+        assertEquals("a".repeat(640), normalizedOfferDescription("a".repeat(650)))
+        assertEquals("a".repeat(639), normalizedOfferDescription("a".repeat(639) + "😀"))
+    }
+
+    @Test
     fun findsReusableBolt12OfferOnlyForItsMintAndUnit() {
         val offer = MintQuoteInfo(
             id = "reusable-usd",

--- a/docs/BOLT12_DESCRIPTION_TESTING.md
+++ b/docs/BOLT12_DESCRIPTION_TESTING.md
@@ -57,3 +57,23 @@ reused. The last presented offer is remembered per mint and currency.
 
 Offline regression tests cover normalization, persisted selection after
 clearing, mint/currency isolation, and preservation of payment history.
+
+
+## Descriptions in paid history
+
+History and recent activity show a two-line description preview. Request and
+transaction details show the entire selectable description. Saved memos take
+precedence; older records can recover descriptions from their encoded BOLT11,
+BOLT12, or Cashu payment request. Incoming receipts missing CDK metadata also
+recover the description from their persisted receive request, matched by payment
+ID or by quote, mint, and currency. This is independent of payment status and
+works again after restarting the app.
+
+`HistoryDescriptionTest` (Android) and `HistoryDescriptionTests` (iOS) cover
+reloading paid reusable requests, multiple receipts, outgoing invoice recovery,
+Cashu request payments, blank descriptions, and mint/currency isolation.
+`HistoryDescriptionJourneyTest` drives the real Android History and detail
+screens with simulated settlement and a long Unicode description. Run it using
+the instrumentation command above, replacing the class argument with
+`com.cashu.me.ui.journeys.HistoryDescriptionJourneyTest`; no live-mint arguments
+are needed. These tests never spend funds.

--- a/docs/BOLT12_DESCRIPTION_TESTING.md
+++ b/docs/BOLT12_DESCRIPTION_TESTING.md
@@ -62,10 +62,12 @@ clearing, mint/currency isolation, and preservation of payment history.
 ## Descriptions in paid history
 
 History and recent activity keep their compact rows without description previews.
-Opening a request or payment shows the entire selectable description immediately
-below its amount, ahead of the QR code and metadata. Described iOS receipts open
-at full height, and descriptions do not use a separate scroll area. Saved memos take
-precedence; older records can recover descriptions from their encoded BOLT11,
+Opening a request or payment keeps its description in a fixed bottom section,
+below the payment facts and above the action buttons. This section remains visible
+while the details above it scroll. Short descriptions display in full; longer ones
+show up to three lines with a native Read more view for the full selectable text.
+Short windows and larger accessibility text use a one-line preview.
+Saved memos take precedence; older records can recover descriptions from their encoded BOLT11,
 BOLT12, or Cashu payment request. Incoming receipts missing CDK metadata also
 recover the description from their persisted receive request, matched by payment
 ID or by quote, mint, and currency. This is independent of payment status and
@@ -75,7 +77,9 @@ works again after restarting the app.
 reloading paid reusable requests, multiple receipts, outgoing invoice recovery,
 Cashu request payments, blank descriptions, and mint/currency isolation.
 `HistoryDescriptionJourneyTest` drives the real Android History and detail
-screens with simulated settlement and a long Unicode description. Run it using
+screens with simulated settlement and a long Unicode description. It checks that
+the footer is visible without scrolling, stays fixed while metadata scrolls, and
+opens the complete text via Read more. Run it using
 the instrumentation command above, replacing the class argument with
 `com.cashu.me.ui.journeys.HistoryDescriptionJourneyTest`; no live-mint arguments
 are needed. These tests never spend funds.

--- a/docs/BOLT12_DESCRIPTION_TESTING.md
+++ b/docs/BOLT12_DESCRIPTION_TESTING.md
@@ -1,0 +1,59 @@
+# Live BOLT12 description checks
+
+These opt-in tests create offers with a fresh, unfunded test wallet. They do
+not pay invoices, issue ecash, or verify payment settlement. Ordinary CI skips
+them, so CI never depends on a public mint's availability.
+
+Use a mint advertising NUT-04 `bolt12` support with
+`options.description: true`, such as `https://mint.hedwig.sh`.
+
+## Android
+
+With a dedicated emulator running and the Android SDK/JDK configured:
+
+```sh
+cd android
+./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+adb install -r app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk
+adb shell pm clear com.cashu.me.debug
+adb shell am instrument -w -r \
+  -e class com.cashu.me.ui.journeys.LiveBolt12DescriptionJourneyTest \
+  -e cashu.liveBolt12Descriptions true \
+  -e cashu.nutshellMintUrl https://mint.hedwig.sh \
+  com.cashu.me.debug.test/com.cashu.me.test.CashuUiTestRunner
+```
+
+The mint URL argument uses the shared live-wallet fixture's existing name.
+The journey adds the real mint through the UI, creates a reusable offer,
+edits and clears its description, reopens it, and edits a fixed 21-sat offer.
+It decodes the copied offers with CDK to assert their descriptions and amounts,
+and compares encoded offers to verify reuse.
+
+## iOS
+
+Select a dedicated iOS simulator and run from the repository root:
+
+```sh
+TEST_RUNNER_BOLT12_DESCRIPTION_MINT_URL=https://mint.hedwig.sh \
+  xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet \
+  -destination 'platform=iOS Simulator,name=YOUR_TEST_SIMULATOR' \
+  -parallel-testing-enabled NO test \
+  -only-testing:CashuWalletTests/LiveBolt12DescriptionTests \
+  -only-testing:CashuWalletUITests/LiveBolt12DescriptionUITests
+```
+
+The native service test decodes amountless and 21-sat offers, including edited
+descriptions, Unicode, the 640-character limit, and the mint's default
+description. The UI test exercises onboarding, the actual editor, clearing,
+reopening, and fixed-amount preservation. Screenshots are attached to its
+XCTest result.
+
+Descriptions normalize whitespace to spaces before minting: payer decoders
+render embedded control characters such as newlines as replacement glyphs.
+Clearing removes the custom description; the mint can embed its own default.
+Offer creation dates and payment history stay intact when an older offer is
+reused. The last presented offer is remembered per mint and currency.
+
+Offline regression tests cover normalization, persisted selection after
+clearing, mint/currency isolation, and preservation of payment history.

--- a/docs/BOLT12_DESCRIPTION_TESTING.md
+++ b/docs/BOLT12_DESCRIPTION_TESTING.md
@@ -61,8 +61,10 @@ clearing, mint/currency isolation, and preservation of payment history.
 
 ## Descriptions in paid history
 
-History and recent activity show a two-line description preview. Request and
-transaction details show the entire selectable description. Saved memos take
+History and recent activity keep their compact rows without description previews.
+Opening a request or payment shows the entire selectable description immediately
+below its amount, ahead of the QR code and metadata. Described iOS receipts open
+at full height, and descriptions do not use a separate scroll area. Saved memos take
 precedence; older records can recover descriptions from their encoded BOLT11,
 BOLT12, or Cashu payment request. Incoming receipts missing CDK metadata also
 recover the description from their persisted receive request, matched by payment

--- a/docs/BOLT12_DESCRIPTION_TESTING.md
+++ b/docs/BOLT12_DESCRIPTION_TESTING.md
@@ -62,11 +62,13 @@ clearing, mint/currency isolation, and preservation of payment history.
 ## Descriptions in paid history
 
 History and recent activity keep their compact rows without description previews.
-Opening a request or payment keeps its description in a fixed bottom section,
-below the payment facts and above the action buttons. This section remains visible
-while the details above it scroll. Short descriptions display in full; longer ones
-show up to three lines with a native Read more view for the full selectable text.
-Short windows and larger accessibility text use a one-line preview.
+Opening a request or payment shows its description directly below Mint in the
+inspector. The QR adapts to the available space around the detail text, and the
+Copy action remains separate. BOLT11 and BOLT12 receive screens share this layout,
+spacing, mint naming, and action styling; BOLT11 keeps its expiry and BOLT12 keeps
+its amount and description editors. Short descriptions display in full; longer
+ones show up to three lines with a native Read more view for the full selectable
+text. Short windows and larger accessibility text use a one-line preview.
 Saved memos take precedence; older records can recover descriptions from their encoded BOLT11,
 BOLT12, or Cashu payment request. Incoming receipts missing CDK metadata also
 recover the description from their persisted receive request, matched by payment
@@ -78,8 +80,8 @@ reloading paid reusable requests, multiple receipts, outgoing invoice recovery,
 Cashu request payments, blank descriptions, and mint/currency isolation.
 `HistoryDescriptionJourneyTest` drives the real Android History and detail
 screens with simulated settlement and a long Unicode description. It checks that
-the footer is visible without scrolling, stays fixed while metadata scrolls, and
-opens the complete text via Read more. Run it using
+the description preview is visible without scrolling, follows Mint in the
+inspector, and opens the complete text via Read more. Run it using
 the instrumentation command above, replacing the class argument with
 `com.cashu.me.ui.journeys.HistoryDescriptionJourneyTest`; no live-mint arguments
 are needed. These tests never spend funds.

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
 		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
+		EA1850000000000000000001 /* PaymentDetailContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1850000000000000000002 /* PaymentDetailContent.swift */; };
 		A09100000000000000000007 /* LifecycleSafeWalletDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */; };
 		A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000006 /* WalletAuditRegressionTests.swift */; };
 		A09100000000000000000003 /* MintURLIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000004 /* MintURLIdentity.swift */; };
@@ -202,6 +203,7 @@
 /* Begin PBXFileReference section */
 		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
 		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
+		EA1850000000000000000002 /* PaymentDetailContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailContent.swift; sourceTree = "<group>"; };
 		A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleSafeWalletDatabase.swift; sourceTree = "<group>"; };
 		A09100000000000000000006 /* WalletAuditRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/WalletAuditRegressionTests.swift; sourceTree = "<group>"; };
 		A09100000000000000000004 /* MintURLIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintURLIdentity.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				6A8EC9492F2580000058C21B /* TransactionIcon.swift */,
 				6A8EC9332F244BD80058C21B /* ScannerWrapperView.swift */,
 				2100000000000010 /* QRCodeView.swift */,
+				EA1850000000000000000002 /* PaymentDetailContent.swift */,
 				DD00000000000014 /* ErrorBannerView.swift */,
 				3DC08FE85DFC643906176894 /* LiquidGlassModifiers.swift */,
 				21000000000000CF /* MintMethodIcons.swift */,
@@ -1104,6 +1107,7 @@
 				110000000000000D /* HistoryView.swift in Sources */,
 				110000000000000E /* SettingsView.swift in Sources */,
 				1100000000000010 /* QRCodeView.swift in Sources */,
+				EA1850000000000000000001 /* PaymentDetailContent.swift in Sources */,
 				6A8EC9482F2580000058C21B /* TransactionIcon.swift in Sources */,
 				6A8EC94A2F2590000058C21B /* PriceService.swift in Sources */,
 				6A8EC94C2F25A0000058C21B /* NostrService.swift in Sources */,

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		AB00000000000008 /* CashuRequestDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC00000000000008 /* CashuRequestDetailView.swift */; };
 		AB0000000000000A /* CashuRequestMintPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000A /* CashuRequestMintPickerSheet.swift */; };
 		AB0000000000000B /* CashuRequestAmountPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000B /* CashuRequestAmountPickerSheet.swift */; };
+		AB0000000000000D /* ReusableOfferDescriptionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000D /* ReusableOfferDescriptionSheet.swift */; };
 		AB0000000000000C /* NostrMintBackupService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0000000000000C /* NostrMintBackupService.swift */; };
 		AB00000000000050 /* TransactionAmountColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000052 /* TransactionAmountColumn.swift */; };
 		AB00000000000051 /* CashuRequestAmountColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000053 /* CashuRequestAmountColumn.swift */; };
@@ -151,6 +152,7 @@
 		F300000000000003 /* AuthorizingOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400000000000003 /* AuthorizingOverlay.swift */; };
 		F300000000000004 /* ClipboardPaymentChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400000000000004 /* ClipboardPaymentChip.swift */; };
 		F300000000000006 /* PaymentRequestDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400000000000006 /* PaymentRequestDecoder.swift */; };
+		F300000000000007 /* MintQuoteDomain.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400000000000007 /* MintQuoteDomain.swift */; };
 		FC31D408CB5FAB113E9A5327 /* IntegrationTestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB989C698CCB0CCD5FA8788D /* IntegrationTestConfig.swift */; };
 		T2A0000000000001 /* MainTabUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1A0000000000001 /* MainTabUITests.swift */; };
 		T2A0000000000002 /* ReceiveUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1A0000000000002 /* ReceiveUITests.swift */; };
@@ -176,6 +178,7 @@
 		T2B0000000000011 /* ScanRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000011 /* ScanRouterTests.swift */; };
 		T2B0000000000012 /* AsciiFieldTerrainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000012 /* AsciiFieldTerrainTests.swift */; };
 		T2B0000000000013 /* AsciiFieldErosionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000013 /* AsciiFieldErosionTests.swift */; };
+		T2B0000000000014 /* MintQuoteDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000014 /* MintQuoteDomainTests.swift */; };
 		T2B0000000000100 /* ConnectMintContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000100 /* ConnectMintContextTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -267,6 +270,7 @@
 		AC00000000000008 /* CashuRequestDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestDetailView.swift; sourceTree = "<group>"; };
 		AC0000000000000A /* CashuRequestMintPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestMintPickerSheet.swift; sourceTree = "<group>"; };
 		AC0000000000000B /* CashuRequestAmountPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuRequestAmountPickerSheet.swift; sourceTree = "<group>"; };
+		AC0000000000000D /* ReusableOfferDescriptionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableOfferDescriptionSheet.swift; sourceTree = "<group>"; };
 		AC0000000000000C /* NostrMintBackupService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrMintBackupService.swift; sourceTree = "<group>"; };
 		AV00000000000011 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
 		AV00000000000012 /* AppVersionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppVersionTests.swift; path = CashuWalletTests/AppVersionTests.swift; sourceTree = "<group>"; };
@@ -338,6 +342,7 @@
 		F400000000000003 /* AuthorizingOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizingOverlay.swift; sourceTree = "<group>"; };
 		F400000000000004 /* ClipboardPaymentChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardPaymentChip.swift; sourceTree = "<group>"; };
 		F400000000000006 /* PaymentRequestDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRequestDecoder.swift; sourceTree = "<group>"; };
+		F400000000000007 /* MintQuoteDomain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintQuoteDomain.swift; sourceTree = "<group>"; };
 		FB989C698CCB0CCD5FA8788D /* IntegrationTestConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = IntegrationTestConfig.swift; path = CashuWallet/Core/IntegrationTestConfig.swift; sourceTree = "<group>"; };
 		FC76C191800770CE8D66B4A0 /* QRContextAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRContextAccessibilityTests.swift; path = CashuWalletTests/QRContextAccessibilityTests.swift; sourceTree = "<group>"; };
 		T1A0000000000001 /* MainTabUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainTabUITests.swift; path = CashuWalletUITests/MainTabUITests.swift; sourceTree = "<group>"; };
@@ -364,6 +369,7 @@
 		T1B0000000000011 /* ScanRouterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScanRouterTests.swift; path = CashuWalletTests/ScanRouterTests.swift; sourceTree = "<group>"; };
 		T1B0000000000012 /* AsciiFieldTerrainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsciiFieldTerrainTests.swift; path = CashuWalletTests/AsciiFieldTerrainTests.swift; sourceTree = "<group>"; };
 		T1B0000000000013 /* AsciiFieldErosionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsciiFieldErosionTests.swift; path = CashuWalletTests/AsciiFieldErosionTests.swift; sourceTree = "<group>"; };
+		T1B0000000000014 /* MintQuoteDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MintQuoteDomainTests.swift; path = CashuWalletTests/MintQuoteDomainTests.swift; sourceTree = "<group>"; };
 		T1B0000000000100 /* ConnectMintContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectMintContextTests.swift; path = CashuWalletTests/ConnectMintContextTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -407,6 +413,7 @@
 				T1B0000000000001 /* InMemoryStorage.swift */,
 				T1B0000000000002 /* WalletStoreTests.swift */,
 				T1B0000000000003 /* MintServiceTests.swift */,
+				T1B0000000000014 /* MintQuoteDomainTests.swift */,
 				T1B0000000000004 /* TransactionServiceTests.swift */,
 				T1B0000000000005 /* NIP44Tests.swift */,
 				T1B0000000000006 /* TokenServiceTests.swift */,
@@ -510,6 +517,7 @@
 				SE00000000000012 /* SeedPhraseEntry.swift */,
 				DD00000000000013 /* HapticFeedback.swift */,
 				F400000000000006 /* PaymentRequestDecoder.swift */,
+				F400000000000007 /* MintQuoteDomain.swift */,
 				AC00000000000003 /* PaymentRequestBuilder.swift */,
 				AC00000000000004 /* NIP44.swift */,
 				AC00000000000005 /* NIP17.swift */,
@@ -580,6 +588,7 @@
 				AC00000000000008 /* CashuRequestDetailView.swift */,
 				AC0000000000000A /* CashuRequestMintPickerSheet.swift */,
 				AC0000000000000B /* CashuRequestAmountPickerSheet.swift */,
+				AC0000000000000D /* ReusableOfferDescriptionSheet.swift */,
 			);
 			path = Receive;
 			sourceTree = "<group>";
@@ -1001,6 +1010,7 @@
 				T2B0000000000001 /* InMemoryStorage.swift in Sources */,
 				T2B0000000000002 /* WalletStoreTests.swift in Sources */,
 				T2B0000000000003 /* MintServiceTests.swift in Sources */,
+				T2B0000000000014 /* MintQuoteDomainTests.swift in Sources */,
 				T2B0000000000004 /* TransactionServiceTests.swift in Sources */,
 				T2B0000000000005 /* NIP44Tests.swift in Sources */,
 				T2B0000000000006 /* TokenServiceTests.swift in Sources */,
@@ -1146,6 +1156,7 @@
 				F300000000000003 /* AuthorizingOverlay.swift in Sources */,
 				F300000000000004 /* ClipboardPaymentChip.swift in Sources */,
 				F300000000000006 /* PaymentRequestDecoder.swift in Sources */,
+				F300000000000007 /* MintQuoteDomain.swift in Sources */,
 				AB00000000000003 /* PaymentRequestBuilder.swift in Sources */,
 				AB00000000000004 /* NIP44.swift in Sources */,
 				AB00000000000005 /* NIP17.swift in Sources */,
@@ -1155,6 +1166,7 @@
 				AB00000000000008 /* CashuRequestDetailView.swift in Sources */,
 				AB0000000000000A /* CashuRequestMintPickerSheet.swift in Sources */,
 				AB0000000000000B /* CashuRequestAmountPickerSheet.swift in Sources */,
+				AB0000000000000D /* ReusableOfferDescriptionSheet.swift in Sources */,
 				FC31D408CB5FAB113E9A5327 /* IntegrationTestConfig.swift in Sources */,
 				A2658AA9B592D1FED82159CB /* CashuTypography.swift in Sources */,
 				E32692A9480E3C49BBF13F46 /* CashuTextRole.swift in Sources */,

--- a/ios/CashuWallet/Core/CashuRequestStore.swift
+++ b/ios/CashuWallet/Core/CashuRequestStore.swift
@@ -115,6 +115,20 @@ class CashuRequestStore: ObservableObject {
         )
     }
 
+    /// Track reuse separately from creation so clearing a description survives reopening.
+    func markQuotePresented(_ quoteId: String) {
+        guard let index = requests.firstIndex(where: { $0.quoteId == quoteId }) else { return }
+        requests[index].lastPresentedAt = Date()
+        persist()
+    }
+
+    func lastPresentedAmountlessOffer(mintURL: String, unit: String) -> CashuRequest? {
+        requests.filter {
+            $0.rail == .bolt12 && $0.amount == nil && $0.mints.contains(mintURL) &&
+                $0.unit.lowercased() == unit.lowercased()
+        }.max { ($0.lastPresentedAt ?? $0.createdAt) < ($1.lastPresentedAt ?? $1.createdAt) }
+    }
+
     /// Re-parameterize an existing intent in place (amount / mint-filter edits).
     /// The NUT-18 id stays stable across edits, so every handed-out copy of the
     /// request — the original amountless one and any later amounted re-encoding —
@@ -135,7 +149,8 @@ class CashuRequestStore: ObservableObject {
             rail: old.rail,
             reusable: old.reusable,
             quoteId: old.quoteId,
-            expiry: old.expiry
+            expiry: old.expiry,
+            lastPresentedAt: old.lastPresentedAt
         )
         persist()
     }

--- a/ios/CashuWallet/Core/MintQuoteDomain.swift
+++ b/ios/CashuWallet/Core/MintQuoteDomain.swift
@@ -3,6 +3,14 @@ import Foundation
 /// Pure mint-quote domain rules (Android `MintQuoteDomain.kt` parity) —
 /// extracted for unit testing.
 enum MintQuoteDomain {
+    /// True when any NUT-04 bolt12 method advertises `description: true`.
+    /// Null or false on every bolt12 method (or no bolt12 method) fails closed.
+    static func reportsBolt12MintDescription(
+        methods: [(method: PaymentMethodKind?, description: Bool?)]
+    ) -> Bool {
+        methods.contains { $0.method == .bolt12 && $0.description == true }
+    }
+
     /// Exact-match rule for reusable-offer reuse: an amountless BOLT12 quote
     /// at the active mint and requested unit whose locally stored memo equals
     /// the requested description (nil → only the plain, description-less

--- a/ios/CashuWallet/Core/MintQuoteDomain.swift
+++ b/ios/CashuWallet/Core/MintQuoteDomain.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Pure mint-quote domain rules (Android `MintQuoteDomain.kt` parity) —
+/// extracted for unit testing.
+enum MintQuoteDomain {
+    /// Exact-match rule for reusable-offer reuse: an amountless BOLT12 quote
+    /// at the active mint and requested unit whose locally stored memo equals
+    /// the requested description (nil → only the plain, description-less
+    /// offer). CDK never returns offer descriptions, so the memo stored locally
+    /// by quote id is the only record — and exact matching keeps reuse
+    /// unambiguous once several amountless offers exist (offers are immutable,
+    /// so a changed description always mints a fresh one).
+    static func isReusableAmountlessOffer(
+        paymentMethod: PaymentMethodKind?,
+        isAmountless: Bool,
+        quoteMintUrl: String,
+        quoteUnit: String,
+        activeMintUrl: String,
+        unit: String,
+        storedMemo: String?,
+        description: String?
+    ) -> Bool {
+        paymentMethod == .bolt12 &&
+            isAmountless &&
+            quoteMintUrl == activeMintUrl &&
+            quoteUnit.lowercased() == unit.lowercased() &&
+            storedMemo == description
+    }
+}

--- a/ios/CashuWallet/Core/MintQuoteDomain.swift
+++ b/ios/CashuWallet/Core/MintQuoteDomain.swift
@@ -3,6 +3,16 @@ import Foundation
 /// Pure mint-quote domain rules (Android `MintQuoteDomain.kt` parity) —
 /// extracted for unit testing.
 enum MintQuoteDomain {
+    /// Payer decoders render control characters, including newlines, as replacement glyphs.
+    static func normalizedOfferDescription(_ raw: String?) -> String? {
+        let printable = (raw ?? "").unicodeScalars.compactMap { scalar -> String? in
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) { return " " }
+            return scalar.properties.generalCategory == .control ? nil : String(scalar)
+        }.joined()
+        let normalized = String(printable.split(separator: " ").joined(separator: " ").prefix(640))
+        return normalized.isEmpty ? nil : normalized
+    }
+
     /// True when any NUT-04 bolt12 method advertises `description: true`.
     /// Null or false on every bolt12 method (or no bolt12 method) fails closed.
     static func reportsBolt12MintDescription(

--- a/ios/CashuWallet/Core/PaymentRequestDecoder.swift
+++ b/ios/CashuWallet/Core/PaymentRequestDecoder.swift
@@ -134,6 +134,22 @@ enum PaymentRequestMode: String, Equatable, Sendable {
 /// preview, recents tap, scan callback, and live decode feedback all share this
 /// single classification path.
 enum PaymentRequestDecoder {
+    /// Recover immutable descriptions from persisted invoices, including older history.
+    static func description(from raw: String?) -> String? {
+        guard let raw, !raw.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        let description: String?
+        if let offer = PaymentRequestParser.bolt12OfferMetadata(from: raw) {
+            description = offer.description
+        } else {
+            switch decode(raw, includeCashuPaymentRequests: true) {
+            case .bolt11(_, let value), .bolt12(_, let value): description = value
+            case .cashuPaymentRequest(let summary): description = summary.description
+            default: description = nil
+            }
+        }
+        return description.flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : $0 }
+    }
+
     static func decode(
         _ raw: String,
         includeCashuPaymentRequests: Bool = false,

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -147,19 +147,20 @@ class LightningService: ObservableObject {
         }
         let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: unit)
 
+        let offerDescription = method == .bolt12 ? MintQuoteDomain.normalizedOfferDescription(description) : nil
         let quote = try await wallet.mintQuote(
             paymentMethod: method.cdkMethod,
             amount: amount.map { Amount(value: $0) },
             // Description is only threaded for BOLT12 offers (NUT-04 optional);
             // mint support on other rails is uneven, so they keep nil.
-            description: method == .bolt12 ? description : nil,
+            description: offerDescription,
             extra: nil
         )
 
         await persistMintQuote(quote, paymentMethod: method)
 
         var info = mintQuoteInfo(from: quote, fallbackAmount: amount, paymentMethod: method)
-        info.description = method == .bolt12 ? description : nil
+        info.description = offerDescription
         return info
     }
 

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -114,7 +114,8 @@ class LightningService: ObservableObject {
         amount: UInt64?,
         method: PaymentMethodKind = .bolt11,
         targetMintURL: String? = nil,
-        unit: Cdk.CurrencyUnit = .sat
+        unit: Cdk.CurrencyUnit = .sat,
+        description: String? = nil
     ) async throws -> MintQuoteInfo {
         guard let activeMint = getActiveMint() else {
             throw WalletError.notInitialized
@@ -149,30 +150,50 @@ class LightningService: ObservableObject {
         let quote = try await wallet.mintQuote(
             paymentMethod: method.cdkMethod,
             amount: amount.map { Amount(value: $0) },
-            description: nil,
+            // Description is only threaded for BOLT12 offers (NUT-04 optional);
+            // mint support on other rails is uneven, so they keep nil.
+            description: method == .bolt12 ? description : nil,
             extra: nil
         )
 
         await persistMintQuote(quote, paymentMethod: method)
 
-        return mintQuoteInfo(from: quote, fallbackAmount: amount, paymentMethod: method)
+        var info = mintQuoteInfo(from: quote, fallbackAmount: amount, paymentMethod: method)
+        info.description = method == .bolt12 ? description : nil
+        return info
     }
 
-    /// Returns the pending amountless BOLT12 offer for one mint and unit, or nil
-    /// if that wallet has none. Offers from another account must never be
-    /// reopened merely because they appeared first in the shared database.
-    func existingAmountlessOffer(
-        mintURL: String,
-        unit: Cdk.CurrencyUnit
-    ) async throws -> MintQuoteInfo? {
+    /// Returns the pending amountless BOLT12 offer matching `description`
+    /// (nil → the plain, description-less offer), or nil if none exists.
+    /// Used to avoid creating a new offer on every visit to the Reusable
+    /// Invoice screen. CDK never returns offer descriptions, so the match
+    /// joins quotes with the locally stored quote-intent memos by quote id —
+    /// keeping reuse unambiguous once several amountless offers exist (offers
+    /// are immutable, so a changed description always mints a fresh one).
+    func existingAmountlessOffer(mintURL: String, unit: Cdk.CurrencyUnit, description: String? = nil) async throws -> MintQuoteInfo? {
         guard let db = walletDatabase() else { return nil }
         let pendingQuotes = try await db.getUnissuedMintQuotes()
-        let requestedContext = MintQuoteWalletContext(mintURL: mintURL, unit: unit)
-        guard let match = MintQuoteContextPolicy.existingAmountlessOffer(
-            in: pendingQuotes,
-            requestedContext: requestedContext
-        ) else { return nil }
-        return mintQuoteInfo(from: match, fallbackAmount: nil, paymentMethod: .bolt12)
+        let memosByQuoteId = Dictionary(
+            CashuRequestStore.shared.requests.compactMap { request in
+                request.quoteId.map { ($0, request.memo) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
+        guard let match = pendingQuotes.first(where: {
+            MintQuoteDomain.isReusableAmountlessOffer(
+                paymentMethod: PaymentMethodKind.from($0.paymentMethod),
+                isAmountless: $0.amount == nil,
+                quoteMintUrl: $0.mintUrl.url,
+                quoteUnit: PaymentRequestDecoder.unitDescription($0.unit),
+                activeMintUrl: mintURL,
+                unit: PaymentRequestDecoder.unitDescription(unit),
+                storedMemo: memosByQuoteId[$0.id] ?? nil,
+                description: description
+            )
+        }) else { return nil }
+        var info = mintQuoteInfo(from: match, fallbackAmount: nil, paymentMethod: .bolt12)
+        info.description = description
+        return info
     }
 
     /// Returns an existing unpaid onchain quote at the active mint, or nil if none exists.

--- a/ios/CashuWallet/Core/Services/MintService.swift
+++ b/ios/CashuWallet/Core/Services/MintService.swift
@@ -528,6 +528,13 @@ class MintService: ObservableObject {
             if !meltMethods.isEmpty {
                 mintInfo.supportedMeltMethods = meltMethods
             }
+
+            // Live NUT-04 advertisement is authoritative, including false.
+            mintInfo.supportsBolt12MintDescription = MintQuoteDomain.reportsBolt12MintDescription(
+                methods: fetchedInfo.nuts.nut04.methods.map {
+                    (PaymentMethodKind.from($0.method), $0.description)
+                }
+            )
         }
 
         mintInfo.lastUpdated = Date()

--- a/ios/CashuWallet/Core/Services/TransactionService.swift
+++ b/ios/CashuWallet/Core/Services/TransactionService.swift
@@ -174,8 +174,10 @@ class TransactionService: ObservableObject {
 
         persistMintQuoteTimestamps(for: allTransactions, using: mintQuoteTimestamps)
 
-        // Sort by date descending (newest first)
-        transactions = allTransactions.sorted { $0.date > $1.date }
+        // Restore from durable request metadata each load, even after payment/relaunch.
+        let requests = walletStore.loadCashuRequests()
+        transactions = allTransactions.map { $0.restoringDescription(from: requests) }
+            .sorted { $0.date > $1.date }
 
         // Post notification that transactions were updated
         NotificationCenter.default.post(name: .cashuTransactionsUpdated, object: nil)

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
@@ -8,7 +8,8 @@ extension WalletManager {
         amount: UInt64?,
         method: PaymentMethodKind = .bolt11,
         targetMintURL: String? = nil,
-        unit: String = "sat"
+        unit: String = "sat",
+        description: String? = nil
     ) async throws -> MintQuoteInfo {
         try await operationCoordinator.perform(
             kind: .mintQuote,
@@ -18,7 +19,8 @@ extension WalletManager {
                 amount: amount,
                 method: method,
                 targetMintURL: targetMintURL,
-                unit: PaymentRequestDecoder.currencyUnit(from: unit)
+                unit: PaymentRequestDecoder.currencyUnit(from: unit),
+                description: description
             )
             self.rememberMintQuoteForScheduling(quote)
             await self.loadTransactionsAssumingWalletOperationLease()
@@ -28,12 +30,14 @@ extension WalletManager {
 
     func existingAmountlessOffer(
         mintURL: String,
-        unit: String
+        unit: String,
+        description: String? = nil
     ) async throws -> MintQuoteInfo? {
         try await operationCoordinator.perform(kind: .mintQuote, resourceID: mintURL) {
             let quote = try await self.lightningService.existingAmountlessOffer(
                 mintURL: mintURL,
-                unit: PaymentRequestDecoder.currencyUnit(from: unit)
+                unit: PaymentRequestDecoder.currencyUnit(from: unit),
+                description: description
             )
             if let quote { self.rememberMintQuoteForScheduling(quote) }
             return quote

--- a/ios/CashuWallet/Core/WalletStore.swift
+++ b/ios/CashuWallet/Core/WalletStore.swift
@@ -39,6 +39,10 @@ final class WalletStore {
         set(tokens, forKey: StorageKeys.pendingReceiveTokens)
     }
 
+    func loadCashuRequests() -> [CashuRequest] {
+        value(forKey: StorageKeys.cashuRequests) ?? []
+    }
+
     func loadSavedTokens() -> [String: String] {
         value(forKey: StorageKeys.savedTokens, legacyKeys: [StorageKeys.Legacy.savedTokens]) ?? [:]
     }

--- a/ios/CashuWallet/Models/Mints/MintInfo.swift
+++ b/ios/CashuWallet/Models/Mints/MintInfo.swift
@@ -24,6 +24,11 @@ struct MintInfo: Identifiable, Equatable, Codable {
     /// Supported NUT-05 payment methods for sending
     var supportedMeltMethods: [PaymentMethodKind] = [.bolt11]
 
+    /// NUT-04 bolt12 `MintMethodSettings.description`. Default false so records
+    /// persisted before this landed, and mints that omit the field, fail closed
+    /// (the Description row stays hidden until a live fetch advertises true).
+    var supportsBolt12MintDescription: Bool = false
+
     /// Required on-chain confirmations for minting, if advertised by the mint
     var onchainMintConfirmations: Int? = nil
     
@@ -86,6 +91,7 @@ extension MintInfo {
         case mintUnits
         case supportedMintMethods
         case supportedMeltMethods
+        case supportsBolt12MintDescription
         case onchainMintConfirmations
         case lastUpdated
     }
@@ -104,6 +110,7 @@ extension MintInfo {
         mintUnits = try container.decodeIfPresent([String].self, forKey: .mintUnits) ?? units
         supportedMintMethods = try container.decodeIfPresent([PaymentMethodKind].self, forKey: .supportedMintMethods) ?? [.bolt11]
         supportedMeltMethods = try container.decodeIfPresent([PaymentMethodKind].self, forKey: .supportedMeltMethods) ?? [.bolt11]
+        supportsBolt12MintDescription = try container.decodeIfPresent(Bool.self, forKey: .supportsBolt12MintDescription) ?? false
         onchainMintConfirmations = try container.decodeIfPresent(Int.self, forKey: .onchainMintConfirmations)
         lastUpdated = try container.decodeIfPresent(Date.self, forKey: .lastUpdated) ?? Date()
     }
@@ -120,6 +127,7 @@ extension MintInfo {
         try container.encode(mintUnits, forKey: .mintUnits)
         try container.encode(supportedMintMethods, forKey: .supportedMintMethods)
         try container.encode(supportedMeltMethods, forKey: .supportedMeltMethods)
+        try container.encode(supportsBolt12MintDescription, forKey: .supportsBolt12MintDescription)
         try container.encodeIfPresent(onchainMintConfirmations, forKey: .onchainMintConfirmations)
         try container.encode(lastUpdated, forKey: .lastUpdated)
     }

--- a/ios/CashuWallet/Models/Quotes/QuoteModels.swift
+++ b/ios/CashuWallet/Models/Quotes/QuoteModels.swift
@@ -37,6 +37,10 @@ struct MintQuoteInfo: Identifiable {
     var hasSettledPayment: Bool {
         amountPaid > 0 && amountIssued >= amountPaid
     }
+    /// Payer-facing description embedded in a BOLT12 offer. CDK never returns
+    /// it (write-only on `mintQuote`), so this is populated from the locally
+    /// stored quote-intent memo (`CashuRequest.memo`) — nil everywhere else.
+    var description: String? = nil
 
     var isExpired: Bool {
         guard let expiry = expiry, expiry > 0 else { return false }

--- a/ios/CashuWallet/Models/Requests/CashuRequest.swift
+++ b/ios/CashuWallet/Models/Requests/CashuRequest.swift
@@ -37,6 +37,12 @@ struct CashuRequest: Codable, Identifiable, Hashable {
     let unit: String
     let mints: [String]
     let memo: String?
+
+    var displayDescription: String? {
+        if let memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return memo }
+        return PaymentRequestDecoder.description(from: encoded)
+    }
+
     let createdAt: Date
     var receivedPayments: [CashuRequestPayment]
 

--- a/ios/CashuWallet/Models/Requests/CashuRequest.swift
+++ b/ios/CashuWallet/Models/Requests/CashuRequest.swift
@@ -57,6 +57,7 @@ struct CashuRequest: Codable, Identifiable, Hashable {
 
     /// One-shot expiry (BOLT11 invoices). nil for reusable / never-expiring rails.
     let expiry: Date?
+    var lastPresentedAt: Date?
 
     init(
         id: String = Self.newId(),
@@ -70,7 +71,8 @@ struct CashuRequest: Codable, Identifiable, Hashable {
         rail: Rail = .ecash,
         reusable: Bool = true,
         quoteId: String? = nil,
-        expiry: Date? = nil
+        expiry: Date? = nil,
+        lastPresentedAt: Date? = nil
     ) {
         self.id = id
         self.encoded = encoded
@@ -84,6 +86,7 @@ struct CashuRequest: Codable, Identifiable, Hashable {
         self.reusable = reusable
         self.quoteId = quoteId
         self.expiry = expiry
+        self.lastPresentedAt = lastPresentedAt
     }
 
     static func newId() -> String {
@@ -130,7 +133,7 @@ struct CashuRequest: Codable, Identifiable, Hashable {
         case id, encoded, amount, unit, mints, memo, createdAt
         case receivedPayments
         case receivedPaymentIds  // legacy: stored as [String], no amounts
-        case rail, reusable, quoteId, expiry
+        case rail, reusable, quoteId, expiry, lastPresentedAt
     }
 
     init(from decoder: Decoder) throws {
@@ -152,6 +155,7 @@ struct CashuRequest: Codable, Identifiable, Hashable {
             ?? (decodedRail == .ecash || decodedRail == .bolt12)
         quoteId = try c.decodeIfPresent(String.self, forKey: .quoteId)
         expiry = try c.decodeIfPresent(Date.self, forKey: .expiry)
+        lastPresentedAt = try c.decodeIfPresent(Date.self, forKey: .lastPresentedAt)
 
         if let payments = try c.decodeIfPresent([CashuRequestPayment].self, forKey: .receivedPayments) {
             receivedPayments = payments
@@ -183,5 +187,6 @@ struct CashuRequest: Codable, Identifiable, Hashable {
         try c.encode(reusable, forKey: .reusable)
         try c.encodeIfPresent(quoteId, forKey: .quoteId)
         try c.encodeIfPresent(expiry, forKey: .expiry)
+        try c.encodeIfPresent(lastPresentedAt, forKey: .lastPresentedAt)
     }
 }

--- a/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
+++ b/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
@@ -6,7 +6,13 @@ struct WalletTransaction: Identifiable {
     let type: TransactionType
     let kind: TransactionKind
     let date: Date
-    let memo: String?
+    var memo: String?
+
+    var displayDescription: String? {
+        if let memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { return memo }
+        return PaymentRequestDecoder.description(from: invoice)
+    }
+
     var status: TransactionStatus
     var statusNote: String? = nil
     
@@ -201,4 +207,17 @@ enum SagaTransactionId {
 }
 
 
-/// Result of a send tokens operation - includes token string and fee paid
+extension WalletTransaction {
+    /// CDK may omit a mint transaction's memo and request after settlement.
+    func restoringDescription(from requests: [CashuRequest]) -> WalletTransaction {
+        let request = requests.first { request in
+            type == .incoming && unit.lowercased() == request.unit.lowercased() &&
+                (request.receivedPayments.contains { $0.transactionId == id } || cashuRequestId == request.id ||
+                    (quoteId != nil && quoteId == request.quoteId &&
+                        request.mints.contains { MintURLIdentity.normalized($0) == mintUrl.map(MintURLIdentity.normalized) }))
+        }
+        var transaction = self
+        transaction.memo = displayDescription ?? request?.displayDescription
+        return transaction
+    }
+}

--- a/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
+++ b/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+extension EnvironmentValues {
+    @Entry var compactPaymentDetails = false
+}
+
+/// Fits the QR around the receipt's actual text, keeping related details together.
+/// Scrolling remains available when accessibility text needs more than one screen.
+struct PaymentDetailContent<Hero: View, Details: View>: View {
+    @ViewBuilder let hero: (CGFloat) -> Hero
+    @ViewBuilder let details: () -> Details
+    @State private var detailsHeight: CGFloat = 0
+
+    var body: some View {
+        GeometryReader { geometry in
+            let qrSize = max(120, min(280, geometry.size.width - 64,
+                                      geometry.size.height - detailsHeight - 64))
+            ScrollView {
+                VStack(spacing: 16) {
+                    hero(qrSize)
+                    details()
+                        .environment(\.compactPaymentDetails, geometry.size.height < 600)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { detailsHeight = $0 }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+    }
+}

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -509,6 +509,13 @@ struct HistoryView: View {
                         .font(.body.weight(.medium))
                         .lineLimit(1)
 
+                    if let description = request.displayDescription {
+                        Text(description)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
                     Text(formatRelativeDate(request.createdAt))
                         .cashuText(.metadata)
                         .foregroundStyle(.secondary)
@@ -568,7 +575,7 @@ struct HistoryView: View {
                 .compactMap { $0 }
                 .joined(separator: ", ")
         }
-        return "\(request.displayTitle), \(amountPart), \(received ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))"
+        return "\(request.displayTitle), \(request.displayDescription.map { "\($0), " } ?? "")\(amountPart), \(received ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))"
     }
 
     // MARK: - Transaction Row
@@ -595,6 +602,13 @@ struct HistoryView: View {
                         .font(.body.weight(.medium))
                         .lineLimit(1)
 
+                    if let description = transaction.displayDescription {
+                        Text(description)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
                     Text(formatRelativeDate(transaction.date))
                         .cashuText(.metadata)
                         .foregroundStyle(.secondary)
@@ -610,7 +624,7 @@ struct HistoryView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(transaction.displayDescription.map { "\($0), " } ?? "")\(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint(
             transaction.isPendingReceiveToken
                 ? "Opens receive review"
@@ -710,7 +724,7 @@ enum HistorySearch {
         guard !query.isEmpty else { return true }
         if transaction.displayTitle.lowercased().contains(query) { return true }
         if "\(transaction.amount)".contains(query) { return true }
-        if let memo = transaction.memo, memo.lowercased().contains(query) { return true }
+        if let memo = transaction.displayDescription, memo.lowercased().contains(query) { return true }
         return false
     }
 
@@ -720,7 +734,7 @@ enum HistorySearch {
         if request.displayTitle.lowercased().contains(query) { return true }
         if let amount = request.amount, "\(amount)".contains(query) { return true }
         if receivedTotal > 0, "\(receivedTotal)".contains(query) { return true }
-        if let memo = request.memo, memo.lowercased().contains(query) { return true }
+        if let memo = request.displayDescription, memo.lowercased().contains(query) { return true }
         return false
     }
 

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -499,6 +499,7 @@ struct HistoryView: View {
         let receivedAmount = totalReceived(for: request)
         return Button {
             HapticFeedback.selection()
+            isSearchFocused = false
             selectedRequest = request
         } label: {
             HStack(spacing: 14) {
@@ -508,13 +509,6 @@ struct HistoryView: View {
                     Text(request.displayTitle)
                         .font(.body.weight(.medium))
                         .lineLimit(1)
-
-                    if let description = request.displayDescription {
-                        Text(description)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
 
                     Text(formatRelativeDate(request.createdAt))
                         .cashuText(.metadata)
@@ -575,7 +569,7 @@ struct HistoryView: View {
                 .compactMap { $0 }
                 .joined(separator: ", ")
         }
-        return "\(request.displayTitle), \(request.displayDescription.map { "\($0), " } ?? "")\(amountPart), \(received ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))"
+        return "\(request.displayTitle), \(amountPart), \(received ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))"
     }
 
     // MARK: - Transaction Row
@@ -583,6 +577,7 @@ struct HistoryView: View {
     private func transactionRow(transaction: WalletTransaction) -> some View {
         return Button {
             HapticFeedback.selection()
+            isSearchFocused = false
             // Unclaimed incoming ecash goes straight to the claim flow — the
             // receive screen already shows amount, fee, mint, and memo, so an
             // intermediate detail sheet would just add a second Receive tap.
@@ -602,13 +597,6 @@ struct HistoryView: View {
                         .font(.body.weight(.medium))
                         .lineLimit(1)
 
-                    if let description = transaction.displayDescription {
-                        Text(description)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-
                     Text(formatRelativeDate(transaction.date))
                         .cashuText(.metadata)
                         .foregroundStyle(.secondary)
@@ -624,7 +612,7 @@ struct HistoryView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(transaction.displayDescription.map { "\($0), " } ?? "")\(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint(
             transaction.isPendingReceiveToken
                 ? "Opens receive review"

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -111,6 +111,7 @@ struct TransactionDetailView: View {
     /// bottom padding, the row-to-CTA gap every receipt shows — fits without
     /// clipping; any tighter and that gap is the first thing cut.
     private var presentationDetents: Set<PresentationDetent> {
+        if transaction.displayDescription != nil { return [.large] }
         if showsQR { return [.fraction(0.94), .large] }
         return transaction.kind == .onchain
             ? [.fraction(0.78), .large]
@@ -126,7 +127,9 @@ struct TransactionDetailView: View {
                         // reusable invoice), else a state glyph that bounces in on
                         // open — green check when completed, red X when failed;
                         // nothing while a no-QR transaction is still pending.
-                        heroSlot
+                        if !showsQR || transaction.displayDescription == nil {
+                            heroSlot
+                        }
 
                         // Receipt amounts use the same primary/secondary ordering
                         // as Home and History. The glyph above carries state colour.
@@ -140,6 +143,11 @@ struct TransactionDetailView: View {
                             useBitcoinSymbol: settings.useBitcoinSymbol
                         )
                         .padding(.top, heroSlotIsEmpty ? 32 : 0)
+
+                        if let description = transaction.displayDescription {
+                            DescriptionDetailRow(description: description)
+                            if showsQR { heroSlot }
+                        }
 
                         // Detail rows on canvas, led by Status + Date. Type is
                         // omitted — the nav title names it.
@@ -180,6 +188,7 @@ struct TransactionDetailView: View {
                     .padding(.horizontal)
                     .padding(.bottom, copyableContent == nil ? 0 : 24)
                 }
+                .scrollBounceBehavior(.basedOnSize)
 
                 // Pending outgoing ecash gains the same one-off status action as
                 // the generated-token screen when automatic checks are disabled.
@@ -352,9 +361,6 @@ struct TransactionDetailView: View {
                 rows.append(("Payment Proof", PaymentRequestDecoder.middleTruncated(preimage), preimage))
             }
         }
-        if let description = transaction.displayDescription {
-            rows.append(("Description", description, nil))
-        }
         return rows
     }
 
@@ -370,29 +376,24 @@ struct TransactionDetailView: View {
         ).formatted()
     }
 
-    @ViewBuilder
     private func detailRow(label: String, value: String) -> some View {
-        if label == "Description" {
-            DescriptionDetailRow(description: value)
-        } else {
-            HStack {
-                Text(label)
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text(value)
-                    .fontWeight(.medium)
-                    .multilineTextAlignment(.trailing)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .textSelection(.enabled)
-            }
-            .font(.subheadline)
-            .padding(.horizontal, 4)
-            .padding(.vertical, 14)
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel(label)
-            .accessibilityValue(value)
+        HStack {
+            Text(label)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
         }
+        .font(.subheadline)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 14)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(value)
     }
 
     /// Same shape as `detailRow` but tap-to-copy: copies the FULL value while

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -127,9 +127,7 @@ struct TransactionDetailView: View {
                         // reusable invoice), else a state glyph that bounces in on
                         // open — green check when completed, red X when failed;
                         // nothing while a no-QR transaction is still pending.
-                        if !showsQR || transaction.displayDescription == nil {
-                            heroSlot
-                        }
+                        heroSlot
 
                         // Receipt amounts use the same primary/secondary ordering
                         // as Home and History. The glyph above carries state colour.
@@ -143,11 +141,6 @@ struct TransactionDetailView: View {
                             useBitcoinSymbol: settings.useBitcoinSymbol
                         )
                         .padding(.top, heroSlotIsEmpty ? 32 : 0)
-
-                        if let description = transaction.displayDescription {
-                            DescriptionDetailRow(description: description)
-                            if showsQR { heroSlot }
-                        }
 
                         // Detail rows on canvas, led by Status + Date. Type is
                         // omitted — the nav title names it.
@@ -189,6 +182,12 @@ struct TransactionDetailView: View {
                     .padding(.bottom, copyableContent == nil ? 0 : 24)
                 }
                 .scrollBounceBehavior(.basedOnSize)
+
+                if let description = transaction.displayDescription {
+                    DescriptionDetailRow(description: description)
+                        .padding(.horizontal)
+                        .layoutPriority(1)
+                }
 
                 // Pending outgoing ecash gains the same one-off status action as
                 // the generated-token screen when automatic checks are disabled.
@@ -587,22 +586,80 @@ struct TransactionReceiptAmountPair: View {
     }
 }
 
-/// Prose uses the full inspector width and remains selectable without truncation.
+/// A bounded, non-scrolling footer keeps descriptions visible on small screens.
 struct DescriptionDetailRow: View {
     let description: String
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var fullHeight: CGFloat = 0
+    @State private var previewHeight: CGFloat = 0
+    @State private var showFullDescription = false
+
+    private var previewLines: Int {
+        verticalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize ? 1 : 3
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Description")
-                .foregroundStyle(.secondary)
+            HStack {
+                Text("Description")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if fullHeight > previewHeight + 1 {
+                    Button { showFullDescription = true } label: {
+                        Text("Read more")
+                            .fontWeight(.medium)
+                            .frame(minHeight: 44)
+                    }
+                    .accessibilityHint("Opens the full description")
+                }
+            }
             Text(description)
+                .lineLimit(previewLines)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
+                .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { previewHeight = $0 }
+                .background {
+                    Text(description)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { fullHeight = $0 }
+                        .hidden()
+                        .accessibilityHidden(true)
+                }
+                .accessibilityIdentifier("payment-description-preview")
         }
         .font(.subheadline)
         .padding(.horizontal, 4)
         .padding(.vertical, 14)
-        .accessibilityElement(children: .combine)
+        .sheet(isPresented: $showFullDescription) {
+            PaymentDescriptionView(description: description)
+                .presentationDetents([.large])
+        }
+    }
+}
+
+private struct PaymentDescriptionView: View {
+    let description: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                Text(description)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding()
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .navigationTitle("Description")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+        }
     }
 }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -13,7 +13,6 @@ struct TransactionDetailView: View {
     @State private var isCheckingClaim = false
     @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
     @State private var manualClaimCheckTask: Task<Void, Never>?
-    @State private var contentHeight: CGFloat = 0
 
     init(transaction: WalletTransaction) {
         self.seed = transaction
@@ -105,109 +104,116 @@ struct TransactionDetailView: View {
     }
 
     /// Every transaction detail opens as a member of the same receipt-sheet
-    /// family. The sheet hugs its measured content (capped at 90% of the
-    /// screen, scrolling past that) instead of guessing a screen fraction:
-    /// fixed fractions clipped the rows behind the bottom actions on smaller
-    /// devices whenever the receipt grew — a Fee row, the fiat conversion
-    /// line, a second CTA — while fitting content on larger ones. Same
-    /// contract as `QRCodeDetailSheet` and the other content-fit receipts.
+    /// family; only the height varies with content. A QR hero needs most of the
+    /// screen, an onchain receipt carries an extra explorer row, and everything
+    /// else fits the standard receipt detent. `.large` stays reachable by drag.
+    /// The QR fraction is sized so the scroll content — including its 24pt
+    /// bottom padding, the row-to-CTA gap every receipt shows — fits without
+    /// clipping; any tighter and that gap is the first thing cut.
+    private var presentationDetents: Set<PresentationDetent> {
+        if showsQR { return [.fraction(0.94), .large] }
+        return transaction.kind == .onchain
+            ? [.fraction(0.78), .large]
+            : [.fraction(0.68), .large]
+    }
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                // Group the state and amount more closely than the receipt facts.
-                VStack(spacing: 16) {
-                    // Hero: an actionable QR (unclaimed token / pending or
-                    // reusable invoice), else a state glyph that bounces in on
-                    // open — green check when completed, red X when failed;
-                    // nothing while a no-QR transaction is still pending.
-                    heroSlot
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: 24) {
+                        // Hero: an actionable QR (unclaimed token / pending or
+                        // reusable invoice), else a state glyph that bounces in on
+                        // open — green check when completed, red X when failed;
+                        // nothing while a no-QR transaction is still pending.
+                        heroSlot
 
-                    // Receipt amounts use the same primary/secondary ordering
-                    // as Home and History. The glyph above carries state colour.
-                    TransactionReceiptAmountPair(
-                        transaction: transaction,
-                        role: showsQR ? .amountCompact : .amountConfirm,
-                        preferredPrimary: settings.homeBalancePrimary,
-                        showFiat: settings.showFiatBalance,
-                        btcPrice: priceService.btcPriceUSD,
-                        currencyCode: settings.bitcoinPriceCurrency,
-                        useBitcoinSymbol: settings.useBitcoinSymbol
-                    )
-                    .padding(.top, heroSlotIsEmpty ? 16 : 0)
+                        // Receipt amounts use the same primary/secondary ordering
+                        // as Home and History. The glyph above carries state colour.
+                        TransactionReceiptAmountPair(
+                            transaction: transaction,
+                            role: showsQR ? .amountCompact : .amountConfirm,
+                            preferredPrimary: settings.homeBalancePrimary,
+                            showFiat: settings.showFiatBalance,
+                            btcPrice: priceService.btcPriceUSD,
+                            currencyCode: settings.bitcoinPriceCurrency,
+                            useBitcoinSymbol: settings.useBitcoinSymbol
+                        )
+                        .padding(.top, heroSlotIsEmpty ? 32 : 0)
+
+                        // Detail rows on canvas, led by Status + Date. Type is
+                        // omitted — the nav title names it.
+                        VStack(spacing: 0) {
+                            ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
+                                if let copyValue = row.copyValue {
+                                    copyableRow(label: row.label, value: row.value, copyValue: copyValue)
+                                } else {
+                                    detailRow(label: row.label, value: row.value)
+                                }
+                            }
+                            if let explorerURL = onchainExplorerURL {
+                                explorerLinkRow(label: "View in block explorer", url: explorerURL)
+                            }
+                        }
+                        .padding(.top, 8)
+                        .padding(.horizontal, 4)
+
+                        if offersManualClaimCheck {
+                            switch manualClaimCheckResult {
+                            case .notClaimed:
+                                InlineNotice(
+                                    message: "This token has not been claimed yet.",
+                                    title: "Status checked",
+                                    severity: .info
+                                )
+                            case .failed(let message):
+                                InlineNotice(
+                                    message: message.text,
+                                    title: "Couldn't check status",
+                                    severity: message.severity
+                                )
+                            case .claimed, nil:
+                                EmptyView()
+                            }
+                        }
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom, copyableContent == nil ? 0 : 24)
                 }
 
-                // Row bottom padding + this gap leaves 24pt before the actions.
-                VStack(spacing: 12) {
-                    // Detail rows on canvas, led by Status + Date. Type is
-                    // omitted — the nav title names it.
-                    VStack(spacing: 0) {
-                        ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
-                            if let copyValue = row.copyValue {
-                                copyableRow(label: row.label, value: row.value, copyValue: copyValue)
-                            } else {
-                                detailRow(label: row.label, value: row.value)
+                // Pending outgoing ecash gains the same one-off status action as
+                // the generated-token screen when automatic checks are disabled.
+                // Keep it after Copy so the two surfaces share the same action order.
+                if offersManualClaimCheck || copyableContent != nil {
+                    VStack(spacing: 12) {
+                        if let content = copyableContent {
+                            Button(action: { copyContent(content) }) {
+                                Text("Copy")
                             }
+                            .flatSheetSecondaryButton()
+                            .accessibilityLabel("Copy \(qrContentTypeLabel)")
+                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                         }
-                        if let explorerURL = onchainExplorerURL {
-                            explorerLinkRow(label: "View in block explorer", url: explorerURL)
-                        }
-                    }
-                    .padding(.horizontal, 4)
 
-                    if offersManualClaimCheck {
-                        switch manualClaimCheckResult {
-                        case .notClaimed:
-                            InlineNotice(
-                                message: "This token has not been claimed yet.",
-                                title: "Status checked",
-                                severity: .info
-                            )
-                        case .failed(let message):
-                            InlineNotice(
-                                message: message.text,
-                                title: "Couldn't check status",
-                                severity: message.severity
-                            )
-                        case .claimed, nil:
-                            EmptyView()
-                        }
-                    }
-
-                    // Pending outgoing ecash gains the same one-off status action as
-                    // the generated-token screen when automatic checks are disabled.
-                    // Keep it after Copy so the two surfaces share the same action order.
-                    if offersManualClaimCheck || copyableContent != nil {
-                        VStack(spacing: 12) {
-                            if let content = copyableContent {
-                                Button(action: { copyContent(content) }) {
-                                    Text("Copy")
+                        if offersManualClaimCheck {
+                            Button(action: { startManualClaimCheck() }) {
+                                if isCheckingClaim {
+                                    ProgressView()
+                                } else {
+                                    Text("Check Status")
                                 }
-                                .flatSheetSecondaryButton()
-                                .accessibilityLabel("Copy \(qrContentTypeLabel)")
-                                .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                             }
-
-                            if offersManualClaimCheck {
-                                Button(action: { startManualClaimCheck() }) {
-                                    if isCheckingClaim {
-                                        ProgressView()
-                                    } else {
-                                        Text("Check Status")
-                                    }
-                                }
-                                .glassButton()
-                                .disabled(isCheckingClaim)
-                                .accessibilityIdentifier("cashu.history.check-token-status")
-                                .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
-                                .accessibilityInputLabels(["Check Status"])
-                            }
+                            .glassButton()
+                            .disabled(isCheckingClaim)
+                            .accessibilityIdentifier("cashu.history.check-token-status")
+                            .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                            .accessibilityInputLabels(["Check Status"])
                         }
                     }
+                    .padding(.horizontal)
+                    .padding(.bottom, 16)
                 }
             }
-            .padding(.horizontal)
-            .padding(.bottom, 16)
-            .contentFitMeasured { contentHeight = $0 }
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
@@ -237,7 +243,7 @@ struct TransactionDetailView: View {
             }
         }
         .compactBottomSheetSurface()
-        .contentFitDetent(contentHeight, estimate: 500, navigationBar: true)
+        .presentationDetents(presentationDetents)
         .presentationDragIndicator(.visible)
     }
 
@@ -280,13 +286,13 @@ struct TransactionDetailView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.success.foreground)
-                .padding(.top, 16)
+                .padding(.top, 24)
                 .accessibilityLabel("Completed")
         } else if transaction.status == .failed {
             Image(systemName: "xmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.error.foreground)
-                .padding(.top, 16)
+                .padding(.top, 24)
                 .accessibilityLabel("Failed")
         }
     }
@@ -346,6 +352,9 @@ struct TransactionDetailView: View {
                 rows.append(("Payment Proof", PaymentRequestDecoder.middleTruncated(preimage), preimage))
             }
         }
+        if let description = transaction.displayDescription {
+            rows.append(("Description", description, nil))
+        }
         return rows
     }
 
@@ -361,25 +370,29 @@ struct TransactionDetailView: View {
         ).formatted()
     }
 
+    @ViewBuilder
     private func detailRow(label: String, value: String) -> some View {
-        HStack {
-            Text(label)
-                .foregroundStyle(.secondary)
-            Spacer()
-            Text(value)
-                .fontWeight(.medium)
-                .multilineTextAlignment(.trailing)
-                .lineLimit(1)
-                .truncationMode(.middle)
-                .textSelection(.enabled)
+        if label == "Description" {
+            DescriptionDetailRow(description: value)
+        } else {
+            HStack {
+                Text(label)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text(value)
+                    .fontWeight(.medium)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+            }
+            .font(.subheadline)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 14)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(label)
+            .accessibilityValue(value)
         }
-        .font(.subheadline)
-        .padding(.horizontal, 4)
-        .padding(.vertical, 12)
-        .frame(minHeight: 44)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(label)
-        .accessibilityValue(value)
     }
 
     /// Same shape as `detailRow` but tap-to-copy: copies the FULL value while
@@ -407,8 +420,7 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 12)
-            .frame(minHeight: 44)
+            .padding(.vertical, 14)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -432,8 +444,7 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 12)
-            .frame(minHeight: 44)
+            .padding(.vertical, 14)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -572,5 +583,25 @@ struct TransactionReceiptAmountPair: View {
                     .accessibilityLabel("Alternate amount: \(secondary)")
             }
         }
+    }
+}
+
+/// Prose uses the full inspector width and remains selectable without truncation.
+struct DescriptionDetailRow: View {
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Description")
+                .foregroundStyle(.secondary)
+            Text(description)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .textSelection(.enabled)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 14)
+        .accessibilityElement(children: .combine)
     }
 }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -9,6 +9,7 @@ struct TransactionDetailView: View {
     @ObservedObject var settings = SettingsManager.shared
     @ObservedObject private var priceService = PriceService.shared
 
+    @State private var contentHeight: CGFloat = 0
     @State private var showShareSheet = false
     @State private var isCheckingClaim = false
     @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
@@ -103,123 +104,35 @@ struct TransactionDetailView: View {
         }
     }
 
-    /// Every transaction detail opens as a member of the same receipt-sheet
-    /// family; only the height varies with content. A QR hero needs most of the
-    /// screen, an onchain receipt carries an extra explorer row, and everything
-    /// else fits the standard receipt detent. `.large` stays reachable by drag.
-    /// The QR fraction is sized so the scroll content — including its 24pt
-    /// bottom padding, the row-to-CTA gap every receipt shows — fits without
-    /// clipping; any tighter and that gap is the first thing cut.
-    private var presentationDetents: Set<PresentationDetent> {
-        if transaction.displayDescription != nil { return [.large] }
-        if showsQR { return [.fraction(0.94), .large] }
-        return transaction.kind == .onchain
-            ? [.fraction(0.78), .large]
-            : [.fraction(0.68), .large]
-    }
+    // Keep upstream's content-fitting receipt sizing. Described live QRs use
+    // the adaptive receive layout so Mint and Description remain visible.
+    private var usesAdaptiveQR: Bool { showsQR && transaction.displayDescription != nil }
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                ScrollView {
-                    VStack(spacing: 24) {
-                        // Hero: an actionable QR (unclaimed token / pending or
-                        // reusable invoice), else a state glyph that bounces in on
-                        // open — green check when completed, red X when failed;
-                        // nothing while a no-QR transaction is still pending.
-                        heroSlot
-
-                        // Receipt amounts use the same primary/secondary ordering
-                        // as Home and History. The glyph above carries state colour.
-                        TransactionReceiptAmountPair(
-                            transaction: transaction,
-                            role: showsQR ? .amountCompact : .amountConfirm,
-                            preferredPrimary: settings.homeBalancePrimary,
-                            showFiat: settings.showFiatBalance,
-                            btcPrice: priceService.btcPriceUSD,
-                            currencyCode: settings.bitcoinPriceCurrency,
-                            useBitcoinSymbol: settings.useBitcoinSymbol
-                        )
-                        .padding(.top, heroSlotIsEmpty ? 32 : 0)
-
-                        // Detail rows on canvas, led by Status + Date. Type is
-                        // omitted — the nav title names it.
-                        VStack(spacing: 0) {
-                            ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
-                                if let copyValue = row.copyValue {
-                                    copyableRow(label: row.label, value: row.value, copyValue: copyValue)
-                                } else {
-                                    detailRow(label: row.label, value: row.value)
-                                }
-                            }
-                            if let explorerURL = onchainExplorerURL {
-                                explorerLinkRow(label: "View in block explorer", url: explorerURL)
-                            }
+            Group {
+                if usesAdaptiveQR {
+                    VStack(spacing: 0) {
+                        PaymentDetailContent { qrSize in
+                            heroSlot(qrSize: qrSize)
+                        } details: {
+                            receiptDetails
                         }
-                        .padding(.top, 8)
-                        .padding(.horizontal, 4)
-
-                        if offersManualClaimCheck {
-                            switch manualClaimCheckResult {
-                            case .notClaimed:
-                                InlineNotice(
-                                    message: "This token has not been claimed yet.",
-                                    title: "Status checked",
-                                    severity: .info
-                                )
-                            case .failed(let message):
-                                InlineNotice(
-                                    message: message.text,
-                                    title: "Couldn't check status",
-                                    severity: message.severity
-                                )
-                            case .claimed, nil:
-                                EmptyView()
-                            }
-                        }
+                        receiptActions
+                            .padding(.horizontal)
+                            .padding(.bottom, 16)
                     }
-                    .padding(.horizontal)
-                    .padding(.bottom, copyableContent == nil ? 0 : 24)
-                }
-                .scrollBounceBehavior(.basedOnSize)
-
-                if let description = transaction.displayDescription {
-                    DescriptionDetailRow(description: description)
-                        .padding(.horizontal)
-                        .layoutPriority(1)
-                }
-
-                // Pending outgoing ecash gains the same one-off status action as
-                // the generated-token screen when automatic checks are disabled.
-                // Keep it after Copy so the two surfaces share the same action order.
-                if offersManualClaimCheck || copyableContent != nil {
+                } else {
                     VStack(spacing: 12) {
-                        if let content = copyableContent {
-                            Button(action: { copyContent(content) }) {
-                                Text("Copy")
-                            }
-                            .flatSheetSecondaryButton()
-                            .accessibilityLabel("Copy \(qrContentTypeLabel)")
-                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
+                        VStack(spacing: 16) {
+                            heroSlot(qrSize: 280)
+                            receiptDetails
                         }
-
-                        if offersManualClaimCheck {
-                            Button(action: { startManualClaimCheck() }) {
-                                if isCheckingClaim {
-                                    ProgressView()
-                                } else {
-                                    Text("Check Status")
-                                }
-                            }
-                            .glassButton()
-                            .disabled(isCheckingClaim)
-                            .accessibilityIdentifier("cashu.history.check-token-status")
-                            .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
-                            .accessibilityInputLabels(["Check Status"])
-                        }
+                        receiptActions
                     }
                     .padding(.horizontal)
                     .padding(.bottom, 16)
+                    .contentFitMeasured { contentHeight = $0 }
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
@@ -251,17 +164,109 @@ struct TransactionDetailView: View {
             }
         }
         .compactBottomSheetSurface()
-        .presentationDetents(presentationDetents)
+        .contentFitDetent(contentHeight, enabled: !usesAdaptiveQR, estimate: 500, navigationBar: true)
         .presentationDragIndicator(.visible)
     }
 
     // MARK: - Subviews
 
+    private var receiptDetails: some View {
+        VStack(spacing: 24) {
+            // Receipt amounts use the same primary/secondary ordering
+            // as Home and History. The glyph above carries state colour.
+            TransactionReceiptAmountPair(
+                transaction: transaction,
+                role: showsQR ? .amountCompact : .amountConfirm,
+                preferredPrimary: settings.homeBalancePrimary,
+                showFiat: settings.showFiatBalance,
+                btcPrice: priceService.btcPriceUSD,
+                currencyCode: settings.bitcoinPriceCurrency,
+                useBitcoinSymbol: settings.useBitcoinSymbol
+            )
+            .padding(.top, heroSlotIsEmpty ? 16 : 0)
+
+            // Detail rows on canvas, led by Status + Date. Type is
+            // omitted — the nav title names it.
+            VStack(spacing: 0) {
+                ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
+                    if let copyValue = row.copyValue {
+                        copyableRow(label: row.label, value: row.value, copyValue: copyValue)
+                    } else {
+                        detailRow(label: row.label, value: row.value)
+                    }
+                    if row.label == "Mint", let description = transaction.displayDescription {
+                        DescriptionDetailRow(description: description)
+                    }
+                }
+                if !detailRows.contains(where: { $0.label == "Mint" }),
+                   let description = transaction.displayDescription {
+                    DescriptionDetailRow(description: description)
+                }
+                if let explorerURL = onchainExplorerURL {
+                    explorerLinkRow(label: "View in block explorer", url: explorerURL)
+                }
+            }
+            .padding(.horizontal, 4)
+
+            if offersManualClaimCheck {
+                switch manualClaimCheckResult {
+                case .notClaimed:
+                    InlineNotice(
+                        message: "This token has not been claimed yet.",
+                        title: "Status checked",
+                        severity: .info
+                    )
+                case .failed(let message):
+                    InlineNotice(
+                        message: message.text,
+                        title: "Couldn't check status",
+                        severity: message.severity
+                    )
+                case .claimed, nil:
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+
+    @ViewBuilder
+    private var receiptActions: some View {
+        if offersManualClaimCheck || copyableContent != nil {
+            VStack(spacing: 12) {
+                if let content = copyableContent {
+                    Button(action: { copyContent(content) }) {
+                        Text("Copy")
+                    }
+                    .flatSheetSecondaryButton()
+                    .accessibilityLabel("Copy \(qrContentTypeLabel)")
+                    .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
+                }
+
+                if offersManualClaimCheck {
+                    Button(action: { startManualClaimCheck() }) {
+                        if isCheckingClaim {
+                            ProgressView()
+                        } else {
+                            Text("Check Status")
+                        }
+                    }
+                    .glassButton()
+                    .disabled(isCheckingClaim)
+                    .accessibilityIdentifier("cashu.history.check-token-status")
+                    .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                    .accessibilityInputLabels(["Check Status"])
+                }
+            }
+        }
+    }
+
+
     /// The hero above the amount. An actionable request shows its QR; otherwise a
     /// state glyph bounces in on open — green check (completed) / red X (failed),
     /// same size as the payment-success screen. A pending, no-QR tx shows nothing.
     @ViewBuilder
-    private var heroSlot: some View {
+    private func heroSlot(qrSize: CGFloat) -> some View {
         if showsQR, let content = qrContent {
             QRCodeView(
                 content: content,
@@ -272,10 +277,9 @@ struct TransactionDetailView: View {
                 onCopy: { copyContent(content) },
                 onShare: { showShareSheet = true }
             )
-            .frame(width: 280, height: 280)
+            .frame(width: qrSize, height: qrSize)
             .padding(16)
             .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-            .padding(.top, 8)
             .contextMenu {
                 Button(action: { copyContent(content) }) {
                     Label("Copy", systemImage: "doc.on.doc")
@@ -294,13 +298,13 @@ struct TransactionDetailView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.success.foreground)
-                .padding(.top, 24)
+                .padding(.top, 16)
                 .accessibilityLabel("Completed")
         } else if transaction.status == .failed {
             Image(systemName: "xmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.error.foreground)
-                .padding(.top, 24)
+                .padding(.top, 16)
                 .accessibilityLabel("Failed")
         }
     }
@@ -342,7 +346,7 @@ struct TransactionDetailView: View {
         }
         if transaction.kind == .onchain {
             if let mintUrl = transaction.mintUrl {
-                rows.append(("Mint", extractMintHost(mintUrl), nil))
+                rows.append(("Mint", walletManager.mints.first(where: { $0.url == mintUrl })?.name ?? extractMintHost(mintUrl), nil))
             }
             // Address/txid are reference blobs — show the decoder's standard
             // 8…6 short form; tap-to-copy carries the full value.
@@ -354,7 +358,7 @@ struct TransactionDetailView: View {
             }
         } else {
             if let mintUrl = transaction.mintUrl {
-                rows.append(("Mint", extractMintHost(mintUrl), nil))
+                rows.append(("Mint", walletManager.mints.first(where: { $0.url == mintUrl })?.name ?? extractMintHost(mintUrl), nil))
             }
             if let preimage = transaction.preimage {
                 rows.append(("Payment Proof", PaymentRequestDecoder.middleTruncated(preimage), preimage))
@@ -389,7 +393,8 @@ struct TransactionDetailView: View {
         }
         .font(.subheadline)
         .padding(.horizontal, 4)
-        .padding(.vertical, 14)
+        .padding(.vertical, 12)
+        .frame(minHeight: 44)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(label)
         .accessibilityValue(value)
@@ -420,7 +425,8 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -444,7 +450,8 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -586,9 +593,10 @@ struct TransactionReceiptAmountPair: View {
     }
 }
 
-/// A bounded, non-scrolling footer keeps descriptions visible on small screens.
+/// Prose belongs to the inspector, with a native reader for longer descriptions.
 struct DescriptionDetailRow: View {
     let description: String
+    @Environment(\.compactPaymentDetails) private var compactPaymentDetails
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @State private var fullHeight: CGFloat = 0
@@ -596,7 +604,7 @@ struct DescriptionDetailRow: View {
     @State private var showFullDescription = false
 
     private var previewLines: Int {
-        verticalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize ? 1 : 3
+        compactPaymentDetails || verticalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize ? 1 : 3
     }
 
     var body: some View {
@@ -632,7 +640,7 @@ struct DescriptionDetailRow: View {
         }
         .font(.subheadline)
         .padding(.horizontal, 4)
-        .padding(.vertical, 14)
+        .padding(.vertical, 12)
         .sheet(isPresented: $showFullDescription) {
             PaymentDescriptionView(description: description)
                 .presentationDetents([.large])

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -551,6 +551,13 @@ struct MainWalletView: View {
                         .font(.body.weight(.medium))
                         .lineLimit(1)
 
+                    if let description = transaction.displayDescription {
+                        Text(description)
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
+                    }
+
                     Text(formatRelativeDate(transaction.date))
                         .cashuText(.metadata)
                         .foregroundStyle(.secondary)
@@ -566,7 +573,7 @@ struct MainWalletView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(transaction.displayDescription.map { "\($0), " } ?? "")\(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint("Opens transaction details")
     }
 

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -551,13 +551,6 @@ struct MainWalletView: View {
                         .font(.body.weight(.medium))
                         .lineLimit(1)
 
-                    if let description = transaction.displayDescription {
-                        Text(description)
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                            .lineLimit(2)
-                    }
-
                     Text(formatRelativeDate(transaction.date))
                         .cashuText(.metadata)
                         .foregroundStyle(.secondary)
@@ -573,7 +566,7 @@ struct MainWalletView: View {
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(rowTitle(for: transaction)), \(transaction.displayDescription.map { "\($0), " } ?? "")\(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
+        .accessibilityLabel("\(rowTitle(for: transaction)), \(formatAmount(transaction)), \(transaction.status == .completed ? "completed" : transaction.displayStatusText.lowercased()), \(formatRelativeDate(transaction.date))")
         .accessibilityHint("Opens transaction details")
     }
 

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -256,6 +256,9 @@ struct CashuRequestDetailView: View {
                         } else {
                             detailRow(label: "Unit", value: request.unit.uppercased())
                         }
+                        if let description = request.displayDescription {
+                            DescriptionDetailRow(description: description)
+                        }
                         detailRow(
                             label: "Created",
                             value: request.createdAt.formatted(date: .abbreviated, time: .shortened)

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -172,9 +172,7 @@ struct CashuRequestDetailView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 24) {
-                    if request.displayDescription == nil {
-                        requestQRCode(request)
-                    }
+                    requestQRCode(request)
 
                     if let amount = request.amount, amount > 0 {
                         if request.unit.lowercased() == "sat" {
@@ -194,11 +192,6 @@ struct CashuRequestDetailView: View {
                                 value: Double(amount)
                             )
                         }
-                    }
-
-                    if let description = request.displayDescription {
-                        DescriptionDetailRow(description: description)
-                        requestQRCode(request)
                     }
 
                     deliveryStatus(for: request)
@@ -253,6 +246,12 @@ struct CashuRequestDetailView: View {
                 .padding(.horizontal)
             }
             .scrollBounceBehavior(.basedOnSize)
+
+            if let description = request.displayDescription {
+                DescriptionDetailRow(description: description)
+                    .padding(.horizontal)
+                    .layoutPriority(1)
+            }
 
             HStack(spacing: 12) {
                 Button(action: { copy(request.encoded) }) {

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -172,28 +172,9 @@ struct CashuRequestDetailView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 24) {
-                    QRCodeView(
-                        content: request.encoded,
-                        showControls: false,
-                        staticOnly: true,
-                        onCopy: { copy(request.encoded) },
-                        onShare: { showShareSheet = true }
-                    )
-                        .frame(width: 280, height: 280)
-                        .padding(16)
-                        .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-                        .padding(.top, 8)
-                        .contextMenu {
-                            Button(action: { copy(request.encoded) }) {
-                                Label("Copy", systemImage: "doc.on.doc")
-                            }
-                            ShareLink(item: request.encoded) {
-                                Label("Share", systemImage: "square.and.arrow.up")
-                            }
-                        }
-                        .sheet(isPresented: $showShareSheet) {
-                            ShareSheet(items: [request.encoded])
-                        }
+                    if request.displayDescription == nil {
+                        requestQRCode(request)
+                    }
 
                     if let amount = request.amount, amount > 0 {
                         if request.unit.lowercased() == "sat" {
@@ -213,6 +194,11 @@ struct CashuRequestDetailView: View {
                                 value: Double(amount)
                             )
                         }
+                    }
+
+                    if let description = request.displayDescription {
+                        DescriptionDetailRow(description: description)
+                        requestQRCode(request)
                     }
 
                     deliveryStatus(for: request)
@@ -256,9 +242,6 @@ struct CashuRequestDetailView: View {
                         } else {
                             detailRow(label: "Unit", value: request.unit.uppercased())
                         }
-                        if let description = request.displayDescription {
-                            DescriptionDetailRow(description: description)
-                        }
                         detailRow(
                             label: "Created",
                             value: request.createdAt.formatted(date: .abbreviated, time: .shortened)
@@ -269,6 +252,7 @@ struct CashuRequestDetailView: View {
                 }
                 .padding(.horizontal)
             }
+            .scrollBounceBehavior(.basedOnSize)
 
             HStack(spacing: 12) {
                 Button(action: { copy(request.encoded) }) {
@@ -326,6 +310,31 @@ struct CashuRequestDetailView: View {
             .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
         } else {
             statusBadge
+        }
+    }
+
+    private func requestQRCode(_ request: CashuRequest) -> some View {
+        QRCodeView(
+            content: request.encoded,
+            showControls: false,
+            staticOnly: true,
+            onCopy: { copy(request.encoded) },
+            onShare: { showShareSheet = true }
+        )
+        .frame(width: 280, height: 280)
+        .padding(16)
+        .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
+        .padding(.top, 8)
+        .contextMenu {
+            Button(action: { copy(request.encoded) }) {
+                Label("Copy", systemImage: "doc.on.doc")
+            }
+            ShareLink(item: request.encoded) {
+                Label("Share", systemImage: "square.and.arrow.up")
+            }
+        }
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(items: [request.encoded])
         }
     }
 

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -170,10 +170,10 @@ struct CashuRequestDetailView: View {
     @ViewBuilder
     private func content(request: CashuRequest) -> some View {
         VStack(spacing: 0) {
-            ScrollView {
-                VStack(spacing: 24) {
-                    requestQRCode(request)
-
+            PaymentDetailContent { qrSize in
+                requestQRCode(request, size: qrSize)
+            } details: {
+                VStack(spacing: 16) {
                     if let amount = request.amount, amount > 0 {
                         if request.unit.lowercased() == "sat" {
                             CurrencyAmountDisplay(
@@ -201,30 +201,24 @@ struct CashuRequestDetailView: View {
                     }
 
                     VStack(spacing: 0) {
+                        if request.rail == .ecash {
+                            editableRow(label: "Mint", value: mintDisplayValue(for: request),
+                                        action: { showMintPicker = true })
+                        } else {
+                            detailRow(label: "Mint", value: mintDisplayValue(for: request))
+                        }
+                        if let description = request.displayDescription {
+                            DescriptionDetailRow(description: description)
+                        }
                         // Only the ecash NUT-18 request can re-mint its Mint /
                         // Amount in place (that's what `regenerate` rebuilds).
                         // Quote-backed rails (BOLT12 offer, etc.) are read-only
                         // here until the unified editable detail lands.
                         if request.rail == .ecash {
-                            editableRow(
-                                label: "Mint",
-                                value: mintDisplayValue(for: request),
-                                action: { showMintPicker = true }
-                            )
-                            editableRow(
-                                label: "Amount",
-                                value: amountDisplayValue(for: request),
-                                action: { showAmountPicker = true }
-                            )
-                        } else {
-                            detailRow(
-                                label: "Mint",
-                                value: mintDisplayValue(for: request)
-                            )
-                            detailRow(
-                                label: "Amount",
-                                value: amountDisplayValue(for: request)
-                            )
+                            editableRow(label: "Amount", value: amountDisplayValue(for: request),
+                                        action: { showAmountPicker = true })
+                        } else if request.amount == nil {
+                            detailRow(label: "Amount", value: amountDisplayValue(for: request))
                         }
                         if unitEditable(for: request) {
                             editableRow(
@@ -232,7 +226,7 @@ struct CashuRequestDetailView: View {
                                 value: request.unit.uppercased(),
                                 action: { showUnitPicker = true }
                             )
-                        } else {
+                        } else if request.rail == .ecash {
                             detailRow(label: "Unit", value: request.unit.uppercased())
                         }
                         detailRow(
@@ -240,17 +234,8 @@ struct CashuRequestDetailView: View {
                             value: request.createdAt.formatted(date: .abbreviated, time: .shortened)
                         )
                     }
-                    .padding(.top, 8)
                     .padding(.horizontal, 4)
                 }
-                .padding(.horizontal)
-            }
-            .scrollBounceBehavior(.basedOnSize)
-
-            if let description = request.displayDescription {
-                DescriptionDetailRow(description: description)
-                    .padding(.horizontal)
-                    .layoutPriority(1)
             }
 
             HStack(spacing: 12) {
@@ -312,7 +297,7 @@ struct CashuRequestDetailView: View {
         }
     }
 
-    private func requestQRCode(_ request: CashuRequest) -> some View {
+    private func requestQRCode(_ request: CashuRequest, size: CGFloat) -> some View {
         QRCodeView(
             content: request.encoded,
             showControls: false,
@@ -320,10 +305,9 @@ struct CashuRequestDetailView: View {
             onCopy: { copy(request.encoded) },
             onShare: { showShareSheet = true }
         )
-        .frame(width: 280, height: 280)
+        .frame(width: size, height: size)
         .padding(16)
         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-        .padding(.top, 8)
         .contextMenu {
             Button(action: { copy(request.encoded) }) {
                 Label("Copy", systemImage: "doc.on.doc")
@@ -352,7 +336,7 @@ struct CashuRequestDetailView: View {
         }
         .font(.subheadline)
         .padding(.vertical, 12)
-        .padding(.horizontal, 8)
+        .padding(.horizontal, 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(label)
         .accessibilityValue(value)
@@ -376,7 +360,7 @@ struct CashuRequestDetailView: View {
             }
             .font(.subheadline)
             .padding(.vertical, 12)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, 4)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -44,6 +44,17 @@ struct ReceiveLightningView: View {
     @State private var showMintPicker = false
     /// Reusable BOLT12 offer: drives the Amount-row pencil → amount picker sheet.
     @State private var showReusableAmountPicker = false
+    /// Reusable BOLT12 offer: drives the Description-row pencil → editor sheet.
+    @State private var showReusableDescriptionEditor = false
+    /// Description the next reusable BOLT12 offer is minted with. Initialized
+    /// once from the newest stored offer intent for this mint so re-opening the
+    /// screen reloads the described offer instead of minting a duplicate (CDK
+    /// never returns offer descriptions — the local memo is the only record).
+    @State private var offerDescription: String?
+    @State private var offerDescriptionLoaded = false
+    // Quote creation is serialized through this handle — a new create cancels
+    // the in-flight one so the slowest task can't clobber the freshest offer.
+    @State private var quoteCreationTask: Task<Void, Never>?
     /// VoiceOver Share action for the QR cards: ShareLink can't be invoked
     /// imperatively, so the accessibility action presents the share sheet.
     @State private var showShareSheet = false
@@ -219,9 +230,14 @@ struct ReceiveLightningView: View {
             }
             .onAppear {
                 syncSelectedMethodWithActiveMint()
+                loadStoredOfferDescriptionIfNeeded()
             }
             .onChange(of: walletManager.activeMint?.id) {
                 syncSelectedMethodWithActiveMint()
+                // Drop the previous mint's description and re-restore.
+                offerDescription = nil
+                offerDescriptionLoaded = false
+                loadStoredOfferDescriptionIfNeeded()
             }
             .onChange(of: selectedMethod) {
                 requestFailure = nil
@@ -628,6 +644,16 @@ struct ReceiveLightningView: View {
                                 value: formatQuoteAmount(quote.amountIssued, unit: quote.unit)
                             )
                         }
+                        // Payer-facing offer description (what the payer sees
+                        // when paying) — editable like the amount, re-mints on
+                        // change (Android "Description" row parity).
+                        editableRow(
+                            icon: "text.alignleft",
+                            label: "Description",
+                            value: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
+                                ?? quote.description ?? "None",
+                            action: { showReusableDescriptionEditor = true }
+                        )
                         if let created = quote.createdAt {
                             detailRow(
                                 label: "Created",
@@ -655,6 +681,13 @@ struct ReceiveLightningView: View {
                 onSelect: {
                     setReusableOfferAmount($0, mintURL: quote.mintURL, unit: quote.unit)
                 }
+            )
+        }
+        .sheet(isPresented: $showReusableDescriptionEditor) {
+            ReusableOfferDescriptionSheet(
+                currentDescription: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
+                    ?? quote.description,
+                onDone: { setReusableOfferDescription($0) }
             )
         }
     }
@@ -1181,6 +1214,7 @@ struct ReceiveLightningView: View {
             amount: quote.isAmountless ? nil : quote.amount,
             unit: quote.unit,
             mints: mintURLs,
+            memo: quote.description,
             reusable: reusable,
             expiry: expiry
         )
@@ -1214,6 +1248,7 @@ struct ReceiveLightningView: View {
         onchainObservation = nil
         monitoredQuoteId = nil
         quoteStatusTask?.cancel()
+        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }
@@ -1223,7 +1258,8 @@ struct ReceiveLightningView: View {
                     amount: target,
                     method: .bolt12,
                     targetMintURL: requestedMintURL,
-                    unit: requestedUnit
+                    unit: requestedUnit,
+                    description: offerDescription
                 )
                 guard !Task.isCancelled else { return }
                 mintQuote = quote
@@ -1241,6 +1277,53 @@ struct ReceiveLightningView: View {
             }
         }
     }
+
+    /// Re-mints the reusable BOLT12 offer with a new payer-facing description
+    /// (Android `setReusableOfferDescription` parity). Blank → nil (plain
+    /// offer, reuse allowed); non-blank → a fresh offer, since offers are
+    /// immutable. The current fixed amount, if any, is preserved.
+    private func setReusableOfferDescription(_ next: String?) {
+        // Strip control/bidi characters (payer-facing text shown by third-party
+        // wallets), then cap. An explicit user choice wins over the restore.
+        let stripped = (next ?? "")
+            .unicodeScalars
+            .filter { $0.properties.generalCategory != .control || $0 == "\n" }
+            .map { String($0) }.joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        offerDescription = stripped.isEmpty ? nil : String(stripped.prefix(Self.maxOfferDescriptionLength))
+        offerDescriptionLoaded = true
+        // Use the amountless flag, not `quote.amount`: CDK may fill amount
+        // after a payment on an amountless offer, and reminting that as a
+        // fixed offer would drop reuse (Android `!quote.isAmountless` parity).
+        if let quote = mintQuote, quote.paymentMethod == .bolt12,
+           !isAmountless, let amount = quote.amount, amount > 0 {
+            setReusableOfferAmount(amount)
+        } else {
+            amountString = ""
+            loadOrCreateAmountlessOffer()
+        }
+    }
+
+    /// One-time restore of the mint's last-used offer description, so a
+    /// re-open reloads the described offer (memo match) instead of silently
+    /// reverting to the plain one.
+    private func loadStoredOfferDescriptionIfNeeded() {
+        guard !offerDescriptionLoaded else { return }
+        guard let mintUrl = walletManager.activeMint?.url else { return }
+        offerDescription = CashuRequestStore.shared.requests
+            .filter {
+                $0.rail == .bolt12 && $0.mints.contains(mintUrl) &&
+                // Only amountless reusable intents — a memo from a one-off
+                // fixed quote must not leak into the reusable offer.
+                $0.amount == nil
+            }
+            .max(by: { $0.createdAt < $1.createdAt })?
+            .memo
+        offerDescriptionLoaded = true
+    }
+
+    /// Defensive cap for the payer-facing BOLT12 offer description.
+    static let maxOfferDescriptionLength = 640
 
     /// Reopen the mint's existing amountless offer by default. The explicit new
     /// action deliberately bypasses that lookup and leaves the prior offer valid.
@@ -1263,6 +1346,7 @@ struct ReceiveLightningView: View {
         expiryTimeRemaining = 0
         quoteStatusTask?.cancel()
         expiryTimer?.invalidate()
+        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }
@@ -1272,7 +1356,8 @@ struct ReceiveLightningView: View {
                 if !forceNew,
                    let existing = try await walletManager.existingAmountlessOffer(
                        mintURL: requestedMintURL,
-                       unit: requestedUnit
+                       unit: requestedUnit,
+                       description: offerDescription
                    ) {
                     quote = existing
                 } else {
@@ -1280,7 +1365,8 @@ struct ReceiveLightningView: View {
                         amount: nil,
                         method: .bolt12,
                         targetMintURL: requestedMintURL,
-                        unit: requestedUnit
+                        unit: requestedUnit,
+                        description: offerDescription
                     )
                 }
                 guard !Task.isCancelled else { return }
@@ -1332,6 +1418,7 @@ struct ReceiveLightningView: View {
         expiryTimeRemaining = 0
         quoteStatusTask?.cancel()
         expiryTimer?.invalidate()
+        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }
@@ -1346,7 +1433,8 @@ struct ReceiveLightningView: View {
                         amount: requestAmount,
                         method: requestMethod,
                         targetMintURL: requestedMintURL,
-                        unit: requestedUnit
+                        unit: requestedUnit,
+                        description: requestMethod == .bolt12 ? offerDescription : nil
                     )
                 }
                 guard !Task.isCancelled else { return }

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -241,6 +241,10 @@ struct ReceiveLightningView: View {
                 offerDescriptionLoaded = false
                 loadStoredOfferDescriptionIfNeeded()
             }
+            .onChange(of: effectiveUnit) {
+                offerDescriptionLoaded = false
+                loadStoredOfferDescriptionIfNeeded()
+            }
             .onChange(of: selectedMethod) {
                 requestFailure = nil
                 onchainObservation = nil
@@ -1233,6 +1237,7 @@ struct ReceiveLightningView: View {
             reusable: reusable,
             expiry: expiry
         )
+        CashuRequestStore.shared.markQuotePresented(quote.id)
     }
 
     /// Re-mints the reusable BOLT12 offer at a new amount, driven by the Amount-row
@@ -1297,14 +1302,7 @@ struct ReceiveLightningView: View {
     /// offer, reuse allowed); non-blank → a fresh offer, since offers are
     /// immutable. The current fixed amount, if any, is preserved.
     private func setReusableOfferDescription(_ next: String?) {
-        // Strip control/bidi characters (payer-facing text shown by third-party
-        // wallets), then cap. An explicit user choice wins over the restore.
-        let stripped = (next ?? "")
-            .unicodeScalars
-            .filter { $0.properties.generalCategory != .control || $0 == "\n" }
-            .map { String($0) }.joined()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        offerDescription = stripped.isEmpty ? nil : String(stripped.prefix(Self.maxOfferDescriptionLength))
+        offerDescription = MintQuoteDomain.normalizedOfferDescription(next)
         offerDescriptionLoaded = true
         // Use the amountless flag, not `quote.amount`: CDK may fill amount
         // after a payment on an amountless offer, and reminting that as a
@@ -1329,15 +1327,8 @@ struct ReceiveLightningView: View {
             offerDescriptionLoaded = true
             return
         }
-        offerDescription = CashuRequestStore.shared.requests
-            .filter {
-                $0.rail == .bolt12 && $0.mints.contains(mintUrl) &&
-                // Only amountless reusable intents — a memo from a one-off
-                // fixed quote must not leak into the reusable offer.
-                $0.amount == nil
-            }
-            .max(by: { $0.createdAt < $1.createdAt })?
-            .memo
+        offerDescription = CashuRequestStore.shared
+            .lastPresentedAmountlessOffer(mintURL: mintUrl, unit: effectiveUnit)?.memo
         offerDescriptionLoaded = true
     }
 

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -47,8 +47,8 @@ struct ReceiveLightningView: View {
     /// Reusable BOLT12 offer: drives the Description-row pencil → editor sheet.
     @State private var showReusableDescriptionEditor = false
     /// Description the next reusable BOLT12 offer is minted with. Initialized
-    /// once from the newest stored offer intent for this mint so re-opening the
-    /// screen reloads the described offer instead of minting a duplicate (CDK
+    /// once from the last presented amountless offer for this mint and unit, so
+    /// reopening reloads the described offer instead of minting a duplicate (CDK
     /// never returns offer descriptions — the local memo is the only record).
     @State private var offerDescription: String?
     @State private var offerDescriptionLoaded = false
@@ -1308,7 +1308,7 @@ struct ReceiveLightningView: View {
         // after a payment on an amountless offer, and reminting that as a
         // fixed offer would drop reuse (Android `!quote.isAmountless` parity).
         if let quote = mintQuote, quote.paymentMethod == .bolt12,
-           !isAmountless, let amount = quote.amount, amount > 0 {
+           !quote.isAmountless, let amount = quote.amount, amount > 0 {
             setReusableOfferAmount(amount)
         } else {
             amountString = ""

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -239,6 +239,11 @@ struct ReceiveLightningView: View {
                 offerDescriptionLoaded = false
                 loadStoredOfferDescriptionIfNeeded()
             }
+            .onChange(of: mintSupportsBolt12Description) {
+                offerDescription = nil
+                offerDescriptionLoaded = false
+                loadStoredOfferDescriptionIfNeeded()
+            }
             .onChange(of: selectedMethod) {
                 requestFailure = nil
                 onchainObservation = nil
@@ -297,6 +302,17 @@ struct ReceiveLightningView: View {
         let methods = walletManager.activeMint?.supportedMintMethods ?? [.bolt11]
         let orderedMethods = PaymentMethodKind.allCases.filter { methods.contains($0) }
         return orderedMethods.isEmpty ? [.bolt11] : orderedMethods
+    }
+
+    /// Fail closed: only mints that advertised NUT-04 bolt12 description=true
+    /// get a Description row / description minting.
+    private var mintSupportsBolt12Description: Bool {
+        walletManager.activeMint?.supportsBolt12MintDescription == true
+    }
+
+    /// Description threaded into mintQuote only when the mint advertises it.
+    private var advertisedOfferDescription: String? {
+        mintSupportsBolt12Description ? offerDescription : nil
     }
 
     /// Picker rows are derived from the mint's supported payment methods.
@@ -644,16 +660,17 @@ struct ReceiveLightningView: View {
                                 value: formatQuoteAmount(quote.amountIssued, unit: quote.unit)
                             )
                         }
-                        // Payer-facing offer description (what the payer sees
-                        // when paying) — editable like the amount, re-mints on
-                        // change (Android "Description" row parity).
-                        editableRow(
-                            icon: "text.alignleft",
-                            label: "Description",
-                            value: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
-                                ?? quote.description ?? "None",
-                            action: { showReusableDescriptionEditor = true }
-                        )
+                        // Payer-facing offer description — only when the mint
+                        // advertised NUT-04 bolt12 MintMethodSettings.description.
+                        if mintSupportsBolt12Description {
+                            editableRow(
+                                icon: "text.alignleft",
+                                label: "Description",
+                                value: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
+                                    ?? quote.description ?? "None",
+                                action: { showReusableDescriptionEditor = true }
+                            )
+                        }
                         if let created = quote.createdAt {
                             detailRow(
                                 label: "Created",
@@ -684,11 +701,13 @@ struct ReceiveLightningView: View {
             )
         }
         .sheet(isPresented: $showReusableDescriptionEditor) {
-            ReusableOfferDescriptionSheet(
-                currentDescription: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
-                    ?? quote.description,
-                onDone: { setReusableOfferDescription($0) }
-            )
+            if mintSupportsBolt12Description {
+                ReusableOfferDescriptionSheet(
+                    currentDescription: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
+                        ?? quote.description,
+                    onDone: { setReusableOfferDescription($0) }
+                )
+            }
         }
     }
 
@@ -1259,7 +1278,7 @@ struct ReceiveLightningView: View {
                     method: .bolt12,
                     targetMintURL: requestedMintURL,
                     unit: requestedUnit,
-                    description: offerDescription
+                    description: advertisedOfferDescription
                 )
                 guard !Task.isCancelled else { return }
                 mintQuote = quote
@@ -1310,6 +1329,11 @@ struct ReceiveLightningView: View {
     private func loadStoredOfferDescriptionIfNeeded() {
         guard !offerDescriptionLoaded else { return }
         guard let mintUrl = walletManager.activeMint?.url else { return }
+        guard mintSupportsBolt12Description else {
+            offerDescription = nil
+            offerDescriptionLoaded = true
+            return
+        }
         offerDescription = CashuRequestStore.shared.requests
             .filter {
                 $0.rail == .bolt12 && $0.mints.contains(mintUrl) &&
@@ -1357,7 +1381,7 @@ struct ReceiveLightningView: View {
                    let existing = try await walletManager.existingAmountlessOffer(
                        mintURL: requestedMintURL,
                        unit: requestedUnit,
-                       description: offerDescription
+                       description: advertisedOfferDescription
                    ) {
                     quote = existing
                 } else {
@@ -1366,7 +1390,7 @@ struct ReceiveLightningView: View {
                         method: .bolt12,
                         targetMintURL: requestedMintURL,
                         unit: requestedUnit,
-                        description: offerDescription
+                        description: advertisedOfferDescription
                     )
                 }
                 guard !Task.isCancelled else { return }
@@ -1434,7 +1458,7 @@ struct ReceiveLightningView: View {
                         method: requestMethod,
                         targetMintURL: requestedMintURL,
                         unit: requestedUnit,
-                        description: requestMethod == .bolt12 ? offerDescription : nil
+                        description: requestMethod == .bolt12 ? advertisedOfferDescription : nil
                     )
                 }
                 guard !Task.isCancelled else { return }

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -566,122 +566,82 @@ struct ReceiveLightningView: View {
     /// on-chain keep the amount-hero + expiry-countdown layout in
     /// `standardRequestDisplayView`.
     @ViewBuilder
+    /// Every receive rail shares the same QR, amount, status, inspector, and actions.
     private func requestDisplayView(quote: MintQuoteInfo) -> some View {
-        if quote.paymentMethod == .bolt12 {
-            reusableOfferDisplayView(quote: quote)
-                .onAppear {
-                    persistReceiveIntent(for: quote)
-                    startQuoteMonitoring(for: quote)
-                }
-                .onChange(of: mintQuote?.id) { _, _ in
-                    if let quote = mintQuote {
-                        persistReceiveIntent(for: quote)
-                        startQuoteMonitoring(for: quote)
-                    }
-                }
-        } else {
-            standardRequestDisplayView(quote: quote)
-        }
-    }
-
-    /// Cashu-Request-style screen for a reusable BOLT12 offer: QR → (amount hero,
-    /// if fixed) → status → read-only Mint / editable Amount / Created rows → Copy.
-    /// Share + New live in the toolbar overflow menu so primary chrome stays calm.
-    /// Editing the Amount row mints a fresh fixed-amount offer (or reverts to the
-    /// amountless one) — that's how a fixed-amount reusable invoice is made.
-    /// No expiry countdown, no rotate affordance.
-    private func reusableOfferDisplayView(quote: MintQuoteInfo) -> some View {
         VStack(spacing: 0) {
-            ScrollView {
-                VStack(spacing: 24) {
-                    QRCodeView(
-                        content: quote.request,
-                        showControls: false,
-                        staticOnly: true,
-                        onCopy: { copyRequest(quote.request) },
-                        onShare: { shareQuoteRequest(quote.request) }
-                    )
-                        .frame(width: 280, height: 280)
-                        .padding(16)
-                        .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-                        .padding(.top, 8)
-                        .contextMenu {
-                            Button(action: { copyRequest(quote.request) }) {
-                                Label("Copy", systemImage: "doc.on.doc")
-                            }
-                            ShareLink(item: quote.request) {
-                                Label("Share", systemImage: "square.and.arrow.up")
-                            }
-                            Button {
-                                createNewAmountlessOffer(for: quote)
-                            } label: {
-                                Label("New reusable invoice", systemImage: "arrow.2.squarepath")
-                            }
-                            .disabled(isCreatingRequest)
-                        }
-                        .sheet(isPresented: $showShareSheet) {
-                            ShareSheet(items: [qrShareText])
-                        }
-
-                    if !quote.isAmountless, let amount = quote.amount, amount > 0 {
-                        if quote.unit.lowercased() == "sat" {
-                            CurrencyAmountDisplay(
-                                sats: amount,
-                                primary: $settings.amountDisplayPrimary,
-                                role: .amountCompact
-                            )
-                            .accessibilityLabel("Offer amount: \(amount) sats")
-                        } else {
-                            AmountLockup(
-                                parts: AmountParts.parse(formatQuoteAmount(amount, unit: quote.unit)),
-                                role: .amountCompact,
-                                value: Double(amount),
-                                accessibilityPrefix: "Offer amount"
-                            )
-                        }
+            PaymentDetailContent { qrSize in
+                QRCodeView(
+                    content: quote.request,
+                    showControls: false,
+                    staticOnly: true,
+                    onCopy: { copyRequest(quote.request) },
+                    onShare: { shareQuoteRequest(quote.request) }
+                )
+                .frame(width: qrSize, height: qrSize)
+                .padding(16)
+                .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
+                .contextMenu {
+                    Button(action: { copyRequest(quote.request) }) {
+                        Label("Copy", systemImage: "doc.on.doc")
                     }
-
+                    ShareLink(item: quote.request) {
+                        Label("Share", systemImage: "square.and.arrow.up")
+                    }
+                }
+                .sheet(isPresented: $showShareSheet) {
+                    ShareSheet(items: [qrShareText])
+                }
+            } details: {
+                VStack(spacing: 16) {
+                    if !quote.isAmountless { amountSummary(for: quote) }
                     statusBadge
 
-                    VStack(spacing: 0) {
-                        detailRow(
-                            label: "Mint",
-                            value: mintDisplayValue(for: quote) ?? "Unknown mint"
-                        )
-                        editableRow(
-                            label: "Amount",
-                            value: quote.isAmountless
-                                ? "Any"
-                                : quote.amount.flatMap { $0 > 0 ? formatQuoteAmount($0, unit: quote.unit) : nil } ?? "Any",
-                            action: { showReusableAmountPicker = true }
-                        )
-                        if quote.amountIssued > 0 {
-                            detailRow(
-                                label: "Total received",
-                                value: formatQuoteAmount(quote.amountIssued, unit: quote.unit)
-                            )
+                    if quote.paymentMethod != .bolt12,
+                       !isPaid && !isExpired && expiryTimeRemaining > 0 {
+                        HStack(spacing: 5) {
+                            Image(systemName: "timer").font(.caption2)
+                            Text("Expires in \(formatTimeRemaining(expiryTimeRemaining))")
+                                .font(.footnote)
                         }
-                        // Payer-facing offer description — only when the mint
-                        // advertised NUT-04 bolt12 MintMethodSettings.description.
-                        if mintSupportsBolt12Description {
+                        .foregroundStyle(expiryTimeRemaining < 60
+                            ? ErrorSeverity.error.foreground : Color.primary.opacity(0.5))
+                    }
+
+                    VStack(spacing: 0) {
+                        detailRow(label: "Mint", value: mintDisplayValue(for: quote) ?? "Unknown mint")
+                        if quote.paymentMethod == .bolt12 && mintSupportsBolt12Description {
                             editableRow(
                                 label: "Description",
                                 value: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
                                     ?? quote.description ?? "None",
                                 action: { showReusableDescriptionEditor = true }
                             )
+                        } else if let description = CashuRequestStore.shared.intent(forQuoteId: quote.id)?.displayDescription
+                            ?? MintQuoteDomain.normalizedOfferDescription(quote.description) {
+                            DescriptionDetailRow(description: description)
                         }
-                        if let created = quote.createdAt {
-                            detailRow(
-                                label: "Created",
-                                value: created.formatted(date: .abbreviated, time: .shortened)
+                        if quote.paymentMethod == .bolt12 {
+                            editableRow(
+                                label: "Amount",
+                                value: quote.isAmountless ? "Any"
+                                    : quote.amount.map { formatQuoteAmount($0, unit: quote.unit) } ?? "Any",
+                                action: { showReusableAmountPicker = true }
                             )
+                            if quote.amountIssued > 0 {
+                                detailRow(label: "Total received",
+                                          value: formatQuoteAmount(quote.amountIssued, unit: quote.unit))
+                            }
+                        }
+                        if let created = quote.createdAt ?? quoteCreatedAt {
+                            detailRow(label: "Created",
+                                      value: created.formatted(date: .abbreviated, time: .shortened))
+                        }
+                        if let explorerURL = blockExplorerURL(for: quote) {
+                            explorerLinkRow(label: blockExplorerLabel(for: quote), url: explorerURL)
                         }
                     }
-                    .padding(.top, 8)
                     .padding(.horizontal, 4)
                 }
-                .padding(.horizontal)
             }
 
             Button(action: { copyRequest(quote.request) }) {
@@ -691,13 +651,15 @@ struct ReceiveLightningView: View {
             .padding(.horizontal)
             .padding(.bottom, 16)
         }
+        .onAppear { startDisplayingQuote(quote) }
+        .onChange(of: mintQuote?.id) {
+            if let quote = mintQuote { startDisplayingQuote(quote) }
+        }
         .sheet(isPresented: $showReusableAmountPicker) {
             CashuRequestAmountPickerSheet(
                 currentAmount: quote.isAmountless ? nil : quote.amount,
                 unit: quote.unit,
-                onSelect: {
-                    setReusableOfferAmount($0, mintURL: quote.mintURL, unit: quote.unit)
-                }
+                onSelect: { setReusableOfferAmount($0, mintURL: quote.mintURL, unit: quote.unit) }
             )
         }
         .sheet(isPresented: $showReusableDescriptionEditor) {
@@ -709,6 +671,12 @@ struct ReceiveLightningView: View {
                 )
             }
         }
+    }
+
+    private func startDisplayingQuote(_ quote: MintQuoteInfo) {
+        if quote.paymentMethod == .bolt12 { persistReceiveIntent(for: quote) }
+        startQuoteMonitoring(for: quote)
+        if quote.paymentMethod != .bolt12 { startExpiryCountdown(quote: quote) }
     }
 
     /// Friendly name of the quote's issuing mint. A quote remains bound to this
@@ -751,86 +719,6 @@ struct ReceiveLightningView: View {
             ))
         }
         return rows
-    }
-
-    private func standardRequestDisplayView(quote: MintQuoteInfo) -> some View {
-        VStack(spacing: 0) {
-            ScrollView {
-                VStack(spacing: 24) {
-                    QRCodeView(
-                        content: quote.request,
-                        showControls: false,
-                        staticOnly: true,
-                        onCopy: { copyRequest(quote.request) },
-                        onShare: { shareQuoteRequest(quote.request) }
-                    )
-                        .frame(width: 280, height: 280)
-                        .padding(16)
-                        .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-                        .padding(.top, 8)
-                        .contextMenu {
-                            Button(action: { copyRequest(quote.request) }) {
-                                Label("Copy", systemImage: "doc.on.doc")
-                            }
-                            ShareLink(item: quote.request) {
-                                Label("Share", systemImage: "square.and.arrow.up")
-                            }
-                        }
-                        .sheet(isPresented: $showShareSheet) {
-                            ShareSheet(items: [qrShareText])
-                        }
-
-                    amountSummary(for: quote)
-
-                    statusBadge
-
-                    if !isPaid && !isExpired && expiryTimeRemaining > 0 {
-                        // Plain caption, no pill — fewer surfaces.
-                        HStack(spacing: 5) {
-                            Image(systemName: "timer")
-                                .font(.caption2)
-                            Text("Expires in \(formatTimeRemaining(expiryTimeRemaining))")
-                                .font(.footnote)
-                        }
-                        .foregroundStyle(expiryTimeRemaining < 60 ? ErrorSeverity.error.foreground : Color.primary.opacity(0.5))
-                    }
-
-                    if walletManager.activeMint != nil || blockExplorerURL(for: quote) != nil {
-                        VStack(spacing: 0) {
-                            if let mint = walletManager.activeMint {
-                                detailRow(
-                                    label: "Mint",
-                                    value: extractMintHost(mint.url)
-                                )
-                            }
-                            if let explorerURL = blockExplorerURL(for: quote) {
-                                explorerLinkRow(label: blockExplorerLabel(for: quote), url: explorerURL)
-                            }
-                        }
-                        .padding(.top, 8)
-                        .padding(.horizontal, 4)
-                    }
-                }
-                .padding(.horizontal)
-            }
-
-            Button(action: { copyRequest(quote.request) }) {
-                Text(copyButtonTitle(for: quote))
-            }
-            .flatSheetSecondaryButton()
-            .padding(.horizontal)
-            .padding(.bottom, 16)
-        }
-        .onAppear {
-            startQuoteMonitoring(for: quote)
-            startExpiryCountdown(quote: quote)
-        }
-        .onChange(of: mintQuote?.id) { _, _ in
-            if let quote = mintQuote {
-                startQuoteMonitoring(for: quote)
-                startExpiryCountdown(quote: quote)
-            }
-        }
     }
 
     private func amountSummary(for quote: MintQuoteInfo) -> some View {
@@ -891,7 +779,7 @@ struct ReceiveLightningView: View {
         }
         .font(.subheadline)
         .padding(.horizontal, 4)
-        .padding(.vertical, 14)
+        .padding(.vertical, 12)
     }
 
     /// Same as `detailRow` but tappable, with a trailing pencil — used for the
@@ -914,7 +802,7 @@ struct ReceiveLightningView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -936,7 +824,7 @@ struct ReceiveLightningView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -664,7 +664,6 @@ struct ReceiveLightningView: View {
                         // advertised NUT-04 bolt12 MintMethodSettings.description.
                         if mintSupportsBolt12Description {
                             editableRow(
-                                icon: "text.alignleft",
                                 label: "Description",
                                 value: CashuRequestStore.shared.intent(forQuoteId: quote.id)?.memo
                                     ?? quote.description ?? "None",

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -52,9 +52,6 @@ struct ReceiveLightningView: View {
     /// never returns offer descriptions — the local memo is the only record).
     @State private var offerDescription: String?
     @State private var offerDescriptionLoaded = false
-    // Quote creation is serialized through this handle — a new create cancels
-    // the in-flight one so the slowest task can't clobber the freshest offer.
-    @State private var quoteCreationTask: Task<Void, Never>?
     /// VoiceOver Share action for the QR cards: ShareLink can't be invoked
     /// imperatively, so the accessibility action presents the share sheet.
     @State private var showShareSheet = false
@@ -1266,7 +1263,6 @@ struct ReceiveLightningView: View {
         onchainObservation = nil
         monitoredQuoteId = nil
         quoteStatusTask?.cancel()
-        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }
@@ -1318,7 +1314,7 @@ struct ReceiveLightningView: View {
             setReusableOfferAmount(amount)
         } else {
             amountString = ""
-            loadOrCreateAmountlessOffer()
+            loadOrCreateAmountlessOffer(mintURL: mintQuote?.mintURL, unit: mintQuote?.unit)
         }
     }
 
@@ -1369,7 +1365,6 @@ struct ReceiveLightningView: View {
         expiryTimeRemaining = 0
         quoteStatusTask?.cancel()
         expiryTimer?.invalidate()
-        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }
@@ -1441,7 +1436,6 @@ struct ReceiveLightningView: View {
         expiryTimeRemaining = 0
         quoteStatusTask?.cancel()
         expiryTimer?.invalidate()
-        quoteCreationTask?.cancel()
 
         requestCreationTask = Task { @MainActor in
             defer { if !Task.isCancelled { isCreatingRequest = false } }

--- a/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
+++ b/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
@@ -26,21 +26,32 @@ struct ReusableOfferDescriptionSheet: View {
         VStack(spacing: 0) {
             header
 
-            TextField(
-                "e.g. Coffee tips",
-                text: $description,
-                axis: .vertical
-            )
-            .lineLimit(2...4)
-            .textFieldStyle(.roundedBorder)
+            // Same glass input as Receive/Send destination fields. Stock
+            // `.roundedBorder` is a different visual system next to the glass
+            // Done button and sheet chrome. Persistent label (not a
+            // placeholder doing double duty) matches Add mint / Android's
+            // floating CashuTextField label.
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Description shown to the payer")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.bottom, 6)
+
+                TextField("e.g. Coffee tips", text: $description, axis: .vertical)
+                    .font(.body)
+                    .lineLimit(2...4)
+                    .accessibilityLabel("Description shown to the payer")
+                    .onChange(of: description) { _, newValue in
+                        if newValue.count > ReceiveLightningView.maxOfferDescriptionLength {
+                            description = String(newValue.prefix(ReceiveLightningView.maxOfferDescriptionLength))
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 14)
+                    .liquidGlassInput(in: RoundedRectangle(cornerRadius: 12))
+            }
             .padding(.horizontal)
             .padding(.top, 16)
-            .accessibilityLabel("Description shown to the payer")
-            .onChange(of: description) { _, newValue in
-                if newValue.count > ReceiveLightningView.maxOfferDescriptionLength {
-                    description = String(newValue.prefix(ReceiveLightningView.maxOfferDescriptionLength))
-                }
-            }
 
             Spacer(minLength: 0)
 

--- a/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
+++ b/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// Description edit sheet for a reusable BOLT12 offer (Android
+/// `ReusableDescriptionEditSheet` parity). The text is embedded in the offer
+/// payers receive. Seeded verbatim from the current offer's stored memo;
+/// never from profile or mint metadata. Empty → removes the description
+/// (plain offer).
+struct ReusableOfferDescriptionSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Current offer description, if any (`nil` = plain offer).
+    let currentDescription: String?
+    /// Called with the new description on Done (`nil` = removed). Sheet
+    /// dismisses afterwards.
+    let onDone: (String?) -> Void
+
+    @State private var description: String
+
+    init(currentDescription: String?, onDone: @escaping (String?) -> Void) {
+        self.currentDescription = currentDescription
+        self.onDone = onDone
+        self._description = State(initialValue: currentDescription ?? "")
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            TextField(
+                "e.g. Coffee tips",
+                text: $description,
+                axis: .vertical
+            )
+            .lineLimit(2...4)
+            .textFieldStyle(.roundedBorder)
+            .padding(.horizontal)
+            .padding(.top, 16)
+            .accessibilityLabel("Description shown to the payer")
+            .onChange(of: description) { _, newValue in
+                if newValue.count > ReceiveLightningView.maxOfferDescriptionLength {
+                    description = String(newValue.prefix(ReceiveLightningView.maxOfferDescriptionLength))
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button(action: confirm) {
+                Text("Done")
+            }
+            .glassButton()
+            .padding(.horizontal)
+            .padding(.top, 16)
+            .padding(.bottom, 16)
+        }
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var header: some View {
+        ZStack {
+            Text("Description")
+                .font(.headline)
+
+            HStack {
+                SheetCloseButton()
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+            }
+            .padding(.horizontal)
+        }
+        .padding(.top, 8)
+    }
+
+    private func confirm() {
+        let trimmed = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        onDone(trimmed.isEmpty ? nil : trimmed)
+        dismiss()
+    }
+}

--- a/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
+++ b/ios/CashuWallet/Views/Receive/ReusableOfferDescriptionSheet.swift
@@ -1,92 +1,92 @@
 import SwiftUI
 
-/// Description edit sheet for a reusable BOLT12 offer (Android
-/// `ReusableDescriptionEditSheet` parity). The text is embedded in the offer
-/// payers receive. Seeded verbatim from the current offer's stored memo;
-/// never from profile or mint metadata. Empty → removes the description
-/// (plain offer).
+/// Edits the payer-facing memo of a reusable BOLT12 offer. A blank draft
+/// removes the description; closing the sheet leaves the offer unchanged.
 struct ReusableOfferDescriptionSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    /// Current offer description, if any (`nil` = plain offer).
-    let currentDescription: String?
-    /// Called with the new description on Done (`nil` = removed). Sheet
-    /// dismisses afterwards.
     let onDone: (String?) -> Void
 
     @State private var description: String
+    @State private var contentHeight: CGFloat = 0
+    @FocusState private var descriptionFocused: Bool
 
     init(currentDescription: String?, onDone: @escaping (String?) -> Void) {
-        self.currentDescription = currentDescription
         self.onDone = onDone
         self._description = State(initialValue: currentDescription ?? "")
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-
-            // Same glass input as Receive/Send destination fields. Stock
-            // `.roundedBorder` is a different visual system next to the glass
-            // Done button and sheet chrome. Persistent label (not a
-            // placeholder doing double duty) matches Add mint / Android's
-            // floating CashuTextField label.
+        NavigationStack {
             VStack(alignment: .leading, spacing: 0) {
-                Text("Description shown to the payer")
-                    .font(.footnote)
+                Text("Add a note for anyone paying this invoice.")
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
-                    .padding(.bottom, 6)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, 16)
 
                 TextField("e.g. Coffee tips", text: $description, axis: .vertical)
                     .font(.body)
-                    .lineLimit(2...4)
-                    .accessibilityLabel("Description shown to the payer")
+                    .textFieldStyle(.plain)
+                    .lineLimit(3...5)
+                    .textInputAutocapitalization(.sentences)
+                    .focused($descriptionFocused)
+                    .accessibilityLabel("Description")
+                    .accessibilityHint("Shown to the payer. Leave blank to remove.")
+                    .accessibilityIdentifier("reusable-description-field")
                     .onChange(of: description) { _, newValue in
                         if newValue.count > ReceiveLightningView.maxOfferDescriptionLength {
                             description = String(newValue.prefix(ReceiveLightningView.maxOfferDescriptionLength))
                         }
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 14)
-                    .liquidGlassInput(in: RoundedRectangle(cornerRadius: 12))
-            }
-            .padding(.horizontal)
-            .padding(.top, 16)
+                    .padding(16)
+                    .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 16))
 
-            Spacer(minLength: 0)
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Leave blank to remove.")
+                    Spacer(minLength: 8)
+                    Text("\(description.count) / \(ReceiveLightningView.maxOfferDescriptionLength)")
+                        .monospacedDigit()
+                        .accessibilityLabel("\(description.count) of \(ReceiveLightningView.maxOfferDescriptionLength) characters")
+                }
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.top, 8)
+                .padding(.bottom, 24)
 
-            Button(action: confirm) {
-                Text("Done")
+                Button("Save", action: confirm)
+                    .glassButton()
+                    .accessibilityIdentifier("reusable-description-save")
             }
-            .glassButton()
-            .padding(.horizontal)
-            .padding(.top, 16)
+            .padding(.horizontal, 20)
+            .padding(.top, 8)
             .padding(.bottom, 16)
-        }
-        .presentationDetents([.medium])
-        .presentationDragIndicator(.visible)
-    }
-
-    private var header: some View {
-        ZStack {
-            Text("Description")
-                .font(.headline)
-
-            HStack {
-                SheetCloseButton()
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(.secondary)
-
-                Spacer()
+            .contentFitMeasured { contentHeight = $0 }
+            .navigationTitle("Description")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton()
+                }
             }
-            .padding(.horizontal)
         }
-        .padding(.top, 8)
+        .contentFitDetent(contentHeight, estimate: 290)
+        .presentationDragIndicator(.visible)
+        .compactBottomSheetSurface()
+        .task { descriptionFocused = true }
     }
 
     private func confirm() {
+        HapticFeedback.selection()
         let trimmed = description.trimmingCharacters(in: .whitespacesAndNewlines)
         onDone(trimmed.isEmpty ? nil : trimmed)
         dismiss()
+    }
+}
+
+#Preview {
+    Color.clear.sheet(isPresented: .constant(true)) {
+        ReusableOfferDescriptionSheet(currentDescription: "Coffee tips") { _ in }
     }
 }

--- a/ios/CashuWalletTests/MintQuoteDomainTests.swift
+++ b/ios/CashuWalletTests/MintQuoteDomainTests.swift
@@ -109,28 +109,41 @@ final class LiveBolt12DescriptionTests: XCTestCase {
     func testLiveOffersEncodeDescriptionsAndPreserveAmounts() async throws {
         let url = try XCTUnwrap(ProcessInfo.processInfo.environment["BOLT12_DESCRIPTION_MINT_URL"],
                                 "Set BOLT12_DESCRIPTION_MINT_URL to enable this test")
-        let database = try WalletSqliteDatabase.newInMemory()
-        let repository = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: database))
-        try await repository.createWallet(mintUrl: MintUrl(url: url), unit: .sat, targetProofCount: nil)
-        let mint = MintInfo(url: url, name: "Live test mint", isActive: true, balance: 0)
-        let service = LightningService(walletRepository: { repository }, walletDatabase: { database }, getActiveMint: { mint })
-        let plain = try await service.createMintQuote(amount: nil, method: .bolt12)
-        XCTAssertNil(try decodeInvoice(invoiceStr: plain.request).amountMsat)
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        weak var releasedDatabase: LifecycleSafeWalletDatabase?
+        do {
+            let database = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("wallet.sqlite").path)
+            releasedDatabase = database
+            let repository = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: database))
+            try await repository.createWallet(mintUrl: MintUrl(url: url), unit: .sat, targetProofCount: nil)
+            let mint = MintInfo(url: url, name: "Live test mint", isActive: true, balance: 0)
+            let service = LightningService(walletRepository: { repository }, walletDatabase: { database }, getActiveMint: { mint })
+            let plain = try await service.createMintQuote(amount: nil, method: .bolt12)
+            XCTAssertNil(try decodeInvoice(invoiceStr: plain.request).amountMsat)
 
-        for description in ["Coffee tips\nThank you ☕", "Updated coffee note", String(repeating: "a", count: 640)] {
-            let quote = try await service.createMintQuote(amount: nil, method: .bolt12, description: description)
-            let decoded = try decodeInvoice(invoiceStr: quote.request)
-            XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " "))
-            XCTAssertNil(decoded.amountMsat)
-            XCTAssertNotEqual(quote.request, plain.request)
+            for description in ["Coffee tips\nThank you ☕", "Updated coffee note", String(repeating: "a", count: 640)] {
+                let quote = try await service.createMintQuote(amount: nil, method: .bolt12, description: description)
+                let decoded = try decodeInvoice(invoiceStr: quote.request)
+                XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " "))
+                XCTAssertNil(decoded.amountMsat)
+                XCTAssertNotEqual(quote.request, plain.request)
+            }
+            for description in ["Fixed amount coffee", "Edited fixed amount", nil] {
+                let quote = try await service.createMintQuote(amount: 21, method: .bolt12, description: description)
+                let decoded = try decodeInvoice(invoiceStr: quote.request)
+                XCTAssertEqual(decoded.amountMsat, 21_000)
+                if let description { XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " ")) }
+                else { XCTAssertEqual(decoded.description, try decodeInvoice(invoiceStr: plain.request).description) }
+            }
         }
-        for description in ["Fixed amount coffee", "Edited fixed amount", nil] {
-            let quote = try await service.createMintQuote(amount: 21, method: .bolt12, description: description)
-            let decoded = try decodeInvoice(invoiceStr: quote.request)
-            XCTAssertEqual(decoded.amountMsat, 21_000)
-            if let description { XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " ")) }
-            else { XCTAssertEqual(decoded.description, try decodeInvoice(invoiceStr: plain.request).description) }
+        // Let native writer teardown finish in this test, not in the next one.
+        let deadline = Date().addingTimeInterval(3)
+        while releasedDatabase != nil, Date() < deadline {
+            try await Task.sleep(for: .milliseconds(20))
         }
+        XCTAssertNil(releasedDatabase)
     }
 
     override func setUpWithError() throws {

--- a/ios/CashuWalletTests/MintQuoteDomainTests.swift
+++ b/ios/CashuWalletTests/MintQuoteDomainTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import CashuWallet
+
+final class MintQuoteDomainTests: XCTestCase {
+    func testReusableOfferReuseMatchesDescriptionExactly() {
+        XCTAssertTrue(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+        XCTAssertTrue(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: "Coffee tips", description: "Coffee tips"
+        ))
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: "Coffee tips", description: "Different memo"
+        ))
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: "Coffee tips", description: nil
+        ))
+    }
+
+    func testReusableOfferMatchRejectsOtherRailsAndFixedAmounts() {
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt11, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: false,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: nil, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+    }
+
+    func testReusableOfferMatchRejectsWrongMintOrUnit() {
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://other.example", quoteUnit: "sat",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+        // Unit match is case-insensitive (Android parity).
+        XCTAssertTrue(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "SAT",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+        XCTAssertFalse(MintQuoteDomain.isReusableAmountlessOffer(
+            paymentMethod: .bolt12, isAmountless: true,
+            quoteMintUrl: "https://mint.example", quoteUnit: "usd",
+            activeMintUrl: "https://mint.example", unit: "sat",
+            storedMemo: nil, description: nil
+        ))
+    }
+}

--- a/ios/CashuWalletTests/MintQuoteDomainTests.swift
+++ b/ios/CashuWalletTests/MintQuoteDomainTests.swift
@@ -1,7 +1,15 @@
+import Cdk
 import XCTest
 @testable import CashuWallet
 
 final class MintQuoteDomainTests: XCTestCase {
+    func testNormalizesDescriptionForPayerDisplay() {
+        XCTAssertEqual(MintQuoteDomain.normalizedOfferDescription("  Coffee tips\r\n\tThank you ☕  "), "Coffee tips Thank you ☕")
+        XCTAssertEqual(MintQuoteDomain.normalizedOfferDescription("Cof\u{0}fee"), "Coffee")
+        XCTAssertNil(MintQuoteDomain.normalizedOfferDescription(" \r\n\t "))
+        XCTAssertEqual(MintQuoteDomain.normalizedOfferDescription(String(repeating: "a", count: 650)), String(repeating: "a", count: 640))
+    }
+
     func testBolt12MintDescriptionAdvertisementFailsClosed() {
         XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: []))
         XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: [
@@ -92,5 +100,41 @@ final class MintQuoteDomainTests: XCTestCase {
             activeMintUrl: "https://mint.example", unit: "sat",
             storedMemo: nil, description: nil
         ))
+    }
+}
+
+/// Opt-in against a real mint. Uses a fresh unfunded wallet and creates quotes only.
+@MainActor
+final class LiveBolt12DescriptionTests: XCTestCase {
+    func testLiveOffersEncodeDescriptionsAndPreserveAmounts() async throws {
+        let url = try XCTUnwrap(ProcessInfo.processInfo.environment["BOLT12_DESCRIPTION_MINT_URL"],
+                                "Set BOLT12_DESCRIPTION_MINT_URL to enable this test")
+        let database = try WalletSqliteDatabase.newInMemory()
+        let repository = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: database))
+        try await repository.createWallet(mintUrl: MintUrl(url: url), unit: .sat, targetProofCount: nil)
+        let mint = MintInfo(url: url, name: "Live test mint", isActive: true, balance: 0)
+        let service = LightningService(walletRepository: { repository }, walletDatabase: { database }, getActiveMint: { mint })
+        let plain = try await service.createMintQuote(amount: nil, method: .bolt12)
+        XCTAssertNil(try decodeInvoice(invoiceStr: plain.request).amountMsat)
+
+        for description in ["Coffee tips\nThank you ☕", "Updated coffee note", String(repeating: "a", count: 640)] {
+            let quote = try await service.createMintQuote(amount: nil, method: .bolt12, description: description)
+            let decoded = try decodeInvoice(invoiceStr: quote.request)
+            XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " "))
+            XCTAssertNil(decoded.amountMsat)
+            XCTAssertNotEqual(quote.request, plain.request)
+        }
+        for description in ["Fixed amount coffee", "Edited fixed amount", nil] {
+            let quote = try await service.createMintQuote(amount: 21, method: .bolt12, description: description)
+            let decoded = try decodeInvoice(invoiceStr: quote.request)
+            XCTAssertEqual(decoded.amountMsat, 21_000)
+            if let description { XCTAssertEqual(decoded.description, description.replacingOccurrences(of: "\n", with: " ")) }
+            else { XCTAssertEqual(decoded.description, try decodeInvoice(invoiceStr: plain.request).description) }
+        }
+    }
+
+    override func setUpWithError() throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["BOLT12_DESCRIPTION_MINT_URL"] == nil,
+                      "Opt-in live mint quote test")
     }
 }

--- a/ios/CashuWalletTests/MintQuoteDomainTests.swift
+++ b/ios/CashuWalletTests/MintQuoteDomainTests.swift
@@ -2,6 +2,28 @@ import XCTest
 @testable import CashuWallet
 
 final class MintQuoteDomainTests: XCTestCase {
+    func testBolt12MintDescriptionAdvertisementFailsClosed() {
+        XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: []))
+        XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: [
+            (method: .bolt12, description: nil),
+        ]))
+        XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: [
+            (method: .bolt12, description: false),
+        ]))
+        XCTAssertFalse(MintQuoteDomain.reportsBolt12MintDescription(methods: [
+            (method: .bolt11, description: true),
+        ]))
+        XCTAssertTrue(MintQuoteDomain.reportsBolt12MintDescription(methods: [
+            (method: .bolt11, description: false),
+            (method: .bolt12, description: true),
+        ]))
+        // Any bolt12 unit advertising true is enough.
+        XCTAssertTrue(MintQuoteDomain.reportsBolt12MintDescription(methods: [
+            (method: .bolt12, description: false),
+            (method: .bolt12, description: true),
+        ]))
+    }
+
     func testReusableOfferReuseMatchesDescriptionExactly() {
         XCTAssertTrue(MintQuoteDomain.isReusableAmountlessOffer(
             paymentMethod: .bolt12, isAmountless: true,

--- a/ios/CashuWalletTests/TransactionServiceTests.swift
+++ b/ios/CashuWalletTests/TransactionServiceTests.swift
@@ -476,3 +476,76 @@ final class MintQuoteContextPolicyTests: XCTestCase {
         )
     }
 }
+
+@MainActor
+final class HistoryDescriptionTests: XCTestCase {
+    private let offer = "lno1pg95xmmxvejk2g8sn7xtz93pqfumuen7l8wthtz45p3ftn58pvrs9xlumvkuu2xet8egzkcklqtes"
+    private let expectedDescription = "Coffee 🌱"
+
+    private func payment(_ id: String = "payment", type: WalletTransaction.TransactionType = .incoming) -> WalletTransaction {
+        var tx = WalletTransaction(id: id, amount: 21, type: type, kind: .lightning,
+            date: Date(), memo: nil, status: .completed, mintUrl: "https://mint.example/")
+        tx.quoteId = "quote"
+        return tx
+    }
+
+    func testPaidReusableRequestAndEveryReceiptKeepDescriptionAfterStoreReload() throws {
+        let suite = "HistoryDescriptionTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let store = CashuRequestStore(userDefaults: defaults)
+        let request = store.upsertQuoteIntent(rail: .bolt12, quoteId: "quote", encoded: offer,
+            mints: ["https://mint.example"], reusable: true)
+        store.attachPayment(requestId: request.id, transactionId: "first", amount: 21)
+        store.attachPayment(requestId: request.id, transactionId: "second", amount: 42)
+        let reloaded = WalletStore(storage: UserDefaultsStorage(defaults: defaults)).loadCashuRequests()
+        XCTAssertEqual(reloaded.count, 1)
+        XCTAssertEqual(reloaded.first?.totalReceived, 63)
+        XCTAssertEqual(reloaded.first?.displayDescription, expectedDescription)
+        for id in ["first", "second"] {
+            let receipt = payment(id).restoringDescription(from: reloaded)
+            XCTAssertEqual(receipt.memo, expectedDescription)
+            XCTAssertTrue(HistorySearch.matches(query: "coffee", transaction: receipt))
+        }
+        XCTAssertTrue(HistorySearch.matches(query: "coffee", request: try XCTUnwrap(reloaded.first), receivedTotal: 63))
+    }
+
+    func testOutgoingInvoiceRecoversDescriptionWithoutLocalRequest() {
+        var tx = payment(type: .outgoing)
+        tx.invoice = offer
+        XCTAssertEqual(tx.restoringDescription(from: []).memo, expectedDescription)
+        tx.status = .pending
+        XCTAssertEqual(tx.displayDescription, expectedDescription)
+    }
+
+    func testQuoteLinkDoesNotCopyDescriptionFromAnotherMintUnitOrDirection() {
+        let request = CashuRequest(encoded: offer, mints: ["https://mint.example"], rail: .bolt12, quoteId: "quote")
+        var wrongMint = payment()
+        wrongMint.mintUrl = "https://other.example"
+        var wrongUnit = payment()
+        wrongUnit.unit = "usd"
+        for tx in [wrongMint, wrongUnit, payment(type: .outgoing)] {
+            XCTAssertNil(tx.restoringDescription(from: [request]).memo)
+        }
+        XCTAssertEqual(payment().restoringDescription(from: [request]).memo, expectedDescription)
+    }
+
+    func testLocalMemoTakesPrecedenceAndEmptyDescriptionsStayHidden() {
+        var tx = payment()
+        tx.invoice = offer
+        tx.memo = "Personal memo"
+        XCTAssertEqual(tx.displayDescription, "Personal memo")
+        tx.invoice = nil
+        tx.memo = " \n "
+        XCTAssertNil(tx.displayDescription)
+        XCTAssertNil(CashuRequest(encoded: "invalid", memo: " ").displayDescription)
+    }
+
+    func testCashuRequestDescriptionSurvivesClaimedReceiptWithoutInvoice() {
+        let request = CashuRequest(id: "cashu", encoded: "creq", memo: expectedDescription,
+            receivedPayments: [.init(transactionId: "payment", amount: 21, receivedAt: Date())])
+        var tx = payment()
+        tx.quoteId = nil
+        XCTAssertEqual(tx.restoringDescription(from: [request]).memo, expectedDescription)
+    }
+}

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -3,6 +3,29 @@ import XCTest
 
 @MainActor
 final class CashuRequestStoreBoundaryTests: XCTestCase {
+    func testClearingDescriptionRestoresLastUsedOfferWithoutChangingHistory() throws {
+        let suiteName = "OfferReuseTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = CashuRequestStore(userDefaults: defaults)
+        let url = "https://mint.example"
+        let plain = store.upsertQuoteIntent(rail: .bolt12, quoteId: "plain", encoded: "lno-plain", mints: [url], reusable: true)
+        store.upsertQuoteIntent(rail: .bolt12, quoteId: "described", encoded: "lno-described", mints: [url], memo: "Coffee", reusable: true)
+        store.upsertQuoteIntent(rail: .bolt12, quoteId: "other-unit", encoded: "lno-usd", unit: "usd", mints: [url], memo: "USD", reusable: true)
+        store.upsertQuoteIntent(rail: .bolt12, quoteId: "fixed", encoded: "lno-fixed", amount: 21, mints: [url], memo: "Fixed", reusable: true)
+        XCTAssertEqual(store.lastPresentedAmountlessOffer(mintURL: url, unit: "sat")?.quoteId, "described")
+        store.attachPayment(quoteId: "plain", transactionId: "payment", amount: 21)
+        store.markQuotePresented("plain")
+        let reloaded = CashuRequestStore(userDefaults: defaults)
+        let restored = try XCTUnwrap(reloaded.lastPresentedAmountlessOffer(mintURL: url, unit: "SAT"))
+        XCTAssertEqual(restored.id, plain.id)
+        XCTAssertNil(restored.memo)
+        XCTAssertEqual(restored.createdAt, plain.createdAt)
+        XCTAssertEqual(restored.totalReceived, 21)
+        XCTAssertEqual(reloaded.lastPresentedAmountlessOffer(mintURL: url, unit: "usd")?.quoteId, "other-unit")
+        XCTAssertNil(reloaded.lastPresentedAmountlessOffer(mintURL: "https://other.example", unit: "sat"))
+    }
+
     func testResetForWalletBoundaryClearsRequestsAndDefaults() {
         let suiteName = "CashuRequestStoreBoundaryTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/ios/CashuWalletUITests/ReceiveUITests.swift
+++ b/ios/CashuWalletUITests/ReceiveUITests.swift
@@ -73,3 +73,91 @@ final class ReceiveUITests: UITestBase {
         )
     }
 }
+
+/// Explicitly enabled live-mint UI coverage. Creates no payments and uses a fresh wallet.
+final class LiveBolt12DescriptionUITests: UITestBase {
+    override func setUpWithError() throws {
+        try XCTSkipIf(ProcessInfo.processInfo.environment["BOLT12_DESCRIPTION_MINT_URL"] == nil,
+                      "Opt-in live mint quote test")
+        try super.setUpWithError()
+    }
+
+    func testEditClearAndReopenLiveOffer() throws {
+        let url = try XCTUnwrap(ProcessInfo.processInfo.environment["BOLT12_DESCRIPTION_MINT_URL"])
+        createWalletWithMint(at: url)
+        openOffer()
+        editDescription("Coffee tips\nThank you")
+        assertDescription("Coffee tips Thank you")
+        tapWhenReady(app.buttons["Close"])
+        openOffer()
+        assertDescription("Coffee tips Thank you")
+        editDescription("Updated coffee note")
+        assertDescription("Updated coffee note")
+        editDescription("   ")
+        assertDescription("None")
+        tapWhenReady(app.buttons["Close"])
+        openOffer()
+        assertDescription("None")
+        let amountRow = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Amount")).firstMatch
+        tapWhenReady(amountRow)
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["1"])
+        tapWhenReady(app.buttons["Done"])
+        assertAmount(amountRow)
+        editDescription("Fixed amount coffee")
+        assertDescription("Fixed amount coffee")
+        assertAmount(amountRow)
+        editDescription("   ")
+        assertDescription("None")
+        assertAmount(amountRow)
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Live BOLT12 offer after clearing and reopening"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    private var descriptionRow: XCUIElement {
+        app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Description")).firstMatch
+    }
+
+    private func openOffer() {
+        tapWhenReady(app.buttons["wallet-action-receive"])
+        tapWhenReady(app.buttons["wallet-flow-receiveLightning"])
+        tapWhenReady(app.buttons["Receive method: Lightning invoice, One-time, instant"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Reusable invoice")).firstMatch)
+        XCTAssertTrue(descriptionRow.waitForExistence(timeout: 30), "Live mint must enable the Description row")
+    }
+
+    private func editDescription(_ draft: String) {
+        if !descriptionRow.isHittable { app.swipeUp() }
+        tapWhenReady(descriptionRow)
+        let field = screen("reusable-description-field")
+        tapWhenReady(field)
+        // A fresh simulator can show the system keyboard's first-use introduction.
+        let keyboardIntroduction = app.buttons["Continue"]
+        if keyboardIntroduction.waitForExistence(timeout: 2) { keyboardIntroduction.tap() }
+        let existing = field.value as? String ?? ""
+        if existing != "e.g. Coffee tips" {
+            field.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: existing.count))
+        }
+        field.typeText(draft)
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Live BOLT12 description editor"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        tapWhenReady(app.buttons["reusable-description-save"])
+        XCTAssertTrue(field.waitForNonExistence(timeout: 10))
+    }
+
+    private func assertDescription(_ text: String) {
+        let updated = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label CONTAINS %@", text), object: descriptionRow)
+        XCTAssertEqual(XCTWaiter.wait(for: [updated], timeout: 30), .completed)
+    }
+
+    private func assertAmount(_ row: XCUIElement) {
+        let updated = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "label CONTAINS %@", "21"), object: row)
+        XCTAssertEqual(XCTWaiter.wait(for: [updated], timeout: 30), .completed)
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional payer-facing descriptions to reusable BOLT12 offers on iOS and Android. The Description row opens a native compact editor with a multiline field, character count, keyboard focus, and a prominent Save action. Clearing removes the custom description; closing leaves the offer unchanged.

Descriptions are available only when the mint advertises support. Offers are matched by mint, currency, and exact description, with fixed amounts preserved during edits. Whitespace is normalized before minting so payer decoders do not show replacement glyphs for line breaks. Input is capped at 640 characters.

Remember the last presented amountless offer separately from its creation date. Clearing a description can reuse an older plain offer and now stays cleared after reopening, while preserving payment history. Android discovery also recognizes the nested NUT-04 `options.description` advertisement returned by current CDK mints.

Descriptions are retained after settlement and app restarts and shown only when opening a request or payment. The description sits directly below Mint in the detail rows. BOLT11 and BOLT12 receive sheets share their layout, spacing, mint naming, and action styling. The QR adapts to the available room around the text; BOLT11 retains its expiry display and BOLT12 retains its amount and description editors. Short descriptions display in full; longer descriptions show up to three lines with Read more opening the complete selectable text in a native view. Short windows and larger accessibility text use one preview line. History and recent activity keep compact rows, while search still matches descriptions. Opening details dismisses the search keyboard. Older records recover missing descriptions from their saved invoice or receive request, with quote/mint/currency matching to keep payments separate.

Rebased onto main at `b2e2d359`, including the receipt sizing/spacing fixes (#333) and iOS received-balance indicator fix (#337). Content-fitting receipts and native minimum row heights are preserved; described live QRs retain the adaptive layout. Amountless BOLT12 recovery, settlement counters, and retry scheduling remain intact. Description edits use the quote’s persisted amountless flag. Fixes the Android onboarding CI timeout by using Compose's infinite-animation frame API so test synchronization can reach idle.

## Validation

- Latest rebase: Android build, lint, and history-description UI journey passed. iOS build and all 17 focused description, search, and received-balance feedback tests passed.

- Live Hedwig mint: native iOS service tests decode real amountless and 21-sat BOLT12 offers, covering Unicode, whitespace normalization, edited descriptions, the 640-character limit, and the mint's default description.
- Live Hedwig mint: Android and iOS UI journeys pass through adding the mint, creating an offer, editing and clearing descriptions, reopening, and preserving a fixed 21-sat amount. Android additionally decodes copied offers and checks encoded equality when reusing them.
- Android unit suite: 692 cases, 6 skipped, zero failures; lint passed.
- iOS: 28 focused native tests passed for live descriptions, normalization, persisted selection, mint/currency isolation, reconciliation, and retry scheduling. The live test uses the production database lifetime handling.
- History regression: 39 focused iOS tests passed; the Android paid-request/outgoing-receipt UI journey passed with simulated settlement. Local iOS UI checks confirmed persistence across two app launches and no description previews in activity rows.
- Final inline layout: Android history checks passed at normal size and 320×568; compact iPhone SE history and receive checks passed. Description previews appear below Mint without scrolling, with Read more for long text. Live BOLT11 and BOLT12 receive flows passed on both platforms, and the resized QRs decoded from the actual screenshots. Android BOLT12 edit/clear/reopen and fixed-amount regression passed. Android lint and all 12 focused native iOS description/search tests passed.
- Android screenshot validation, the three previously failing onboarding journeys, and six focused Compose editor/onboarding tests passed.
- Native editor layouts checked with the keyboard, including iOS light and dark appearances.

The live tests create offers in unfunded test wallets. No funds are sent; live payment settlement remains untested. Paid-history coverage uses simulated receipts. Live checks are opt-in and skipped in normal CI. See [the reproduction guide](https://github.com/cashubtc/wallet/blob/e58ed65632c793a288493acb572f8d2497e303af/docs/BOLT12_DESCRIPTION_TESTING.md).


