### PR TITLE
fix(android): honor Cashu Request privacy settings

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
@@ -15,6 +15,7 @@ import com.cashu.me.Models.MintInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -65,8 +66,14 @@ class StorageDataStoreInstrumentedTest {
         val storeName = uniqueStoreName("settings_store")
         context.seedSharedPreferences(storeName) {
             putBoolean(StorageKeys.settingsUseBitcoinSymbol, true)
+            putBoolean(StorageKeys.settingsEnablePaymentRequests, false)
+            putBoolean(StorageKeys.settingsReceivePaymentRequestsAutomatically, false)
             putString(StorageKeys.settingsBitcoinPriceCurrency, "EUR")
             putString(StorageKeys.settingsNostrRelays, json.encodeToString(ListSerializer(String.serializer()), listOf("wss://relay.example")))
+            putString(
+                StorageKeys.cashuRequestsProcessedNip17Ids,
+                json.encodeToString(ListSerializer(String.serializer()), listOf("event-1")),
+            )
             putString(
                 StorageKeys.settingsP2PKKeys,
                 """[{"id":"p2pk-1","publicKey":"02${"a".repeat(64)}","label":"P2PK key","createdAtEpochMillis":1,"used":false,"usedCount":0}]""",
@@ -76,15 +83,50 @@ class StorageDataStoreInstrumentedTest {
         val store = SettingsStore(context, storeName)
 
         assertEquals(true, store.useBitcoinSymbol)
+        assertFalse(store.enablePaymentRequests)
+        assertFalse(store.receivePaymentRequestsAutomatically)
         assertEquals("EUR", store.bitcoinPriceCurrency)
         assertEquals(listOf("wss://relay.example"), store.nostrRelays)
         assertEquals(1, store.p2pkKeys.size)
+        assertEquals(
+            """["event-1"]""",
+            DataStorePreferenceStore(context, storeName)
+                .string(StorageKeys.cashuRequestsProcessedNip17Ids),
+        )
 
         store.clearWalletScopedData()
 
         assertEquals(true, store.useBitcoinSymbol)
+        assertTrue(store.enablePaymentRequests)
+        assertTrue(store.receivePaymentRequestsAutomatically)
         assertEquals("EUR", store.bitcoinPriceCurrency)
         assertEquals(emptyList<Any>(), store.p2pkKeys)
+        assertNull(
+            DataStorePreferenceStore(context, storeName)
+                .string(StorageKeys.cashuRequestsProcessedNip17Ids),
+        )
+    }
+
+    @Test
+    fun cashuRequestPrivacyDefaultsMatchIos() {
+        val store = SettingsStore(context, uniqueStoreName("settings_store"))
+
+        assertTrue(store.enablePaymentRequests)
+        assertTrue(store.receivePaymentRequestsAutomatically)
+    }
+
+    @Test
+    fun enablingAutomaticCashuRequestClaimsDrainsEligibleHeldPaymentsOnce() {
+        val store = SettingsStore(context, uniqueStoreName("settings_store"))
+        store.receivePaymentRequestsAutomatically = false
+        val manager = SettingsManager(store, AndroidSecureStorage(context))
+        var drainCount = 0
+        manager.claimEligibleHeldPayments = { drainCount += 1 }
+
+        manager.setReceivePaymentRequestsAutomatically(true)
+        manager.setReceivePaymentRequestsAutomatically(true)
+
+        assertEquals(1, drainCount)
     }
 
     @Test

--- a/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
+++ b/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
@@ -84,6 +84,8 @@ class AppContainer(context: Context) {
     init {
         npcService.quoteClaimHandler = walletManager
         settingsManager.sentryService = sentryService
+        settingsManager.claimEligibleHeldPayments =
+            cashuRequestListener::claimEligibleHeldPaymentsAsync
         // Seed-derived primary P2PK key (iOS primaryP2PKPublicKey/PrivateKeyHex):
         // included in the signing set so ecash locked to the wallet's own key
         // (e.g. NPC locked quotes, locked receive requests) is redeemable.

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -18,6 +21,7 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Models.PendingReceiveToken
 import com.cashu.me.Models.TokenInfo
@@ -38,8 +42,11 @@ class CashuRequestListener(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private val metadataStore = DataStorePreferenceStore(context.applicationContext, "settings_store")
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
-    private val sinceKey = "cashuRequests.nip17.since.v1"
     private var client: NostrInboxClient? = null
+    private val eventMutex = Mutex()
+    private val heldClaimMutex = Mutex()
+    private var processedIds: Set<String> = emptySet()
+    private var processedOrder: List<String> = emptyList()
     private val mutableState = MutableStateFlow(CashuRequestListenerState())
     val state: StateFlow<CashuRequestListenerState> = mutableState.asStateFlow()
 
@@ -63,7 +70,12 @@ class CashuRequestListener(
             mutableState.value = CashuRequestListenerState(lastError = "No Nostr relays configured.")
             return
         }
-        val since = metadataStore.long(sinceKey, (System.currentTimeMillis() / 1000) - 48 * 60 * 60)
+        loadProcessedIds()
+        // The old moving cursor is unsafe for NIP-59 gift wraps because their
+        // created_at values are deliberately backdated. Always re-scan a fixed
+        // window and de-duplicate by event id instead.
+        metadataStore.removeKeys(listOf(LegacySinceKey))
+        val since = lookbackSince(System.currentTimeMillis() / 1000)
         val recipientPrivateKey = NIP44.hexToBytes(privateKeyHex)
         client = NostrInboxClient(
             pubkeyHex = nostr.publicKeyHex,
@@ -87,30 +99,35 @@ class CashuRequestListener(
     }
 
     private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
-        if (event.kind != 1059) return
-        metadataStore.putLong(sinceKey, event.createdAt)
-        client?.updateSince(event.createdAt)
-        val rumor = runCatching { NIP17.unwrap(event, recipientPrivateKey) }
-            .onFailure { AppLogger.wallet.debug("CashuRequestListener: NIP-17 unwrap failed: ${it.message}") }
-            .getOrNull() ?: return
-        if (rumor.kind != 14) return
-        tryClaim(rumor.content, event.id)
+        eventMutex.withLock {
+            if (event.kind != 1059) return
+            if (event.id in processedIds) return
+            val rumor = runCatching { NIP17.unwrap(event, recipientPrivateKey) }
+                .onFailure { AppLogger.wallet.debug("CashuRequestListener: NIP-17 unwrap failed: ${it.message}") }
+                .getOrNull()
+            if (rumor == null || rumor.kind != 14) {
+                markProcessed(event.id)
+                return
+            }
+            if (shouldMarkProcessed(tryClaim(rumor.content, event.id))) {
+                markProcessed(event.id)
+            }
+        }
     }
 
-    private suspend fun tryClaim(rumorContent: String, eventId: String) {
+    private suspend fun tryClaim(rumorContent: String, eventId: String): ClaimOutcome {
         val payload = runCatching { paymentPayloadToToken(rumorContent) }
             .onFailure { AppLogger.wallet.debug("CashuRequestListener: malformed PaymentRequestPayload") }
-            .getOrNull() ?: return
-        val info = TokenInfo.parse(payload.token) ?: return
+            .getOrNull() ?: return ClaimOutcome.Unclaimable
+        val info = TokenInfo.parse(payload.token) ?: return ClaimOutcome.Unclaimable
         val shouldAutoClaim = shouldAutoClaim(
             autoClaimEnabled = settingsManager.state.value.receivePaymentRequestsAutomatically,
             mintKnown = walletManager.isMintKnown(info.mint),
         )
         if (!shouldAutoClaim) {
-            holdForApproval(payload, info, eventId)
-            return
+            return holdForApproval(payload, info, eventId)
         }
-        runCatching {
+        return runCatching {
             val amount = walletManager.receiveCashuRequestPayment(
                 tokenString = payload.token,
                 requestId = payload.requestId,
@@ -123,15 +140,17 @@ class CashuRequestListener(
                     amount = amount,
                 )
             }
-        }.onFailure { error ->
-            AppLogger.wallet.error("CashuRequestListener: redeem failed", error)
-            scope.launch {
+            ClaimOutcome.Claimed
+        }.getOrElse { error ->
+            AppLogger.wallet.error("CashuRequestListener: redeem failed; payment remains retryable", error)
+            scope.launch(Dispatchers.Main.immediate) {
                 mutableState.value = CashuRequestListenerState(
                     isRunning = client != null,
                     lastError = error.userFacingWalletMessage,
                     heldForApproval = mutableState.value.heldForApproval,
                 )
             }
+            ClaimOutcome.TransientFailure
         }
     }
 
@@ -139,20 +158,20 @@ class CashuRequestListener(
         payload: PaymentPayloadToken,
         info: TokenInfo,
         eventId: String,
-    ) {
+    ): ClaimOutcome {
         val existing = walletManager.state.value.pendingReceiveTokens
             .firstOrNull { it.token == payload.token }
         if (existing != null) {
             mutableState.value = mutableState.value.copy(heldForApproval = existing)
-            return
+            return ClaimOutcome.Held
         }
 
         val listenerHeldCount = walletManager.state.value.pendingReceiveTokens.count {
-            it.cashuRequestId != null || it.processedId != null
+            it.isCashuRequestPayment
         }
         if (listenerHeldCount >= MaxHeldPayments) {
             AppLogger.wallet.info("CashuRequestListener: approval backlog full; deferring payment")
-            return
+            return ClaimOutcome.TransientFailure
         }
 
         val pending = PendingReceiveToken(
@@ -165,13 +184,87 @@ class CashuRequestListener(
             cashuRequestId = payload.requestId,
             processedId = eventId,
         )
-        walletManager.savePendingReceiveToken(pending)
-        walletManager.loadTransactions()
-        mutableState.value = mutableState.value.copy(
-            lastError = null,
-            heldForApproval = pending,
+        return runCatching {
+            walletManager.savePendingReceiveToken(pending)
+            walletManager.loadTransactions()
+            mutableState.value = mutableState.value.copy(
+                lastError = null,
+                heldForApproval = pending,
+            )
+            AppLogger.wallet.info("CashuRequestListener: payment held for explicit approval")
+            ClaimOutcome.Held
+        }.getOrElse { error ->
+            AppLogger.wallet.error("CashuRequestListener: failed to persist held payment", error)
+            ClaimOutcome.TransientFailure
+        }
+    }
+
+    suspend fun claimHeldPayment(pending: PendingReceiveToken): Long {
+        val amount = heldClaimMutex.withLock {
+            walletManager.claimPendingReceiveToken(pending)
+        }
+        if (mutableState.value.heldForApproval?.tokenId == pending.tokenId) {
+            mutableState.value = mutableState.value.copy(heldForApproval = null)
+        }
+        claimEligibleHeldPayments()
+        return amount
+    }
+
+    fun declineHeldPayment(pending: PendingReceiveToken) {
+        walletManager.removePendingReceiveToken(pending.tokenId)
+        if (mutableState.value.heldForApproval?.tokenId == pending.tokenId) {
+            mutableState.value = mutableState.value.copy(heldForApproval = null)
+        }
+        scope.launch { walletManager.loadTransactions() }
+    }
+
+    suspend fun claimEligibleHeldPayments() {
+        if (!settingsManager.state.value.receivePaymentRequestsAutomatically) return
+        heldClaimMutex.withLock {
+            val eligible = walletManager.state.value.pendingReceiveTokens.filter { pending ->
+                shouldClaimHeldPayment(
+                    autoClaimEnabled = settingsManager.state.value.receivePaymentRequestsAutomatically,
+                    listenerHeld = pending.isCashuRequestPayment,
+                    mintKnown = walletManager.isMintKnown(pending.mintUrl),
+                )
+            }
+            for (pending in eligible) {
+                runCatching { walletManager.claimPendingReceiveToken(pending) }
+                    .onSuccess {
+                        if (mutableState.value.heldForApproval?.tokenId == pending.tokenId) {
+                            mutableState.value = mutableState.value.copy(heldForApproval = null)
+                        }
+                    }
+                    .onFailure {
+                        AppLogger.wallet.error(
+                            "CashuRequestListener: held-payment claim failed; leaving it in History",
+                            it,
+                        )
+                    }
+            }
+        }
+    }
+
+    fun claimEligibleHeldPaymentsAsync() {
+        scope.launch { claimEligibleHeldPayments() }
+    }
+
+    private fun loadProcessedIds() {
+        val stored = metadataStore.string(StorageKeys.cashuRequestsProcessedNip17Ids)
+            ?.let { raw -> runCatching { json.decodeFromString<List<String>>(raw) }.getOrNull() }
+            .orEmpty()
+            .takeLast(MaxProcessedIds)
+        processedOrder = stored.distinct()
+        processedIds = processedOrder.toSet()
+    }
+
+    private fun markProcessed(id: String) {
+        processedOrder = appendProcessedId(processedOrder, id, MaxProcessedIds)
+        processedIds = processedOrder.toSet()
+        metadataStore.putString(
+            StorageKeys.cashuRequestsProcessedNip17Ids,
+            json.encodeToString(processedOrder),
         )
-        AppLogger.wallet.info("CashuRequestListener: payment held for explicit approval")
     }
 
     data class PaymentPayloadToken(
@@ -179,12 +272,43 @@ class CashuRequestListener(
         val requestId: String?,
     )
 
+    internal enum class ClaimOutcome {
+        Claimed,
+        Unclaimable,
+        TransientFailure,
+        Held,
+    }
+
     companion object {
-        private const val MaxHeldPayments = 50
+        internal const val MaxHeldPayments = 50
+        internal const val MaxProcessedIds = 1_000
+        internal const val LookbackWindowSeconds = 7 * 24 * 60 * 60L
+        private const val LegacySinceKey = "cashuRequests.nip17.since.v1"
         private val payloadJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
         internal fun shouldAutoClaim(autoClaimEnabled: Boolean, mintKnown: Boolean): Boolean =
             autoClaimEnabled && mintKnown
+
+        internal fun shouldClaimHeldPayment(
+            autoClaimEnabled: Boolean,
+            listenerHeld: Boolean,
+            mintKnown: Boolean,
+        ): Boolean = autoClaimEnabled && listenerHeld && mintKnown
+
+        internal fun shouldMarkProcessed(outcome: ClaimOutcome): Boolean =
+            outcome != ClaimOutcome.TransientFailure
+
+        internal fun lookbackSince(nowEpochSeconds: Long): Long =
+            nowEpochSeconds - LookbackWindowSeconds
+
+        internal fun appendProcessedId(
+            current: List<String>,
+            id: String,
+            limit: Int,
+        ): List<String> {
+            if (id in current) return current
+            return (current + id).takeLast(limit)
+        }
 
         fun paymentPayloadToToken(content: String): PaymentPayloadToken {
             val fields = payloadJson.parseToJsonElement(content).jsonObject

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -19,10 +19,13 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
+import com.cashu.me.Models.PendingReceiveToken
+import com.cashu.me.Models.TokenInfo
 
 data class CashuRequestListenerState(
     val isRunning: Boolean = false,
     val lastError: String? = null,
+    val heldForApproval: PendingReceiveToken? = null,
 )
 
 class CashuRequestListener(
@@ -41,6 +44,10 @@ class CashuRequestListener(
     val state: StateFlow<CashuRequestListenerState> = mutableState.asStateFlow()
 
     fun start() {
+        if (!settingsManager.state.value.enablePaymentRequests) {
+            stop()
+            return
+        }
         if (client != null) return
         val nostr = nostrService.state.value
         val privateKeyHex = nostrService.currentPrivateKey()
@@ -65,14 +72,18 @@ class CashuRequestListener(
         ) { event ->
             handle(event, recipientPrivateKey)
         }.also { it.start() }
-        mutableState.value = CashuRequestListenerState(isRunning = true)
+        mutableState.value = mutableState.value.copy(isRunning = true, lastError = null)
         AppLogger.wallet.info("CashuRequestListener: started on ${relays.size} relays since=$since")
     }
 
     fun stop() {
         client?.stop()
         client = null
-        mutableState.value = CashuRequestListenerState(isRunning = false)
+        mutableState.value = mutableState.value.copy(isRunning = false)
+    }
+
+    fun dismissHeldPayment() {
+        mutableState.value = mutableState.value.copy(heldForApproval = null)
     }
 
     private suspend fun handle(event: NostrIncomingEvent, recipientPrivateKey: ByteArray) {
@@ -90,6 +101,15 @@ class CashuRequestListener(
         val payload = runCatching { paymentPayloadToToken(rumorContent) }
             .onFailure { AppLogger.wallet.debug("CashuRequestListener: malformed PaymentRequestPayload") }
             .getOrNull() ?: return
+        val info = TokenInfo.parse(payload.token) ?: return
+        val shouldAutoClaim = shouldAutoClaim(
+            autoClaimEnabled = settingsManager.state.value.receivePaymentRequestsAutomatically,
+            mintKnown = walletManager.isMintKnown(info.mint),
+        )
+        if (!shouldAutoClaim) {
+            holdForApproval(payload, info, eventId)
+            return
+        }
         runCatching {
             val amount = walletManager.receiveCashuRequestPayment(
                 tokenString = payload.token,
@@ -109,9 +129,49 @@ class CashuRequestListener(
                 mutableState.value = CashuRequestListenerState(
                     isRunning = client != null,
                     lastError = error.userFacingWalletMessage,
+                    heldForApproval = mutableState.value.heldForApproval,
                 )
             }
         }
+    }
+
+    private suspend fun holdForApproval(
+        payload: PaymentPayloadToken,
+        info: TokenInfo,
+        eventId: String,
+    ) {
+        val existing = walletManager.state.value.pendingReceiveTokens
+            .firstOrNull { it.token == payload.token }
+        if (existing != null) {
+            mutableState.value = mutableState.value.copy(heldForApproval = existing)
+            return
+        }
+
+        val listenerHeldCount = walletManager.state.value.pendingReceiveTokens.count {
+            it.cashuRequestId != null || it.processedId != null
+        }
+        if (listenerHeldCount >= MaxHeldPayments) {
+            AppLogger.wallet.info("CashuRequestListener: approval backlog full; deferring payment")
+            return
+        }
+
+        val pending = PendingReceiveToken(
+            tokenId = payload.token.take(64),
+            token = payload.token,
+            amount = info.amount,
+            dateEpochMillis = System.currentTimeMillis(),
+            mintUrl = info.mint,
+            unit = info.unit,
+            cashuRequestId = payload.requestId,
+            processedId = eventId,
+        )
+        walletManager.savePendingReceiveToken(pending)
+        walletManager.loadTransactions()
+        mutableState.value = mutableState.value.copy(
+            lastError = null,
+            heldForApproval = pending,
+        )
+        AppLogger.wallet.info("CashuRequestListener: payment held for explicit approval")
     }
 
     data class PaymentPayloadToken(
@@ -120,7 +180,11 @@ class CashuRequestListener(
     )
 
     companion object {
+        private const val MaxHeldPayments = 50
         private val payloadJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+        internal fun shouldAutoClaim(autoClaimEnabled: Boolean, mintKnown: Boolean): Boolean =
+            autoClaimEnabled && mintKnown
 
         fun paymentPayloadToToken(content: String): PaymentPayloadToken {
             val fields = payloadJson.parseToJsonElement(content).jsonObject

--- a/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrInboxClient.kt
@@ -37,8 +37,7 @@ class NostrInboxClient(
     private val sockets = mutableSetOf<WebSocket>()
     @Volatile
     private var running = false
-    @Volatile
-    private var sinceTimestamp = since
+    private val sinceTimestamp = since
 
     fun start() {
         if (running) return
@@ -55,10 +54,6 @@ class NostrInboxClient(
             sockets.forEach { it.close(1000, "closed") }
             sockets.clear()
         }
-    }
-
-    fun updateSince(timestamp: Long) {
-        if (timestamp > sinceTimestamp) sinceTimestamp = timestamp
     }
 
     private suspend fun connectLoop(relay: String) {
@@ -92,7 +87,6 @@ class NostrInboxClient(
         val event = runCatching {
             json.decodeFromJsonElement<NostrIncomingEvent>(array[2].jsonObject)
         }.getOrNull() ?: return
-        updateSince(event.createdAt)
         onEvent(event)
     }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -61,6 +61,7 @@ object StorageKeys {
     const val walletProcessedCashuRequests = "wallet.processedCashuRequests"
     const val cashuRequests = "cashuRequests.v1"
     const val cashuRequestsCurrentId = "cashuRequests.currentId.v1"
+    const val cashuRequestsProcessedNip17Ids = "cashuRequests.processedNIP17Ids.v1"
 
     const val settingsUseBitcoinSymbol = "settings.useBitcoinSymbol"
     const val settingsShowFiatBalance = "settings.showFiatBalance"

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
@@ -169,7 +169,6 @@ class SettingsManager(
     }
     fun setCheckSentTokens(value: Boolean) = update { settingsStore.checkSentTokens = value }
     fun setAutoPasteEcashReceive(value: Boolean) = update { settingsStore.autoPasteEcashReceive = value }
-    // TODO(runtime-parity): Payment request processing is not started from these Swift parity toggles yet.
     fun setEnablePaymentRequests(value: Boolean) = update { settingsStore.enablePaymentRequests = value }
     fun setReceivePaymentRequestsAutomatically(value: Boolean) = update {
         settingsStore.receivePaymentRequestsAutomatically = value

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
@@ -17,8 +17,8 @@ data class SettingsState(
     val checkSentTokens: Boolean = true,
     val autoPasteEcashReceive: Boolean = true,
     val useWebsockets: Boolean = true,
-    val enablePaymentRequests: Boolean = false,
-    val receivePaymentRequestsAutomatically: Boolean = false,
+    val enablePaymentRequests: Boolean = true,
+    val receivePaymentRequestsAutomatically: Boolean = true,
     val showP2PKButtonInDrawer: Boolean = false,
     val amountDisplayPrimary: String = "fiat",
     val homeBalanceUnit: String = "sat",
@@ -134,6 +134,7 @@ class SettingsManager(
 
     // Wired by AppContainer (same pattern as NPCService.quoteClaimHandler).
     var sentryService: SentryService? = null
+    var claimEligibleHeldPayments: (() -> Unit)? = null
 
     // Wired by AppContainer: the seed-derived primary P2PK key (iOS
     // primaryP2PKPublicKey/PrivateKeyHex). Null until the wallet seed is loaded.
@@ -170,8 +171,14 @@ class SettingsManager(
     fun setCheckSentTokens(value: Boolean) = update { settingsStore.checkSentTokens = value }
     fun setAutoPasteEcashReceive(value: Boolean) = update { settingsStore.autoPasteEcashReceive = value }
     fun setEnablePaymentRequests(value: Boolean) = update { settingsStore.enablePaymentRequests = value }
-    fun setReceivePaymentRequestsAutomatically(value: Boolean) = update {
-        settingsStore.receivePaymentRequestsAutomatically = value
+    fun setReceivePaymentRequestsAutomatically(value: Boolean) {
+        val previous = state.value.receivePaymentRequestsAutomatically
+        update {
+            settingsStore.receivePaymentRequestsAutomatically = value
+        }
+        if (value && !previous) {
+            claimEligibleHeldPayments?.invoke()
+        }
     }
     fun setShowP2PKButtonInDrawer(value: Boolean) = update { settingsStore.showP2PKButtonInDrawer = value }
     // Mirrors Swift SettingsManager.sentryEnabled didSet: persist, then start/stop the SDK on change.

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -59,11 +59,11 @@ class SettingsStore(
         set(value) = store.putBoolean(StorageKeys.settingsUseWebsockets, value)
 
     var enablePaymentRequests: Boolean
-        get() = store.boolean(StorageKeys.settingsEnablePaymentRequests, false)
+        get() = store.boolean(StorageKeys.settingsEnablePaymentRequests, true)
         set(value) = store.putBoolean(StorageKeys.settingsEnablePaymentRequests, value)
 
     var receivePaymentRequestsAutomatically: Boolean
-        get() = store.boolean(StorageKeys.settingsReceivePaymentRequestsAutomatically, false)
+        get() = store.boolean(StorageKeys.settingsReceivePaymentRequestsAutomatically, true)
         set(value) = store.putBoolean(StorageKeys.settingsReceivePaymentRequestsAutomatically, value)
 
     var showP2PKButtonInDrawer: Boolean
@@ -210,9 +210,12 @@ class SettingsStore(
     }
 
     private val walletScopedKeys = setOf(
+        StorageKeys.settingsEnablePaymentRequests,
+        StorageKeys.settingsReceivePaymentRequestsAutomatically,
         StorageKeys.settingsP2PKKeys,
         StorageKeys.settingsNostrSignerType,
         StorageKeys.settingsNostrMintBackupEnabled,
+        StorageKeys.cashuRequestsProcessedNip17Ids,
         StorageKeys.walletNostrMintBackupLastBackupDate,
         StorageKeys.npcEnabled,
         StorageKeys.npcAutomaticClaim,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -861,6 +861,13 @@ class WalletManager(
         return amount
     }
 
+    fun isMintKnown(url: String): Boolean {
+        val normalized = normalizedMintUrlForSelection(url) ?: return false
+        return state.value.mints.any {
+            normalizedMintUrlForSelection(it.url) == normalized
+        }
+    }
+
     suspend fun receiveNfcCashuRequestPayment(
         tokenString: String,
         processedId: String,
@@ -912,7 +919,23 @@ class WalletManager(
     }
 
     suspend fun claimPendingReceiveToken(token: PendingReceiveToken): Long {
-        val amount = receiveTokens(token.token)
+        val amount = if (token.cashuRequestId != null || token.processedId != null) {
+            receiveCashuRequestPayment(
+                tokenString = token.token,
+                requestId = token.cashuRequestId,
+                processedId = token.processedId,
+            ).also { received ->
+                if (received > 0 && !token.cashuRequestId.isNullOrBlank()) {
+                    cashuRequestStore.attachPayment(
+                        requestId = token.cashuRequestId,
+                        transactionId = token.processedId ?: token.cashuRequestId,
+                        amount = received,
+                    )
+                }
+            }
+        } else {
+            receiveTokens(token.token)
+        }
         removePendingReceiveToken(token.tokenId)
         return amount
     }

--- a/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
@@ -35,6 +35,7 @@ data class PendingReceiveToken(
     val processedId: String? = null,
 ) {
     val id: String get() = tokenId
+    val isCashuRequestPayment: Boolean get() = cashuRequestId != null || processedId != null
 }
 
 @Serializable

--- a/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
@@ -31,6 +31,8 @@ data class PendingReceiveToken(
     val dateEpochMillis: Long,
     val mintUrl: String,
     val unit: String = "sat",
+    val cashuRequestId: String? = null,
+    val processedId: String? = null,
 ) {
     val id: String get() = tokenId
 }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
@@ -147,7 +147,11 @@ fun ReceiveEcashDetailScreen(
                     onReceive = { review?.let(::claim) },
                     onReceiveLater = {
                         review?.let {
-                            walletManager.savePendingReceiveToken(pendingReceiveTokenFrom(it))
+                            val alreadyPending = walletManager.state.value.pendingReceiveTokens
+                                .any { pending -> pending.token == it.token }
+                            if (!alreadyPending) {
+                                walletManager.savePendingReceiveToken(pendingReceiveTokenFrom(it))
+                            }
                             onDone()
                         }
                     },

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
@@ -38,6 +38,7 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Models.PendingReceiveToken
 import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.GhostButton
@@ -69,8 +70,13 @@ fun ReceiveEcashDetailScreen(
     payload: String,
     onDone: () -> Unit,
     onDismissLockChanged: (Boolean) -> Unit = {},
+    claimPendingReceiveToken: suspend (PendingReceiveToken) -> Long =
+        walletManager::claimPendingReceiveToken,
+    onDeclinePendingReceiveToken: (PendingReceiveToken) -> Unit =
+        { walletManager.removePendingReceiveToken(it.tokenId) },
 ) {
     val settings by settingsManager.state.collectAsState()
+    val walletState by walletManager.state.collectAsState()
     val priceState by priceService.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
@@ -104,8 +110,12 @@ fun ReceiveEcashDetailScreen(
         if (status != null) return
         status = TokenClaimStatus.Claiming
         scope.launch {
-            status = claimToken(target, walletManager)
+            status = claimToken(target, walletManager, claimPendingReceiveToken)
         }
+    }
+
+    val heldPayment = walletState.pendingReceiveTokens.firstOrNull {
+        it.token == (parsed as? TokenParseOutcome.Ok)?.token && it.isCashuRequestPayment
     }
 
     // Surface (not a bare Box): the overlay renders outside any Material
@@ -145,14 +155,20 @@ fun ReceiveEcashDetailScreen(
                     onFlipPrimary = { settingsManager.setAmountDisplayPrimary(it.rawValue) },
                     onClose = onDone,
                     onReceive = { review?.let(::claim) },
-                    onReceiveLater = {
-                        review?.let {
-                            val alreadyPending = walletManager.state.value.pendingReceiveTokens
-                                .any { pending -> pending.token == it.token }
-                            if (!alreadyPending) {
-                                walletManager.savePendingReceiveToken(pendingReceiveTokenFrom(it))
-                            }
+                    secondaryActionText = if (heldPayment != null) "Decline" else "Receive later",
+                    onSecondaryAction = {
+                        if (heldPayment != null) {
+                            onDeclinePendingReceiveToken(heldPayment)
                             onDone()
+                        } else {
+                            review?.let {
+                                val alreadyPending = walletManager.state.value.pendingReceiveTokens
+                                    .any { pending -> pending.token == it.token }
+                                if (!alreadyPending) {
+                                    walletManager.savePendingReceiveToken(pendingReceiveTokenFrom(it))
+                                }
+                                onDone()
+                            }
                         }
                     },
                 )
@@ -174,7 +190,8 @@ private fun ConfirmContent(
     onFlipPrimary: (AmountDisplayPrimary) -> Unit,
     onClose: () -> Unit,
     onReceive: () -> Unit,
-    onReceiveLater: () -> Unit,
+    secondaryActionText: String,
+    onSecondaryAction: () -> Unit,
 ) {
     val info = parsed.info
     val isSatToken = info.unit.equals("sat", ignoreCase = true)
@@ -248,8 +265,8 @@ private fun ConfirmContent(
             )
             Spacer(Modifier.height(CashuTheme.spacing.snug))
             GhostButton(
-                text = "Receive later",
-                onClick = onReceiveLater,
+                text = secondaryActionText,
+                onClick = onSecondaryAction,
             )
             Spacer(Modifier.navigationBarsPadding())
         }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -101,6 +101,8 @@ internal const val MinClaimingBeatMillis = 500L
 internal suspend fun claimToken(
     review: TokenReview,
     walletManager: WalletManager,
+    claimPendingReceiveToken: suspend (PendingReceiveToken) -> Long =
+        walletManager::claimPendingReceiveToken,
 ): TokenClaimStatus {
     val startedAt = System.currentTimeMillis()
     val result = try {
@@ -108,7 +110,7 @@ internal suspend fun claimToken(
             .firstOrNull { it.token == review.token }
         Result.success(
             if (pending != null) {
-                walletManager.claimPendingReceiveToken(pending)
+                claimPendingReceiveToken(pending)
             } else {
                 walletManager.receiveTokens(review.token)
             },

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -104,7 +104,15 @@ internal suspend fun claimToken(
 ): TokenClaimStatus {
     val startedAt = System.currentTimeMillis()
     val result = try {
-        Result.success(walletManager.receiveTokens(review.token))
+        val pending = walletManager.state.value.pendingReceiveTokens
+            .firstOrNull { it.token == review.token }
+        Result.success(
+            if (pending != null) {
+                walletManager.claimPendingReceiveToken(pending)
+            } else {
+                walletManager.receiveTokens(review.token)
+            },
+        )
     } catch (c: CancellationException) {
         throw c
     } catch (t: Throwable) {
@@ -115,9 +123,6 @@ internal suspend fun claimToken(
     if (elapsed < MinClaimingBeatMillis) delay(MinClaimingBeatMillis - elapsed)
     return result.fold(
         onSuccess = { credited ->
-            // If this token was previously saved via "Receive later", clear the
-            // stored pending record — it's redeemed now.
-            walletManager.removePendingReceiveToken(review.token.take(64))
             TokenClaimStatus.Claimed(
                 // The gateway reports what was actually credited (net of the
                 // receive-swap fee); fall back to the reviewed net amount.

--- a/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
@@ -102,6 +102,22 @@ fun PrivacyScreen(
                 onCheckedChange = settingsManager::setUseWebsockets,
             )
 
+            SectionHeader("Payment requests")
+            ToggleRow(
+                title = "Listen for payment requests",
+                subtitle = "Receive ecash sent to your Nostr key while the app is open",
+                checked = settings.enablePaymentRequests,
+                onCheckedChange = settingsManager::setEnablePaymentRequests,
+            )
+            CanvasDivider(leadingInset = 16.dp)
+            ToggleRow(
+                title = "Receive automatically",
+                subtitle = "Automatically receive payments from mints you already trust",
+                checked = settings.receivePaymentRequestsAutomatically,
+                onCheckedChange = settingsManager::setReceivePaymentRequestsAutomatically,
+                enabled = settings.enablePaymentRequests,
+            )
+
             SectionHeader("Convenience")
             ToggleRow(
                 title = "Auto-paste ecash on Receive",

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -109,12 +109,13 @@ private fun CashuAppContent(container: AppContainer) {
     }
 
     val isRuntimeReadyRef by rememberUpdatedState(isRuntimeReady)
+    val shouldListenForRequests = isRuntimeReady && settings.enablePaymentRequests
+    val shouldListenForRequestsRef by rememberUpdatedState(shouldListenForRequests)
 
     LaunchedEffect(isRuntimeReady) {
         if (isRuntimeReady) {
-            container.cashuRequestListener.start()
-            val settings = container.settingsManager.state.value
-            if (settings.checkPendingOnStartup && settings.checkSentTokens) {
+            val currentSettings = container.settingsManager.state.value
+            if (currentSettings.checkPendingOnStartup && currentSettings.checkSentTokens) {
                 container.walletManager.checkAllPendingTokens()
             }
             // Runtime became ready while the process is already foregrounded —
@@ -126,6 +127,13 @@ private fun CashuAppContent(container: AppContainer) {
         } else {
             container.cashuRequestListener.stop()
             container.walletManager.stopPendingQuoteForegroundPolling()
+        }
+    }
+    LaunchedEffect(shouldListenForRequests) {
+        if (shouldListenForRequests) {
+            container.cashuRequestListener.start()
+        } else {
+            container.cashuRequestListener.stop()
         }
     }
 
@@ -163,7 +171,7 @@ private fun CashuAppContent(container: AppContainer) {
                 Lifecycle.Event.ON_START,
                 Lifecycle.Event.ON_RESUME -> {
                     container.appLockManager.appBecameActive()
-                    if (isRuntimeReadyRef) {
+                    if (shouldListenForRequestsRef) {
                         container.cashuRequestListener.start()
                     }
                 }
@@ -248,6 +256,30 @@ private fun AuthenticatedShell(container: AppContainer) {
     val pendingDeepLink by container.navigationManager.pendingDeepLink.collectAsState()
     val connectivityState by container.connectivityObserver.state.collectAsState()
     val appLockState by container.appLockManager.state.collectAsState()
+    val cashuRequestListenerState by container.cashuRequestListener.state.collectAsState()
+
+    // Incoming payments that are not eligible for silent receipt are already
+    // persisted before being surfaced. Present the normal Receive review when
+    // the shell is idle; closing it leaves the payment claimable from History.
+    LaunchedEffect(
+        cashuRequestListenerState.heldForApproval?.tokenId,
+        receiveTokenDetail,
+        activeFlow,
+        scannerTarget,
+        showContactless,
+        appLockState.isLocked,
+    ) {
+        val held = cashuRequestListenerState.heldForApproval ?: return@LaunchedEffect
+        val canPresent = receiveTokenDetail == null &&
+            activeFlow == null &&
+            scannerTarget == null &&
+            !showContactless &&
+            !appLockState.isLocked
+        if (canPresent) {
+            receiveTokenDetail = held.token
+            container.cashuRequestListener.dismissHeldPayment()
+        }
+    }
 
     LaunchedEffect(pendingDeepLink) {
         val deepLink = pendingDeepLink ?: return@LaunchedEffect

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -136,7 +136,6 @@ private fun CashuAppContent(container: AppContainer) {
             container.cashuRequestListener.stop()
         }
     }
-
     // App-process foreground (not Activity): M3 ModalBottomSheet runs in its own
     // Dialog window and can ON_STOP the Activity while the user is still in the
     // app. Quote detection must keep running — iOS scenePhase parity.
@@ -383,6 +382,14 @@ private fun AuthenticatedShell(container: AppContainer) {
                 payload = lastReceiveTokenDetail,
                 onDone = { receiveTokenDetail = null },
                 onDismissLockChanged = { receiveDetailDismissLocked = it },
+                claimPendingReceiveToken = { pending ->
+                    if (pending.isCashuRequestPayment) {
+                        container.cashuRequestListener.claimHeldPayment(pending)
+                    } else {
+                        container.walletManager.claimPendingReceiveToken(pending)
+                    }
+                },
+                onDeclinePendingReceiveToken = container.cashuRequestListener::declineHeldPayment,
             )
         }
         // System back (including predictive back) must dismiss the topmost overlay

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -33,5 +34,13 @@ class CashuRequestListenerTest {
         assertEquals("sat", fields["unit"]!!.jsonPrimitive.content)
         assertEquals("Thanks", fields["memo"]!!.jsonPrimitive.content)
         assertEquals(1, entry["proofs"]!!.jsonArray.size)
+    }
+
+    @Test
+    fun automaticClaimRequiresOptInAndPreviouslyTrustedMint() {
+        assertFalse(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = false, mintKnown = false))
+        assertFalse(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = false, mintKnown = true))
+        assertFalse(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = true, mintKnown = false))
+        assertTrue(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = true, mintKnown = true))
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestListenerTest.kt
@@ -43,4 +43,85 @@ class CashuRequestListenerTest {
         assertFalse(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = true, mintKnown = false))
         assertTrue(CashuRequestListener.shouldAutoClaim(autoClaimEnabled = true, mintKnown = true))
     }
+
+    @Test
+    fun heldAutomaticClaimRequiresListenerOwnershipAndKnownMint() {
+        assertFalse(
+            CashuRequestListener.shouldClaimHeldPayment(
+                autoClaimEnabled = false,
+                listenerHeld = true,
+                mintKnown = true,
+            ),
+        )
+        assertFalse(
+            CashuRequestListener.shouldClaimHeldPayment(
+                autoClaimEnabled = true,
+                listenerHeld = false,
+                mintKnown = true,
+            ),
+        )
+        assertFalse(
+            CashuRequestListener.shouldClaimHeldPayment(
+                autoClaimEnabled = true,
+                listenerHeld = true,
+                mintKnown = false,
+            ),
+        )
+        assertTrue(
+            CashuRequestListener.shouldClaimHeldPayment(
+                autoClaimEnabled = true,
+                listenerHeld = true,
+                mintKnown = true,
+            ),
+        )
+    }
+
+    @Test
+    fun transientFailuresRemainRetryable() {
+        assertFalse(
+            CashuRequestListener.shouldMarkProcessed(
+                CashuRequestListener.ClaimOutcome.TransientFailure,
+            ),
+        )
+        assertTrue(
+            CashuRequestListener.shouldMarkProcessed(
+                CashuRequestListener.ClaimOutcome.Held,
+            ),
+        )
+        assertTrue(
+            CashuRequestListener.shouldMarkProcessed(
+                CashuRequestListener.ClaimOutcome.Claimed,
+            ),
+        )
+        assertTrue(
+            CashuRequestListener.shouldMarkProcessed(
+                CashuRequestListener.ClaimOutcome.Unclaimable,
+            ),
+        )
+    }
+
+    @Test
+    fun listenerUsesFixedLookbackAndBoundedProcessedIds() {
+        val now = 2_000_000L
+        assertEquals(
+            now - CashuRequestListener.LookbackWindowSeconds,
+            CashuRequestListener.lookbackSince(now),
+        )
+        assertEquals(
+            listOf("b", "c"),
+            CashuRequestListener.appendProcessedId(
+                current = listOf("a", "b"),
+                id = "c",
+                limit = 2,
+            ),
+        )
+        assertEquals(
+            listOf("a", "b"),
+            CashuRequestListener.appendProcessedId(
+                current = listOf("a", "b"),
+                id = "b",
+                limit = 2,
+            ),
+        )
+    }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/SettingsManagerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/SettingsManagerTest.kt
@@ -7,6 +7,14 @@ import org.junit.Test
 
 class SettingsManagerTest {
     @Test
+    fun cashuRequestPrivacyDefaultsMatchIos() {
+        val defaults = SettingsState()
+
+        assertEquals(true, defaults.enablePaymentRequests)
+        assertEquals(true, defaults.receivePaymentRequestsAutomatically)
+    }
+
+    @Test
     fun p2pkSendNormalizationAcceptsXOnlyHex() {
         val xOnly = "a".repeat(64)
 


### PR DESCRIPTION
## Summary

- honor the Cashu Request listener and automatic-receipt privacy settings at runtime
- only auto-claim payments from already-trusted mints; persist all others for explicit approval
- align Android defaults, wallet-boundary behavior, and held-payment draining with iOS
- use a fixed seven-day NIP-59 lookback with bounded processed-event IDs so transient failures and a full approval backlog remain retryable
- serialize inbox event handling to avoid duplicate relay deliveries racing each other
- preserve Cashu Request attribution when a held payment is claimed
- add explicit **Decline** behavior for listener-held payments while keeping **Receive later** for ordinary tokens
- expand unit and DataStore instrumentation coverage for privacy defaults, retry outcomes, event retention, and settings transitions

## Why

Android previously started the Cashu Request listener and claimed incoming payments without honoring its stored privacy settings. The initial fix added the controls, but Android still differed from iOS in defaults, retry behavior, held-payment queue handling, and approval actions. This update closes those gaps and avoids advancing a relay cursor past payments that have not been claimed or durably held.

## Verification

- `./gradlew --no-daemon :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin :app:lintDebug :app:assembleRelease --stacktrace`
