### PR TITLE
fix(android): make Nostr inbox delivery retry-safe

### DIFF
--- a/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
+++ b/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
@@ -69,11 +69,11 @@ class AppContainer(context: Context) {
     val priceService = PriceService(settingsStore)
     val mintDiscoveryManager = MintDiscoveryManager(settingsManager, cdkGateway)
     val cashuRequestListener = CashuRequestListener(
-        context = appContext,
         nostrService = nostrService,
         settingsManager = settingsManager,
         walletManager = walletManager,
         cashuRequestStore = cashuRequestStore,
+        walletStore = walletStore,
     )
     val nfcReceiveCoordinator = NfcReceiveCoordinator(
         context = appContext,
@@ -82,6 +82,7 @@ class AppContainer(context: Context) {
     )
 
     init {
+        walletManager.cashuRequestListener = cashuRequestListener
         npcService.quoteClaimHandler = walletManager
         settingsManager.sentryService = sentryService
         // Seed-derived primary P2PK key (iOS primaryP2PKPublicKey/PrivateKeyHex):

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -32,10 +32,10 @@ class CashuRequestListener(
     private val walletStore: WalletStore,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private val processedLock = Any()
-    private val processedIds = mutableSetOf<String>()
-    private val processedOrder = mutableListOf<String>()
-    private val inFlightIds = mutableSetOf<String>()
+    private val processedEvents = ProcessedNip17EventTracker(
+        load = walletStore::loadProcessedNip17GiftWraps,
+        save = walletStore::saveProcessedNip17GiftWraps,
+    )
     private var client: NostrInboxClient? = null
     private val mutableState = MutableStateFlow(CashuRequestListenerState())
     val state: StateFlow<CashuRequestListenerState> = mutableState.asStateFlow()
@@ -78,17 +78,13 @@ class CashuRequestListener(
 
     fun resetForWalletBoundary(restart: Boolean) {
         stop()
-        synchronized(processedLock) {
-            processedIds.clear()
-            processedOrder.clear()
-            inFlightIds.clear()
-        }
+        processedEvents.clear()
         if (restart) start()
     }
 
     private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
         if (event.kind != 1059) return
-        if (!beginProcessing(event.id)) return
+        if (!processedEvents.begin(event.id)) return
 
         var terminalOutcome = false
         try {
@@ -101,7 +97,7 @@ class CashuRequestListener(
             }
             terminalOutcome = tryClaim(rumor.content, event.id) != ClaimOutcome.TransientFailure
         } finally {
-            finishProcessing(event.id, terminalOutcome)
+            processedEvents.finish(event.id, terminalOutcome)
         }
     }
 
@@ -135,38 +131,7 @@ class CashuRequestListener(
     }
 
     private fun reloadProcessedIds() {
-        val stored = walletStore.loadProcessedNip17GiftWraps()
-            .distinct()
-            .takeLast(MaxProcessedIds)
-        synchronized(processedLock) {
-            processedOrder.clear()
-            processedOrder.addAll(stored)
-            processedIds.clear()
-            processedIds.addAll(stored)
-            inFlightIds.clear()
-        }
-    }
-
-    private fun beginProcessing(eventId: String): Boolean = synchronized(processedLock) {
-        if (eventId in processedIds || eventId in inFlightIds) {
-            false
-        } else {
-            inFlightIds += eventId
-            true
-        }
-    }
-
-    private fun finishProcessing(eventId: String, terminalOutcome: Boolean) {
-        synchronized(processedLock) {
-            inFlightIds -= eventId
-            if (!terminalOutcome || !processedIds.add(eventId)) return
-            processedOrder += eventId
-            if (processedOrder.size > MaxProcessedIds) {
-                val removed = processedOrder.removeAt(0)
-                processedIds -= removed
-            }
-            walletStore.saveProcessedNip17GiftWraps(processedOrder)
-        }
+        processedEvents.reload()
     }
 
     private enum class ClaimOutcome { Claimed, Unclaimable, TransientFailure }
@@ -178,7 +143,6 @@ class CashuRequestListener(
 
     companion object {
         internal const val LookbackSeconds = 7L * 24 * 60 * 60
-        private const val MaxProcessedIds = 1_000
         private val payloadJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
         internal fun subscriptionSince(nowEpochSeconds: Long): Long =
@@ -218,6 +182,62 @@ class CashuRequestListener(
                 token = "cashuA$encoded",
                 requestId = fields["id"]?.jsonPrimitive?.contentOrNull,
             )
+        }
+    }
+}
+
+internal class ProcessedNip17EventTracker(
+    private val load: () -> List<String>,
+    private val save: (List<String>) -> Unit,
+    private val maxProcessedIds: Int = 1_000,
+) {
+    private val lock = Any()
+    private val processedIds = mutableSetOf<String>()
+    private val processedOrder = mutableListOf<String>()
+    private val inFlightIds = mutableSetOf<String>()
+
+    init {
+        require(maxProcessedIds > 0) { "maxProcessedIds must be positive." }
+    }
+
+    fun reload() {
+        val stored = load().distinct().takeLast(maxProcessedIds)
+        synchronized(lock) {
+            processedOrder.clear()
+            processedOrder.addAll(stored)
+            processedIds.clear()
+            processedIds.addAll(stored)
+            inFlightIds.clear()
+        }
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            processedIds.clear()
+            processedOrder.clear()
+            inFlightIds.clear()
+        }
+    }
+
+    fun begin(eventId: String): Boolean = synchronized(lock) {
+        if (eventId in processedIds || eventId in inFlightIds) {
+            false
+        } else {
+            inFlightIds += eventId
+            true
+        }
+    }
+
+    fun finish(eventId: String, terminalOutcome: Boolean) {
+        synchronized(lock) {
+            inFlightIds -= eventId
+            if (!terminalOutcome || !processedIds.add(eventId)) return
+            processedOrder += eventId
+            if (processedOrder.size > maxProcessedIds) {
+                val removed = processedOrder.removeAt(0)
+                processedIds -= removed
+            }
+            save(processedOrder.toList())
         }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -1,6 +1,5 @@
 package com.cashu.me.Core
 
-import android.content.Context
 import java.util.Base64
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -26,16 +25,17 @@ data class CashuRequestListenerState(
 )
 
 class CashuRequestListener(
-    context: Context,
     private val nostrService: NostrService,
     private val settingsManager: SettingsManager,
     private val walletManager: WalletManager,
     private val cashuRequestStore: CashuRequestStore,
+    private val walletStore: WalletStore,
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
-    private val metadataStore = DataStorePreferenceStore(context.applicationContext, "settings_store")
-    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
-    private val sinceKey = "cashuRequests.nip17.since.v1"
+    private val processedLock = Any()
+    private val processedIds = mutableSetOf<String>()
+    private val processedOrder = mutableListOf<String>()
+    private val inFlightIds = mutableSetOf<String>()
     private var client: NostrInboxClient? = null
     private val mutableState = MutableStateFlow(CashuRequestListenerState())
     val state: StateFlow<CashuRequestListenerState> = mutableState.asStateFlow()
@@ -56,7 +56,8 @@ class CashuRequestListener(
             mutableState.value = CashuRequestListenerState(lastError = "No Nostr relays configured.")
             return
         }
-        val since = metadataStore.long(sinceKey, (System.currentTimeMillis() / 1000) - 48 * 60 * 60)
+        reloadProcessedIds()
+        val since = subscriptionSince(System.currentTimeMillis() / 1000)
         val recipientPrivateKey = NIP44.hexToBytes(privateKeyHex)
         client = NostrInboxClient(
             pubkeyHex = nostr.publicKeyHex,
@@ -75,22 +76,40 @@ class CashuRequestListener(
         mutableState.value = CashuRequestListenerState(isRunning = false)
     }
 
-    private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
-        if (event.kind != 1059) return
-        metadataStore.putLong(sinceKey, event.createdAt)
-        client?.updateSince(event.createdAt)
-        val rumor = runCatching { NIP17.unwrap(event, recipientPrivateKey) }
-            .onFailure { AppLogger.wallet.debug("CashuRequestListener: NIP-17 unwrap failed: ${it.message}") }
-            .getOrNull() ?: return
-        if (rumor.kind != 14) return
-        tryClaim(rumor.content, event.id)
+    fun resetForWalletBoundary(restart: Boolean) {
+        stop()
+        synchronized(processedLock) {
+            processedIds.clear()
+            processedOrder.clear()
+            inFlightIds.clear()
+        }
+        if (restart) start()
     }
 
-    private suspend fun tryClaim(rumorContent: String, eventId: String) {
+    private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
+        if (event.kind != 1059) return
+        if (!beginProcessing(event.id)) return
+
+        var terminalOutcome = false
+        try {
+            val rumor = runCatching { NIP17.unwrap(event, recipientPrivateKey) }
+                .onFailure { AppLogger.wallet.debug("CashuRequestListener: NIP-17 unwrap failed: ${it.message}") }
+                .getOrNull()
+            if (rumor == null || rumor.kind != 14) {
+                terminalOutcome = true
+                return
+            }
+            terminalOutcome = tryClaim(rumor.content, event.id) != ClaimOutcome.TransientFailure
+        } finally {
+            finishProcessing(event.id, terminalOutcome)
+        }
+    }
+
+    private suspend fun tryClaim(rumorContent: String, eventId: String): ClaimOutcome {
         val payload = runCatching { paymentPayloadToToken(rumorContent) }
             .onFailure { AppLogger.wallet.debug("CashuRequestListener: malformed PaymentRequestPayload") }
-            .getOrNull() ?: return
-        runCatching {
+            .getOrNull() ?: return ClaimOutcome.Unclaimable
+        return runCatching {
             val amount = walletManager.receiveCashuRequestPayment(
                 tokenString = payload.token,
                 requestId = payload.requestId,
@@ -103,6 +122,7 @@ class CashuRequestListener(
                     amount = amount,
                 )
             }
+            ClaimOutcome.Claimed
         }.onFailure { error ->
             AppLogger.wallet.error("CashuRequestListener: redeem failed", error)
             scope.launch {
@@ -111,8 +131,45 @@ class CashuRequestListener(
                     lastError = error.userFacingWalletMessage,
                 )
             }
+        }.getOrElse { ClaimOutcome.TransientFailure }
+    }
+
+    private fun reloadProcessedIds() {
+        val stored = walletStore.loadProcessedNip17GiftWraps()
+            .distinct()
+            .takeLast(MaxProcessedIds)
+        synchronized(processedLock) {
+            processedOrder.clear()
+            processedOrder.addAll(stored)
+            processedIds.clear()
+            processedIds.addAll(stored)
+            inFlightIds.clear()
         }
     }
+
+    private fun beginProcessing(eventId: String): Boolean = synchronized(processedLock) {
+        if (eventId in processedIds || eventId in inFlightIds) {
+            false
+        } else {
+            inFlightIds += eventId
+            true
+        }
+    }
+
+    private fun finishProcessing(eventId: String, terminalOutcome: Boolean) {
+        synchronized(processedLock) {
+            inFlightIds -= eventId
+            if (!terminalOutcome || !processedIds.add(eventId)) return
+            processedOrder += eventId
+            if (processedOrder.size > MaxProcessedIds) {
+                val removed = processedOrder.removeAt(0)
+                processedIds -= removed
+            }
+            walletStore.saveProcessedNip17GiftWraps(processedOrder)
+        }
+    }
+
+    private enum class ClaimOutcome { Claimed, Unclaimable, TransientFailure }
 
     data class PaymentPayloadToken(
         val token: String,
@@ -120,7 +177,12 @@ class CashuRequestListener(
     )
 
     companion object {
+        internal const val LookbackSeconds = 7L * 24 * 60 * 60
+        private const val MaxProcessedIds = 1_000
         private val payloadJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+        internal fun subscriptionSince(nowEpochSeconds: Long): Long =
+            nowEpochSeconds - LookbackSeconds
 
         fun paymentPayloadToToken(content: String): PaymentPayloadToken {
             val fields = payloadJson.parseToJsonElement(content).jsonObject

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Core
 
 import java.util.Base64
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -37,11 +38,20 @@ class CashuRequestListener(
         save = walletStore::saveProcessedNip17GiftWraps,
     )
     private var client: NostrInboxClient? = null
+    private val retiringClients = mutableSetOf<NostrInboxClient>()
+    private val listenerGeneration = AtomicLong()
+    private var pausedForWalletBoundary = false
+    private var startAfterRetirement = false
     private val mutableState = MutableStateFlow(CashuRequestListenerState())
     val state: StateFlow<CashuRequestListenerState> = mutableState.asStateFlow()
 
+    @Synchronized
     fun start() {
-        if (client != null) return
+        if (client != null || pausedForWalletBoundary) return
+        if (retiringClients.isNotEmpty()) {
+            startAfterRetirement = true
+            return
+        }
         val nostr = nostrService.state.value
         val privateKeyHex = nostrService.currentPrivateKey()
         if (!nostr.isInitialized || nostr.publicKeyHex.isBlank() || privateKeyHex.isNullOrBlank()) {
@@ -59,35 +69,91 @@ class CashuRequestListener(
         reloadProcessedIds()
         val since = subscriptionSince(System.currentTimeMillis() / 1000)
         val recipientPrivateKey = NIP44.hexToBytes(privateKeyHex)
-        client = NostrInboxClient(
+        val generation = listenerGeneration.incrementAndGet()
+        val newClient = NostrInboxClient(
             pubkeyHex = nostr.publicKeyHex,
             relays = relays,
             since = since,
         ) { event ->
-            handle(event, recipientPrivateKey)
-        }.also { it.start() }
+            handle(event, recipientPrivateKey, generation)
+        }
+        client = newClient
+        newClient.start()
         mutableState.value = CashuRequestListenerState(isRunning = true)
         AppLogger.wallet.info("CashuRequestListener: started on ${relays.size} relays since=$since")
     }
 
     fun stop() {
-        client?.stop()
-        client = null
-        mutableState.value = CashuRequestListenerState(isRunning = false)
+        val detached = synchronized(this) {
+            startAfterRetirement = false
+            detachClient()?.also { retiringClients += it }
+        } ?: return
+        detached.stop()
+        scope.launch {
+            detached.stopAndJoin()
+            val shouldRestart = synchronized(this@CashuRequestListener) {
+                retiringClients -= detached
+                val requested = startAfterRetirement &&
+                    retiringClients.isEmpty() &&
+                    !pausedForWalletBoundary
+                if (requested) startAfterRetirement = false
+                requested
+            }
+            if (shouldRestart) start()
+        }
     }
 
-    fun resetForWalletBoundary(restart: Boolean) {
-        stop()
+    suspend fun pauseForWalletBoundary() {
+        quiesceForWalletBoundary()
+    }
+
+    suspend fun resetForWalletBoundary(restart: Boolean) {
+        quiesceForWalletBoundary()
         processedEvents.clear()
+        synchronized(this) {
+            pausedForWalletBoundary = false
+        }
         if (restart) start()
     }
 
-    private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
+    private suspend fun quiesceForWalletBoundary() {
+        val clients = synchronized(this) {
+            pausedForWalletBoundary = true
+            startAfterRetirement = false
+            detachClient()?.let { retiringClients += it }
+            retiringClients.toList()
+        }
+        clients.forEach { it.stop() }
+        clients.forEach { it.stopAndJoin() }
+        synchronized(this) {
+            retiringClients.removeAll(clients.toSet())
+        }
+    }
+
+    /** Must be called while holding this listener's monitor. */
+    private fun detachClient(): NostrInboxClient? {
+        listenerGeneration.incrementAndGet()
+        val detached = client
+        client = null
+        mutableState.value = CashuRequestListenerState(isRunning = false)
+        return detached
+    }
+
+    private fun isCurrentGeneration(generation: Long): Boolean =
+        listenerGeneration.get() == generation
+
+    private suspend fun handle(
+        event: NostrIncomingEvent,
+        recipientPrivateKey: ByteArray,
+        generation: Long,
+    ) {
+        if (!isCurrentGeneration(generation)) return
         if (event.kind != 1059) return
         if (!processedEvents.begin(event.id)) return
 
         var terminalOutcome = false
         try {
+            if (!isCurrentGeneration(generation)) return
             val rumor = runCatching { NIP17.unwrap(event, recipientPrivateKey) }
                 .onFailure { AppLogger.wallet.debug("CashuRequestListener: NIP-17 unwrap failed: ${it.message}") }
                 .getOrNull()
@@ -95,13 +161,21 @@ class CashuRequestListener(
                 terminalOutcome = true
                 return
             }
-            terminalOutcome = tryClaim(rumor.content, event.id) != ClaimOutcome.TransientFailure
+            if (!isCurrentGeneration(generation)) return
+            terminalOutcome = tryClaim(rumor.content, event.id, generation) != ClaimOutcome.TransientFailure
         } finally {
-            processedEvents.finish(event.id, terminalOutcome)
+            processedEvents.finish(
+                eventId = event.id,
+                terminalOutcome = terminalOutcome && isCurrentGeneration(generation),
+            )
         }
     }
 
-    private suspend fun tryClaim(rumorContent: String, eventId: String): ClaimOutcome {
+    private suspend fun tryClaim(
+        rumorContent: String,
+        eventId: String,
+        generation: Long,
+    ): ClaimOutcome {
         val payload = runCatching { paymentPayloadToToken(rumorContent) }
             .onFailure { AppLogger.wallet.debug("CashuRequestListener: malformed PaymentRequestPayload") }
             .getOrNull() ?: return ClaimOutcome.Unclaimable
@@ -121,11 +195,15 @@ class CashuRequestListener(
             ClaimOutcome.Claimed
         }.onFailure { error ->
             AppLogger.wallet.error("CashuRequestListener: redeem failed", error)
-            scope.launch {
-                mutableState.value = CashuRequestListenerState(
-                    isRunning = client != null,
-                    lastError = error.userFacingWalletMessage,
-                )
+            if (isCurrentGeneration(generation)) {
+                scope.launch {
+                    if (isCurrentGeneration(generation)) {
+                        mutableState.value = CashuRequestListenerState(
+                            isRunning = mutableState.value.isRunning,
+                            lastError = error.userFacingWalletMessage,
+                        )
+                    }
+                }
             }
         }.getOrElse { ClaimOutcome.TransientFailure }
     }

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestStore.kt
@@ -192,6 +192,11 @@ class CashuRequestStore(
         mutableState.value = loadState()
     }
 
+    /** Clear both observable and persisted request state before changing wallets. */
+    fun resetForWalletBoundary() {
+        reset()
+    }
+
     fun reset() {
         persist(emptyList(), null)
     }

--- a/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
@@ -37,8 +37,7 @@ class NostrInboxClient(
     private val sockets = mutableSetOf<WebSocket>()
     @Volatile
     private var running = false
-    @Volatile
-    private var sinceTimestamp = since
+    private val sinceTimestamp = since
 
     fun start() {
         if (running) return
@@ -55,10 +54,6 @@ class NostrInboxClient(
             sockets.forEach { it.close(1000, "closed") }
             sockets.clear()
         }
-    }
-
-    fun updateSince(timestamp: Long) {
-        if (timestamp > sinceTimestamp) sinceTimestamp = timestamp
     }
 
     private suspend fun connectLoop(relay: String) {
@@ -92,7 +87,6 @@ class NostrInboxClient(
         val event = runCatching {
             json.decodeFromJsonElement<NostrIncomingEvent>(array[2].jsonObject)
         }.getOrNull() ?: return
-        updateSince(event.createdAt)
         onEvent(event)
     }
 

--- a/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
@@ -4,9 +4,7 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
@@ -27,7 +25,8 @@ class NostrInboxClient(
     since: Long,
     private val onEvent: suspend (NostrIncomingEvent) -> Unit,
 ) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val lifecycleJob = SupervisorJob()
+    private val scope = CoroutineScope(lifecycleJob + Dispatchers.IO)
     private val client = OkHttpClient.Builder()
         .connectTimeout(15, TimeUnit.SECONDS)
         .readTimeout(0, TimeUnit.SECONDS)
@@ -40,7 +39,7 @@ class NostrInboxClient(
     private val sinceTimestamp = since
 
     fun start() {
-        if (running) return
+        if (running || !lifecycleJob.isActive) return
         running = true
         relays.distinct().forEach { relay ->
             scope.launch { connectLoop(relay) }
@@ -49,11 +48,16 @@ class NostrInboxClient(
 
     fun stop() {
         running = false
-        scope.coroutineContext.cancelChildren()
+        lifecycleJob.cancel()
         synchronized(sockets) {
             sockets.forEach { it.close(1000, "closed") }
             sockets.clear()
         }
+    }
+
+    suspend fun stopAndJoin() {
+        stop()
+        lifecycleJob.join()
     }
 
     private suspend fun connectLoop(relay: String) {
@@ -70,9 +74,23 @@ class NostrInboxClient(
         val request = runCatching { Request.Builder().url(relay).build() }.getOrNull() ?: return
         val listener = InboxWebSocketListener()
         val socket = client.newWebSocket(request, listener)
-        synchronized(sockets) { sockets += socket }
-        listener.awaitClosed()
-        synchronized(sockets) { sockets -= socket }
+        val accepted = synchronized(sockets) {
+            if (running) {
+                sockets += socket
+                true
+            } else {
+                false
+            }
+        }
+        if (!accepted) {
+            socket.close(1000, "closed")
+            return
+        }
+        try {
+            listener.awaitClosed()
+        } finally {
+            synchronized(sockets) { sockets -= socket }
+        }
     }
 
     private fun subscribe(socket: WebSocket) {
@@ -81,12 +99,14 @@ class NostrInboxClient(
     }
 
     private suspend fun handleMessage(text: String) {
+        if (!running) return
         val array = runCatching { json.parseToJsonElement(text).jsonArray }.getOrNull() ?: return
         val messageType = array.firstOrNull()?.jsonPrimitive?.content ?: return
         if (messageType != "EVENT" || array.size < 3) return
         val event = runCatching {
             json.decodeFromJsonElement<NostrIncomingEvent>(array[2].jsonObject)
         }.getOrNull() ?: return
+        if (!running) return
         onEvent(event)
     }
 
@@ -94,11 +114,15 @@ class NostrInboxClient(
         private val closed = kotlinx.coroutines.CompletableDeferred<Unit>()
 
         override fun onOpen(webSocket: WebSocket, response: Response) {
-            subscribe(webSocket)
+            if (running) {
+                subscribe(webSocket)
+            } else {
+                webSocket.close(1000, "closed")
+            }
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
-            scope.launch { handleMessage(text) }
+            if (running) scope.launch { handleMessage(text) }
         }
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -59,6 +59,7 @@ object StorageKeys {
     const val walletMintQuoteTimestamps = "wallet.mintQuoteTimestamps"
     const val walletProcessedNPCQuotes = "wallet.processedNPCQuotes"
     const val walletProcessedCashuRequests = "wallet.processedCashuRequests"
+    const val walletProcessedNip17GiftWraps = "wallet.processedNip17GiftWraps"
     const val cashuRequests = "cashuRequests.v1"
     const val cashuRequestsCurrentId = "cashuRequests.currentId.v1"
 
@@ -127,6 +128,7 @@ object StorageKeys {
         walletMintQuoteTimestamps,
         walletProcessedNPCQuotes,
         walletProcessedCashuRequests,
+        walletProcessedNip17GiftWraps,
         cashuRequests,
         cashuRequestsCurrentId,
         settingsP2PKKeys,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -54,6 +54,8 @@ class WalletManager(
     private val databasePathManager: WalletDatabasePathManager,
     private val gateway: CdkWalletGateway,
 ) : WalletServiceProtocol, NPCQuoteClaimHandler {
+    internal var cashuRequestListener: CashuRequestListener? = null
+
     private val exceptionHandler = CoroutineExceptionHandler { _, error ->
         AppLogger.wallet.error("Unhandled wallet coroutine error", error)
         update { copy(isLoading = false, errorMessage = error.message ?: error::class.simpleName) }
@@ -241,6 +243,7 @@ class WalletManager(
 
     override suspend fun deleteWallet() {
         withLoading {
+            cashuRequestListener?.stop()
             nwcManager.resetForWalletBoundary()
             gateway.closeWalletRepository()
             secureStorage.delete(StorageKeys.secureWalletMnemonic)
@@ -250,6 +253,7 @@ class WalletManager(
             settingsManager.resetWalletScopedData()
             npcService.resetForWalletBoundary()
             nostrMintBackupService.resetForWalletBoundary()
+            cashuRequestListener?.resetForWalletBoundary(restart = false)
             MintLogoBitmapCache.clear()
             update {
                 WalletState(
@@ -1063,6 +1067,7 @@ class WalletManager(
         val settingsSnapshot = settingsManager.snapshotWalletScopedData()
         val nwcSnapshot = nwcManager.snapshotWalletScopedData()
 
+        cashuRequestListener?.stop()
         runCatching {
             // NwcService retains the native CDK wallet, so it must stop before
             // the repository/database it is backed by is closed.
@@ -1095,6 +1100,7 @@ class WalletManager(
                     loadCachedState(needsOnboarding = false)
                     nwcManager.startIfEnabled()
                 }
+                cashuRequestListener?.resetForWalletBoundary(restart = true)
             } else {
                 secureStorage.delete(StorageKeys.secureWalletMnemonic)
                 update {
@@ -1105,9 +1111,11 @@ class WalletManager(
                         canExitOnboarding = false,
                     )
                 }
+                cashuRequestListener?.resetForWalletBoundary(restart = false)
             }
             throw error
         }
+        cashuRequestListener?.resetForWalletBoundary(restart = !needsOnboarding)
     }
 
     private fun loadCachedState(needsOnboarding: Boolean) {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -249,6 +249,7 @@ class WalletManager(
             secureStorage.delete(StorageKeys.secureWalletMnemonic)
             secureStorage.delete(StorageKeys.secureNostrPrivateKey)
             databasePathManager.removeWalletDatabaseFiles()
+            cashuRequestStore.resetForWalletBoundary()
             walletStore.removeAllWalletData()
             settingsManager.resetWalletScopedData()
             npcService.resetForWalletBoundary()
@@ -1073,6 +1074,7 @@ class WalletManager(
             // the repository/database it is backed by is closed.
             nwcManager.resetForWalletBoundary()
             gateway.closeWalletRepository()
+            cashuRequestStore.resetForWalletBoundary()
             walletStore.removeAllWalletData()
             settingsManager.prepareForWalletReplacement()
             nostrService.resetForWalletBoundary(deleteStoredKey = false)
@@ -1087,6 +1089,7 @@ class WalletManager(
         }.onFailure { error ->
             gateway.closeWalletRepository()
             walletStore.restoreWalletScopedData(walletSnapshot)
+            cashuRequestStore.reload()
             settingsManager.restoreWalletScopedData(settingsSnapshot)
             nwcManager.restoreWalletScopedData(nwcSnapshot)
             nostrMintBackupService.reloadStoredState()

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -25,6 +25,7 @@ import org.cashudevkit.PendingMelt
 import org.cashudevkit.QuoteState as CdkQuoteState
 import com.cashu.me.Core.CDK.CdkWalletGateway
 import com.cashu.me.Core.Platform.WalletDatabasePathManager
+import com.cashu.me.Core.Platform.WalletFileBackup
 import com.cashu.me.Core.Protocols.SecureStorage
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Core.Protocols.WalletServiceProtocol
@@ -54,6 +55,13 @@ class WalletManager(
     private val databasePathManager: WalletDatabasePathManager,
     private val gateway: CdkWalletGateway,
 ) : WalletServiceProtocol, NPCQuoteClaimHandler {
+    private data class WalletReplacementSnapshot(
+        val databaseBackups: List<WalletFileBackup>,
+        val wallet: PreferenceSnapshot,
+        val settings: SettingsWalletScopedSnapshot,
+        val nwc: NwcWalletScopedSnapshot,
+    )
+
     internal var cashuRequestListener: CashuRequestListener? = null
 
     private val exceptionHandler = CoroutineExceptionHandler { _, error ->
@@ -243,7 +251,7 @@ class WalletManager(
 
     override suspend fun deleteWallet() {
         withLoading {
-            cashuRequestListener?.stop()
+            cashuRequestListener?.pauseForWalletBoundary()
             nwcManager.resetForWalletBoundary()
             gateway.closeWalletRepository()
             secureStorage.delete(StorageKeys.secureWalletMnemonic)
@@ -1063,12 +1071,25 @@ class WalletManager(
 
     private suspend fun installCleanWallet(mnemonic: String, needsOnboarding: Boolean) {
         val previousMnemonic = secureStorage.loadString(StorageKeys.secureWalletMnemonic)
-        val backups = databasePathManager.backupWalletDatabaseFiles()
-        val walletSnapshot = walletStore.snapshotWalletScopedData()
-        val settingsSnapshot = settingsManager.snapshotWalletScopedData()
-        val nwcSnapshot = nwcManager.snapshotWalletScopedData()
+        cashuRequestListener?.pauseForWalletBoundary()
+        val replacementSnapshot = try {
+            WalletReplacementSnapshot(
+                // Capture preference state before moving the database so a
+                // preparation failure can resume the untouched wallet.
+                wallet = walletStore.snapshotWalletScopedData(),
+                settings = settingsManager.snapshotWalletScopedData(),
+                nwc = nwcManager.snapshotWalletScopedData(),
+                databaseBackups = databasePathManager.backupWalletDatabaseFiles(),
+            )
+        } catch (error: Throwable) {
+            cashuRequestListener?.resetForWalletBoundary(restart = previousMnemonic != null)
+            throw error
+        }
+        val backups = replacementSnapshot.databaseBackups
+        val walletSnapshot = replacementSnapshot.wallet
+        val settingsSnapshot = replacementSnapshot.settings
+        val nwcSnapshot = replacementSnapshot.nwc
 
-        cashuRequestListener?.stop()
         runCatching {
             // NwcService retains the native CDK wallet, so it must stop before
             // the repository/database it is backed by is closed.

--- a/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
@@ -79,6 +79,11 @@ class WalletStore(
     fun saveProcessedCashuRequests(requestIds: List<String>) =
         saveList(StorageKeys.walletProcessedCashuRequests, String.serializer(), requestIds)
 
+    fun loadProcessedNip17GiftWraps(): List<String> =
+        loadList(StorageKeys.walletProcessedNip17GiftWraps, String.serializer())
+    fun saveProcessedNip17GiftWraps(eventIds: List<String>) =
+        saveList(StorageKeys.walletProcessedNip17GiftWraps, String.serializer(), eventIds)
+
     override fun loadCashuRequests(): List<CashuRequest> =
         loadList(StorageKeys.cashuRequests, CashuRequest.serializer()).map { it.withLegacyPaymentFallback() }
     override fun saveCashuRequests(requests: List<CashuRequest>) =

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import com.cashu.me.Core.Protocols.StorageKeys
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -49,5 +50,53 @@ class CashuRequestListenerTest {
     @Test
     fun processedGiftWrapsAreClearedAtWalletBoundary() {
         assertTrue(StorageKeys.walletProcessedNip17GiftWraps in StorageKeys.walletBoundaryKeys)
+    }
+
+    @Test
+    fun transientGiftWrapCanRetryButTerminalGiftWrapIsPersistentlyDeduplicated() {
+        var stored = emptyList<String>()
+        val tracker = ProcessedNip17EventTracker(
+            load = { stored },
+            save = { stored = it },
+        )
+        tracker.reload()
+
+        assertTrue(tracker.begin("retryable"))
+        tracker.finish("retryable", terminalOutcome = false)
+        assertTrue(tracker.begin("retryable"))
+
+        tracker.finish("retryable", terminalOutcome = true)
+        assertEquals(listOf("retryable"), stored)
+        assertFalse(tracker.begin("retryable"))
+
+        val reloaded = ProcessedNip17EventTracker(
+            load = { stored },
+            save = { stored = it },
+        )
+        reloaded.reload()
+        assertFalse(reloaded.begin("retryable"))
+    }
+
+    @Test
+    fun concurrentRelayDuplicateIsSuppressedAndProcessedHistoryIsBounded() {
+        var stored = emptyList<String>()
+        val tracker = ProcessedNip17EventTracker(
+            load = { stored },
+            save = { stored = it },
+            maxProcessedIds = 2,
+        )
+        tracker.reload()
+
+        assertTrue(tracker.begin("event-1"))
+        assertFalse(tracker.begin("event-1"))
+        tracker.finish("event-1", terminalOutcome = true)
+        assertTrue(tracker.begin("event-2"))
+        tracker.finish("event-2", terminalOutcome = true)
+        assertTrue(tracker.begin("event-3"))
+        tracker.finish("event-3", terminalOutcome = true)
+
+        assertEquals(listOf("event-2", "event-3"), stored)
+        assertTrue(tracker.begin("event-1"))
+        assertFalse(tracker.begin("event-2"))
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import com.cashu.me.Core.Protocols.StorageKeys
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -33,5 +34,20 @@ class CashuRequestListenerTest {
         assertEquals("sat", fields["unit"]!!.jsonPrimitive.content)
         assertEquals("Thanks", fields["memo"]!!.jsonPrimitive.content)
         assertEquals(1, entry["proofs"]!!.jsonArray.size)
+    }
+
+    @Test
+    fun subscriptionAlwaysUsesFixedSevenDayLookback() {
+        val now = 2_000_000_000L
+
+        assertEquals(
+            now - CashuRequestListener.LookbackSeconds,
+            CashuRequestListener.subscriptionSince(now),
+        )
+    }
+
+    @Test
+    fun processedGiftWrapsAreClearedAtWalletBoundary() {
+        assertTrue(StorageKeys.walletProcessedNip17GiftWraps in StorageKeys.walletBoundaryKeys)
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestStoreTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestStoreTest.kt
@@ -199,9 +199,11 @@ class CashuRequestStoreTest {
         assertNull(store.state.value.currentRequestId)
         assertNull(persistence.currentCashuRequestId)
 
-        store.reset()
+        store.resetForWalletBoundary()
         assertTrue(persistence.requests.isEmpty())
         assertNull(persistence.currentCashuRequestId)
+        assertTrue(store.state.value.requests.isEmpty())
+        assertNull(store.state.value.currentRequestId)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- replace the moving Nostr `since` cursor with a fixed seven-day replay window
- persist and bound terminally handled NIP-17 gift-wrap IDs while leaving transient failures retryable
- suppress concurrent duplicate delivery from multiple relays
- reset listener and Cashu Request state across wallet deletion and replacement
- reload Cashu Request state if wallet replacement rolls back
- add behavioral coverage for transient retry, persistent de-duplication, concurrent relay duplicates, bounded history, and wallet-boundary reset

## Why

NIP-59 gift wraps use randomized backdated timestamps. Advancing the relay subscription cursor to the latest received timestamp could therefore skip later payments whose timestamps were backdated further. Replaying a fixed window and de-duplicating terminal outcomes by event ID matches the iOS delivery model while keeping network or mint failures retryable.

Cashu Request state is wallet-scoped. Clearing only its persisted keys left the in-memory store populated when deleting or replacing a wallet in the same process, allowing previous-wallet request history to remain visible. The boundary flow now clears the observable store and restores it from the snapshot on rollback.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest :app:lintDebug :app:assembleRelease --stacktrace`
- `git diff --check`
