### PR TITLE
Translate restore failures into wallet copy

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
@@ -215,8 +215,13 @@ object WalletErrorMessages {
             message.contains("FfiException") ||
             message.contains("errorMessage") ||
             message.contains("CALL_ERROR") ||
+            message.contains("::") ||
+            lowered.contains("cashudevkit") ||
+            lowered.contains("cdk_wallet") ||
+            lowered.contains("uniffi") ||
             lowered.contains("code=") ||
             lowered.contains("unknown error response") ||
+            lowered.contains("backtrace") ||
             lowered.contains("failed printing to std") ||
             lowered.contains("os error") ||
             lowered.contains("panicked at") ||

--- a/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.unit.sp
 import com.cashu.me.Core.Bip39WordList
 import com.cashu.me.Core.NostrMintBackupService
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.mintUrlCandidates
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.RestoreMintResult
@@ -94,6 +95,9 @@ sealed interface RestoreMintPhase {
     data class Recovered(val result: RestoreMintResult) : RestoreMintPhase
     data class Failed(val message: String) : RestoreMintPhase
 }
+
+internal fun restoreMintFailurePhase(error: Throwable): RestoreMintPhase.Failed =
+    RestoreMintPhase.Failed(error.userFacingWalletMessage)
 
 @Composable
 fun restoreOnboardingTitleStyle(): TextStyle =
@@ -719,9 +723,7 @@ fun RestoreProgressStep(
         runCatching { walletManager.restoreFromMint(url) }
             .onSuccess { phases[url] = RestoreMintPhase.Recovered(it) }
             .onFailure {
-                phases[url] = RestoreMintPhase.Failed(
-                    it.message ?: "Could not restore from this mint.",
-                )
+                phases[url] = restoreMintFailurePhase(it)
             }
     }
 

--- a/android/app/src/test/java/com/cashu/me/ui/restore/RestoreWalletFailureMessageTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/restore/RestoreWalletFailureMessageTest.kt
@@ -1,0 +1,81 @@
+package com.cashu.me.ui.restore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RestoreWalletFailureMessageTest {
+    @Test
+    fun mapsCdkNetworkFailureToWalletFacingCopy() {
+        val phase = restoreMintFailurePhase(
+            IllegalStateException(
+                "FfiError.Cdk(code=11001, errorMessage=Connection refused)",
+            ),
+        )
+
+        assertEquals(
+            "Couldn't reach the mint. Check your connection and try again.",
+            phase.message,
+        )
+        assertNoImplementationDetails(phase.message)
+    }
+
+    @Test
+    fun mapsQuotedFfiFailureToWalletFacingCopy() {
+        val phase = restoreMintFailurePhase(
+            IllegalStateException(
+                "FfiException(CALL_ERROR, errorMessage: \"Token Already Spent\")",
+            ),
+        )
+
+        assertEquals("This token was already redeemed.", phase.message)
+        assertNoImplementationDetails(phase.message)
+    }
+
+    @Test
+    fun hidesUnknownCdkNamespaceBehindGenericFallback() {
+        val phase = restoreMintFailurePhase(
+            IllegalStateException(
+                "FfiError.Internal(errorMessage=cdk_wallet::Error::Unknown(Custom(42)))",
+            ),
+        )
+
+        assertEquals(
+            "The wallet couldn't finish that action. Try again in a moment.",
+            phase.message,
+        )
+        assertNoImplementationDetails(phase.message)
+    }
+
+    @Test
+    fun hidesUnhelpfulThrowableWrapperBehindGenericFallback() {
+        val phase = restoreMintFailurePhase(IllegalStateException())
+
+        assertEquals(
+            "The wallet couldn't finish that action. Try again in a moment.",
+            phase.message,
+        )
+        assertNoImplementationDetails(phase.message)
+    }
+
+    @Test
+    fun translatedFailureKeepsTheRetryRowState() {
+        val phase: RestoreMintPhase = restoreMintFailurePhase(
+            IllegalStateException("Network request timed out"),
+        )
+
+        // RestoreProgressRow renders its Retry action for every Failed phase.
+        assertTrue(phase is RestoreMintPhase.Failed)
+    }
+
+    private fun assertNoImplementationDetails(message: String) {
+        val lowered = message.lowercase()
+        assertFalse(lowered.contains("ffi"))
+        assertFalse(lowered.contains("cdk"))
+        assertFalse(lowered.contains("exception"))
+        assertFalse(lowered.contains("errormessage"))
+        assertFalse(lowered.contains("code="))
+        assertFalse(message.contains("::"))
+    }
+}


### PR DESCRIPTION
## What changed

- translate each per-mint restore failure through the shared wallet-facing error mapper
- preserve the failed state and Retry action
- harden fallback handling against CDK, UniFFI, backtrace, and Rust implementation text
- add focused tests for representative wrapper strings and safe fallback behavior

## Why

The restore results UI rendered `Throwable.message` directly, allowing CDK/FFI implementation details to reach users.

## Impact

Restore failures now use actionable wallet copy while retaining the existing per-mint retry workflow.

## Checks

- focused `RestoreWalletFailureMessageTest`
- full `:app:testDebugUnitTest`
- `:app:lintDebug`
