### PR TITLE
Align Home action hints with unified flows

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/home/HomeActionAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/home/HomeActionAccessibilityComposeTest.kt
@@ -1,0 +1,80 @@
+package com.cashu.me.ui.home
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class HomeActionAccessibilityComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun homeActionsExposeOneLabelAndUnifiedFlowClickHints() {
+        var receiveClicks = 0
+        var sendClicks = 0
+
+        compose.setCashuContent {
+            ActionDuet(
+                onReceive = { receiveClicks += 1 },
+                onSend = { sendClicks += 1 },
+                receiveEnabled = true,
+                sendEnabled = true,
+            )
+        }
+
+        assertActionSemantics(
+            tag = UiTestTags.WalletReceive,
+            label = "Receive",
+            clickLabel = HomeActionAccessibility.ReceiveClickLabel,
+        )
+        assertActionSemantics(
+            tag = UiTestTags.WalletSend,
+            label = "Send",
+            clickLabel = HomeActionAccessibility.SendClickLabel,
+        )
+
+        compose.onNodeWithTag(UiTestTags.WalletReceive).performClick()
+        compose.onNodeWithTag(UiTestTags.WalletSend).performClick()
+
+        compose.runOnIdle {
+            assertEquals(1, receiveClicks)
+            assertEquals(1, sendClicks)
+        }
+    }
+
+    private fun assertActionSemantics(
+        tag: String,
+        label: String,
+        clickLabel: String,
+    ) {
+        val node = compose.onNodeWithTag(tag)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+
+        assertEquals(
+            listOf(label),
+            node.config[SemanticsProperties.ContentDescription],
+        )
+        assertEquals(
+            clickLabel,
+            node.config[SemanticsActions.OnClick].label,
+        )
+        assertFalse(clickLabel.contains(label, ignoreCase = true))
+        assertFalse(clickLabel.contains("option", ignoreCase = true))
+        assertFalse(clickLabel.contains("chooser", ignoreCase = true))
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -53,6 +53,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.SubcomposeLayout
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.testTag as semanticsTestTag
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
@@ -90,6 +97,15 @@ private const val RECENT_LIMIT = 5
 
 // iOS MainWalletView: the received-delta beat auto-dismisses after 2.5s.
 private const val RECEIVED_DELTA_DISMISS_MS = 2_500L
+
+internal object HomeActionAccessibility {
+    const val ReceiveClickLabel =
+        "open the unified flow for a pasted ecash token or a new Cashu Request, " +
+            "Lightning invoice, BOLT12 offer, or Bitcoin address"
+    const val SendClickLabel =
+        "open the unified flow for ecash, Lightning addresses, BOLT11 invoices, " +
+            "BOLT12 offers, Bitcoin addresses, or Cashu Requests"
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -537,7 +553,7 @@ private fun HomeBalanceHero(
 private val PAGE_DOT_SIZE = 6.dp
 
 @Composable
-private fun ActionDuet(
+internal fun ActionDuet(
     onReceive: () -> Unit,
     onSend: () -> Unit,
     receiveEnabled: Boolean,
@@ -559,7 +575,13 @@ private fun ActionDuet(
             onClick = onReceive,
             modifier = Modifier
                 .weight(1f)
-                .testTag(UiTestTags.WalletReceive),
+                .homeActionSemantics(
+                    label = "Receive",
+                    onClickLabel = HomeActionAccessibility.ReceiveClickLabel,
+                    testTag = UiTestTags.WalletReceive,
+                    enabled = receiveEnabled,
+                    onClick = onReceive,
+                ),
             enabled = receiveEnabled,
             colors = actionColors,
         )
@@ -568,9 +590,40 @@ private fun ActionDuet(
             onClick = onSend,
             modifier = Modifier
                 .weight(1f)
-                .testTag(UiTestTags.WalletSend),
+                .homeActionSemantics(
+                    label = "Send",
+                    onClickLabel = HomeActionAccessibility.SendClickLabel,
+                    testTag = UiTestTags.WalletSend,
+                    enabled = sendEnabled,
+                    onClick = onSend,
+                ),
             enabled = sendEnabled,
             colors = actionColors,
         )
+    }
+}
+
+/**
+ * Replaces the Button's descendant semantics with one TalkBack node: the
+ * visible label is spoken once, while the click action describes the unified
+ * destination and accepted inputs.
+ */
+private fun Modifier.homeActionSemantics(
+    label: String,
+    onClickLabel: String,
+    testTag: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+): Modifier = clearAndSetSemantics {
+    contentDescription = label
+    semanticsTestTag = testTag
+    role = Role.Button
+    if (enabled) {
+        onClick(label = onClickLabel) {
+            onClick()
+            true
+        }
+    } else {
+        disabled()
     }
 }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -38,7 +38,7 @@ Platform-specific differences are intentionally excluded, including iCloud backu
 
 - [ ] **[P2 · iOS → Android] Add an accessible loading label.** iOS shows “Loading Wallet…” with its progress indicator; Android shows an unlabeled indicator. **Done when:** Android visually or semantically identifies the startup operation as loading the wallet.
 
-- [ ] **[P2 · Converge] Update Home action hints for the unified flows.** iOS accessibility hints still describe opening “options” for ecash and Lightning even though the buttons now open unified Send/Receive surfaces; Android exposes only the button names. **Done when:** both platforms describe the actual destination and supported inputs without referring to a retired chooser.
+- [x] **[P2 · Converge] Update Home action hints for the unified flows.** iOS accessibility hints still describe opening “options” for ecash and Lightning even though the buttons now open unified Send/Receive surfaces; Android exposes only the button names. **Done when:** both platforms describe the actual destination and supported inputs without referring to a retired chooser.
 
 ## Send — unified destination and payment flow
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		T2B0000000000009 /* PaymentRequestDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000009 /* PaymentRequestDecoderTests.swift */; };
 		T2B000000000000A /* CurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000A /* CurrencyTests.swift */; };
 		T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000B /* ReceiveAutoPasteTests.swift */; };
