### PR TITLE
Support fiat-primary unified Send entry

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
@@ -56,6 +56,29 @@ class AmountFormatter(
         return "$number ${unit.uppercase()}"
     }
 
+    /**
+     * Partial-aware fiat entry presentation. The keypad owns the decimal
+     * fraction, so keep its trailing zeroes while applying the saved currency's
+     * canonical symbol and integer grouping.
+     */
+    fun entryFiatDisplay(raw: String, currencyCode: String): String {
+        val parts = raw.split(".")
+        val intValue = parts.getOrNull(0)?.toLongOrNull() ?: 0L
+        val grouped = NumberFormat.getIntegerInstance(locale).format(intValue)
+        val number = if (raw.contains(".")) {
+            "$grouped.${parts.getOrNull(1).orEmpty()}"
+        } else {
+            grouped
+        }
+        val format = NumberFormat.getCurrencyInstance(Locale.US).apply {
+            runCatching { currency = java.util.Currency.getInstance(currencyCode.uppercase()) }
+        }
+        val decimalFormat = format as? java.text.DecimalFormat
+        val prefix = decimalFormat?.positivePrefix?.trim().orEmpty()
+        val suffix = decimalFormat?.positiveSuffix?.trim().orEmpty()
+        return "$prefix$number$suffix"
+    }
+
     fun formatBitcoin(amountSats: Long, useBitcoinSymbol: Boolean): String {
         val btc = amountSats.toDouble() / 100_000_000.0
         val symbol = if (useBitcoinSymbol) "₿" else "BTC"

--- a/android/app/src/main/java/com/cashu/me/ui/components/AmountEntryHero.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/AmountEntryHero.kt
@@ -30,6 +30,7 @@ private val HeroMinFontSize = 26.sp
  * @param isSat    true for a sat wallet; false routes through the unit code
  * @param unit     effective unit code for non-sat mints (e.g. "USD")
  * @param decimals fractional places for the empty-state placeholder
+ * @param fiatCurrencyCode applies the saved fiat symbol instead of a mint-unit suffix
  * @param color    dims to `onSurfaceVariant` on insufficient balance (Send Ecash)
  */
 @Composable
@@ -40,6 +41,7 @@ fun AmountEntryHero(
     decimals: Int,
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
+    fiatCurrencyCode: String? = null,
     color: Color = MaterialTheme.colorScheme.onSurface,
 ) {
     val raw = when {
@@ -48,7 +50,11 @@ fun AmountEntryHero(
         else -> "0"
     }
     AmountText(
-        text = formatter.entryDisplay(raw, isSat, unit, useBitcoinSymbol),
+        text = if (fiatCurrencyCode != null) {
+            formatter.entryFiatDisplay(raw, fiatCurrencyCode)
+        } else {
+            formatter.entryDisplay(raw, isSat, unit, useBitcoinSymbol)
+        },
         modifier = Modifier.fillMaxWidth(),
         style = MaterialTheme.typography.displayMedium
             .copy(

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendAmountEntry.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendAmountEntry.kt
@@ -1,0 +1,110 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.UnitAmountEntry
+import kotlin.math.roundToLong
+
+internal data class UnifiedSendEntryContext(
+    val primary: AmountDisplayPrimary,
+    val btcPrice: Double,
+)
+
+internal enum class UnifiedSendAmountValidation {
+    Empty,
+    InsufficientBalance,
+    Valid,
+}
+
+/**
+ * Conversion boundary for unified Send's sat-denominated payment rails.
+ *
+ * The keypad keeps a unit-native raw string (integer sats or fiat cents), while
+ * quotes and payments always receive the converted sat value.
+ */
+internal object UnifiedSendAmountEntry {
+    fun context(preferredPrimary: String, btcPrice: Double): UnifiedSendEntryContext {
+        val preferred = AmountDisplayPrimary.fromRaw(preferredPrimary)
+        val effective = if (preferred == AmountDisplayPrimary.Fiat && btcPrice.isFinite() && btcPrice > 0.0) {
+            AmountDisplayPrimary.Fiat
+        } else {
+            AmountDisplayPrimary.Sats
+        }
+        return UnifiedSendEntryContext(effective, btcPrice)
+    }
+
+    fun amountSats(raw: String, context: UnifiedSendEntryContext): Long =
+        when (context.primary) {
+            AmountDisplayPrimary.Sats -> raw.toLongOrNull()?.takeIf { it > 0L } ?: 0L
+            AmountDisplayPrimary.Fiat -> fiatCentsToSats(
+                cents = UnitAmountEntry.baseUnits(raw, FIAT_DECIMALS),
+                btcPrice = context.btcPrice,
+            )
+        }
+
+    fun rawForSats(amountSats: Long, context: UnifiedSendEntryContext): String {
+        if (amountSats <= 0L) return ""
+        return when (context.primary) {
+            AmountDisplayPrimary.Sats -> amountSats.toString()
+            AmountDisplayPrimary.Fiat -> {
+                if (!context.btcPrice.isFinite() || context.btcPrice <= 0.0) return ""
+                val cents = (
+                    amountSats.toDouble() /
+                        SATS_PER_BITCOIN *
+                        context.btcPrice *
+                        CENTS_PER_FIAT
+                    ).roundToLong()
+                if (cents !in 1..MAX_ENTRY_BASE_UNITS) {
+                    ""
+                } else {
+                    UnitAmountEntry.entryString(cents, FIAT_DECIMALS)
+                }
+            }
+        }
+    }
+
+    /**
+     * Fiat cents cannot represent every sat balance exactly. Pick the closest
+     * keypad value that never exceeds the balance so Send Max remains valid.
+     */
+    fun maxRawForBalance(balanceSats: Long, context: UnifiedSendEntryContext): String {
+        var raw = rawForSats(balanceSats, context)
+        if (context.primary != AmountDisplayPrimary.Fiat) return raw
+        var cents = UnitAmountEntry.baseUnits(raw, FIAT_DECIMALS)
+        while (cents > 0L && amountSats(raw, context) > balanceSats) {
+            cents -= 1L
+            raw = UnitAmountEntry.entryString(cents, FIAT_DECIMALS)
+        }
+        return raw
+    }
+
+    fun convert(
+        raw: String,
+        from: UnifiedSendEntryContext,
+        to: UnifiedSendEntryContext,
+    ): String {
+        if (raw.isEmpty() || from.primary == to.primary) return raw
+        return rawForSats(amountSats(raw, from), to)
+    }
+
+    fun validation(amountSats: Long, balanceSats: Long): UnifiedSendAmountValidation =
+        when {
+            amountSats <= 0L -> UnifiedSendAmountValidation.Empty
+            amountSats > balanceSats -> UnifiedSendAmountValidation.InsufficientBalance
+            else -> UnifiedSendAmountValidation.Valid
+        }
+
+    private fun fiatCentsToSats(cents: Long, btcPrice: Double): Long {
+        if (cents <= 0L || !btcPrice.isFinite() || btcPrice <= 0.0) return 0L
+        val sats = cents.toDouble() /
+            CENTS_PER_FIAT /
+            btcPrice *
+            SATS_PER_BITCOIN
+        if (!sats.isFinite() || sats <= 0.0 || sats > Long.MAX_VALUE.toDouble()) return 0L
+        return sats.roundToLong()
+    }
+
+    private const val FIAT_DECIMALS = 2
+    private const val CENTS_PER_FIAT = 100.0
+    private const val SATS_PER_BITCOIN = 100_000_000.0
+    private const val MAX_ENTRY_BASE_UNITS = 99_999_999_999L
+}

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -61,10 +61,12 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.CashuPaymentRequestRoute
 import com.cashu.me.Core.PaymentRequestDecodeResult
 import com.cashu.me.Core.PaymentRequestDecoder
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.Wallet.WalletMessage
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
@@ -145,6 +147,7 @@ private sealed interface SendStatus {
 fun UnifiedSendScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
+    priceService: PriceService,
     onClose: () -> Unit,
     onScan: () -> Unit,
     onContactless: () -> Unit,
@@ -158,6 +161,7 @@ fun UnifiedSendScreen(
 ) {
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
     val clipboard = LocalClipboardManager.current
@@ -185,8 +189,13 @@ fun UnifiedSendScreen(
     var quoteError by remember { mutableStateOf<String?>(null) }
     var confirmError by remember { mutableStateOf<String?>(null) }
 
+    val entryContext = UnifiedSendAmountEntry.context(
+        preferredPrimary = settings.amountDisplayPrimary,
+        btcPrice = priceState.btcPrice,
+    )
+    var previousEntryContext by remember { mutableStateOf(entryContext) }
     val activeMintUrl = selectedMintUrl ?: walletState.activeMint?.url
-    val enteredAmount = amount.toLongOrNull() ?: 0L
+    val enteredAmount = UnifiedSendAmountEntry.amountSats(amount, entryContext)
     val confirmAmount = locked?.let { rail ->
         when (rail) {
             is LockedRail.Melt -> rail.knownAmount ?: enteredAmount
@@ -360,6 +369,19 @@ fun UnifiedSendScreen(
         onPrefilledConsumed()
     }
 
+    // Re-express an in-progress amount when fiat entry becomes available (or
+    // the saved primary changes), preserving the economic amount through sats.
+    LaunchedEffect(entryContext.primary, entryContext.btcPrice) {
+        if (previousEntryContext.primary != entryContext.primary) {
+            amount = UnifiedSendAmountEntry.convert(
+                raw = amount,
+                from = previousEntryContext,
+                to = entryContext,
+            )
+        }
+        previousEntryContext = entryContext
+    }
+
     // Confirm entry prefetches the melt quote (iOS shows fee/total skeleton).
     LaunchedEffect(step, locked, confirmAmount, activeMintUrl) {
         if (step != SendStep.Confirm) return@LaunchedEffect
@@ -528,8 +550,13 @@ fun UnifiedSendScreen(
                         },
                         onPickMint = { mintPickerOpen = true },
                         onUseMax = {
-                            activeMint?.balance?.takeIf { it > 0 }?.let { amount = it.toString() }
+                            activeMint?.balance?.takeIf { it > 0 }?.let {
+                                amount = UnifiedSendAmountEntry.maxRawForBalance(it, entryContext)
+                            }
                         },
+                        amountSats = enteredAmount,
+                        entryPrimary = entryContext.primary,
+                        fiatCurrencyCode = priceState.currencyCode,
                         useBitcoinSymbol = settings.useBitcoinSymbol,
                         formatter = formatter,
                         onContinue = {
@@ -795,13 +822,17 @@ private fun AmountFace(
     balanceText: String?,
     onPickMint: () -> Unit,
     onUseMax: () -> Unit,
+    amountSats: Long,
+    entryPrimary: AmountDisplayPrimary,
+    fiatCurrencyCode: String,
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
     onContinue: () -> Unit,
 ) {
-    val amountValue = amount.toLongOrNull() ?: 0L
     val mintBalance = mint?.balance ?: 0L
-    val insufficient = amountValue > 0 && amountValue > mintBalance
+    val validation = UnifiedSendAmountEntry.validation(amountSats, mintBalance)
+    val insufficient = validation == UnifiedSendAmountValidation.InsufficientBalance
+    val isFiatEntry = entryPrimary == AmountDisplayPrimary.Fiat
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -823,11 +854,12 @@ private fun AmountFace(
         Spacer(Modifier.weight(1f))
         AmountEntryHero(
             entryRaw = amount,
-            isSat = true,
-            unit = "sat",
-            decimals = 0,
+            isSat = !isFiatEntry,
+            unit = if (isFiatEntry) fiatCurrencyCode else "sat",
+            decimals = if (isFiatEntry) 2 else 0,
             useBitcoinSymbol = useBitcoinSymbol,
             formatter = formatter,
+            fiatCurrencyCode = fiatCurrencyCode.takeIf { isFiatEntry },
         )
         Spacer(Modifier.weight(1f))
         if (insufficient) {
@@ -842,7 +874,8 @@ private fun AmountFace(
             onAmountChange = onAmountChange,
             buttonText = "Continue",
             onButtonClick = onContinue,
-            buttonEnabled = amountValue > 0 && !insufficient,
+            decimals = if (isFiatEntry) 2 else 0,
+            buttonEnabled = validation == UnifiedSendAmountValidation.Valid,
         )
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -536,6 +536,7 @@ private fun AuthenticatedShell(container: AppContainer) {
             WalletFlow.Send -> UnifiedSendScreen(
                 walletManager = container.walletManager,
                 settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 onClose = close,
                 onScan = {
                     flowHandoff.requestScanner(close)

--- a/android/app/src/test/java/com/cashu/me/Core/AmountFormatterTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/AmountFormatterTest.kt
@@ -91,6 +91,11 @@ class AmountFormatterTest {
     }
 
     @Test
+    fun fiatEntryPreservesKeypadCentsWithTheCurrencySymbol() {
+        assertEquals("$1,234.50", formatter.entryFiatDisplay(raw = "1234.50", currencyCode = "USD"))
+    }
+
+    @Test
     fun usdUsesBareLeadingDollarSymbolRegardlessOfDeviceLocale() {
         val germanFormatter = AmountFormatter(Locale.GERMANY)
 

--- a/android/app/src/test/java/com/cashu/me/ui/send/UnifiedSendAmountEntryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/UnifiedSendAmountEntryTest.kt
@@ -1,0 +1,98 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnifiedSendAmountEntryTest {
+    private val fiat = UnifiedSendEntryContext(
+        primary = AmountDisplayPrimary.Fiat,
+        btcPrice = 50_000.0,
+    )
+    private val sats = UnifiedSendEntryContext(
+        primary = AmountDisplayPrimary.Sats,
+        btcPrice = 50_000.0,
+    )
+
+    @Test
+    fun savedFiatPrimaryConvertsKeypadCentsToSats() {
+        assertEquals(25_000L, UnifiedSendAmountEntry.amountSats("12.50", fiat))
+        assertEquals(25_000L, UnifiedSendAmountEntry.amountSats("25000", sats))
+    }
+
+    @Test
+    fun fiatEntryFallsBackToSatsWithoutAUsablePrice() {
+        assertEquals(
+            AmountDisplayPrimary.Sats,
+            UnifiedSendAmountEntry.context("fiat", btcPrice = 0.0).primary,
+        )
+        assertEquals(
+            AmountDisplayPrimary.Sats,
+            UnifiedSendAmountEntry.context("fiat", btcPrice = Double.NaN).primary,
+        )
+    }
+
+    @Test
+    fun validationUsesConvertedSatsAndProtectsBalanceLimit() {
+        assertEquals(
+            UnifiedSendAmountValidation.Empty,
+            UnifiedSendAmountEntry.validation(
+                amountSats = UnifiedSendAmountEntry.amountSats("", fiat),
+                balanceSats = 25_000L,
+            ),
+        )
+        assertEquals(
+            UnifiedSendAmountValidation.Valid,
+            UnifiedSendAmountEntry.validation(
+                amountSats = UnifiedSendAmountEntry.amountSats("12.50", fiat),
+                balanceSats = 25_000L,
+            ),
+        )
+        assertEquals(
+            UnifiedSendAmountValidation.InsufficientBalance,
+            UnifiedSendAmountEntry.validation(
+                amountSats = UnifiedSendAmountEntry.amountSats("12.51", fiat),
+                balanceSats = 25_000L,
+            ),
+        )
+        assertEquals(
+            1_999_999_999_980L,
+            UnifiedSendAmountEntry.amountSats("999999999999999999999999.99", fiat),
+        )
+        assertEquals(
+            UnifiedSendAmountValidation.InsufficientBalance,
+            UnifiedSendAmountEntry.validation(
+                amountSats = UnifiedSendAmountEntry.amountSats(
+                    "999999999999999999999999.99",
+                    fiat,
+                ),
+                balanceSats = 25_000L,
+            ),
+        )
+    }
+
+    @Test
+    fun sendMaxUsesFiatEntryWithoutExceedingTheSatBalance() {
+        val balance = 12_350L
+        val raw = UnifiedSendAmountEntry.maxRawForBalance(balance, fiat)
+        val paidSats = UnifiedSendAmountEntry.amountSats(raw, fiat)
+
+        assertEquals("6.17", raw)
+        assertEquals(12_340L, paidSats)
+        assertTrue(paidSats <= balance)
+        assertTrue(UnifiedSendAmountEntry.amountSats("6.18", fiat) > balance)
+    }
+
+    @Test
+    fun sendMaxRemainsExactInSatsPrimary() {
+        assertEquals("12350", UnifiedSendAmountEntry.maxRawForBalance(12_350L, sats))
+        assertEquals(
+            12_350L,
+            UnifiedSendAmountEntry.amountSats(
+                UnifiedSendAmountEntry.maxRawForBalance(12_350L, sats),
+                sats,
+            ),
+        )
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -44,7 +44,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Send — unified destination and payment flow
 
-- [ ] **[P1 · iOS → Android] Support fiat-primary amount entry.** iOS converts keypad input according to the saved sats/fiat primary setting; Android’s unified Send amount step always interprets the input as sats. **Done when:** Android entry, Send Max, validation, and amount presentation honor the selected primary unit without changing the sat amount being paid.
+- [x] **[P1 · iOS → Android] Support fiat-primary amount entry.** iOS converts keypad input according to the saved sats/fiat primary setting; Android’s unified Send amount step always interprets the input as sats. **Done when:** Android entry, Send Max, validation, and amount presentation honor the selected primary unit without changing the sat amount being paid.
 
 - [ ] **[P1 · iOS → Android] Honor the preferred unit on payment confirmation.** Android confirmation renders a fixed sat string; iOS keeps the saved primary value and alternate conversion available. **Done when:** Android confirmation leads with the persisted primary unit and makes the alternate value available visually and to accessibility services through a native Android presentation. An identical iOS flip control is not required.
 


### PR DESCRIPTION
## What changed

- make the Android unified Send keypad honor the persisted sats/fiat primary-unit preference
- convert fiat input to the exact sat amount used for quotes and payment
- make Send Max, validation, and amount presentation unit-aware
- add focused regression coverage for conversion, limits, formatting, and Send Max
- mark the matching parity checklist item complete

## Why

The unified Android Send flow always interpreted keypad digits as sats. That diverged from the saved display preference and could make fiat-primary users enter or review a materially different amount than intended.

## User impact

Fiat-primary users can now enter, validate, maximize, and review a Send amount in their chosen fiat currency while the underlying payment remains correctly denominated in sats. Sats-primary behavior is preserved.

## Validation

- focused amount and unified-Send suites: 28 tests passed
- `:app:assembleDebug`: passed
- `git diff origin/main...HEAD --check`: passed
