### PR TITLE
Show Cashu Request fee estimates on Android

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -342,6 +342,8 @@ class FakeWalletGateway(
 
     override suspend fun calculateReceiveFee(tokenString: String): Long = 0
 
+    override suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long = 0
+
     override suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean = true
 
     override suspend fun listTransactions(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -70,6 +70,14 @@ interface CdkWalletGateway {
     ): NfcReceiveReceipt
     suspend fun settleForeignNfcToken(tokenString: String, settlementMintUrl: String): ForeignNfcSettlement
     suspend fun calculateReceiveFee(tokenString: String): Long
+
+    /**
+     * Exact input fee for paying a Cashu Request from [mintUrl].
+     *
+     * The preview must use the same `includeFee = true` coin selection as
+     * `payCashuPaymentRequest`, then release any prepared proofs.
+     */
+    suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long
     suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean
     suspend fun listTransactions(unitsByMint: Map<String, List<String>>): List<WalletTransaction>
     suspend fun payCashuPaymentRequest(encoded: String, customAmountSats: Long?, preferredMintURL: String?)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -564,6 +564,33 @@ class CdkWalletGatewayImpl : WalletGateway {
         }.getOrDefault(0L)
     }
 
+    override suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long = cdkCall {
+        require(amountSats > 0) { "Cashu Request fee preview requires an amount." }
+        val options = CdkSendOptions(
+            memo = null,
+            conditions = null,
+            amountSplitTarget = CdkSplitTarget.None,
+            sendKind = CdkSendKind.OnlineExact,
+            // CDK's pay_request includes the recipient's input fee so they net
+            // the requested amount. The preview must use the identical mode.
+            includeFee = true,
+            useP2bk = false,
+            maxProofs = null,
+            metadata = emptyMap(),
+            p2pkSigningKeys = emptyList(),
+            p2pkLockedProofSendMode = CdkP2pkLockedProofSendMode.SWAP,
+        )
+        val prepared = walletFor(mintUrl, CdkCurrencyUnit.Sat)
+            .prepareSend(amountSats.toCdkAmount(), options)
+        try {
+            prepared.fee().value.toLong()
+        } finally {
+            // A preview must never leave proofs reserved for a payment the user
+            // has not confirmed.
+            prepared.cancel()
+        }
+    }
+
     override suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean = cdkCall {
         val tokenObj = CdkToken.decode(token)
         val tokenUnit = tokenObj.unit() ?: CdkCurrencyUnit.Sat

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -1115,6 +1115,9 @@ class WalletManager(
 
     suspend fun calculateReceiveFee(tokenString: String): Long = gateway.calculateReceiveFee(tokenString)
 
+    suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long =
+        gateway.estimateCashuPaymentRequestFee(amountSats, mintUrl)
+
     suspend fun checkTokenSpent(tokenString: String, mintUrl: String): Boolean =
         gateway.checkTokenSpendable(tokenString, mintUrl)
 

--- a/android/app/src/main/java/com/cashu/me/ui/send/CashuRequestFeeEstimate.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/CashuRequestFeeEstimate.kt
@@ -1,0 +1,85 @@
+package com.cashu.me.ui.send
+
+import kotlinx.coroutines.CancellationException
+
+internal data class CashuRequestFeeEstimateKey(
+    val request: String,
+    val amountSats: Long,
+    val mintUrl: String,
+)
+
+internal sealed interface CashuRequestFeeEstimate {
+    val key: CashuRequestFeeEstimateKey?
+
+    data object Unrequested : CashuRequestFeeEstimate {
+        override val key: CashuRequestFeeEstimateKey? = null
+    }
+
+    data class Loading(
+        override val key: CashuRequestFeeEstimateKey,
+    ) : CashuRequestFeeEstimate
+
+    data class NoFee(
+        override val key: CashuRequestFeeEstimateKey,
+    ) : CashuRequestFeeEstimate
+
+    data class Amount(
+        override val key: CashuRequestFeeEstimateKey,
+        val sats: Long,
+    ) : CashuRequestFeeEstimate
+
+    data class Unavailable(
+        override val key: CashuRequestFeeEstimateKey,
+    ) : CashuRequestFeeEstimate
+}
+
+internal data class CashuRequestFeePresentation(
+    val value: String,
+    val loading: Boolean = false,
+    val valueMonospaced: Boolean = false,
+)
+
+internal fun CashuRequestFeeEstimate.presentation(
+    formatAmount: (Long) -> String,
+): CashuRequestFeePresentation =
+    when (this) {
+        is CashuRequestFeeEstimate.Loading -> CashuRequestFeePresentation(
+            value = "",
+            loading = true,
+            valueMonospaced = true,
+        )
+        is CashuRequestFeeEstimate.NoFee -> CashuRequestFeePresentation(value = "No fee")
+        is CashuRequestFeeEstimate.Amount -> CashuRequestFeePresentation(
+            value = formatAmount(sats),
+            valueMonospaced = true,
+        )
+        CashuRequestFeeEstimate.Unrequested,
+        is CashuRequestFeeEstimate.Unavailable -> CashuRequestFeePresentation(value = "Unavailable")
+    }
+
+internal suspend fun resolveCashuRequestFeeEstimate(
+    key: CashuRequestFeeEstimateKey,
+    estimate: suspend (amountSats: Long, mintUrl: String) -> Long,
+): CashuRequestFeeEstimate =
+    try {
+        val fee = estimate(key.amountSats, key.mintUrl)
+        require(fee >= 0L) { "Cashu Request fee estimate cannot be negative." }
+        if (fee == 0L) {
+            CashuRequestFeeEstimate.NoFee(key)
+        } else {
+            CashuRequestFeeEstimate.Amount(key, fee)
+        }
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (_: Throwable) {
+        CashuRequestFeeEstimate.Unavailable(key)
+    }
+
+/**
+ * Accept a preview only while its request, amount, and mint are still current.
+ * This is an explicit backstop in addition to `LaunchedEffect` cancellation.
+ */
+internal fun CashuRequestFeeEstimate.acceptIfCurrent(
+    result: CashuRequestFeeEstimate,
+): CashuRequestFeeEstimate =
+    if (this is CashuRequestFeeEstimate.Loading && key == result.key) result else this

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -184,6 +184,9 @@ fun UnifiedSendScreen(
     var topUpError by remember { mutableStateOf<String?>(null) }
     var quoteError by remember { mutableStateOf<String?>(null) }
     var confirmError by remember { mutableStateOf<String?>(null) }
+    var cashuRequestFeeEstimate by remember {
+        mutableStateOf<CashuRequestFeeEstimate>(CashuRequestFeeEstimate.Unrequested)
+    }
 
     val activeMintUrl = selectedMintUrl ?: walletState.activeMint?.url
     val enteredAmount = amount.toLongOrNull() ?: 0L
@@ -207,6 +210,21 @@ fun UnifiedSendScreen(
         is CashuPaymentRequestRoute.PayWithEcash -> route.mint
         else -> walletState.mints.firstOrNull { it.url == activeMintUrl } ?: walletState.activeMint
     }
+    val cashuRequestFeeKey = (locked as? LockedRail.Creq)?.let { rail ->
+        (cashuRoute as? CashuPaymentRequestRoute.PayWithEcash)?.let { route ->
+            CashuRequestFeeEstimateKey(
+                request = rail.raw,
+                amountSats = route.amountSats,
+                mintUrl = route.mint.url,
+            )
+        }
+    }
+    // Render loading on the very first confirmation frame and whenever the
+    // route changes; the effect below then fills this reserved row in place.
+    val displayedCashuRequestFeeEstimate = cashuRequestFeeKey?.let { key ->
+        cashuRequestFeeEstimate.takeIf { it.key == key }
+            ?: CashuRequestFeeEstimate.Loading(key)
+    } ?: CashuRequestFeeEstimate.Unrequested
     // Only a scanned/deep-linked Cashu Request hides the raw string and swaps
     // the header (iOS CashuPaymentRequestPayView); typed/pasted ones keep the
     // "To" pill like iOS's UnifiedSendView.
@@ -221,6 +239,7 @@ fun UnifiedSendScreen(
         topUpError = null
         quoteError = null
         confirmError = null
+        cashuRequestFeeEstimate = CashuRequestFeeEstimate.Unrequested
         cameFromAmount = false
         if (toInput) step = SendStep.Input
     }
@@ -378,6 +397,22 @@ fun UnifiedSendScreen(
         } catch (failure: Throwable) {
             quoteError = failure.userFacingWalletMessage
         }
+    }
+
+    // Cashu Request payments use CDK's include-fee coin selection. Key the
+    // preview to every input that can change that selection, cancel obsolete
+    // work automatically, and reject a stale completion as a final backstop.
+    LaunchedEffect(step, cashuRequestFeeKey) {
+        val key = cashuRequestFeeKey
+        if (step != SendStep.Confirm || key == null) {
+            cashuRequestFeeEstimate = CashuRequestFeeEstimate.Unrequested
+            return@LaunchedEffect
+        }
+        cashuRequestFeeEstimate = CashuRequestFeeEstimate.Loading(key)
+        val result = resolveCashuRequestFeeEstimate(key) { amountSats, mintUrl ->
+            walletManager.estimateCashuPaymentRequestFee(amountSats, mintUrl)
+        }
+        cashuRequestFeeEstimate = cashuRequestFeeEstimate.acceptIfCurrent(result)
     }
 
     // Block sheet dismissal while the melt is in flight — a stray swipe must
@@ -570,6 +605,7 @@ fun UnifiedSendScreen(
                             }
                         },
                         quote = meltQuote,
+                        cashuRequestFeeEstimate = displayedCashuRequestFeeEstimate,
                         quoteError = quoteError,
                         onRetryQuote = {
                             quoteError = null
@@ -856,6 +892,7 @@ private fun ConfirmFace(
     onPickMint: () -> Unit,
     onCreateTopUp: (mintUrl: String, requestedAmountSats: Long) -> Unit,
     quote: MeltQuoteInfo?,
+    cashuRequestFeeEstimate: CashuRequestFeeEstimate,
     quoteError: String?,
     onRetryQuote: () -> Unit,
     confirmError: String?,
@@ -945,6 +982,16 @@ private fun ConfirmFace(
                     CanvasDivider(leadingInset = 16.dp)
                     InspectorRow(label = "Memo", value = creqDescription)
                 }
+                CanvasDivider(leadingInset = 16.dp)
+                val feePresentation = cashuRequestFeeEstimate.presentation { fee ->
+                    formatter.formatWalletSats(fee, useBitcoinSymbol)
+                }
+                InspectorRow(
+                    label = "Fee",
+                    value = feePresentation.value,
+                    valueMonospaced = feePresentation.valueMonospaced,
+                    loading = feePresentation.loading,
+                )
                 when (val route = cashuRoute) {
                     is CashuPaymentRequestRoute.PayWithEcash -> {
                         CanvasDivider(leadingInset = 16.dp)

--- a/android/app/src/test/java/com/cashu/me/ui/send/CashuRequestFeeEstimateTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/CashuRequestFeeEstimateTest.kt
@@ -1,0 +1,81 @@
+package com.cashu.me.ui.send
+
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class CashuRequestFeeEstimateTest {
+    private val key = CashuRequestFeeEstimateKey(
+        request = "creqA",
+        amountSats = 21L,
+        mintUrl = "https://mint.example",
+    )
+
+    @Test
+    fun loadingReservesEstimateForTheCurrentPayment() {
+        assertEquals(
+            CashuRequestFeePresentation(
+                value = "",
+                loading = true,
+                valueMonospaced = true,
+            ),
+            CashuRequestFeeEstimate.Loading(key).presentation { "$it sat" },
+        )
+    }
+
+    @Test
+    fun zeroFeeIsPresentedAsNoFee() = runBlocking {
+        val result = resolveCashuRequestFeeEstimate(key) { _, _ -> 0L }
+
+        assertEquals(CashuRequestFeeEstimate.NoFee(key), result)
+        assertEquals("No fee", result.presentation { "$it sat" }.value)
+    }
+
+    @Test
+    fun nonzeroFeePreservesTheEstimatedAmount() = runBlocking {
+        val result = resolveCashuRequestFeeEstimate(key) { amount, mintUrl ->
+            assertEquals(21L, amount)
+            assertEquals("https://mint.example", mintUrl)
+            3L
+        }
+
+        assertEquals(CashuRequestFeeEstimate.Amount(key, 3L), result)
+        assertEquals("3 sat", result.presentation { "$it sat" }.value)
+    }
+
+    @Test
+    fun estimationFailureIsUnavailableAndNeverZero() = runBlocking {
+        val result = resolveCashuRequestFeeEstimate(key) { _, _ ->
+            throw IOException("mint unavailable")
+        }
+
+        assertEquals(CashuRequestFeeEstimate.Unavailable(key), result)
+        assertEquals("Unavailable", result.presentation { "$it sat" }.value)
+    }
+
+    @Test
+    fun staleResultCannotReplaceNewRequestLoadingState() {
+        val nextKey = key.copy(request = "creqB", amountSats = 34L)
+        val current = CashuRequestFeeEstimate.Loading(nextKey)
+        val stale = CashuRequestFeeEstimate.Amount(key, 3L)
+
+        assertEquals(current, current.acceptIfCurrent(stale))
+    }
+
+    @Test
+    fun cancellationIsPropagatedInsteadOfBecomingUnavailable() {
+        try {
+            runBlocking {
+                resolveCashuRequestFeeEstimate(key) { _, _ ->
+                    throw CancellationException("route changed")
+                }
+            }
+            fail("Expected cancellation")
+        } catch (_: CancellationException) {
+            // Expected: LaunchedEffect owns cancellation and starts the new key.
+        }
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -48,7 +48,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Honor the preferred unit on payment confirmation.** Android confirmation renders a fixed sat string; iOS keeps the saved primary value and alternate conversion available. **Done when:** Android confirmation leads with the persisted primary unit and makes the alternate value available visually and to accessibility services through a native Android presentation. An identical iOS flip control is not required.
 
-- [ ] **[P1 · iOS → Android] Show the Cashu Request fee estimate before payment.** iOS calculates the input fee and shows loading, no-fee, amount, or unavailable state; Android omits a fee row from Cashu Request confirmation. **Done when:** Android reserves and fills a fee row before the Pay action and does not present an unknown estimate as zero.
+- [x] **[P1 · iOS → Android] Show the Cashu Request fee estimate before payment.** iOS calculates the input fee and shows loading, no-fee, amount, or unavailable state; Android omits a fee row from Cashu Request confirmation. **Done when:** Android reserves and fills a fee row before the Pay action and does not present an unknown estimate as zero.
 
 - [ ] **[P1 · iOS → Android] Preserve relevant payment facts through terminal states.** Android’s processing, success, and failure screen can drop facts shown during confirmation. **Done when:** each rail has a documented stable row set across processing, success, and failure: amount and method; mint when applicable; destination for on-chain; network/input fees when applicable; and Cashu Request memo, route, or fee context when applicable.
 


### PR DESCRIPTION
## What changed

- add an Android Cashu Request fee preview that uses CDK's exact `includeFee = true` coin selection and immediately cancels the prepared send
- reserve a Fee row on confirmation and render explicit loading, No fee, formatted amount, or Unavailable states
- key fee work by request, amount, and mint, cancel obsolete work, and reject stale completions
- add focused regression coverage and mark the parity checklist item complete

## Why

Android omitted the fee row entirely for Cashu Requests. The wallet boundary also exposed request payment execution but no non-mutating preview, so confirmation could not distinguish a genuinely free payment from an unknown estimate.

## Impact

Users now see the applicable Cashu Request input fee before Pay. Unknown or failed estimates are shown as Unavailable rather than zero, and changing the request, amount, or paying mint cannot surface a stale estimate.

## Checks

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.send.CashuRequestFeeEstimateTest --tests com.cashu.me.Core.CDK.CdkGatewayThreadingTest --tests com.cashu.me.Core.CashuPaymentRequestMintSelectorTest --stacktrace`
- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.send.CashuRequestFeeEstimateTest :app:assembleDebug :app:compileDebugAndroidTestKotlin --stacktrace`
- `git diff --cached --check`
