### PR TITLE
Honor preferred primary balance unit on Android home

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/components/AccessibilitySemanticsComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/components/AccessibilitySemanticsComposeTest.kt
@@ -97,6 +97,8 @@ class AccessibilitySemanticsComposeTest {
         compose.onNodeWithTag("balanceDisplay")
             .assertIsDisplayed()
             .assertHasNoClickAction()
+        compose.onNodeWithContentDescription("Balance: 42 sat")
+            .assertIsDisplayed()
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
             .performScrollTo()
             .assertIsDisplayed()
@@ -122,5 +124,23 @@ class AccessibilitySemanticsComposeTest {
             assertEquals(1, rowClicks)
             assertFalse(privacyEnabled)
         }
+    }
+
+    @Test
+    fun balanceAccessibilityNamesThePreferredPrimaryAmount() {
+        compose.setCashuContent {
+            BalanceDisplay(
+                amount = AmountDisplayText(
+                    primary = "\$20.00",
+                    secondary = "100,000 sat",
+                    effectivePrimary = AmountDisplayPrimary.Fiat,
+                ),
+            )
+        }
+
+        compose.onNodeWithContentDescription("Balance: \$20.00")
+            .assertIsDisplayed()
+        compose.onNodeWithText("100,000 sat")
+            .assertIsDisplayed()
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/components/BalanceDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/BalanceDisplay.kt
@@ -21,6 +21,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -86,6 +88,9 @@ fun BalanceDisplay(
         ) {
             AmountText(
                 text = amount.primary,
+                modifier = Modifier.clearAndSetSemantics {
+                    contentDescription = "Balance: ${amount.primary}"
+                },
                 style = MaterialTheme.typography.displayMedium.copy(
                     fontWeight = FontWeight.Bold,
                     fontSize = BalanceHeroFontSize,

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -116,7 +116,7 @@ fun HomeScreen(
     val balanceDisplay = remember(walletState.balance, settings, priceState) {
         formatter.displayText(
             amountSats = walletState.balance,
-            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
+            preferredPrimary = settings.amountDisplayPrimary,
             showFiat = settings.showFiatBalance && priceState.btcPrice > 0,
             btcPrice = priceState.btcPrice,
             currencyCode = settings.bitcoinPriceCurrency,

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -26,7 +26,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 ## App shell and Wallet home
 
-- [ ] **[P1 · iOS → Android] Honor the preferred primary balance unit on Wallet home.** Android always constructs the home balance with sats as the primary value, even when the user selected fiat; iOS uses `amountDisplayPrimary`. Neither Home implementation currently offers an amount-flip control. **Done when:** Android opens with the saved sats/fiat preference and its visible and accessibility values consistently reflect that preference. A Home-specific flip interaction, if desired, is a separate product decision.
+- [x] **[P1 · iOS → Android] Honor the preferred primary balance unit on Wallet home.** Android always constructs the home balance with sats as the primary value, even when the user selected fiat; iOS uses `amountDisplayPrimary`. Neither Home implementation currently offers an amount-flip control. **Done when:** Android opens with the saved sats/fiat preference and its visible and accessibility values consistently reflect that preference. A Home-specific flip interaction, if desired, is a separate product decision.
 
 - [ ] **[P1 · iOS → Android] Gate payment actions on wallet runtime readiness.** iOS shows “Preparing wallet…” and disables Receive/Send until the runtime is ready; Android enables them based on mint presence alone. **Done when:** Android exposes a preparation state and cannot enter a money-moving flow before the runtime is ready.
 


### PR DESCRIPTION
## Change

- use the persisted `amountDisplayPrimary` preference for Android Wallet Home instead of forcing sats as the primary balance
- make the balance TalkBack semantics announce the actual primary amount shown
- add focused accessibility semantics coverage
- check off the matching iOS/Android parity item

## Root cause

Android Home passed a hardcoded sats primary preference to `AmountFormatter`, ignoring the user's saved sats/fiat selection. The balance semantics likewise did not explicitly expose the rendered primary amount.

## Impact

Wallet Home now opens with the saved primary balance unit and its accessibility announcement matches the visible primary value.

## Validation

- AmountFormatter unit tests
- debug AndroidTest compilation
- two managed-device accessibility tests on Pixel 2 API 35
- `lintDebug`