+		T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000C /* HomeActionAccessibilityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -289,6 +290,7 @@
 		T1B0000000000009 /* PaymentRequestDecoderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PaymentRequestDecoderTests.swift; path = ../CI/IntegrationTests/Tests/PaymentRequestDecoderTests.swift; sourceTree = "<group>"; };
 		T1B000000000000A /* CurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CurrencyTests.swift; path = ../CI/IntegrationTests/Tests/CurrencyTests.swift; sourceTree = "<group>"; };
 		T1B000000000000B /* ReceiveAutoPasteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiveAutoPasteTests.swift; path = CashuWalletTests/ReceiveAutoPasteTests.swift; sourceTree = "<group>"; };
+		T1B000000000000C /* HomeActionAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeActionAccessibilityTests.swift; path = CashuWalletTests/HomeActionAccessibilityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -339,6 +341,7 @@
 				T1B0000000000009 /* PaymentRequestDecoderTests.swift */,
 				T1B000000000000A /* CurrencyTests.swift */,
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
+				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -880,6 +883,7 @@
 				T2B0000000000009 /* PaymentRequestDecoderTests.swift in Sources */,
 				T2B000000000000A /* CurrencyTests.swift in Sources */,
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
+				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -1,6 +1,18 @@
 import CoreNFC
 import SwiftUI
 
+enum HomeActionAccessibility {
+    static let receiveHint = """
+    Opens the unified flow for a pasted ecash token or a new Cashu Request, \
+    Lightning invoice, BOLT12 offer, or Bitcoin address
+    """
+
+    static let sendHint = """
+    Opens the unified flow for ecash, Lightning addresses, BOLT11 invoices, \
+    BOLT12 offers, Bitcoin addresses, or Cashu Requests
+    """
+}
+
 struct MainWalletView: View {
     /// Called when the user taps "View all activity" — switches the tab
     /// container to the History tab. Lives at the call-site so
@@ -442,13 +454,13 @@ struct MainWalletView: View {
                     actionButton(
                         "Receive",
                         identifier: "wallet-action-receive",
-                        hint: "Opens options to receive ecash or lightning payments"
+                        hint: HomeActionAccessibility.receiveHint
                     ) { activeSheet = .receive }
 
                     actionButton(
                         "Send",
                         identifier: "wallet-action-send",
-                        hint: "Opens options to send ecash or pay lightning invoices"
+                        hint: HomeActionAccessibility.sendHint
                     ) { activeSheet = .send }
                 }
             }
