### PR TITLE
Fix seed phrase TalkBack semantics

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/SeedPhraseAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/onboarding/SeedPhraseAccessibilityComposeTest.kt
@@ -1,0 +1,111 @@
+package com.cashu.me.ui.onboarding
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SeedPhraseAccessibilityComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val words = listOf(
+        "abandon",
+        "ability",
+        "able",
+        "about",
+        "above",
+        "absent",
+        "absorb",
+        "abstract",
+        "absurd",
+        "abuse",
+        "access",
+        "accident",
+    )
+
+    @Test
+    fun hiddenPhraseExposesOnlyOneRevealAction() {
+        setSeedPhraseContent()
+
+        compose.onAllNodes(
+            hasContentDescription("Reveal seed phrase"),
+        ).assertCountEquals(1)
+        compose.onAllNodes(hasClickAction()).assertCountEquals(1)
+        compose.onNodeWithContentDescription(
+            "Reveal seed phrase",
+        )
+            .assertIsDisplayed()
+            .assertHasClickAction()
+
+        words.forEach { word ->
+            compose.onNodeWithText(word).assertDoesNotExist()
+        }
+        compose.onNodeWithText("01").assertDoesNotExist()
+        compose.onNodeWithText("••••••").assertDoesNotExist()
+    }
+
+    @Test
+    fun revealReplacesActionWithOrderedNumberedWords() {
+        setSeedPhraseContent()
+
+        compose.onNodeWithContentDescription(
+            "Reveal seed phrase",
+        ).performClick()
+
+        compose.onNodeWithContentDescription(
+            "Reveal seed phrase",
+        ).assertDoesNotExist()
+        compose.onAllNodes(hasClickAction()).assertCountEquals(0)
+        compose.onNodeWithTag(
+            UiTestTags.SeedPhrase,
+        ).assertIsDisplayed()
+
+        val expectedLabels = words.mapIndexed { index, word -> "${index + 1}. $word" }
+        val expectedLabelSet = expectedLabels.toSet()
+        val wordNodeMatcher = SemanticsMatcher("numbered seed word") { node ->
+            node.config
+                .getOrNull(SemanticsProperties.ContentDescription)
+                ?.singleOrNull() in expectedLabelSet
+        }
+        val actualLabels = compose.onAllNodes(
+            wordNodeMatcher,
+        ).fetchSemanticsNodes().map { node ->
+            node.config[SemanticsProperties.ContentDescription].single()
+        }
+
+        assertEquals(expectedLabels, actualLabels)
+    }
+
+    private fun setSeedPhraseContent() {
+        compose.setCashuContent {
+            var revealed by remember { mutableStateOf(false) }
+            SeedPhraseReveal(
+                words = words,
+                revealed = revealed,
+                onReveal = { revealed = true },
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -60,6 +60,15 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag as semanticsTestTag
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -514,40 +523,14 @@ private fun ShowMnemonicFace(
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Box(
+            SeedPhraseReveal(
+                words = words,
+                revealed = revealed,
+                onReveal = ::reveal,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = HeaderPadding)
-                    .clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        enabled = !revealed,
-                        onClickLabel = "Reveal seed phrase",
-                        onClick = ::reveal,
-                    )
-                    .testTag(UiTestTags.RevealSeed),
-                contentAlignment = Alignment.Center,
-            ) {
-                SeedGrid(words = words, revealed = revealed)
-                if (!revealed) {
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.Visibility,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.size(RevealEyeSize),
-                        )
-                        Text(
-                            text = "Tap to reveal",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
+                    .padding(horizontal = HeaderPadding),
+            )
             GhostButton(
                 text = if (copied) "Copied" else "Copy",
                 onClick = {
@@ -611,6 +594,65 @@ private fun ShowMnemonicFace(
 }
 
 /**
+ * Keeps the masked phrase out of TalkBack's tree and replaces the whole visual
+ * with one reveal control. Once revealed, the control semantics disappear so
+ * TalkBack can traverse the ordered words in [SeedGrid].
+ */
+@Composable
+internal fun SeedPhraseReveal(
+    words: List<String>,
+    revealed: Boolean,
+    onReveal: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val accessibilityModifier = if (revealed) {
+        Modifier
+    } else {
+        Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClickLabel = "Reveal seed phrase",
+                onClick = onReveal,
+            )
+            .clearAndSetSemantics {
+                semanticsTestTag = UiTestTags.RevealSeed
+                contentDescription = "Reveal seed phrase"
+                role = Role.Button
+                onClick(label = "Reveal seed phrase") {
+                    onReveal()
+                    true
+                }
+            }
+    }
+
+    Box(
+        modifier = modifier.then(accessibilityModifier),
+        contentAlignment = Alignment.Center,
+    ) {
+        SeedGrid(words = words, revealed = revealed)
+        if (!revealed) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Visibility,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(RevealEyeSize),
+                )
+                Text(
+                    text = "Tap to reveal",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
  * 3-column × 4-row seed grid, plain on the canvas (no card chrome) — iOS
  * mnemonicWordsGrid. Zero-padded indices in a fixed trailing-aligned column,
  * monospaced medium words.
@@ -630,7 +672,18 @@ private fun SeedGrid(words: List<String>, revealed: Boolean) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .testTag(if (revealed) UiTestTags.SeedPhrase else UiTestTags.HiddenSeedPhrase)
+            .then(
+                if (revealed) {
+                    Modifier.semantics {
+                        semanticsTestTag = UiTestTags.SeedPhrase
+                        isTraversalGroup = true
+                    }
+                } else {
+                    Modifier.clearAndSetSemantics {
+                        semanticsTestTag = UiTestTags.HiddenSeedPhrase
+                    }
+                },
+            )
             .then(if (revealed) Modifier else Modifier.blur(SeedBlurRadius)),
         verticalArrangement = Arrangement.spacedBy(SeedGridRowGap),
     ) {
@@ -642,7 +695,18 @@ private fun SeedGrid(words: List<String>, revealed: Boolean) {
                 rowWords.forEachIndexed { columnIndex, word ->
                     val number = rowIndex * 3 + columnIndex + 1
                     Row(
-                        modifier = Modifier.weight(1f),
+                        modifier = Modifier
+                            .weight(1f)
+                            .then(
+                                if (revealed) {
+                                    Modifier.clearAndSetSemantics {
+                                        contentDescription = "$number. $word"
+                                        traversalIndex = number.toFloat()
+                                    }
+                                } else {
+                                    Modifier
+                                },
+                            ),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
                     ) {


### PR DESCRIPTION
## What changed

- replace the hidden seed grid's accessibility descendants with one button-role “Reveal seed phrase” action
- keep hidden indices, placeholders, and words out of TalkBack's semantics tree
- expose all twelve numbered words in deterministic order after reveal
- preserve the existing visual masking, layout, tap behavior, and haptics
- add focused Compose instrumentation coverage

## Why

The hidden grid only obscured its visible text. Its numbered placeholders remained accessibility descendants, causing TalkBack to announce multiple meaningless elements instead of one reveal action.

## Impact

TalkBack users encounter a single clear action while the seed is hidden and an ordered, navigable word list only after they reveal it.

## Checks

- `:app:compileDebugAndroidTestKotlin`
- full `:app:testDebugUnitTest`
- `:app:lintDebug`
- focused API 35 managed-device test: 2/2 passed
