### PR TITLE
Explain iOS payment route changes

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -52,7 +52,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Preserve relevant payment facts through terminal states.** Android’s processing, success, and failure screen can drop facts shown during confirmation. **Done when:** each rail has a documented stable row set across processing, success, and failure: amount and method; mint when applicable; destination for on-chain; network/input fees when applicable; and Cashu Request memo, route, or fee context when applicable.
 
-- [ ] **[P1 · Android → iOS] Explain rail-changing fallback and recovery routes.** Android explicitly identifies Lightning fallback, adding a requested mint, or topping up the target mint; iOS can rely only on a mint row or CTA wording. **Done when:** iOS names a route whenever it materially changes how the request will be paid or what recovery will occur. The ordinary compatible-mint route does not need a duplicate “Pay from” label.
+- [x] **[P1 · Android → iOS] Explain rail-changing fallback and recovery routes.** Android explicitly identifies Lightning fallback, adding a requested mint, or topping up the target mint; iOS can rely only on a mint row or CTA wording. **Done when:** iOS names a route whenever it materially changes how the request will be paid or what recovery will occur. The ordinary compatible-mint route does not need a duplicate “Pay from” label.
 
 - [ ] **[P2 · Converge] Remove platform names from payment warnings.** Android says “supported on Android” and “Android can pay…” while iOS says “this wallet.” **Done when:** shared limitations and fallback messages use product language and equivalent terminology on both platforms.
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		T2B000000000000A /* CurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000A /* CurrencyTests.swift */; };
 		T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000B /* ReceiveAutoPasteTests.swift */; };
 		T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000C /* HomeActionAccessibilityTests.swift */; };
+		T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000D /* CashuRequestRouteExplanationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -291,6 +292,7 @@
 		T1B000000000000A /* CurrencyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CurrencyTests.swift; path = ../CI/IntegrationTests/Tests/CurrencyTests.swift; sourceTree = "<group>"; };
 		T1B000000000000B /* ReceiveAutoPasteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiveAutoPasteTests.swift; path = CashuWalletTests/ReceiveAutoPasteTests.swift; sourceTree = "<group>"; };
 		T1B000000000000C /* HomeActionAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeActionAccessibilityTests.swift; path = CashuWalletTests/HomeActionAccessibilityTests.swift; sourceTree = "<group>"; };
+		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +344,7 @@
 				T1B000000000000A /* CurrencyTests.swift */,
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
 				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
+				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -884,6 +887,7 @@
 				T2B000000000000A /* CurrencyTests.swift in Sources */,
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
 				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
+				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
@@ -16,6 +16,73 @@ enum CashuRequestRoute {
     case acquireThenPay(CashuPaymentRequestSummary)
 }
 
