### PR TITLE
Add iOS Wallet no-mint empty state

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -30,7 +30,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 - [ ] **[P1 · iOS → Android] Gate payment actions on wallet runtime readiness.** iOS shows “Preparing wallet…” and disables Receive/Send until the runtime is ready; Android enables them based on mint presence alone. **Done when:** Android exposes a preparation state and cannot enter a money-moving flow before the runtime is ready.
 
-- [ ] **[P1 · Android → iOS] Add the no-mint Wallet empty state and CTA.** Android explains that a mint is needed and provides “Add mint”; iOS shows the generic “No Activity Yet” state even when no mint exists. **Done when:** iOS distinguishes “no mint” from “no activity” and links directly to mint setup.
+- [x] **[P1 · Android → iOS] Add the no-mint Wallet empty state and CTA.** Android explains that a mint is needed and provides “Add mint”; iOS shows the generic “No Activity Yet” state even when no mint exists. **Done when:** iOS distinguishes “no mint” from “no activity” and links directly to mint setup.
 
 - [ ] **[P1 · iOS → Android] Keep Receive usable without an active mint.** iOS can create an any-mint Cashu Request without an active mint; Android disables Receive on Home and pins new requests to the active mint. **Done when:** Android allows the any-mint ecash receive path without a mint while clearly disabling or explaining receive methods that truly require one.
 

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -501,16 +501,28 @@ struct MainWalletView: View {
     private var recentContent: some View {
         let items = recentItems
         if items.isEmpty {
-            // Same shared component, size, and centered placement as the
-            // History empty state, but with its own tray icon and copy
-            // (recent-activity framing vs. History's clock + "history"). No
-            // "Recent" header here: with nothing to label it's redundant, and
-            // dropping it matches History's clean full-screen empty state.
-            NativeEmptyState(
-                title: "No Activity Yet",
-                systemImage: "tray",
-                description: "Your recent payments will show up here."
-            )
+            Group {
+                if walletManager.mints.isEmpty {
+                    NativeEmptyState(
+                        title: "Add a mint to get started",
+                        systemImage: "bitcoinsign.bank.building",
+                        description: "Mints custody your ecash. Add one to begin.",
+                        actionTitle: "Add mint",
+                        action: { activeSheet = .addMint }
+                    )
+                } else {
+                    // Same shared component, size, and centered placement as the
+                    // History empty state, but with its own tray icon and copy
+                    // (recent-activity framing vs. History's clock + "history"). No
+                    // "Recent" header here: with nothing to label it's redundant,
+                    // and dropping it matches History's clean full-screen empty state.
+                    NativeEmptyState(
+                        title: "No Activity Yet",
+                        systemImage: "tray",
+                        description: "Your recent payments will show up here."
+                    )
+                }
+            }
             .containerRelativeFrame(.vertical)
             .padding(.horizontal, 16)
         } else {
@@ -722,6 +734,11 @@ struct MainWalletView: View {
                 .canvasSheetBackground()
         case .flow(let flow):
             flowView(for: flow)
+        case .addMint:
+            AddMintSheet()
+                .environmentObject(walletManager)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         case .discoverMints:
             MintDiscoverySheet { url in
                 Task { try? await walletManager.addMint(url: url) }
@@ -796,6 +813,7 @@ private enum WalletSheet: Identifiable {
     case send
     case scanner
     case flow(WalletFlow)
+    case addMint
     case discoverMints
 
     var id: String {
@@ -808,6 +826,8 @@ private enum WalletSheet: Identifiable {
             return "scanner"
         case .flow(let flow):
             return "flow-\(flow.id)"
+        case .addMint:
+            return "addMint"
         case .discoverMints:
             return "discoverMints"
         }

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -6,6 +6,27 @@ final class MainTabUITests: UITestBase {
 
     // MARK: - Tests
 
+    func testWalletNoMintEmptyStateLinksToMintSetup() throws {
+        waitForMainTab()
+
+        XCTAssertTrue(
+            app.staticTexts["Add a mint to get started"].waitForExistence(timeout: 5),
+            "A wallet without mints should explain that a mint is required"
+        )
+
+        let addMint = app.buttons["Add mint"]
+        tapWhenReady(addMint)
+
+        XCTAssertTrue(
+            app.navigationBars["Add Mint"].waitForExistence(timeout: 5),
+            "The Wallet empty-state CTA should open mint setup directly"
+        )
+        XCTAssertTrue(
+            app.textFields["mints-add-url-field"].waitForExistence(timeout: 5),
+            "Mint setup should expose the mint URL field"
+        )
+    }
+
     func testPrimaryNavigationAndEmptyMintsState() throws {
         waitForMainTab()
 


### PR DESCRIPTION
## What changed

- Distinguish the Wallet no-mint state from the no-activity state on iOS.
- Add an **Add mint** call to action that opens `AddMintSheet` directly.
- Add focused UI coverage for the empty-state copy and setup journey.
- Mark the corresponding App shell and Wallet home parity item complete.

## Root cause

`MainWalletView` used the generic no-activity state even when the wallet had no configured mint, leaving users without a direct setup path.

## Impact

Users without a mint now get clear guidance and can enter mint setup directly from Wallet home.

## Validation

- `git diff --check`
- Signed simulator `build-for-testing`
- `MainTabUITests.testWalletNoMintEmptyStateLinksToMintSetup` on iPhone 17 Pro (iOS 26.4.1)
