### PR TITLE
fix(ios): preserve mint list during iCloud restore

### DIFF
--- a/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
@@ -12,9 +12,42 @@ struct ICloudBackupInfo: Sendable {
 /// instead of an unconditional "Backed up ✓".
 enum ICloudBackupOutcome: Equatable {
     case success(mintCount: Int)
+    case deferred
     case unavailable
     case noSeed
     case failed(String)
+}
+
+enum ICloudRestoreState {
+    private static let incompleteKey = "cashu.local.icloudRestoreIncomplete"
+
+    static func isIncomplete(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: incompleteKey)
+    }
+
+    static func setIncomplete(
+        _ incomplete: Bool,
+        defaults: UserDefaults = .standard
+    ) {
+        if incomplete {
+            defaults.set(true, forKey: incompleteKey)
+        } else {
+            defaults.removeObject(forKey: incompleteKey)
+        }
+    }
+}
+
+enum ICloudRestorePolicy {
+    static func shouldPerformBackup(restoreIncomplete: Bool) -> Bool {
+        !restoreIncomplete
+    }
+
+    static func needsOnboarding(
+        hasStoredMnemonic: Bool,
+        restoreIncomplete: Bool
+    ) -> Bool {
+        !hasStoredMnemonic || restoreIncomplete
+    }
 }
 
 extension WalletManager {
@@ -59,7 +92,8 @@ extension WalletManager {
     var iCloudBackupEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Self.iCloudEnabledKey) }
         set {
-            setICloudBackupEnabledLocally(newValue)
+            UserDefaults.standard.set(newValue, forKey: Self.iCloudEnabledKey)
+            objectWillChange.send()
             if newValue {
                 performICloudBackup()
             } else {
@@ -68,11 +102,12 @@ extension WalletManager {
         }
     }
 
-    /// Updates the device-local preference without changing the remote backup.
-    /// Restore uses this to prevent clean-wallet installation and per-mint
-    /// recovery from replacing the only known mint list with an incomplete one.
-    private func setICloudBackupEnabledLocally(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: Self.iCloudEnabledKey)
+    var hasIncompleteICloudRestore: Bool {
+        ICloudRestoreState.isIncomplete()
+    }
+
+    func setICloudRestoreIncomplete(_ incomplete: Bool) {
+        ICloudRestoreState.setIncomplete(incomplete)
         objectWillChange.send()
     }
 
@@ -123,6 +158,13 @@ extension WalletManager {
 
     @discardableResult
     func performICloudBackup() -> ICloudBackupOutcome {
+        guard ICloudRestorePolicy.shouldPerformBackup(
+            restoreIncomplete: hasIncompleteICloudRestore
+        ) else {
+            AppLogger.wallet.info("iCloud backup deferred: wallet restore is incomplete")
+            lastICloudBackupOutcome = .deferred
+            return .deferred
+        }
         guard iCloudBackupEnabled, iCloudAvailable() else {
             AppLogger.wallet.error("iCloud backup skipped: iCloud unavailable")
             lastICloudBackupOutcome = .unavailable
@@ -170,24 +212,20 @@ extension WalletManager {
         }
         AppLogger.wallet.info("iCloud restore: starting, \(backup.mintURLs.count) mint(s) to restore")
 
-        // Installing a clean wallet normally performs an immediate backup. Keep
-        // backup writes disabled until every original mint has been recovered,
-        // otherwise the clean install (zero mints) or a partial restore can
-        // overwrite the only list of mints still needing recovery.
-        let wasBackupEnabled = iCloudBackupEnabled
-        setICloudBackupEnabledLocally(false)
-        do {
-            try await initializeRestoredWallet(mnemonic: recoveredMnemonic)
-        } catch {
-            setICloudBackupEnabledLocally(wasBackupEnabled)
-            throw error
-        }
+        // Keep the user's backup preference intact while independently
+        // suppressing writes. Persist the marker so an interruption cannot make
+        // a partial wallet look complete on the next launch.
+        setICloudRestoreIncomplete(true)
+        try await initializeRestoredWallet(mnemonic: recoveredMnemonic)
 
         var failedMintCount = 0
         for url in backup.mintURLs {
             do {
                 _ = try await restoreFromMint(url: url)
             } catch {
+                if error is CancellationError {
+                    throw error
+                }
                 failedMintCount += 1
                 AppLogger.wallet.error("iCloud restore: mint recovery failed for \(url): \(error)")
             }
@@ -202,6 +240,7 @@ extension WalletManager {
         }
 
         // Only a complete restore may replace the backed-up mint list.
+        setICloudRestoreIncomplete(false)
         iCloudBackupEnabled = true
         AppLogger.wallet.info("iCloud restore: complete, balance \(self.balance)")
     }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
@@ -59,14 +59,21 @@ extension WalletManager {
     var iCloudBackupEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: Self.iCloudEnabledKey) }
         set {
-            UserDefaults.standard.set(newValue, forKey: Self.iCloudEnabledKey)
-            objectWillChange.send()
+            setICloudBackupEnabledLocally(newValue)
             if newValue {
                 performICloudBackup()
             } else {
                 clearICloudBackupData()
             }
         }
+    }
+
+    /// Updates the device-local preference without changing the remote backup.
+    /// Restore uses this to prevent clean-wallet installation and per-mint
+    /// recovery from replacing the only known mint list with an incomplete one.
+    private func setICloudBackupEnabledLocally(_ enabled: Bool) {
+        UserDefaults.standard.set(enabled, forKey: Self.iCloudEnabledKey)
+        objectWillChange.send()
     }
 
     var lastICloudBackupDate: Date? {
@@ -162,11 +169,40 @@ extension WalletManager {
             throw WalletError.networkError("iCloud Keychain item is missing.")
         }
         AppLogger.wallet.info("iCloud restore: starting, \(backup.mintURLs.count) mint(s) to restore")
-        try await initializeRestoredWallet(mnemonic: recoveredMnemonic)
-        for url in backup.mintURLs {
-            _ = try? await restoreFromMint(url: url)
+
+        // Installing a clean wallet normally performs an immediate backup. Keep
+        // backup writes disabled until every original mint has been recovered,
+        // otherwise the clean install (zero mints) or a partial restore can
+        // overwrite the only list of mints still needing recovery.
+        let wasBackupEnabled = iCloudBackupEnabled
+        setICloudBackupEnabledLocally(false)
+        do {
+            try await initializeRestoredWallet(mnemonic: recoveredMnemonic)
+        } catch {
+            setICloudBackupEnabledLocally(wasBackupEnabled)
+            throw error
         }
-        AppLogger.wallet.info("iCloud restore: complete, balance \(self.balance)")
+
+        var failedMintCount = 0
+        for url in backup.mintURLs {
+            do {
+                _ = try await restoreFromMint(url: url)
+            } catch {
+                failedMintCount += 1
+                AppLogger.wallet.error("iCloud restore: mint recovery failed for \(url): \(error)")
+            }
+        }
+
+        guard failedMintCount == 0 else {
+            AppLogger.wallet.error("iCloud restore: \(failedMintCount) mint(s) failed; preserving existing backup")
+            throw WalletError.networkError(
+                "Could not restore \(failedMintCount) of \(backup.mintURLs.count) mints. "
+                    + "Your iCloud backup was preserved. Try again when all mints are reachable."
+            )
+        }
+
+        // Only a complete restore may replace the backed-up mint list.
         iCloudBackupEnabled = true
+        AppLogger.wallet.info("iCloud restore: complete, balance \(self.balance)")
     }
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -25,11 +25,14 @@ enum WalletStartupPolicy {
         return now - lastRefresh >= keysetRefreshInterval
     }
 
-    /// A CDK/database failure must not hide a wallet whose complete cached home
-    /// model was already published. Without a cache, onboarding is the only
-    /// recoverable presentation.
-    static func needsOnboardingAfterRuntimeFailure(cachedWalletPublished: Bool) -> Bool {
-        !cachedWalletPublished
+    /// A CDK/database failure must not hide a complete wallet whose cached home
+    /// model was already published. An interrupted iCloud restore is never
+    /// complete, so it must return to recovery even when partial cache exists.
+    static func needsOnboardingAfterRuntimeFailure(
+        cachedWalletPublished: Bool,
+        iCloudRestoreIncomplete: Bool = false
+    ) -> Bool {
+        iCloudRestoreIncomplete || !cachedWalletPublished
     }
 }
 
@@ -46,6 +49,7 @@ extension WalletManager {
         if IntegrationTestConfig.shouldResetWallet {
             try? keychainService.deleteMnemonic()
             try? keychainService.deleteNostrPrivateKey()
+            setICloudRestoreIncomplete(false)
             SettingsManager.shared.resetWalletScopedData()
         }
 
@@ -85,7 +89,10 @@ extension WalletManager {
             if let storedMnemonic {
                 mnemonic = storedMnemonic
                 loadCachedWalletState()
-                needsOnboarding = false
+                needsOnboarding = ICloudRestorePolicy.needsOnboarding(
+                    hasStoredMnemonic: true,
+                    restoreIncomplete: hasIncompleteICloudRestore
+                )
                 isInitialized = true
                 publishedCachedWallet = true
                 WalletStartupInstrumentation.signposter.emitEvent(
@@ -112,7 +119,10 @@ extension WalletManager {
                 startDeferredStartupMaintenance()
                 SentryService.breadcrumb("Wallet loaded", category: "wallet.lifecycle")
             } else {
-                needsOnboarding = true
+                needsOnboarding = ICloudRestorePolicy.needsOnboarding(
+                    hasStoredMnemonic: false,
+                    restoreIncomplete: hasIncompleteICloudRestore
+                )
                 isRuntimeReady = true
                 isInitialized = true
                 // Neither cloud synchronization nor logging setup is required
@@ -131,7 +141,8 @@ extension WalletManager {
             // A runtime-open failure must not hide already-published balances
             // and history or incorrectly send an existing wallet to onboarding.
             needsOnboarding = WalletStartupPolicy.needsOnboardingAfterRuntimeFailure(
-                cachedWalletPublished: publishedCachedWallet
+                cachedWalletPublished: publishedCachedWallet,
+                iCloudRestoreIncomplete: hasIncompleteICloudRestore
             )
         }
     }
@@ -238,6 +249,15 @@ extension WalletManager {
 
     func completeOnboarding() {
         transactionService.loadCachedState()
+        if hasIncompleteICloudRestore {
+            // Choosing a different onboarding path after an interrupted iCloud
+            // restore is also a valid completion. Release the write barrier only
+            // once that replacement wallet and its mint list are final.
+            setICloudRestoreIncomplete(false)
+            if iCloudBackupEnabled {
+                performICloudBackup()
+            }
+        }
         needsOnboarding = false
         guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
         CashuRequestListener.shared.attach(walletManager: self)

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -121,6 +121,13 @@ struct OnboardingView: View {
         .sheet(isPresented: $showConceptSheet) {
             conceptSheet
         }
+        .onAppear {
+            guard walletManager.hasIncompleteICloudRestore else { return }
+            currentStep = .iCloudRestore
+            iCloudRestorePhase = .preview
+            detectedICloudBackup = nil
+            isDetectingICloudBackup = true
+        }
     }
 
     // Quiet crossfade between steps — no lateral slide. A horizontal push read

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -1581,6 +1581,7 @@ struct ICloudBackupSettingsView: View {
     private func backupErrorMessage(for outcome: ICloudBackupOutcome) -> String? {
         switch outcome {
         case .success: return nil
+        case .deferred: return "iCloud backup is paused until wallet recovery finishes."
         case .unavailable: return "iCloud is unavailable. Sign in to iCloud in Settings and try again."
         case .noSeed: return "There's no wallet seed to back up."
         case .failed(let message): return message

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -278,6 +278,49 @@ final class WalletStoreTests: XCTestCase {
         ))
     }
 
+    func testIncompleteICloudRestoreSuppressesBackupWrites() {
+        XCTAssertFalse(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: true))
+        XCTAssertTrue(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: false))
+    }
+
+    func testIncompleteICloudRestoreRequiresOnboardingWithStoredSeed() {
+        XCTAssertTrue(ICloudRestorePolicy.needsOnboarding(
+            hasStoredMnemonic: true,
+            restoreIncomplete: true
+        ))
+        XCTAssertFalse(ICloudRestorePolicy.needsOnboarding(
+            hasStoredMnemonic: true,
+            restoreIncomplete: false
+        ))
+        XCTAssertTrue(ICloudRestorePolicy.needsOnboarding(
+            hasStoredMnemonic: false,
+            restoreIncomplete: false
+        ))
+    }
+
+    func testIncompleteICloudRestoreOverridesPublishedCacheAfterRuntimeFailure() {
+        XCTAssertTrue(WalletStartupPolicy.needsOnboardingAfterRuntimeFailure(
+            cachedWalletPublished: true,
+            iCloudRestoreIncomplete: true
+        ))
+    }
+
+    func testIncompleteICloudRestoreStatePersistsUntilCleared() {
+        let suiteName = "ICloudRestoreStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(ICloudRestoreState.isIncomplete(defaults: defaults))
+
+        ICloudRestoreState.setIncomplete(true, defaults: defaults)
+        XCTAssertTrue(ICloudRestoreState.isIncomplete(
+            defaults: UserDefaults(suiteName: suiteName)!
+        ))
+
+        ICloudRestoreState.setIncomplete(false, defaults: defaults)
+        XCTAssertFalse(ICloudRestoreState.isIncomplete(defaults: defaults))
+    }
+
     // MARK: - removeAllWalletData
 
     func testRemoveAllWalletDataClearsMints() {


### PR DESCRIPTION
## Summary

- preserve the remote iCloud mint list until every mint has been recovered
- keep the user's backup preference separate from the temporary restore write barrier
- persist incomplete restore state so an interrupted or failed restore resumes in onboarding after relaunch
- defer automatic backup writes until recovery completes, while preserving task cancellation
- cover restore-state persistence, backup suppression, and launch/onboarding policy with unit tests

## Why

Installing a clean wallet can trigger an immediate backup before its mints have been recovered. That could replace the only complete iCloud mint list with an empty or partial list. A persistent restore marker now prevents those writes and also ensures a partial wallet is not treated as fully restored after the app restarts.

## Validation

- Targeted `CashuWalletTests/WalletStoreTests` passed on an iPhone 17 simulator.
- `git diff --check` passed.