@@ -460,14 +472,14 @@ struct MainWalletView: View {
                 }
                 .glassButton()
                 .accessibilityIdentifier("wallet-action-receive")
-                .accessibilityHint("Opens options to receive ecash or lightning payments")
+                .accessibilityHint(HomeActionAccessibility.receiveHint)
 
                 Button { activeSheet = .send } label: {
                     Text("Send")
                 }
                 .glassButton()
                 .accessibilityIdentifier("wallet-action-send")
-                .accessibilityHint("Opens options to send ecash or pay lightning invoices")
+                .accessibilityHint(HomeActionAccessibility.sendHint)
             }
             .disabled(!walletManager.isRuntimeReady)
         }

--- a/ios/CashuWalletTests/HomeActionAccessibilityTests.swift
+++ b/ios/CashuWalletTests/HomeActionAccessibilityTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CashuWallet
+
+final class HomeActionAccessibilityTests: XCTestCase {
+    func testReceiveHintDescribesUnifiedDestinationAndInputs() {
+        XCTAssertEqual(
+            HomeActionAccessibility.receiveHint,
+            "Opens the unified flow for a pasted ecash token or a new Cashu Request, " +
+                "Lightning invoice, BOLT12 offer, or Bitcoin address"
+        )
+        assertNoRetiredChooserWording(HomeActionAccessibility.receiveHint)
+    }
+
+    func testSendHintDescribesUnifiedDestinationAndInputs() {
+        XCTAssertEqual(
+            HomeActionAccessibility.sendHint,
+            "Opens the unified flow for ecash, Lightning addresses, BOLT11 invoices, " +
+                "BOLT12 offers, Bitcoin addresses, or Cashu Requests"
+        )
+        assertNoRetiredChooserWording(HomeActionAccessibility.sendHint)
+    }
+
+    private func assertNoRetiredChooserWording(
+        _ hint: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let lowercased = hint.lowercased()
+        XCTAssertFalse(lowercased.contains("option"), file: file, line: line)
+        XCTAssertFalse(lowercased.contains("chooser"), file: file, line: line)
+    }
+}


### PR DESCRIPTION
## Summary

- replace iOS Home's retired chooser wording with hints for the unified Receive and Send flows and their supported inputs
- give Android's Home actions one TalkBack node with a concise button label and a custom click hint covering the same flows and inputs
- add focused accessibility regressions on both platforms and mark the completed parity item

## Root cause

The Home actions were not updated when Send and Receive moved to unified destination surfaces. iOS retained copy about opening payment “options,” while Android relied on the visible button text alone and exposed no destination or input guidance.

## Impact

VoiceOver and TalkBack users now hear where each Home action leads and which ecash, Lightning, BOLT12, Bitcoin, and Cashu Request inputs it supports. Android keeps the visible action name as a single spoken label and puts the extra guidance on the click action to avoid a duplicate announcement.

## Validation

- `./gradlew --no-daemon :app:compileDebugAndroidTestKotlin --stacktrace`
- `./gradlew --no-daemon :app:pixel2Api35DebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.ui.home.HomeActionAccessibilityComposeTest --stacktrace` — 1 test passed
- `xcodebuild -project CashuWallet.xcodeproj -scheme CashuWallet -destination 'platform=iOS Simulator,id=8ED87EF5-4E5A-4DB2-8407-C60EC7F43079' -derivedDataPath /private/tmp/wallet-parity-action-hints-derived-data test -only-testing:CashuWalletTests/HomeActionAccessibilityTests -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO` — 2 tests passed