+/// User-visible explanation for a Cashu Request route that materially changes
+/// rails or requires recovery. The ordinary compatible-mint path intentionally
+/// maps to nil so confirmations do not repeat the mint selector as "Pay from".
+enum CashuRequestRouteExplanation: Equatable, Sendable {
+    enum State: Equatable, Sendable {
+        case compatibleMint
+        case lightningFallback
+        case addRequestedMint(targetMintURL: String?)
+        case topUpTargetMint(targetMintURL: String?)
+        case unavailable
+    }
+
+    case lightningFallback
+    case addRequestedMint(target: String?)
+    case topUpTargetMint(target: String?)
+
+    init?(state: State) {
+        switch state {
+        case .compatibleMint, .unavailable:
+            return nil
+        case .lightningFallback:
+            self = .lightningFallback
+        case .addRequestedMint(let targetMintURL):
+            self = .addRequestedMint(target: Self.displayTarget(from: targetMintURL))
+        case .topUpTargetMint(let targetMintURL):
+            self = .topUpTargetMint(target: Self.displayTarget(from: targetMintURL))
+        }
+    }
+
+    /// Localized row value shared by confirmation and terminal status screens.
+    var localizedValue: String {
+        switch self {
+        case .lightningFallback:
+            return String(localized: "Lightning fallback")
+        case .addRequestedMint(let target):
+            if let target {
+                return String(localized: "Add requested mint: \(target)")
+            }
+            return String(localized: "Add requested mint")
+        case .topUpTargetMint(let target):
+            if let target {
+                return String(localized: "Top up target mint: \(target)")
+            }
+            return String(localized: "Top up target mint")
+        }
+    }
+
+    private static func displayTarget(from rawURL: String?) -> String? {
+        guard let rawURL else { return nil }
+        let trimmed = rawURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        guard let components = URLComponents(string: trimmed) else {
+            return trimmed
+        }
+        if let host = components.host, !host.isEmpty {
+            if let port = components.port {
+                return "\(host):\(port)"
+            }
+            return host
+        }
+        // A malformed absolute URL is not useful payment context. A bare mint
+        // name remains useful and is kept as a safe fallback.
+        return components.scheme == nil ? trimmed : nil
+    }
+}
+
 /// Progress checkpoints for the "Add mint & pay" flow, driven back to the
 /// confirm screen's overlay so the user sees what's happening.
 enum AddMintPayStage: Equatable {

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -175,6 +175,7 @@ struct ScannerWrapperView: View {
     @State private var scannedCashuPaymentRequest: CashuPaymentRequestSummary?
     @State private var scannedMeltMode: MeltView.MeltMode = .lightning
     @State private var scannedMeltAutoQuote = false
+    @State private var scannedMeltRouteExplanation: CashuRequestRouteExplanation?
     @State private var navigateToDetail = false
     @State private var navigateToMelt = false
     @State private var navigateToCashuPaymentRequest = false
@@ -343,6 +344,7 @@ struct ScannerWrapperView: View {
                         initialRequest: meltRequest,
                         initialMode: scannedMeltMode,
                         autoQuoteOnAppear: scannedMeltAutoQuote,
+                        routeExplanation: scannedMeltRouteExplanation,
                         onComplete: {
                             dismiss()
                         }
@@ -501,6 +503,7 @@ struct ScannerWrapperView: View {
                 scannedMeltRequest = bolt11
                 scannedMeltMode = .lightning
                 scannedMeltAutoQuote = true
+                scannedMeltRouteExplanation = CashuRequestRouteExplanation(state: .lightningFallback)
                 navigateToMelt = true
             }
 
@@ -521,6 +524,7 @@ struct ScannerWrapperView: View {
                     scannedMeltMode = .lightning
                     scannedMeltAutoQuote = true
                 }
+                scannedMeltRouteExplanation = nil
                 navigateToMelt = true
 
             case .lightningAddress:
@@ -530,6 +534,7 @@ struct ScannerWrapperView: View {
                 scannedMeltRequest = content
                 scannedMeltMode = .lightning
                 scannedMeltAutoQuote = false
+                scannedMeltRouteExplanation = nil
                 navigateToMelt = true
 
             case .cashuPaymentRequest, .unrecognized:
@@ -561,6 +566,29 @@ struct ScannerWrapperView: View {
     }
 }
 
+/// Native detail row used whenever a Cashu Request changes rail or enters a
+/// recovery route. Grouping keeps VoiceOver's route label and value together.
+struct CashuRequestRouteExplanationRow: View {
+    let explanation: CashuRequestRouteExplanation
+
+    var body: some View {
+        HStack {
+            Label("Route", systemImage: "arrow.triangle.branch")
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(explanation.localizedValue)
+                .fontWeight(.medium)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+                .truncationMode(.tail)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 14)
+        .accessibilityElement(children: .combine)
+    }
+}
+
 struct CashuPaymentRequestPayView: View {
     let request: CashuPaymentRequestSummary
     var onComplete: (() -> Void)?
@@ -577,6 +605,7 @@ struct CashuPaymentRequestPayView: View {
     /// Drives the full-screen processing → success → failure status screen.
     /// nil while the user is still on the confirm screen.
     @State private var paymentPhase: PaymentStatusView.Phase?
+    @State private var activeRouteExplanation: CashuRequestRouteExplanation?
     @State private var showingMintPicker = false
     @State private var selectedMint: MintInfo?
 
@@ -866,6 +895,10 @@ struct CashuPaymentRequestPayView: View {
             let memo = requestMemo
 
             VStack(spacing: 0) {
+                if let routeExplanation {
+                    CashuRequestRouteExplanationRow(explanation: routeExplanation)
+                    canvasDivider
+                }
                 if let memo {
                     detailRow(icon: "quote.bubble", label: "Memo", value: memo)
                     canvasDivider
@@ -1062,6 +1095,19 @@ struct CashuPaymentRequestPayView: View {
     /// Whether the target mint isn't in the wallet yet (affects CTA wording).
     private var acquireAddsNewMint: Bool { selectedPaymentMint == nil }
 
+    private var routeExplanation: CashuRequestRouteExplanation? {
+        guard request.isSatUnit, paymentAmount != nil else {
+            return CashuRequestRouteExplanation(state: .unavailable)
+        }
+        guard needsAcquire else {
+            return CashuRequestRouteExplanation(state: .compatibleMint)
+        }
+        let state: CashuRequestRouteExplanation.State = acquireAddsNewMint
+            ? .addRequestedMint(targetMintURL: acquireTargetURL)
+            : .topUpTargetMint(targetMintURL: acquireTargetURL)
+        return CashuRequestRouteExplanation(state: state)
+    }
+
     private var payButtonTitle: String {
         guard needsAcquire else { return "Pay" }
         if acquireAddsNewMint {
@@ -1178,6 +1224,7 @@ struct CashuPaymentRequestPayView: View {
 
         guard canPay, let mint = selectedPaymentMint else { return }
 
+        activeRouteExplanation = routeExplanation
         isPaying = true
         errorMessage = nil
         HapticFeedback.impact(.medium)
@@ -1213,6 +1260,7 @@ struct CashuPaymentRequestPayView: View {
     /// Add/fund the target mint over Lightning, then pay the request. Falls back
     /// to a top-up QR (`NeedsExternalTopUp`) when no held mint can bankroll it.
     private func runAcquireAndPay(targetMintURL: String, amount: UInt64) {
+        activeRouteExplanation = routeExplanation
         isPaying = true
         errorMessage = nil
         HapticFeedback.impact(.medium)
@@ -1275,8 +1323,15 @@ struct CashuPaymentRequestPayView: View {
                 isPending: paymentAmount == nil
             ),
             statusMintRow,
-            statusFeeRow,
         ]
+        if let explanation = activeRouteExplanation {
+            rows.append(.init(
+                icon: "arrow.triangle.branch",
+                label: "Route",
+                value: explanation.localizedValue
+            ))
+        }
+        rows.append(statusFeeRow)
         if let memo = requestMemo {
             rows.append(.init(icon: "quote.bubble", label: "Memo", value: memo))
         }
@@ -1559,6 +1614,13 @@ struct CashuTopUpInvoiceSheet: View {
                             }
 
                         CurrencyAmountDisplay(sats: context.amount, primary: $settings.amountDisplayPrimary)
+
+                        if let explanation = CashuRequestRouteExplanation(
+                            state: .topUpTargetMint(targetMintURL: context.targetMintURL)
+                        ) {
+                            CashuRequestRouteExplanationRow(explanation: explanation)
+                                .padding(.horizontal)
+                        }
 
                         statusRow
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1162,6 +1162,9 @@ struct UnifiedSendView: View {
     @State private var errorSeverity: ErrorSeverity = .error
     @State private var errorShowsMintAction = false
     @State private var errorIsTerminal = false
+    /// Persisted across confirmation → processing/success/failure so a
+    /// rail-changing or recovery route cannot disappear as wallet state updates.
+    @State private var activeRouteExplanation: CashuRequestRouteExplanation?
     @State private var inputHint: String?
     @State private var autoAdvanceTask: Task<Void, Never>?
     /// Set when the user taps the pill to edit: auto-advance stays suppressed while
@@ -1603,6 +1606,7 @@ struct UnifiedSendView: View {
             switch walletManager.routeForCashuPaymentRequest(summary, rawContent: raw) {
             case .payWithEcash, .acquireThenPay:
                 locked = .cashuRequest(summary)
+                activeRouteExplanation = nil
                 selectedMint = nil
                 errorMessage = nil
                 HapticFeedback.selection()
@@ -1613,7 +1617,12 @@ struct UnifiedSendView: View {
                     goToAmount()
                 }
             case .payBolt11Fallback(let bolt11):
-                lockMelt(request: bolt11, mode: .lightning, decoded: PaymentRequestDecoder.decode(bolt11))
+                lockMelt(
+                    request: bolt11,
+                    mode: .lightning,
+                    decoded: PaymentRequestDecoder.decode(bolt11),
+                    routeExplanation: CashuRequestRouteExplanation(state: .lightningFallback)
+                )
                 startMeltConfirm()
             }
         case .unrecognized:
@@ -1626,8 +1635,14 @@ struct UnifiedSendView: View {
         }
     }
 
-    private func lockMelt(request: String, mode: MeltView.MeltMode, decoded: PaymentRequestDecodeResult) {
+    private func lockMelt(
+        request: String,
+        mode: MeltView.MeltMode,
+        decoded: PaymentRequestDecodeResult,
+        routeExplanation: CashuRequestRouteExplanation? = nil
+    ) {
         locked = .melt(request: request, mode: mode, decoded: decoded)
+        activeRouteExplanation = routeExplanation
         selectedMint = nil
         meltQuote = nil
         errorMessage = nil
@@ -1811,6 +1826,10 @@ struct UnifiedSendView: View {
                 creqDetailRow(icon: "arrow.up.right", label: "To", value: request)
                 creqDivider
             }
+            if let explanation = activeRouteExplanation {
+                CashuRequestRouteExplanationRow(explanation: explanation)
+                creqDivider
+            }
             creqDetailRow(
                 icon: "arrow.up.arrow.down",
                 label: "Network fee",
@@ -1913,6 +1932,13 @@ struct UnifiedSendView: View {
                     label: "Amount",
                     value: AmountFormatter.sats(quote.amount, useBitcoinSymbol: settings.useBitcoinSymbol)
                 ))
+                if let explanation = activeRouteExplanation {
+                    rows.append(.init(
+                        icon: "arrow.triangle.branch",
+                        label: "Route",
+                        value: explanation.localizedValue
+                    ))
+                }
                 rows.append(.init(
                     icon: "arrow.up.arrow.down",
                     label: "Network fee",
@@ -1944,6 +1970,13 @@ struct UnifiedSendView: View {
                 isPending: paymentAmountForCreq == nil
             ))
             rows.append(creqStatusMintRow)
+            if let explanation = activeRouteExplanation {
+                rows.append(.init(
+                    icon: "arrow.triangle.branch",
+                    label: "Route",
+                    value: explanation.localizedValue
+                ))
+            }
             rows.append(creqStatusFeeRow)
             if let memo = creq.description?.trimmingCharacters(in: .whitespacesAndNewlines), !memo.isEmpty {
                 rows.append(.init(icon: "quote.bubble", label: "Memo", value: memo))
@@ -2218,6 +2251,7 @@ struct UnifiedSendView: View {
         }
 
         guard let creq = currentCreq, creqCanPay, let mint = selectedPaymentMint else { return }
+        activeRouteExplanation = creqRouteExplanation
         HapticFeedback.impact(.medium)
         errorMessage = nil
         withAnimation(.smooth(duration: 0.3)) { step = .sending }
@@ -2240,6 +2274,7 @@ struct UnifiedSendView: View {
     /// to a top-up QR (`NeedsExternalTopUp`) when no held mint can bankroll it.
     private func runCreqAcquireAndPay(targetMintURL: String, amount: UInt64) {
         guard let creq = currentCreq else { return }
+        activeRouteExplanation = creqRouteExplanation
         HapticFeedback.impact(.medium)
         errorMessage = nil
         withAnimation(.smooth(duration: 0.3)) { step = .sending }
@@ -2354,6 +2389,19 @@ struct UnifiedSendView: View {
     private var acquireTargetHost: String? { acquireTargetURL.map(extractMintHost) }
     private var needsAcquire: Bool { acquireTargetURL != nil }
     private var acquireAddsNewMint: Bool { selectedPaymentMint == nil }
+
+    private var creqRouteExplanation: CashuRequestRouteExplanation? {
+        guard let creq = currentCreq, creq.isSatUnit, paymentAmountForCreq != nil else {
+            return CashuRequestRouteExplanation(state: .unavailable)
+        }
+        guard needsAcquire else {
+            return CashuRequestRouteExplanation(state: .compatibleMint)
+        }
+        let state: CashuRequestRouteExplanation.State = acquireAddsNewMint
+            ? .addRequestedMint(targetMintURL: acquireTargetURL)
+            : .topUpTargetMint(targetMintURL: acquireTargetURL)
+        return CashuRequestRouteExplanation(state: state)
+    }
 
     private var creqPayButtonTitle: String {
         guard needsAcquire else { return "Pay" }
@@ -2479,6 +2527,10 @@ struct UnifiedSendView: View {
             VStack(spacing: 0) {
                 if creqTopMint(creq) == nil {
                     creqMintRow(creq)
+                    creqDivider
+                }
+                if let explanation = creqRouteExplanation {
+                    CashuRequestRouteExplanationRow(explanation: explanation)
                     creqDivider
                 }
                 if let memo = creqMemo(creq) {
@@ -2767,6 +2819,7 @@ struct MeltView: View {
     @ObservedObject private var priceService = PriceService.shared
 
     private let autoQuoteOnAppear: Bool
+    private let routeExplanation: CashuRequestRouteExplanation?
     private let onComplete: (() -> Void)?
 
     @State private var requestInput: String
@@ -2845,9 +2898,11 @@ struct MeltView: View {
         initialAmount: String = "",
         initialMode: MeltMode = .lightning,
         autoQuoteOnAppear: Bool = false,
+        routeExplanation: CashuRequestRouteExplanation? = nil,
         onComplete: (() -> Void)? = nil
     ) {
         self.autoQuoteOnAppear = autoQuoteOnAppear
+        self.routeExplanation = routeExplanation
         self.onComplete = onComplete
         _requestInput = State(initialValue: initialRequest)
         _amountString = State(initialValue: initialAmount)
@@ -3268,6 +3323,10 @@ struct MeltView: View {
         } details: {
             VStack(spacing: 0) {
                 meltDetailRow(icon: "bolt", label: "Method", value: methodName)
+                if let routeExplanation {
+                    meltDivider
+                    CashuRequestRouteExplanationRow(explanation: routeExplanation)
+                }
                 meltDivider
                 if quote?.paymentMethod == .onchain {
                     meltDetailRow(
@@ -3369,6 +3428,13 @@ struct MeltView: View {
             // spinner). The mint — a top chip on confirm, which the status scaffold has
             // no room for — becomes the trailing row here.
             rows.append(.init(icon: "bolt", label: "Method", value: quote.paymentMethod.displayName))
+            if let routeExplanation {
+                rows.append(.init(
+                    icon: "arrow.triangle.branch",
+                    label: "Route",
+                    value: routeExplanation.localizedValue
+                ))
+            }
             if quote.paymentMethod == .onchain {
                 rows.append(.init(
                     icon: "arrow.up.right",

--- a/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import CashuWallet
+
+final class CashuRequestRouteExplanationTests: XCTestCase {
+    func testCompatibleMintRouteHasNoRedundantExplanation() {
+        XCTAssertNil(CashuRequestRouteExplanation(state: .compatibleMint))
+    }
+
+    func testLightningFallbackNamesTheRailChange() {
+        XCTAssertEqual(
+            CashuRequestRouteExplanation(state: .lightningFallback),
+            .lightningFallback
+        )
+    }
+
+    func testAddMintRecoveryNamesRequestedMintHost() {
+        XCTAssertEqual(
+            CashuRequestRouteExplanation(
+                state: .addRequestedMint(targetMintURL: "https://mint.example.com:3338/path")
+            ),
+            .addRequestedMint(target: "mint.example.com:3338")
+        )
+    }
+
+    func testTopUpRecoveryNamesTargetMintHost() {
+        XCTAssertEqual(
+            CashuRequestRouteExplanation(
+                state: .topUpTargetMint(targetMintURL: "https://target.example.com/")
+            ),
+            .topUpTargetMint(target: "target.example.com")
+        )
+    }
+
+    func testUnavailableRouteDoesNotInventAnExplanation() {
+        XCTAssertNil(CashuRequestRouteExplanation(state: .unavailable))
+    }
+
+    func testMissingOrMalformedTargetKeepsGenericRecoveryExplanation() {
+        XCTAssertEqual(
+            CashuRequestRouteExplanation(state: .addRequestedMint(targetMintURL: "  ")),
+            .addRequestedMint(target: nil)
+        )
+        XCTAssertEqual(
+            CashuRequestRouteExplanation(state: .topUpTargetMint(targetMintURL: "https://")),
+            .topUpTargetMint(target: nil)
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- add typed iOS explanations for Lightning fallback, adding the requested mint, and topping up the target mint
- omit redundant route copy for ordinary compatible-mint payments
- preserve route context through confirmation, processing, success, failure, and external top-up recovery
- wire both scanner-originated and manual/unified request paths
- add focused mapper and edge-case tests
- mark the matching parity checklist item complete

## Why

iOS could expose only a mint row or recovery CTA even when paying a request materially changed rails or required a different recovery path. Users had to infer how the wallet would pay or what an action would do.

## User impact

iOS now names meaningful payment-route changes before and after payment while keeping the normal compatible-mint path concise.

## Validation

- focused `CashuRequestRouteExplanationTests`: 6 tests passed
- clean generic iOS Simulator build: passed
- `plutil -lint ios/CashuWallet.xcodeproj/project.pbxproj`: passed
- `git diff origin/main...HEAD --check`: passed
