### PR TITLE
Drive Home receive beat from explicit payment events

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -223,6 +223,7 @@ class CashuRequestListener(
                 tokenString = payload.token,
                 requestId = payload.requestId,
                 processedId = eventId,
+                confirmationOwner = ReceiveConfirmationOwner.Home,
             )
             if (amount > 0 && !payload.requestId.isNullOrBlank()) {
                 cashuRequestStore.attachPayment(

--- a/android/app/src/main/java/com/cashu/me/Core/ReceivedPaymentEvent.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/ReceivedPaymentEvent.kt
@@ -1,0 +1,42 @@
+package com.cashu.me.Core
+
+/**
+ * Identifies which surface owns confirmation feedback for a successful
+ * incoming payment.
+ *
+ * Receive flows render their own success terminal (and therefore its haptic).
+ * Passive receipts have no such terminal, so Home owns the success haptic.
+ */
+enum class ReceiveConfirmationOwner {
+    InFlow,
+    Home,
+}
+
+data class ReceivedPaymentEvent(
+    val amount: Long,
+    val unit: String,
+    val confirmationOwner: ReceiveConfirmationOwner,
+) {
+    val homeOwnsSuccessHaptic: Boolean
+        get() = confirmationOwner == ReceiveConfirmationOwner.Home
+}
+
+/**
+ * Build a presentation event only from a confirmed, positive credit.
+ *
+ * Balance refreshes deliberately have no path through this function: callers
+ * invoke it at the successful mint/redeem boundary instead.
+ */
+internal fun confirmedReceivedPaymentEvent(
+    amount: Long,
+    unit: String,
+    confirmationOwner: ReceiveConfirmationOwner,
+): ReceivedPaymentEvent? = amount
+    .takeIf { it > 0L }
+    ?.let {
+        ReceivedPaymentEvent(
+            amount = it,
+            unit = unit.ifBlank { "sat" }.lowercase(),
+            confirmationOwner = confirmationOwner,
+        )
+    }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -11,10 +11,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -76,6 +80,11 @@ class WalletManager(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate + exceptionHandler)
     private val mutableState = MutableStateFlow(WalletState())
     val state: StateFlow<WalletState> = mutableState.asStateFlow()
+    private val mutableReceivedPayments = MutableSharedFlow<ReceivedPaymentEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val receivedPayments: SharedFlow<ReceivedPaymentEvent> = mutableReceivedPayments.asSharedFlow()
     private val initializationMutex = Mutex()
     private val mintMetadataFetcher = WalletMintMetadataFetcher(allowCleartextLocalTestMints)
     private val mintQuoteSyncService = WalletMintQuoteSyncService(gateway, walletStore)
@@ -518,27 +527,47 @@ class WalletManager(
     fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> = gateway.subscribeToMintQuote(quoteId)
 
     override suspend fun mintTokens(quoteId: String): Long =
-        withLoadingResult {
+        mintTokens(
+            quoteId = quoteId,
+            unit = "sat",
+            confirmationOwner = ReceiveConfirmationOwner.InFlow,
+        )
+
+    suspend fun mintTokens(
+        quoteId: String,
+        unit: String,
+        confirmationOwner: ReceiveConfirmationOwner,
+    ): Long {
+        val amount = withLoadingResult {
             gateway.mintTokens(quoteId).also {
                 refreshBalance()
                 loadTransactions()
             }
         }
+        publishReceivedPayment(amount, unit, confirmationOwner)
+        return amount
+    }
 
     /**
      * Silent single-quote check + mint if paid. Used by Receive (per-quote
      * poll) and transaction detail open — must not flip the global loading
      * flag (passive UX). Forced past unpaid backoff (brief debounce only).
      */
-    suspend fun refreshPendingMintQuote(quoteId: String): Boolean {
-        val minted = mintQuoteSyncService.syncPendingMintQuote(
+    suspend fun refreshPendingMintQuote(
+        quoteId: String,
+        confirmationOwner: ReceiveConfirmationOwner,
+    ): Boolean {
+        val result = mintQuoteSyncService.syncPendingMintQuote(
             quoteId,
             allowPendingOnchainMintAttempt = true,
             force = true,
         )
-        if (minted) refreshBalance()
+        if (result.minted) refreshBalance()
         loadTransactions()
-        return minted
+        result.receivedAmount?.let { amount ->
+            publishReceivedPayment(amount, result.unit, confirmationOwner)
+        }
+        return result.minted
     }
 
     /**
@@ -595,19 +624,27 @@ class WalletManager(
                 ordered.take(MintQuoteCheckBackoff.MAX_PASSIVE_CHECKS_PER_PASS)
             }
             var mintedCount = 0
+            val receivedPayments = mutableListOf<MintQuoteSyncResult>()
             toCheck.forEach { quote ->
-                if (
-                    mintQuoteSyncService.syncPendingMintQuote(
-                        quote.id,
-                        allowPendingOnchainMintAttempt = false,
-                        force = force,
-                    )
-                ) {
+                val result = mintQuoteSyncService.syncPendingMintQuote(
+                    quote.id,
+                    allowPendingOnchainMintAttempt = false,
+                    force = force,
+                )
+                if (result.minted) {
                     mintedCount += 1
                 }
+                if (result.receivedAmount != null) receivedPayments += result
             }
             if (mintedCount > 0) refreshBalance()
             loadTransactions()
+            receivedPayments.forEach { result ->
+                publishReceivedPayment(
+                    amount = checkNotNull(result.receivedAmount),
+                    unit = result.unit,
+                    confirmationOwner = ReceiveConfirmationOwner.Home,
+                )
+            }
             return mintedCount
         } finally {
             isSyncingMintQuotes.set(false)
@@ -629,6 +666,11 @@ class WalletManager(
             p2pkPubkey?.let(settingsManager::markP2PKKeyUsed)
             refreshBalance()
             loadTransactions()
+            publishReceivedPayment(
+                amount = amount,
+                unit = "sat",
+                confirmationOwner = ReceiveConfirmationOwner.Home,
+            )
             amount > 0 || isNPCQuoteProcessed(quote.id)
         } catch (error: Throwable) {
             if (mintQuoteSyncService.isAlreadyIssuedMintError(error)) {
@@ -863,7 +905,17 @@ class WalletManager(
     }
 
     override suspend fun receiveTokens(tokenString: String): Long =
-        withLoadingResult {
+        receiveTokens(
+            tokenString = tokenString,
+            confirmationOwner = ReceiveConfirmationOwner.InFlow,
+        )
+
+    private suspend fun receiveTokens(
+        tokenString: String,
+        confirmationOwner: ReceiveConfirmationOwner?,
+    ): Long {
+        val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
+        val amount = withLoadingResult {
             val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
             val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
             gateway.receiveEcashToken(tokenString, signingKeys).also {
@@ -884,13 +936,21 @@ class WalletManager(
                 loadTransactions()
             }
         }
+        confirmationOwner?.let { publishReceivedPayment(amount, unit, it) }
+        return amount
+    }
 
-    suspend fun receiveCashuRequestPayment(tokenString: String, requestId: String?, processedId: String? = requestId): Long {
+    suspend fun receiveCashuRequestPayment(
+        tokenString: String,
+        requestId: String?,
+        processedId: String? = requestId,
+        confirmationOwner: ReceiveConfirmationOwner = ReceiveConfirmationOwner.InFlow,
+    ): Long {
         val normalizedProcessedId = processedId?.trim()?.takeIf { it.isNotEmpty() }
         if (normalizedProcessedId != null && normalizedProcessedId in walletStore.loadProcessedCashuRequests()) {
             return 0
         }
-        val amount = receiveTokens(tokenString)
+        val amount = receiveTokens(tokenString, confirmationOwner)
         normalizedProcessedId?.let { id ->
             walletStore.saveProcessedCashuRequests((walletStore.loadProcessedCashuRequests() + id).distinct().sorted())
         }
@@ -907,38 +967,56 @@ class WalletManager(
     suspend fun receiveNfcCashuRequestPayment(
         tokenString: String,
         processedId: String,
-    ): com.cashu.me.Core.CDK.NfcReceiveReceipt = withLoadingResult {
-        require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
-        val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
-        val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
-        gateway.receiveNfcEcashToken(tokenString, signingKeys).also {
-            p2pkPubkeys.forEach(settingsManager::markP2PKKeyUsed)
-            trackMintForReceivedToken(
-                tokenString = tokenString,
-                onTrackingFailed = { AppLogger.wallet.error("Failed to track mint for received NFC token", it) },
-                ensureMintTracked = { ensureMintTracked(it) },
-            )
-            walletStore.saveProcessedCashuRequests(
-                (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
-            )
-            refreshBalance()
-            loadTransactions()
+    ): com.cashu.me.Core.CDK.NfcReceiveReceipt {
+        val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
+        val receipt = withLoadingResult {
+            require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
+            val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
+            val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
+            gateway.receiveNfcEcashToken(tokenString, signingKeys).also {
+                p2pkPubkeys.forEach(settingsManager::markP2PKKeyUsed)
+                trackMintForReceivedToken(
+                    tokenString = tokenString,
+                    onTrackingFailed = { AppLogger.wallet.error("Failed to track mint for received NFC token", it) },
+                    ensureMintTracked = { ensureMintTracked(it) },
+                )
+                walletStore.saveProcessedCashuRequests(
+                    (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
+                )
+                refreshBalance()
+                loadTransactions()
+            }
         }
+        publishReceivedPayment(
+            receipt.amountReceived,
+            unit,
+            ReceiveConfirmationOwner.InFlow,
+        )
+        return receipt
     }
 
     suspend fun settleForeignNfcToken(
         tokenString: String,
         settlementMintUrl: String,
         processedId: String,
-    ): com.cashu.me.Core.CDK.ForeignNfcSettlement = withLoadingResult {
-        require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
-        gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
-            walletStore.saveProcessedCashuRequests(
-                (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
-            )
-            refreshBalance()
-            loadTransactions()
+    ): com.cashu.me.Core.CDK.ForeignNfcSettlement {
+        val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
+        val settlement = withLoadingResult {
+            require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
+            gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
+                walletStore.saveProcessedCashuRequests(
+                    (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
+                )
+                refreshBalance()
+                loadTransactions()
+            }
         }
+        publishReceivedPayment(
+            settlement.amountReceived,
+            unit,
+            ReceiveConfirmationOwner.InFlow,
+        )
+        return settlement
     }
 
     fun savePendingReceiveToken(token: PendingReceiveToken) {
@@ -970,7 +1048,7 @@ class WalletManager(
                 }
             }
         } else {
-            receiveTokens(token.token)
+            receiveTokens(token.token, ReceiveConfirmationOwner.InFlow)
         }
         removePendingReceiveToken(token.tokenId)
         return amount
@@ -1027,7 +1105,9 @@ class WalletManager(
     }
 
     suspend fun reclaimPendingToken(pendingToken: PendingToken): Long {
-        val amount = receiveTokens(pendingToken.token)
+        // Reclaiming our own unspent outgoing token restores balance, but is
+        // not an incoming payment and must not publish a Home receive beat.
+        val amount = receiveTokens(pendingToken.token, confirmationOwner = null)
         removePendingToken(pendingToken.tokenId)
         loadTransactions()
         return amount
@@ -1309,6 +1389,16 @@ class WalletManager(
 
     private fun update(transform: WalletState.() -> WalletState) {
         mutableState.value = mutableState.value.transform()
+    }
+
+    private fun publishReceivedPayment(
+        amount: Long,
+        unit: String,
+        confirmationOwner: ReceiveConfirmationOwner,
+    ) {
+        confirmedReceivedPaymentEvent(amount, unit, confirmationOwner)?.let {
+            mutableReceivedPayments.tryEmit(it)
+        }
     }
 
     fun launch(block: suspend CoroutineScope.() -> Unit) {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
@@ -6,6 +6,12 @@ import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.Models.PaymentMethodKind
 import kotlinx.coroutines.CancellationException
 
+internal data class MintQuoteSyncResult(
+    val minted: Boolean,
+    val receivedAmount: Long? = null,
+    val unit: String = "sat",
+)
+
 internal class WalletMintQuoteSyncService(
     private val gateway: CdkWalletGateway,
     private val walletStore: WalletStore,
@@ -24,12 +30,12 @@ internal class WalletMintQuoteSyncService(
         quoteId: String,
         allowPendingOnchainMintAttempt: Boolean,
         force: Boolean = false,
-    ): Boolean {
+    ): MintQuoteSyncResult {
         val now = System.currentTimeMillis()
         val prior = checkThrottle[quoteId]
-        if (!MintQuoteCheckBackoff.shouldCheck(prior, now, force)) return false
+        if (!MintQuoteCheckBackoff.shouldCheck(prior, now, force)) return MintQuoteSyncResult(minted = false)
 
-        if (!mintQuoteSyncsInFlight.add(quoteId)) return false
+        if (!mintQuoteSyncsInFlight.add(quoteId)) return MintQuoteSyncResult(minted = false)
         return try {
             val updatedQuote = try {
                 gateway.checkMintQuote(quoteId).also { rememberMintQuoteTimestamp(it.id) }
@@ -40,7 +46,7 @@ internal class WalletMintQuoteSyncService(
                 if (!isMissingQuoteError(error)) {
                     AppLogger.wallet.error("Failed to refresh pending quote $quoteId", error)
                 }
-                return false
+                return MintQuoteSyncResult(minted = false)
             }
 
             val shouldAttemptMint = updatedQuote.state == MintQuoteState.Paid ||
@@ -48,7 +54,7 @@ internal class WalletMintQuoteSyncService(
                 (allowPendingOnchainMintAttempt && updatedQuote.paymentMethod == PaymentMethodKind.Onchain)
             if (!shouldAttemptMint) {
                 checkThrottle[quoteId] = MintQuoteCheckBackoff.afterUnpaidOrError(prior, now)
-                return false
+                return MintQuoteSyncResult(minted = false)
             }
 
             if (updatedQuote.paymentMethod == PaymentMethodKind.Bolt12 &&
@@ -58,11 +64,12 @@ internal class WalletMintQuoteSyncService(
                 // Still fully caught up — treat as a quiet miss so passive
                 // polling backs off instead of re-hitting every 30s.
                 checkThrottle[quoteId] = MintQuoteCheckBackoff.afterUnpaidOrError(prior, now)
-                return false
+                return MintQuoteSyncResult(minted = false)
             }
 
+            var receivedAmount: Long? = null
             val minted = try {
-                gateway.mintTokens(quoteId)
+                receivedAmount = gateway.mintTokens(quoteId)
                 true
             } catch (error: CancellationException) {
                 throw error
@@ -85,7 +92,11 @@ internal class WalletMintQuoteSyncService(
             } else {
                 MintQuoteCheckBackoff.afterUnpaidOrError(prior, now)
             }
-            minted
+            MintQuoteSyncResult(
+                minted = minted,
+                receivedAmount = receivedAmount?.takeIf { minted },
+                unit = updatedQuote.unit,
+            )
         } finally {
             mintQuoteSyncsInFlight.remove(quoteId)
         }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -45,6 +45,7 @@ import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
+import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.resolveTransactionForDetail
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TransactionDisplay
@@ -118,7 +119,12 @@ fun TransactionDetailScreen(
             openId = transactionId,
         )?.mintQuoteIdForStatusRefresh
             ?: return@LaunchedEffect
-        runCatching { walletManager.refreshPendingMintQuote(quoteId) }
+        runCatching {
+            walletManager.refreshPendingMintQuote(
+                quoteId,
+                confirmationOwner = ReceiveConfirmationOwner.Home,
+            )
+        }
     }
     // Tap-to-copy inspector rows (Address / Transaction ID / Payment Proof):
     // which row last copied, for the ContentCopy → green Check swap.

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountDisplayText
@@ -65,11 +66,14 @@ import com.cashu.me.Core.HomeBalance
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.PriceService
+import com.cashu.me.Core.ReceivedPaymentEvent
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TransactionDisplay
+import com.cashu.me.Core.WalletHaptic
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.displayText
 import com.cashu.me.Core.recentCompletedTransactions
+import com.cashu.me.Core.rememberWalletHaptics
 import com.cashu.me.Models.WalletTransaction
 import com.cashu.me.ui.components.BalanceDisplay
 import com.cashu.me.ui.components.BalanceHeroHeight
@@ -110,6 +114,7 @@ fun HomeScreen(
     val settings by settingsManager.state.collectAsState()
     val priceState by priceService.state.collectAsState()
     val formatter = remember { AmountFormatter() }
+    val haptics = rememberWalletHaptics()
     val scope = rememberCoroutineScope()
     var refreshing by remember { mutableStateOf(false) }
 
@@ -128,29 +133,23 @@ fun HomeScreen(
         recentCompletedTransactions(walletState.transactions, RECENT_LIMIT)
     }
 
-    // Received-delta beat (iOS MainWalletView "payment-received celebration"):
-    // when the balance rises while Home is composed (receives land behind the
-    // flow sheet), a transient monochrome "+N" takes over the fiat slot for
-    // 2.5s, then fiat fades back. Rapid receives coalesce last-write-wins (the
-    // LaunchedEffect restart cancels the prior dismiss timer); a balance drop
-    // clears the beat immediately. Tracking only starts once the wallet is
-    // initialized and idle, so the startup 0 → N load can't fire a spurious
-    // beat (iOS keys this off an explicit token-received notification instead).
-    var lastObservedBalance by remember { mutableStateOf<Long?>(null) }
-    var receivedDelta by remember { mutableStateOf<String?>(null) }
-    LaunchedEffect(walletState.balance, walletState.isInitialized, walletState.isLoading) {
-        if (!walletState.isInitialized || walletState.isLoading) return@LaunchedEffect
-        val previous = lastObservedBalance
-        lastObservedBalance = walletState.balance
-        if (previous != null && walletState.balance > previous) {
-            receivedDelta = "+" + formatter.formatSats(
-                walletState.balance - previous,
-                includeUnit = false,
-            )
+    // Received-payment beat (iOS MainWalletView notification parity): collect
+    // only explicit, confirmed credits from WalletManager. Balance refreshes,
+    // restore, mint recovery, and reclaim therefore cannot trigger it.
+    //
+    // A receive flow owns its PaymentStatusScreen success haptic. Home performs
+    // the success haptic only for passive receipts with no in-flow terminal.
+    // collectLatest keeps rapid receipts last-write-wins and restarts the 2.5s
+    // dismissal timer.
+    var receivedPayment by remember { mutableStateOf<ReceivedPaymentEvent?>(null) }
+    LaunchedEffect(walletManager) {
+        walletManager.receivedPayments.collectLatest { event ->
+            receivedPayment = event
+            if (event.homeOwnsSuccessHaptic) {
+                haptics.perform(WalletHaptic.Success)
+            }
             delay(RECEIVED_DELTA_DISMISS_MS)
-            receivedDelta = null
-        } else {
-            receivedDelta = null
+            receivedPayment = null
         }
     }
 
@@ -211,7 +210,8 @@ fun HomeScreen(
                         satAmount = balanceDisplay,
                         persistedUnit = settings.homeBalanceUnit,
                         onUnitSelected = settingsManager::setHomeBalanceUnit,
-                        receivedDelta = receivedDelta,
+                        receivedPayment = receivedPayment,
+                        formatter = formatter,
                     )
                 },
                 triptych = {
@@ -433,7 +433,8 @@ private fun HomeBalanceHero(
     satAmount: AmountDisplayText,
     persistedUnit: String,
     onUnitSelected: (String) -> Unit,
-    receivedDelta: String?,
+    receivedPayment: ReceivedPaymentEvent?,
+    formatter: AmountFormatter,
 ) {
     val units = HomeBalance.homeBalanceUnits(balancesByUnit)
     val resolvedUnit = HomeBalance.resolvedUnit(persistedUnit, units)
@@ -472,6 +473,9 @@ private fun HomeBalanceHero(
                 ) { page ->
                     val unit = units.getOrElse(page) { "sat" }
                     val isSat = unit.equals("sat", ignoreCase = true)
+                    val receivedDelta = receivedPayment
+                        ?.takeIf { it.unit.equals(unit, ignoreCase = true) }
+                        ?.displayDelta(formatter)
                     BalanceDisplay(
                         amount = if (isSat) {
                             satAmount
@@ -485,14 +489,16 @@ private fun HomeBalanceHero(
                                 effectivePrimary = AmountDisplayPrimary.Sats,
                             )
                         },
-                        receivedDelta = if (isSat) receivedDelta else null,
+                        receivedDelta = receivedDelta,
                         modifier = Modifier.fillMaxWidth(),
                     )
                 }
             } else {
                 BalanceDisplay(
                     amount = satAmount,
-                    receivedDelta = receivedDelta,
+                    receivedDelta = receivedPayment
+                        ?.takeIf { it.unit.equals("sat", ignoreCase = true) }
+                        ?.displayDelta(formatter),
                     modifier = Modifier.fillMaxWidth(),
                 )
             }
@@ -533,6 +539,16 @@ private fun HomeBalanceHero(
         }
     }
 }
+
+private fun ReceivedPaymentEvent.displayDelta(formatter: AmountFormatter): String =
+    if (unit.equals("sat", ignoreCase = true)) {
+        "+" + formatter.formatSats(amount, includeUnit = false)
+    } else {
+        "+" + CurrencyAmount(
+            amount,
+            CurrencyRegistry.currencyForMintUnit(unit),
+        ).formatted()
+    }
 
 private val PAGE_DOT_SIZE = 6.dp
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -73,6 +73,7 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
 import com.cashu.me.Core.OnchainPaymentObservation
+import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
@@ -340,7 +341,12 @@ fun ReceiveLightningScreen(
                     abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
                     continue
                 }
-                val minted = runCatching { walletManager.refreshPendingMintQuote(quoteId) }
+                val minted = runCatching {
+                    walletManager.refreshPendingMintQuote(
+                        quoteId,
+                        confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                    )
+                }
                     .getOrDefault(false)
                 if (!minted) continue
                 abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
@@ -608,7 +614,12 @@ fun ReceiveLightningScreen(
                                 // Mint on the wallet's app-lifetime scope so a
                                 // dismissal never cancels a mint mid-flight.
                                 walletManager.launch {
-                                    runCatching { walletManager.refreshPendingMintQuote(quote.id) }
+                                    runCatching {
+                                        walletManager.refreshPendingMintQuote(
+                                            quote.id,
+                                            confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                        )
+                                    }
                                 }
                             }
                             delay(30_000)
@@ -653,7 +664,12 @@ fun ReceiveLightningScreen(
                                 liveQuote.state == MintQuoteState.Issued
                             ) {
                                 walletManager.launch {
-                                    runCatching { walletManager.refreshPendingMintQuote(liveQuote.id) }
+                                    runCatching {
+                                        walletManager.refreshPendingMintQuote(
+                                            liveQuote.id,
+                                            confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                        )
+                                    }
                                 }
                             }
                             return@LaunchedEffect
@@ -664,7 +680,15 @@ fun ReceiveLightningScreen(
                             // Finish the UX immediately and mint on the wallet's
                             // app-lifetime scope so the dismiss never cancels it
                             // (iOS: unstructured task that outlives the sheet).
-                            walletManager.launch { runCatching { walletManager.mintTokens(liveQuote.id) } }
+                            walletManager.launch {
+                                runCatching {
+                                    walletManager.mintTokens(
+                                        quoteId = liveQuote.id,
+                                        unit = liveQuote.unit,
+                                        confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                    )
+                                }
+                            }
                             successInfo = ReceiveSuccessInfo(
                                 amountLabel = amountLabel,
                                 mintName = activeMint?.name,

--- a/android/app/src/test/java/com/cashu/me/Core/ReceivedPaymentEventTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/ReceivedPaymentEventTest.kt
@@ -1,0 +1,52 @@
+package com.cashu.me.Core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReceivedPaymentEventTest {
+    @Test
+    fun onlyPositiveConfirmedCreditsCreateAReceiveBeat() {
+        assertNull(
+            confirmedReceivedPaymentEvent(
+                amount = 0,
+                unit = "sat",
+                confirmationOwner = ReceiveConfirmationOwner.Home,
+            ),
+        )
+        assertNull(
+            confirmedReceivedPaymentEvent(
+                amount = -21,
+                unit = "sat",
+                confirmationOwner = ReceiveConfirmationOwner.Home,
+            ),
+        )
+
+        val event = confirmedReceivedPaymentEvent(
+            amount = 21,
+            unit = "SAT",
+            confirmationOwner = ReceiveConfirmationOwner.Home,
+        )
+        assertEquals(21L, event?.amount)
+        assertEquals("sat", event?.unit)
+    }
+
+    @Test
+    fun homeOwnsHapticOnlyWhenNoReceiveFlowOwnsConfirmation() {
+        val inFlow = confirmedReceivedPaymentEvent(
+            amount = 21,
+            unit = "sat",
+            confirmationOwner = ReceiveConfirmationOwner.InFlow,
+        )
+        val background = confirmedReceivedPaymentEvent(
+            amount = 21,
+            unit = "sat",
+            confirmationOwner = ReceiveConfirmationOwner.Home,
+        )
+
+        assertFalse(checkNotNull(inFlow).homeOwnsSuccessHaptic)
+        assertTrue(checkNotNull(background).homeOwnsSuccessHaptic)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -34,7 +34,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 - [ ] **[P1 · iOS → Android] Keep Receive usable without an active mint.** iOS can create an any-mint Cashu Request without an active mint; Android disables Receive on Home and pins new requests to the active mint. **Done when:** Android allows the any-mint ecash receive path without a mint while clearly disabling or explaining receive methods that truly require one.
 
-- [ ] **[P1 · iOS → Android] Drive the received-amount beat from an explicit receive event.** Android infers a receive from any balance increase, which can show a false `+amount` after a restore, mint operation, or unrelated balance refresh; iOS uses a receipt notification. **Done when:** Android only shows the beat for a confirmed incoming payment and only lets Home own the success haptic for background receipts that have no in-flow confirmation.
+- [x] **[P1 · iOS → Android] Drive the received-amount beat from an explicit receive event.** Android infers a receive from any balance increase, which can show a false `+amount` after a restore, mint operation, or unrelated balance refresh; iOS uses a receipt notification. **Done when:** Android only shows the beat for a confirmed incoming payment and only lets Home own the success haptic for background receipts that have no in-flow confirmation.
 
 - [ ] **[P2 · iOS → Android] Add an accessible loading label.** iOS shows “Loading Wallet…” with its progress indicator; Android shows an unlabeled indicator. **Done when:** Android visually or semantically identifies the startup operation as loading the wallet.
 


### PR DESCRIPTION
## What changed

- replace Wallet Home's balance-increase heuristic with a one-shot explicit received-payment event stream
- publish events only after confirmed ecash, mint-quote, Cashu Request, npub.cash, and NFC credits
- assign confirmation ownership so in-flow success terminals keep their haptic while Home haptics only passive receipts without a flow confirmation
- keep self-reclaims, restores, mint setup, and ordinary balance refreshes out of the received-payment event path
- preserve unit-aware `+amount` display and tick the completed parity checklist item

## Root cause

Home inferred incoming payments by comparing consecutive wallet balances. Any unrelated positive balance reconciliation was therefore indistinguishable from a real receipt and could trigger a false `+amount` celebration.

## Impact

Wallet Home now celebrates only confirmed incoming payments. Users no longer see false receipt beats after restore/recovery/refresh operations, and successful receive flows no longer compete with Home for the success haptic.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest`
- `./gradlew --no-daemon :app:lintDebug :app:assembleDebug`
- focused `ReceivedPaymentEventTest` covers positive-credit filtering and Home vs in-flow haptic ownership
