### PR TITLE
Validate custom onboarding mint URLs

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LiveLocalMintMainActivityJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LiveLocalMintMainActivityJourneyTest.kt
@@ -49,6 +49,7 @@ class LiveLocalMintMainActivityJourneyTest {
             .tapText("Add mint")
             .awaitTag(UiTestTags.AddMintSheet)
             .typeIntoTag(UiTestTags.AddMintUrl, mintUrl)
+            .pressSystemBack()
             .tapTag(UiTestTags.AddMintSubmit)
             .awaitTag(UiTestTags.mintRow(mintUrl), timeoutMillis = 20_000)
     }

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/FirstMintUrlDraft.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/FirstMintUrlDraft.kt
@@ -1,0 +1,34 @@
+package com.cashu.me.ui.onboarding
+
+import com.cashu.me.Core.normalizeUserMintUrl
+
+internal const val InvalidFirstMintUrlMessage = "That doesn't look like a mint URL."
+
+internal data class FirstMintUrlDraft(
+    val input: String = "",
+    val error: String? = null,
+) {
+    fun updateInput(value: String): FirstMintUrlDraft =
+        if (value == input) this else copy(input = value, error = null)
+
+    fun stage(existingUrls: Collection<String>): FirstMintUrlStage {
+        val normalized = normalizeUserMintUrl(input)
+            ?: return FirstMintUrlStage(
+                draft = copy(error = InvalidFirstMintUrlMessage),
+            )
+        if (existingUrls.any { it.equals(normalized, ignoreCase = true) }) {
+            return FirstMintUrlStage(
+                draft = copy(error = "That mint is already in the list."),
+            )
+        }
+        return FirstMintUrlStage(
+            draft = FirstMintUrlDraft(),
+            stagedUrl = normalized,
+        )
+    }
+}
+
+internal data class FirstMintUrlStage(
+    val draft: FirstMintUrlDraft,
+    val stagedUrl: String? = null,
+)

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -690,8 +690,7 @@ private fun FirstMintFace(
     var selected by remember { mutableStateOf(setOf<String>()) }
     var customUrls by remember { mutableStateOf(listOf<String>()) }
     var customInputOpen by remember { mutableStateOf(false) }
-    var customInput by remember { mutableStateOf("") }
-    var localError by remember { mutableStateOf<String?>(null) }
+    var customDraft by remember { mutableStateOf(FirstMintUrlDraft()) }
     val clipboard = LocalClipboardManager.current
 
     fun toggle(url: String) {
@@ -700,16 +699,12 @@ private fun FirstMintFace(
     }
 
     fun commitCustomUrl() {
-        val normalized = normalizeMintUrl(customInput) ?: return
         val existing = RecommendedMints.map { it.url } + customUrls
-        if (existing.any { it.equals(normalized, ignoreCase = true) }) {
-            localError = "That mint is already in the list."
-            return
-        }
-        localError = null
+        val result = customDraft.stage(existing)
+        customDraft = result.draft
+        val normalized = result.stagedUrl ?: return
         customUrls = customUrls + normalized
         selected = selected + normalized
-        customInput = ""
         customInputOpen = false
     }
 
@@ -778,26 +773,25 @@ private fun FirstMintFace(
             } else {
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
                 CashuTextField(
-                    value = customInput,
-                    onValueChange = {
-                        customInput = it
-                        localError = null
-                    },
+                    value = customDraft.input,
+                    onValueChange = { customDraft = customDraft.updateInput(it) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UiTestTags.CustomMintUrl),
                     placeholder = "https://mint.example.com",
                     textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
                     singleLine = true,
-                    isError = localError != null,
+                    isError = customDraft.error != null,
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.None,
                         keyboardType = KeyboardType.Uri,
                     ),
                     trailingIcon = {
-                        if (customInput.isBlank()) {
+                        if (customDraft.input.isBlank()) {
                             IconButton(onClick = {
-                                clipboard.getText()?.text?.let { customInput = it.trim() }
+                                clipboard.getText()?.text?.let {
+                                    customDraft = customDraft.updateInput(it.trim())
+                                }
                             }) {
                                 Icon(Icons.Outlined.ContentPaste, contentDescription = "Paste")
                             }
@@ -809,7 +803,7 @@ private fun FirstMintFace(
                     },
                 )
             }
-            val notice = localError ?: errorText
+            val notice = customDraft.error ?: errorText
             if (notice != null) {
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
                 InlineNotice(text = notice)
@@ -920,15 +914,3 @@ private fun RecommendedMintAvatar(name: String, url: String, iconUrl: String?, s
 /** iOS shortenUrl: strip scheme + trailing slash for display. */
 private fun shortenMintUrl(url: String): String =
     url.removePrefix("https://").removePrefix("http://").trimEnd('/')
-
-/** iOS normalizedMintUrl: quote-strip, https-default, trailing-slash trim. */
-private fun normalizeMintUrl(raw: String): String? {
-    var trimmed = raw.trim().trim('"', '\'')
-    if (trimmed.isEmpty()) return null
-    if (!trimmed.startsWith("http://", ignoreCase = true) &&
-        !trimmed.startsWith("https://", ignoreCase = true)
-    ) {
-        trimmed = "https://$trimmed"
-    }
-    return trimmed.trimEnd('/')
-}

--- a/android/app/src/test/java/com/cashu/me/Core/MintUrlInputTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintUrlInputTest.kt
@@ -17,6 +17,14 @@ class MintUrlInputTest {
     }
 
     @Test
+    fun normalizeUserMintUrlRejectsMalformedOrMissingHosts() {
+        assertNull(normalizeUserMintUrl("https:///mint.example.com"))
+        assertNull(normalizeUserMintUrl("https://"))
+        assertNull(normalizeUserMintUrl("https://mint example.com"))
+        assertNull(normalizeUserMintUrl("https://[not-an-ipv6-address]"))
+    }
+
+    @Test
     fun mintUrlCandidatesParsesClipboardSeparatorsAndDeduplicates() {
         assertEquals(
             listOf("https://mint.one", "https://mint.two/path"),

--- a/android/app/src/test/java/com/cashu/me/ui/onboarding/FirstMintUrlDraftTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/onboarding/FirstMintUrlDraftTest.kt
@@ -1,0 +1,43 @@
+package com.cashu.me.ui.onboarding
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FirstMintUrlDraftTest {
+    @Test
+    fun validUrlIsNormalizedAndStaged() {
+        val result = FirstMintUrlDraft(" 'mint.example.com/path/' ").stage(emptyList())
+
+        assertEquals("https://mint.example.com/path", result.stagedUrl)
+        assertEquals(FirstMintUrlDraft(), result.draft)
+    }
+
+    @Test
+    fun malformedHostIsRejectedWithoutStaging() {
+        val result = FirstMintUrlDraft("https:///missing-host").stage(emptyList())
+
+        assertNull(result.stagedUrl)
+        assertEquals(InvalidFirstMintUrlMessage, result.draft.error)
+        assertEquals("https:///missing-host", result.draft.input)
+    }
+
+    @Test
+    fun normalizedDuplicateIsRejectedWithoutStaging() {
+        val result = FirstMintUrlDraft("MINT.EXAMPLE.COM/").stage(
+            existingUrls = listOf("https://mint.example.com"),
+        )
+
+        assertNull(result.stagedUrl)
+        assertEquals("That mint is already in the list.", result.draft.error)
+    }
+
+    @Test
+    fun validationErrorRemainsUntilInputActuallyChanges() {
+        val rejected = FirstMintUrlDraft("not a url").stage(emptyList()).draft
+
+        assertEquals(InvalidFirstMintUrlMessage, rejected.error)
+        assertEquals(InvalidFirstMintUrlMessage, rejected.updateInput("not a url").error)
+        assertNull(rejected.updateInput("mint.example.com").error)
+    }
+}


### PR DESCRIPTION
## What changed

- route custom onboarding mint URLs through the shared mint URL validator
- reject malformed or hostless values with “That doesn't look like a mint URL.”
- keep the inline explanation visible until the input actually changes
- add focused validation, staging, duplicate, and error-lifecycle tests

## Why

The onboarding-specific normalizer accepted any non-empty value after adding a scheme, allowing malformed mint URLs to be staged without useful feedback.

## Impact

Only validated mint URLs can be staged during onboarding, and users receive persistent, actionable feedback for invalid input.

## Checks

- focused `MintUrlInputTest`
- focused `FirstMintUrlDraftTest`
- full `:app:testDebugUnitTest`
- `:app:lintDebug`
- `git diff --cached --check`
