### PR TITLE
Surface onboarding startup failures

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/WalletStartupFailureComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/WalletStartupFailureComposeTest.kt
@@ -1,0 +1,48 @@
+package com.cashu.me.ui.onboarding
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.WalletStartupFailure
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WalletStartupFailureComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun welcomeShowsStartupFailureAndInvokesRetry() {
+        var retries = 0
+        val failure = WalletStartupFailure(
+            message = "The wallet couldn't start. Try again in a moment.",
+        )
+
+        compose.setCashuContent {
+            WelcomeFace(
+                creating = false,
+                errorText = null,
+                startupFailure = failure,
+                retryingStartup = false,
+                onRetryStartup = { retries += 1 },
+                onCreate = {},
+                onRestore = {},
+                onInfo = {},
+            )
+        }
+
+        compose.onNodeWithText(failure.message).assertIsDisplayed()
+        compose.onNodeWithTag(UiTestTags.RetryWalletStartup)
+            .assertIsDisplayed()
+            .performClick()
+        compose.runOnIdle { assertEquals(1, retries) }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -139,18 +139,26 @@ class WalletManager(
                         openWalletRepositoryWithRecovery(mnemonic)
                         deriveNostrKey(mnemonic)
                     }
-                    update { copy(isRuntimeReady = true, errorMessage = null) }
+                    update {
+                        copy(
+                            isRuntimeReady = true,
+                            errorMessage = null,
+                            startupFailure = null,
+                        )
+                    }
                     if (runStartupMaintenance) {
                         startDeferredStartupMaintenance(hasStoredWallet)
                     }
                 }.onFailure { error ->
                     AppLogger.wallet.error("Wallet runtime initialization failed", error)
+                    val startupFailure = walletStartupFailure(hasStoredWallet)
                     update {
                         copy(
                             isInitialized = true,
                             isRuntimeReady = false,
                             isLoading = false,
-                            errorMessage = error.message,
+                            errorMessage = startupFailure.message,
+                            startupFailure = startupFailure,
                         )
                     }
                 }
@@ -1078,7 +1086,7 @@ class WalletManager(
         }
     }
 
-    fun clearError() = update { copy(errorMessage = null) }
+    fun clearError() = update { copy(errorMessage = null, startupFailure = null) }
 
     fun backupMnemonic(): String? = secureStorage.loadString(StorageKeys.secureWalletMnemonic)
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletState.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletState.kt
@@ -6,6 +6,30 @@ import com.cashu.me.Models.PendingReceiveToken
 import com.cashu.me.Models.PendingToken
 import com.cashu.me.Models.WalletTransaction
 
