### PR TITLE
Keep Receive usable without a mint

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MainActivityJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MainActivityJourneyTest.kt
@@ -1,8 +1,10 @@
 package com.cashu.me.ui.journeys
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.accessibility.enableAccessibilityChecks
 import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -87,6 +89,30 @@ class MainActivityJourneyTest {
             .pressSystemBack()
             .assertTagDoesNotExist(UiTestTags.ReceiveSheet)
             .awaitTag(UiTestTags.WalletScreen)
+    }
+
+    @Test
+    fun receiveWithoutMintCreatesAnyMintRequestAndExplainsBitcoinRequirement() {
+        launch(FixtureMode.SeededWithoutMint)
+
+        robot.awaitTag(UiTestTags.WalletScreen)
+            .tapText("Receive")
+            .awaitTag(UiTestTags.ReceiveSheet)
+            .awaitText("Ecash requests and token scans still work without one.", substring = true)
+        compose.onNodeWithContentDescription("Bitcoin").assertIsNotEnabled()
+        robot.tapDescription("Ecash")
+            .awaitText("Any mint")
+    }
+
+    @Test
+    fun newEcashRequestDoesNotPinTheActiveMint() {
+        launch(FixtureMode.SeededWithMint)
+
+        robot.awaitTag(UiTestTags.WalletScreen)
+            .tapText("Receive")
+            .awaitTag(UiTestTags.ReceiveSheet)
+            .tapDescription("Ecash")
+            .awaitText("Any mint")
     }
 
     @Test

--- a/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -245,13 +246,15 @@ fun CircularMethodButton(
     label: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     Column(
-        modifier = modifier,
+        modifier = modifier.alpha(if (enabled) 1f else 0.38f),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Surface(
             onClick = onClick,
+            enabled = enabled,
             modifier = Modifier.size(MethodButtonSize),
             shape = CircleShape,
             color = MaterialTheme.colorScheme.secondaryContainer,

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -220,7 +220,9 @@ fun HomeScreen(
                         onReceive = onReceive,
                         // Send opens the unified surface directly — no chooser.
                         onSend = onSend,
-                        receiveEnabled = walletState.activeMint != null,
+                        // The unified Receive sheet always has mint-independent
+                        // ecash paths (paste/scan and an any-mint NUT-18 request).
+                        receiveEnabled = true,
                         // iOS parity: Send is tappable at zero balance; the sheet shows
                         // "Nothing to send yet" with a Receive CTA instead of disabling here.
                         sendEnabled = walletState.activeMint != null,

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
@@ -108,6 +108,8 @@ fun ReceiveEcashScreen(
 
     // iOS "New Request": publish a fresh any-amount NUT-18 request over the
     // wallet's Nostr identity and open its inspector — no intermediate form.
+    // Keep it mint-agnostic even when an active mint exists; the request detail
+    // screen lets the user opt into a specific mint later.
     fun createNewRequest() {
         val nostr = nostrService.state.value
         val relays = settings.nostrRelays
@@ -118,7 +120,7 @@ fun ReceiveEcashScreen(
         inputHint = null
         runCatching {
             val id = com.cashu.me.Models.CashuRequest.newId()
-            val mints = listOfNotNull(walletState.activeMint?.url)
+            val mints = emptyList<String>()
             val encoded = PaymentRequestBuilder.build(
                 id = id,
                 amount = null,
@@ -272,6 +274,14 @@ fun ReceiveEcashScreen(
                     icon = Icons.Outlined.CurrencyBitcoin,
                     label = "Bitcoin",
                     onClick = onReceiveBitcoin,
+                    enabled = walletState.activeMint != null,
+                )
+            }
+            if (walletState.activeMint == null) {
+                Spacer(Modifier.height(CashuTheme.spacing.comfortable))
+                InlineNotice(
+                    text = "Add a mint to receive bitcoin. Ecash requests and token scans still work without one.",
+                    severity = NoticeSeverity.Info,
                 )
             }
         }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -32,7 +32,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 - [ ] **[P1 · Android → iOS] Add the no-mint Wallet empty state and CTA.** Android explains that a mint is needed and provides “Add mint”; iOS shows the generic “No Activity Yet” state even when no mint exists. **Done when:** iOS distinguishes “no mint” from “no activity” and links directly to mint setup.
 
-- [ ] **[P1 · iOS → Android] Keep Receive usable without an active mint.** iOS can create an any-mint Cashu Request without an active mint; Android disables Receive on Home and pins new requests to the active mint. **Done when:** Android allows the any-mint ecash receive path without a mint while clearly disabling or explaining receive methods that truly require one.
+- [x] **[P1 · iOS → Android] Keep Receive usable without an active mint.** iOS can create an any-mint Cashu Request without an active mint; Android disables Receive on Home and pins new requests to the active mint. **Done when:** Android allows the any-mint ecash receive path without a mint while clearly disabling or explaining receive methods that truly require one.
 
 - [ ] **[P1 · iOS → Android] Drive the received-amount beat from an explicit receive event.** Android infers a receive from any balance increase, which can show a false `+amount` after a restore, mint operation, or unrelated balance refresh; iOS uses a receipt notification. **Done when:** Android only shows the beat for a confirmed incoming payment and only lets Home own the success haptic for background receipts that have no in-flow confirmation.
 


### PR DESCRIPTION
## Change

- Keep the Wallet Home Receive action available without an active mint.
- Create new NUT-18 ecash requests as mint-agnostic (`mints = []`), matching iOS.
- Disable and dim the Bitcoin receive method when no active mint exists, with copy explaining that ecash requests and token scans remain available.
- Mark the corresponding parity-checklist item complete.

## Root cause

Home coupled the entire unified Receive entry point to active-mint presence, even though paste/scan and any-mint ecash requests do not require one. New requests also inherited the active mint, while the Bitcoin quote flow is the only method on this surface that truly requires an active mint.

## Impact

Wallets with no configured mint can now open Receive and share an any-mint ecash request. Wallets with a mint retain the existing Bitcoin/Lightning receive flow, while fresh ecash requests no longer silently pin the selected mint.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin --stacktrace`
- Managed Pixel 2 API 35: complete `MainActivityJourneyTest` class, 12/12 passed, including no-mint Receive, active-mint any-mint request, and Bitcoin/Lightning regression coverage.
