### PR TITLE
Honor preferred unit on send confirmation

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/PaymentConfirmationAmount.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/PaymentConfirmationAmount.kt
@@ -1,0 +1,116 @@
+package com.cashu.me.ui.send
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.displayMintUnitAmount
+import com.cashu.me.ui.components.AmountText
+import com.cashu.me.ui.theme.CashuTheme
+import com.cashu.me.ui.theme.withMonoDigits
+
+internal data class PaymentConfirmationAmountPresentation(
+    val primary: String,
+    val alternate: String?,
+    val talkBackDescription: String,
+)
+
+internal fun paymentConfirmationAmountPresentation(
+    amount: Long,
+    unit: String,
+    preferredPrimary: String,
+    showFiat: Boolean,
+    btcPrice: Double?,
+    currencyCode: String,
+    useBitcoinSymbol: Boolean,
+    formatter: AmountFormatter = AmountFormatter(),
+): PaymentConfirmationAmountPresentation {
+    val display = formatter.displayMintUnitAmount(
+        amount = amount,
+        unit = unit,
+        preferredPrimary = preferredPrimary,
+        showFiat = showFiat,
+        btcPrice = btcPrice,
+        currencyCode = currencyCode,
+        useBitcoinSymbol = useBitcoinSymbol,
+    )
+    val description = buildString {
+        append("Payment amount, ")
+        append(display.primary)
+        display.secondary?.let {
+            append(". Alternate value, ")
+            append(it)
+        }
+    }
+    return PaymentConfirmationAmountPresentation(
+        primary = display.primary,
+        alternate = display.secondary,
+        talkBackDescription = description,
+    )
+}
+
+/**
+ * Read-only confirmation hero. The persisted primary unit leads while the
+ * conversion remains visible as supporting information; the whole pair is one
+ * concise TalkBack stop instead of an iOS-style unit-flip control.
+ */
+@Composable
+internal fun PaymentConfirmationAmount(
+    amount: Long,
+    unit: String,
+    preferredPrimary: String,
+    showFiat: Boolean,
+    btcPrice: Double?,
+    currencyCode: String,
+    useBitcoinSymbol: Boolean,
+    formatter: AmountFormatter,
+    modifier: Modifier = Modifier,
+) {
+    val presentation = paymentConfirmationAmountPresentation(
+        amount = amount,
+        unit = unit,
+        preferredPrimary = preferredPrimary,
+        showFiat = showFiat,
+        btcPrice = btcPrice,
+        currencyCode = currencyCode,
+        useBitcoinSymbol = useBitcoinSymbol,
+        formatter = formatter,
+    )
+    Column(
+        modifier = modifier.clearAndSetSemantics {
+            contentDescription = presentation.talkBackDescription
+        },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    ) {
+        AmountText(
+            text = presentation.primary,
+            style = MaterialTheme.typography.displayMedium.withMonoDigits(),
+        )
+        presentation.alternate?.let { alternate ->
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ) {
+                Text(
+                    text = alternate,
+                    modifier = Modifier.padding(
+                        horizontal = CashuTheme.spacing.default,
+                        vertical = CashuTheme.spacing.micro,
+                    ),
+                    style = MaterialTheme.typography.labelLarge.withMonoDigits(),
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -65,6 +65,7 @@ import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.CashuPaymentRequestRoute
 import com.cashu.me.Core.PaymentRequestDecodeResult
 import com.cashu.me.Core.PaymentRequestDecoder
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.Wallet.WalletMessage
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
@@ -145,6 +146,7 @@ private sealed interface SendStatus {
 fun UnifiedSendScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
+    priceService: PriceService,
     onClose: () -> Unit,
     onScan: () -> Unit,
     onContactless: () -> Unit,
@@ -158,6 +160,7 @@ fun UnifiedSendScreen(
 ) {
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
@@ -582,6 +585,10 @@ fun UnifiedSendScreen(
                         mintBalance = activeMint?.balance ?: 0L,
                         formatter = formatter,
                         useBitcoinSymbol = settings.useBitcoinSymbol,
+                        preferredPrimary = settings.amountDisplayPrimary,
+                        showFiat = settings.showFiatBalance,
+                        btcPrice = priceState.btcPrice,
+                        currencyCode = priceState.currencyCode,
                         topUpLoading = topUpLoading,
                         topUpError = topUpError,
                         onPay = ::pay,
@@ -862,6 +869,10 @@ private fun ConfirmFace(
     mintBalance: Long,
     formatter: AmountFormatter,
     useBitcoinSymbol: Boolean,
+    preferredPrimary: String,
+    showFiat: Boolean,
+    btcPrice: Double?,
+    currencyCode: String,
     topUpLoading: Boolean,
     topUpError: String?,
     onPay: () -> Unit,
@@ -869,6 +880,7 @@ private fun ConfirmFace(
     val isMelt = rail is LockedRail.Melt
     val isOnchain = (rail as? LockedRail.Melt)?.decoded is PaymentRequestDecodeResult.Onchain
     val cashuAmountLabel = (rail as? LockedRail.Creq)?.decoded?.summary?.let(PaymentRequestDecoder::amountLabel)
+    val amountUnit = (rail as? LockedRail.Creq)?.decoded?.summary?.unit ?: "sat"
     val creqDescription = (rail as? LockedRail.Creq)?.decoded?.summary?.description
     val hideCreqDestination = (rail as? LockedRail.Creq)?.fromScan == true
     val total = quote?.totalAmount ?: amountSats
@@ -893,9 +905,15 @@ private fun ConfirmFace(
         }
         if (!hideCreqDestination) rail?.let { ToPill(destination = it.raw) }
         Spacer(Modifier.height(CashuTheme.spacing.section))
-        AmountText(
-            text = cashuAmountLabel ?: formatter.formatWalletSats(amountSats, useBitcoinSymbol),
-            style = MaterialTheme.typography.displayMedium.withMonoDigits(),
+        PaymentConfirmationAmount(
+            amount = amountSats,
+            unit = amountUnit,
+            preferredPrimary = preferredPrimary,
+            showFiat = showFiat,
+            btcPrice = btcPrice,
+            currencyCode = currencyCode,
+            useBitcoinSymbol = useBitcoinSymbol,
+            formatter = formatter,
         )
         Spacer(Modifier.height(CashuTheme.spacing.section))
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -536,6 +536,7 @@ private fun AuthenticatedShell(container: AppContainer) {
             WalletFlow.Send -> UnifiedSendScreen(
                 walletManager = container.walletManager,
                 settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 onClose = close,
                 onScan = {
                     flowHandoff.requestScanner(close)

--- a/android/app/src/test/java/com/cashu/me/ui/send/PaymentConfirmationAmountTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/PaymentConfirmationAmountTest.kt
@@ -1,0 +1,72 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.AmountFormatter
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PaymentConfirmationAmountTest {
+    private val formatter = AmountFormatter(Locale.US)
+
+    @Test
+    fun satsPrimaryLeadsAndTalkBackIncludesFiatAlternate() {
+        val presentation = paymentConfirmationAmountPresentation(
+            amount = 100_000,
+            unit = "sat",
+            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
+            showFiat = true,
+            btcPrice = 20_000.0,
+            currencyCode = "USD",
+            useBitcoinSymbol = false,
+            formatter = formatter,
+        )
+
+        assertEquals("100,000 sat", presentation.primary)
+        assertEquals("$20.00", presentation.alternate)
+        assertEquals(
+            "Payment amount, 100,000 sat. Alternate value, $20.00",
+            presentation.talkBackDescription,
+        )
+    }
+
+    @Test
+    fun fiatPrimaryLeadsAndTalkBackIncludesSatsAlternate() {
+        val presentation = paymentConfirmationAmountPresentation(
+            amount = 100_000,
+            unit = "sat",
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            showFiat = true,
+            btcPrice = 20_000.0,
+            currencyCode = "USD",
+            useBitcoinSymbol = false,
+            formatter = formatter,
+        )
+
+        assertEquals("$20.00", presentation.primary)
+        assertEquals("100,000 sat", presentation.alternate)
+        assertEquals(
+            "Payment amount, $20.00. Alternate value, 100,000 sat",
+            presentation.talkBackDescription,
+        )
+    }
+
+    @Test
+    fun nonSatRequestStaysInItsNativeUnitWithoutBitcoinConversion() {
+        val presentation = paymentConfirmationAmountPresentation(
+            amount = 1_234,
+            unit = "usd",
+            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
+            showFiat = true,
+            btcPrice = 20_000.0,
+            currencyCode = "USD",
+            useBitcoinSymbol = false,
+            formatter = formatter,
+        )
+
+        assertEquals("$12.34", presentation.primary)
+        assertNull(presentation.alternate)
+        assertEquals("Payment amount, $12.34", presentation.talkBackDescription)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -46,7 +46,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Support fiat-primary amount entry.** iOS converts keypad input according to the saved sats/fiat primary setting; Android’s unified Send amount step always interprets the input as sats. **Done when:** Android entry, Send Max, validation, and amount presentation honor the selected primary unit without changing the sat amount being paid.
 
-- [ ] **[P1 · iOS → Android] Honor the preferred unit on payment confirmation.** Android confirmation renders a fixed sat string; iOS keeps the saved primary value and alternate conversion available. **Done when:** Android confirmation leads with the persisted primary unit and makes the alternate value available visually and to accessibility services through a native Android presentation. An identical iOS flip control is not required.
+- [x] **[P1 · iOS → Android] Honor the preferred unit on payment confirmation.** Android confirmation renders a fixed sat string; iOS keeps the saved primary value and alternate conversion available. **Done when:** Android confirmation leads with the persisted primary unit and makes the alternate value available visually and to accessibility services through a native Android presentation. An identical iOS flip control is not required.
 
 - [ ] **[P1 · iOS → Android] Show the Cashu Request fee estimate before payment.** iOS calculates the input fee and shows loading, no-fee, amount, or unavailable state; Android omits a fee row from Cashu Request confirmation. **Done when:** Android reserves and fills a fee row before the Pay action and does not present an unknown estimate as zero.
 


### PR DESCRIPTION
## What changed

- inject the existing Android price service into Unified Send confirmation
- lead with the persisted sats/fiat primary unit for Lightning, BOLT12, on-chain, and sat Cashu Request confirmations
- show the alternate conversion in a read-only Material supporting capsule
- expose the primary and alternate values as one concise TalkBack description
- keep non-sat Cashu Requests in their native unit without a BTC conversion
- mark the matching iOS/Android parity checklist item complete

## Why

Unified Send's confirmation hero bypassed the persisted amount-display preference and always formatted the payment as sats. It also never received live/cached fiat price state, so it could not provide the alternate value available on iOS.

## Impact

Users now see their saved primary unit first at the final payment decision point while retaining the exact alternate value visually and through TalkBack. The presentation is read-only and Android-native; payment amounts and rail behavior are unchanged.

## Checks

- `:app:testDebugUnitTest --tests com.cashu.me.ui.send.PaymentConfirmationAmountTest --tests com.cashu.me.Core.AmountFormatterTest --tests com.cashu.me.ui.send.SendDestinationResolverTest --tests com.cashu.me.ui.send.SendCashuRequestTopUpTest` (19 tests, passed)
- `:app:assembleDebug` (passed)
- `git diff --check` (passed)
