### PR TITLE
Label the wallet startup loading state

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/shell/WalletLoadingAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/shell/WalletLoadingAccessibilityComposeTest.kt
@@ -1,0 +1,36 @@
+package com.cashu.me.ui.shell
+
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.App.AppContainer
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WalletLoadingAccessibilityComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun startupGateIdentifiesWalletLoadingAsIndeterminateProgress() {
+        compose.setContent {
+            CashuApp(containerFlow = MutableStateFlow<AppContainer?>(null))
+        }
+
+        val loadingNode = compose.onNodeWithContentDescription("Loading wallet…")
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+
+        assertEquals(
+            ProgressBarRangeInfo.Indeterminate,
+            loadingNode.config[SemanticsProperties.ProgressBarRangeInfo],
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -14,12 +14,15 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -32,6 +35,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.unit.IntOffset
@@ -41,6 +49,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.flow.StateFlow
+import com.cashu.me.R
 import com.cashu.me.App.AppContainer
 import com.cashu.me.Core.Navigation.CashuRoute
 import com.cashu.me.Core.PaymentRequestDecodeResult
@@ -564,7 +573,22 @@ private fun LoadingScreen() {
             .background(MaterialTheme.colorScheme.background),
         contentAlignment = Alignment.Center,
     ) {
-        LoadingIndicator()
+        val loadingLabel = stringResource(R.string.loading_wallet)
+        Column(
+            modifier = Modifier.clearAndSetSemantics {
+                contentDescription = loadingLabel
+                progressBarRangeInfo = ProgressBarRangeInfo.Indeterminate
+            },
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+        ) {
+            LoadingIndicator()
+            Text(
+                text = loadingLabel,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="nfc_receive_service_description">Receive Cashu payments by NFC</string>
     <string name="nfc_receive_aid_description">Cashu NFC payment request</string>
     <string name="app_name">Cashu</string>
+    <string name="loading_wallet">Loading wallet…</string>
 </resources>

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -36,7 +36,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 - [ ] **[P1 · iOS → Android] Drive the received-amount beat from an explicit receive event.** Android infers a receive from any balance increase, which can show a false `+amount` after a restore, mint operation, or unrelated balance refresh; iOS uses a receipt notification. **Done when:** Android only shows the beat for a confirmed incoming payment and only lets Home own the success haptic for background receipts that have no in-flow confirmation.
 
-- [ ] **[P2 · iOS → Android] Add an accessible loading label.** iOS shows “Loading Wallet…” with its progress indicator; Android shows an unlabeled indicator. **Done when:** Android visually or semantically identifies the startup operation as loading the wallet.
+- [x] **[P2 · iOS → Android] Add an accessible loading label.** iOS shows “Loading Wallet…” with its progress indicator; Android shows an unlabeled indicator. **Done when:** Android visually or semantically identifies the startup operation as loading the wallet.
 
 - [ ] **[P2 · Converge] Update Home action hints for the unified flows.** iOS accessibility hints still describe opening “options” for ecash and Lightning even though the buttons now open unified Send/Receive surfaces; Android exposes only the button names. **Done when:** both platforms describe the actual destination and supported inputs without referring to a retired chooser.
 


### PR DESCRIPTION
## What changed

- Show a visible “Loading wallet…” label beneath the Android startup indicator.
- Expose the startup state as one coherent accessibility node with an operation label and indeterminate progress semantics.
- Add focused Compose accessibility coverage and mark the matching parity-checklist item complete.

## Root cause

Android rendered a bare startup `LoadingIndicator`, so users—especially TalkBack users—could not tell which operation was in progress.

## Impact

Wallet startup now identifies that the wallet is loading both visually and semantically, bringing Android in line with the iOS loading state.

## Validation

- `./gradlew --no-daemon :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin :app:testDebugUnitTest --stacktrace` — passed.
- Focused `WalletLoadingAccessibilityComposeTest` compiles and asserts the accessible label plus indeterminate progress semantics.
- A connected-device run was attempted, but the emulator disconnected before Gradle discovered it (`No connected devices`).