### PR TITLE
Gate Android wallet flows on runtime readiness

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/home/HomeRuntimeReadinessComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/home/HomeRuntimeReadinessComposeTest.kt
@@ -1,0 +1,63 @@
+package com.cashu.me.ui.home
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.AmountDisplayText
+import com.cashu.me.ui.components.BalanceDisplay
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HomeRuntimeReadinessComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun preparationStateIsVisibleAndPaymentActionsCannotBeInvoked() {
+        var receiveClicks = 0
+        var sendClicks = 0
+
+        compose.setCashuContent {
+            Column {
+                BalanceDisplay(
+                    amount = AmountDisplayText(
+                        primary = "42 sat",
+                        secondary = "\$0.01",
+                        effectivePrimary = AmountDisplayPrimary.Sats,
+                    ),
+                    statusMessage = PREPARING_WALLET_LABEL,
+                )
+                ActionDuet(
+                    onReceive = { receiveClicks += 1 },
+                    onSend = { sendClicks += 1 },
+                    receiveEnabled = false,
+                    sendEnabled = false,
+                )
+            }
+        }
+
+        compose.onNodeWithText(PREPARING_WALLET_LABEL).assertIsDisplayed()
+        compose.onNodeWithTag(UiTestTags.WalletReceive)
+            .assertIsNotEnabled()
+            .performTouchInput { click() }
+        compose.onNodeWithTag(UiTestTags.WalletSend)
+            .assertIsNotEnabled()
+            .performTouchInput { click() }
+        compose.runOnIdle {
+            assertEquals(0, receiveClicks)
+            assertEquals(0, sendClicks)
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/BalanceDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/BalanceDisplay.kt
@@ -46,6 +46,9 @@ private sealed interface BalanceStatusLine {
     /** Transient "+2,500" received beat (takes over the fiat slot). */
     data class Delta(val text: String) : BalanceStatusLine
 
+    /** A wallet lifecycle message that takes precedence over the regular sub-amount. */
+    data class Status(val text: String) : BalanceStatusLine
+
     /** The regular fiat/secondary sub-amount. */
     data class Secondary(val text: String) : BalanceStatusLine
 
@@ -63,6 +66,8 @@ private sealed interface BalanceStatusLine {
  *   it takes over the secondary slot with the sanctioned celebration spring
  *   (scale 0.9 + fade in, fade out), then the fiat line fades back. Same slot,
  *   so the swap never reflows the balance.
+ * @param statusMessage wallet lifecycle copy, such as runtime preparation,
+ *   shown ahead of the regular secondary amount.
  */
 @Composable
 fun BalanceDisplay(
@@ -70,6 +75,7 @@ fun BalanceDisplay(
     modifier: Modifier = Modifier,
     padding: PaddingValues = PaddingValues(),
     receivedDelta: String? = null,
+    statusMessage: String? = null,
 ) {
     val reduceMotion = rememberReducedMotion()
     Column(
@@ -95,6 +101,7 @@ fun BalanceDisplay(
         }
         val statusLine: BalanceStatusLine = when {
             receivedDelta != null -> BalanceStatusLine.Delta(receivedDelta)
+            statusMessage != null -> BalanceStatusLine.Status(statusMessage)
             amount.secondary != null -> BalanceStatusLine.Secondary(amount.secondary)
             else -> BalanceStatusLine.None
         }
@@ -132,6 +139,12 @@ fun BalanceDisplay(
                             style = MaterialTheme.typography.titleMedium
                                 .withMonoDigits()
                                 .copy(fontWeight = FontWeight.SemiBold),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    is BalanceStatusLine.Status ->
+                        Text(
+                            text = line.text,
+                            style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     is BalanceStatusLine.Secondary ->

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -111,6 +111,26 @@ internal object HomeActionAccessibility {
             "BOLT12 offers, Bitcoin addresses, or Cashu Requests"
 }
 
+internal const val PREPARING_WALLET_LABEL = "Preparing wallet…"
+
+internal data class HomePaymentActionAvailability(
+    val isPreparingWallet: Boolean,
+    val receiveEnabled: Boolean,
+    val sendEnabled: Boolean,
+)
+
+internal fun homePaymentActionAvailability(
+    isRuntimeReady: Boolean,
+    hasActiveMint: Boolean,
+): HomePaymentActionAvailability {
+    return HomePaymentActionAvailability(
+        isPreparingWallet = !isRuntimeReady,
+        // Unified Receive always has mint-independent ecash paths.
+        receiveEnabled = isRuntimeReady,
+        sendEnabled = isRuntimeReady && hasActiveMint,
+    )
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
@@ -133,6 +153,10 @@ fun HomeScreen(
     val haptics = rememberWalletHaptics()
     val scope = rememberCoroutineScope()
     var refreshing by remember { mutableStateOf(false) }
+    val paymentActions = homePaymentActionAvailability(
+        isRuntimeReady = walletState.isRuntimeReady,
+        hasActiveMint = walletState.activeMint != null,
+    )
 
     val balanceDisplay = remember(walletState.balance, settings, priceState) {
         formatter.displayText(
@@ -228,6 +252,9 @@ fun HomeScreen(
                         onUnitSelected = settingsManager::setHomeBalanceUnit,
                         receivedPayment = receivedPayment,
                         formatter = formatter,
+                        statusMessage = PREPARING_WALLET_LABEL.takeIf {
+                            paymentActions.isPreparingWallet
+                        },
                     )
                 },
                 triptych = {
@@ -238,10 +265,10 @@ fun HomeScreen(
                         onSend = onSend,
                         // The unified Receive sheet always has mint-independent
                         // ecash paths (paste/scan and an any-mint NUT-18 request).
-                        receiveEnabled = true,
+                        receiveEnabled = paymentActions.receiveEnabled,
                         // iOS parity: Send is tappable at zero balance; the sheet shows
                         // "Nothing to send yet" with a Receive CTA instead of disabling here.
-                        sendEnabled = walletState.activeMint != null,
+                        sendEnabled = paymentActions.sendEnabled,
                     )
                 },
                 onOpenSettings = onOpenSettings,
@@ -453,6 +480,7 @@ private fun HomeBalanceHero(
     onUnitSelected: (String) -> Unit,
     receivedPayment: ReceivedPaymentEvent?,
     formatter: AmountFormatter,
+    statusMessage: String?,
 ) {
     val units = HomeBalance.homeBalanceUnits(balancesByUnit)
     val resolvedUnit = HomeBalance.resolvedUnit(persistedUnit, units)
@@ -508,6 +536,7 @@ private fun HomeBalanceHero(
                             )
                         },
                         receivedDelta = receivedDelta,
+                        statusMessage = statusMessage,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
@@ -517,6 +546,7 @@ private fun HomeBalanceHero(
                     receivedDelta = receivedPayment
                         ?.takeIf { it.unit.equals("sat", ignoreCase = true) }
                         ?.displayDelta(formatter),
+                    statusMessage = statusMessage,
                     modifier = Modifier.fillMaxWidth(),
                 )
             }

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -259,6 +259,8 @@ private enum class AppGate { Loading, Onboarding, Shell }
 @Composable
 private fun AuthenticatedShell(container: AppContainer) {
     val navController = rememberNavController()
+    val walletState by container.walletManager.state.collectAsState()
+    val isRuntimeReadyRef by rememberUpdatedState(walletState.isRuntimeReady)
     var showContactless by remember { mutableStateOf(false) }
     var scannerTarget by remember { mutableStateOf<ScannerTarget?>(null) }
     // The active money flow, hosted in a modal bottom sheet (iOS WalletFlow sheets).
@@ -279,6 +281,20 @@ private fun AuthenticatedShell(container: AppContainer) {
     // A fresh flow starts unlocked, whatever the last one left behind.
     LaunchedEffect(activeFlow) { flowDismissLocked = false }
     LaunchedEffect(receiveTokenDetail) { receiveDetailDismissLocked = false }
+    LaunchedEffect(walletState.isRuntimeReady) {
+        if (!walletState.isRuntimeReady) {
+            activeFlow = null
+            receiveTokenDetail = null
+            showContactless = false
+        }
+    }
+
+    val openPaymentFlow: (WalletFlow) -> Unit = { flow ->
+        if (isRuntimeReadyRef) activeFlow = flow
+    }
+    val openReceiveDetail: (String) -> Unit = { payload ->
+        if (isRuntimeReadyRef) receiveTokenDetail = payload
+    }
 
     val pendingDeepLink by container.navigationManager.pendingDeepLink.collectAsState()
     val connectivityState by container.connectivityObserver.state.collectAsState()
@@ -295,9 +311,11 @@ private fun AuthenticatedShell(container: AppContainer) {
         scannerTarget,
         showContactless,
         appLockState.isLocked,
+        walletState.isRuntimeReady,
     ) {
         val held = cashuRequestListenerState.heldForApproval ?: return@LaunchedEffect
-        val canPresent = receiveTokenDetail == null &&
+        val canPresent = walletState.isRuntimeReady &&
+            receiveTokenDetail == null &&
             activeFlow == null &&
             scannerTarget == null &&
             !showContactless &&
@@ -308,23 +326,28 @@ private fun AuthenticatedShell(container: AppContainer) {
         }
     }
 
-    LaunchedEffect(pendingDeepLink) {
+    LaunchedEffect(pendingDeepLink, walletState.isRuntimeReady) {
         val deepLink = pendingDeepLink ?: return@LaunchedEffect
+        // Keep payment deep links pending until the encrypted seed and CDK
+        // repository are available. Non-payment destinations can open normally.
+        if (!walletState.isRuntimeReady && deepLink.route in paymentRoutes) {
+            return@LaunchedEffect
+        }
         when (deepLink.route) {
             CashuRoute.Receive -> {
                 val payload = deepLink.payload.orEmpty()
                 if (payload.isNotBlank()) {
                     // Deep-linked token: full-screen claim page (iOS presents
                     // ReceiveTokenDetailView via .fullScreenCover from ContentView).
-                    receiveTokenDetail = payload
+                    openReceiveDetail(payload)
                 } else {
                     // Bare cashu: link with no token — open the paste sheet.
-                    activeFlow = WalletFlow.ReceiveEcash
+                    openPaymentFlow(WalletFlow.ReceiveEcash)
                 }
             }
             CashuRoute.Send -> {
                 pendingSendScan = deepLink.payload.orEmpty()
-                activeFlow = WalletFlow.Send
+                openPaymentFlow(WalletFlow.Send)
             }
             CashuRoute.Mints -> {
                 pendingMintScan = deepLink.payload.orEmpty()
@@ -334,7 +357,7 @@ private fun AuthenticatedShell(container: AppContainer) {
             CashuRoute.History -> navController.navigateToTab(TopTab.History)
             CashuRoute.Settings -> navController.navigate(Routes.SETTINGS)
             CashuRoute.Scanner -> scannerTarget = ScannerTarget.Auto
-            CashuRoute.Contactless -> showContactless = true
+            CashuRoute.Contactless -> if (isRuntimeReadyRef) showContactless = true
         }
         container.navigationManager.consumeDeepLink()
     }
@@ -350,13 +373,13 @@ private fun AuthenticatedShell(container: AppContainer) {
             container = container,
             connectivityState = connectivityState,
             onScan = { scannerTarget = ScannerTarget.Auto },
-            onReceiveEcash = { activeFlow = WalletFlow.ReceiveEcash },
-            onReceiveLightning = { activeFlow = WalletFlow.ReceiveLightning },
-            onSend = { activeFlow = WalletFlow.Send },
+            onReceiveEcash = { openPaymentFlow(WalletFlow.ReceiveEcash) },
+            onReceiveLightning = { openPaymentFlow(WalletFlow.ReceiveLightning) },
+            onSend = { openPaymentFlow(WalletFlow.Send) },
             pendingMintScan = pendingMintScan,
             onPendingMintScanConsumed = { pendingMintScan = null },
             // Pending "Receive later" tokens claim on the full-screen page.
-            onClaimReceiveToken = { receiveTokenDetail = it },
+            onClaimReceiveToken = openReceiveDetail,
             navController = navController,
         )
         AnimatedVisibility(
@@ -377,15 +400,19 @@ private fun AuthenticatedShell(container: AppContainer) {
                         // In-sheet scan (ScannerTarget.Receive): back to the
                         // sheet's Review face — the user is inside the paste flow.
                         onReceiveInSheet = {
-                            pendingReceiveScan = it
-                            activeFlow = WalletFlow.ReceiveEcash
+                            if (isRuntimeReadyRef) {
+                                pendingReceiveScan = it
+                                openPaymentFlow(WalletFlow.ReceiveEcash)
+                            }
                         },
                         // Main scan button: tokens read as a brand-new full
                         // screen, never the home sheet (iOS scanner parity).
-                        onReceiveDetail = { receiveTokenDetail = it },
+                        onReceiveDetail = openReceiveDetail,
                         onSend = {
-                            pendingSendScan = it
-                            activeFlow = WalletFlow.Send
+                            if (isRuntimeReadyRef) {
+                                pendingSendScan = it
+                                openPaymentFlow(WalletFlow.Send)
+                            }
                         },
                         onMint = {
                             pendingMintScan = it
@@ -402,7 +429,7 @@ private fun AuthenticatedShell(container: AppContainer) {
         var lastReceiveTokenDetail by remember { mutableStateOf("") }
         if (receiveTokenDetail != null) lastReceiveTokenDetail = receiveTokenDetail!!
         AnimatedVisibility(
-            visible = receiveTokenDetail != null,
+            visible = walletState.isRuntimeReady && receiveTokenDetail != null,
             enter = overlayEnter,
             exit = overlayExit,
         ) {
@@ -448,13 +475,17 @@ private fun AuthenticatedShell(container: AppContainer) {
     }
 
     WalletFlowSheetHost(
-        flow = activeFlow,
+        // The effect above clears stale state; this synchronous gate also
+        // prevents a sheet from mounting for a frame if readiness drops.
+        flow = activeFlow.takeIf { walletState.isRuntimeReady },
         dismissLocked = flowDismissLocked,
         onDismissed = {
             activeFlow = null
             flowHandoff.completeDismissal(
                 openScanner = { scannerTarget = ScannerTarget.Auto },
-                openContactless = { showContactless = true },
+                openContactless = {
+                    if (isRuntimeReadyRef) showContactless = true
+                },
             )
         },
         snackbarHostState = container.snackbarHostState,
@@ -543,18 +574,24 @@ private fun AuthenticatedShell(container: AppContainer) {
         }
     }
 
-    if (showContactless) {
+    if (walletState.isRuntimeReady && showContactless) {
         ContactlessPaySheet(
             walletManager = container.walletManager,
             onDismissed = { showContactless = false },
             onLightningRequest = { invoice ->
                 showContactless = false
                 pendingSendScan = invoice
-                activeFlow = WalletFlow.Send
+                openPaymentFlow(WalletFlow.Send)
             },
         )
     }
 }
+
+private val paymentRoutes = setOf(
+    CashuRoute.Receive,
+    CashuRoute.Send,
+    CashuRoute.Contactless,
+)
 
 // Camera-surface overlay motion: slide up over the shell, slide back down on close.
 private val overlayEnter = slideInVertically(

--- a/android/app/src/test/java/com/cashu/me/ui/home/HomeRuntimeReadinessTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/home/HomeRuntimeReadinessTest.kt
@@ -1,0 +1,43 @@
+package com.cashu.me.ui.home
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HomeRuntimeReadinessTest {
+    @Test
+    fun paymentActionsStayDisabledWhileRuntimeIsPreparing() {
+        val availability = homePaymentActionAvailability(
+            isRuntimeReady = false,
+            hasActiveMint = true,
+        )
+
+        assertTrue(availability.isPreparingWallet)
+        assertFalse(availability.receiveEnabled)
+        assertFalse(availability.sendEnabled)
+    }
+
+    @Test
+    fun paymentActionsUseExistingPrerequisitesAfterRuntimeIsReady() {
+        val availability = homePaymentActionAvailability(
+            isRuntimeReady = true,
+            hasActiveMint = true,
+        )
+
+        assertFalse(availability.isPreparingWallet)
+        assertTrue(availability.receiveEnabled)
+        assertTrue(availability.sendEnabled)
+    }
+
+    @Test
+    fun receiveStaysAvailableWithoutMintOnceRuntimeIsReady() {
+        val availability = homePaymentActionAvailability(
+            isRuntimeReady = true,
+            hasActiveMint = false,
+        )
+
+        assertFalse(availability.isPreparingWallet)
+        assertTrue(availability.receiveEnabled)
+        assertFalse(availability.sendEnabled)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -29,7 +29,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Honor the preferred primary balance unit on Wallet home.** Android always constructs the home balance with sats as the primary value, even when the user selected fiat; iOS uses the saved primary display. **Done when:** Android opens with the saved sats/fiat preference and its visible and accessibility values consistently reflect that preference. A Home-specific unit-switch interaction, if desired, is outside this parity item.
 
-- [ ] **[P1 · iOS → Android] Gate payment actions on wallet runtime readiness.** iOS shows “Preparing wallet…” and disables Receive/Send until the runtime is ready; Android enables them based on mint presence alone. **Done when:** Android exposes a preparation state and cannot enter a money-moving flow before the runtime is ready.
+- [x] **[P1 · iOS → Android] Gate payment actions on wallet runtime readiness.** iOS shows “Preparing wallet…” and disables Receive/Send until the runtime is ready; Android enables them based on mint presence alone. **Done when:** Android exposes a preparation state and cannot enter a money-moving flow before the runtime is ready.
 
 - [ ] **[P1 · Android → iOS] Add the no-mint Wallet empty state and CTA.** Android explains that a mint is needed and provides “Add mint”; iOS shows the generic “No Activity Yet” state even when no mint exists. **Done when:** iOS distinguishes “no mint” from “no activity” and links directly to mint setup.
 

--- a/ios/CashuWallet/App/ContentView.swift
+++ b/ios/CashuWallet/App/ContentView.swift
@@ -28,6 +28,14 @@ struct ContentView: View {
             }
         }
         .animation(.easeInOut(duration: 0.35), value: walletManager.needsOnboarding)
+        .onChange(of: navigationManager.pendingDeepLinkToken) {
+            navigationManager.presentPendingReceiveTokenIfReady(
+                isRuntimeReady: walletManager.isRuntimeReady
+            )
+        }
+        .onChange(of: walletManager.isRuntimeReady, initial: true) { _, isRuntimeReady in
+            navigationManager.presentPendingReceiveTokenIfReady(isRuntimeReady: isRuntimeReady)
+        }
         .fullScreenCover(isPresented: $navigationManager.showReceiveTokenSheet) {
             if let token = navigationManager.pendingDeepLinkToken {
                 ReceiveTokenDetailView(

--- a/ios/CashuWallet/Core/Navigation/NavigationManager.swift
+++ b/ios/CashuWallet/Core/Navigation/NavigationManager.swift
@@ -57,14 +57,27 @@ class NavigationManager: ObservableObject {
             return
         }
         
-        // Store the token and trigger the receive sheet
+        // Store the token before presentation. ContentView waits for the wallet
+        // runtime before presenting this payment surface.
         pendingDeepLinkToken = token
         
         // Dismiss any open sheets first
         dismissAll()
         
-        // Show the receive token sheet
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+    }
+
+    /// Presents a queued Cashu token only after the encrypted wallet runtime is
+    /// available. Re-check the token after the presentation delay so a newer
+    /// deep link cannot present stale content.
+    func presentPendingReceiveTokenIfReady(isRuntimeReady: Bool) {
+        guard isRuntimeReady,
+              !showReceiveTokenSheet,
+              let token = pendingDeepLinkToken else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self,
+                  self.pendingDeepLinkToken == token,
+                  !self.showReceiveTokenSheet else { return }
             self.showReceiveTokenSheet = true
         }
     }


### PR DESCRIPTION
## Change

- show “Preparing wallet…” in the Android Wallet Home balance status slot while the runtime initializes
- disable Home Receive and Send until runtime readiness joins their existing prerequisites
- guard shell payment-flow, receive-detail, contactless, scanner handoff, and payment deep-link entry points until the runtime is ready
- add focused unit and Compose coverage
- check off the matching iOS/Android parity item

## Root cause

Android already published `WalletState.isRuntimeReady`, but Home ignored it and enabled payment actions from mint presence alone. Shell routing also mounted money-moving surfaces without enforcing that readiness boundary.

## Impact

Users can still see their cache-first Wallet Home during startup, now with an explicit preparation state. They cannot enter a money-moving flow until the encrypted seed and CDK repository are ready; pending payment deep links resume once readiness is reached.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.home.HomeRuntimeReadinessTest :app:compileDebugAndroidTestKotlin --stacktrace`
- `./gradlew --no-daemon :app:lintDebug :app:testDebugUnitTest --stacktrace`
- `git diff --check`

No Android emulator was attached, so the focused Compose instrumentation test was compile-validated but not device-executed.