+/**
+ * Sanitized startup failure shown before a wallet runtime is available.
+ *
+ * Startup errors can originate in CDK/FFI, secure storage, or SQLite. Keep the
+ * implementation detail out of UI state and always pair the explanation with
+ * an action the welcome screen can perform.
+ */
+data class WalletStartupFailure(
+    val message: String,
+    val recoveryActionLabel: String = "Try Again",
+)
+
+internal fun walletStartupFailure(hasStoredWallet: Boolean): WalletStartupFailure =
+    if (hasStoredWallet) {
+        WalletStartupFailure(
+            message = "The saved wallet couldn't be opened. Try again. " +
+                "If this keeps happening, restore it from your seed phrase.",
+        )
+    } else {
+        WalletStartupFailure(
+            message = "The wallet couldn't start. Try again in a moment.",
+        )
+    }
+
 data class WalletState(
     val balance: Long = 0,
     val pendingBalance: Long = 0,
@@ -16,6 +40,7 @@ data class WalletState(
     val canExitOnboarding: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
+    val startupFailure: WalletStartupFailure? = null,
     // Per-unit totals across mints ("sat" included). The primary balance model
     // stays sat-denominated; there is deliberately no global active unit — unit
     // selection lives per flow, matching iOS.

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.launch
 import com.cashu.me.Core.MnemonicInput
 import com.cashu.me.Core.NostrMintBackupService
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.WalletStartupFailure
 import com.cashu.me.Core.mintUrlCandidates
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.ui.components.CanvasDivider
@@ -179,10 +180,12 @@ fun OnboardingScreen(
     nostrMintBackupService: NostrMintBackupService,
 ) {
     val scope = rememberCoroutineScope()
+    val walletState by walletManager.state.collectAsState()
 
     var step: OnboardingStep by remember { mutableStateOf(OnboardingStep.Welcome) }
     var infoOpen by remember { mutableStateOf(false) }
     var creating by remember { mutableStateOf(false) }
+    var retryingStartup by remember { mutableStateOf(false) }
     var createError by remember { mutableStateOf<String?>(null) }
     var restoring by remember { mutableStateOf(false) }
     var restoreError by remember { mutableStateOf<String?>(null) }
@@ -238,6 +241,18 @@ fun OnboardingScreen(
             OnboardingStep.Welcome -> WelcomeFace(
                 creating = creating,
                 errorText = createError,
+                startupFailure = walletState.startupFailure,
+                retryingStartup = retryingStartup,
+                onRetryStartup = {
+                    scope.launch {
+                        retryingStartup = true
+                        try {
+                            walletManager.initialize()
+                        } finally {
+                            retryingStartup = false
+                        }
+                    }
+                },
                 onCreate = {
                     scope.launch {
                         creating = true
@@ -337,9 +352,12 @@ fun OnboardingScreen(
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun WelcomeFace(
+internal fun WelcomeFace(
     creating: Boolean,
     errorText: String?,
+    startupFailure: WalletStartupFailure?,
+    retryingStartup: Boolean,
+    onRetryStartup: () -> Unit,
     onCreate: () -> Unit,
     onRestore: () -> Unit,
     onInfo: () -> Unit,
@@ -366,6 +384,21 @@ private fun WelcomeFace(
             )
         }
         Spacer(Modifier.weight(1f))
+        if (startupFailure != null) {
+            Column(
+                modifier = Modifier.padding(horizontal = CtaPadding),
+                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                InlineNotice(text = startupFailure.message)
+                PrimaryButton(
+                    text = startupFailure.recoveryActionLabel,
+                    onClick = onRetryStartup,
+                    loading = retryingStartup,
+                    modifier = Modifier.testTag(UiTestTags.RetryWalletStartup),
+                )
+            }
+            Spacer(Modifier.height(CashuTheme.spacing.snug))
+        }
         if (errorText != null) {
             InlineNotice(
                 text = errorText,
@@ -386,12 +419,13 @@ private fun WelcomeFace(
                 onClick = onCreate,
                 modifier = Modifier.testTag(UiTestTags.CreateWallet),
                 loading = creating,
+                enabled = !retryingStartup,
                 colors = ButtonDefaults.filledTonalButtonColors(),
             )
             SecondaryButton(
                 text = "Restore Wallet",
                 onClick = onRestore,
-                enabled = !creating,
+                enabled = !creating && !retryingStartup,
             )
             GhostButton(
                 text = "What is ecash?",

--- a/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
@@ -11,6 +11,7 @@ object UiTestTags {
     const val ScannerRoot = "cashu.scanner"
     const val OnboardingRoot = "cashu.onboarding"
     const val CreateWallet = "cashu.onboarding.create"
+    const val RetryWalletStartup = "cashu.onboarding.startup.retry"
     const val RevealSeed = "cashu.onboarding.seed.reveal"
     const val SeedPhrase = "cashu.onboarding.seed.phrase"
     const val HiddenSeedPhrase = "cashu.onboarding.seed.hidden"

--- a/android/app/src/test/java/com/cashu/me/Core/WalletStartupFailureTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletStartupFailureTest.kt
@@ -1,0 +1,27 @@
+package com.cashu.me.Core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WalletStartupFailureTest {
+    @Test
+    fun freshWalletFailureUsesUserFacingCopyAndRetry() {
+        val failure = walletStartupFailure(hasStoredWallet = false)
+
+        assertEquals("The wallet couldn't start. Try again in a moment.", failure.message)
+        assertEquals("Try Again", failure.recoveryActionLabel)
+    }
+
+    @Test
+    fun storedWalletFailureOffersSeedRecoveryWithoutTechnicalDetails() {
+        val failure = walletStartupFailure(hasStoredWallet = true)
+
+        assertTrue(failure.message.contains("restore it from your seed phrase"))
+        assertEquals("Try Again", failure.recoveryActionLabel)
+        assertFalse(failure.message.contains("CDK", ignoreCase = true))
+        assertFalse(failure.message.contains("FFI", ignoreCase = true))
+        assertFalse(failure.message.contains("SQLite", ignoreCase = true))
+    }
+}


### PR DESCRIPTION
## What changed

- present sanitized wallet startup failures on the onboarding welcome screen
- add a progress-aware retry action that invokes the existing retry-safe initialization path
- keep raw CDK/FFI implementation details out of user-visible copy
- add focused JVM and Compose coverage

## Why

`WalletManager.initialize()` stored a raw exception message in wallet state, while onboarding observed only its local create-action error. Initialization failures could therefore leave users on the welcome screen without an explanation or recovery action.

## Impact

Users now receive wallet-facing failure copy and can retry initialization directly from onboarding.

## Checks

- focused `WalletStartupFailureTest`
- `:app:compileDebugAndroidTestKotlin`
- full `:app:testDebugUnitTest`
- `:app:lintDebug`

The Compose interaction test compiled successfully but was not executed because no emulator or device was attached for that branch.
