### PR TITLE
Preserve payment facts through Send terminal states

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
@@ -161,7 +161,7 @@ class FunctionalWalletJourneyTest {
             .awaitText("2 sat")
             .tapTag(UiTestTags.SendPaymentSubmit)
             .awaitText("Payment sent")
-            .awaitText("Fee")
+            .awaitText("Network fee")
             .awaitText("₿2")
 
         assertEquals(477L, runBlocking { fake.totalBalance(FakeWalletGateway.TestMintUrl) })

--- a/android/app/src/androidTest/java/com/cashu/me/ui/send/SendPaymentStatusDetailsComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/send/SendPaymentStatusDetailsComposeTest.kt
@@ -1,0 +1,83 @@
+package com.cashu.me.ui.send
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.ui.components.PaymentStatusPhase
+import com.cashu.me.ui.components.PaymentStatusScreen
+import com.cashu.me.ui.setCashuContent
+import java.util.Locale
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SendPaymentStatusDetailsComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun paymentFactsStayVisibleAcrossProcessingSuccessAndFailure() {
+        var phase by mutableStateOf(PaymentStatusPhase.Processing)
+        val details = SendPaymentDetails(
+            listOf(
+                SendPaymentDetailRow(
+                    SendPaymentDetailKey.Method,
+                    "Method",
+                    SendPaymentDetailValue.Text("BOLT11"),
+                ),
+                SendPaymentDetailRow(
+                    SendPaymentDetailKey.Amount,
+                    "Amount",
+                    SendPaymentDetailValue.Sats(21),
+                    valueMonospaced = true,
+                ),
+                SendPaymentDetailRow(
+                    SendPaymentDetailKey.NetworkFee,
+                    "Network fee",
+                    SendPaymentDetailValue.Sats(3, isUpperBound = true),
+                    valueMonospaced = true,
+                ),
+            ),
+        )
+
+        compose.setCashuContent {
+            PaymentStatusScreen(
+                phase = phase,
+                title = when (phase) {
+                    PaymentStatusPhase.Processing -> "Sending payment…"
+                    PaymentStatusPhase.Success -> "Payment sent"
+                    PaymentStatusPhase.Failure -> "Payment failed"
+                },
+                rows = {
+                    SendPaymentDetailRows(
+                        details = details,
+                        formatter = AmountFormatter(Locale.US),
+                        useBitcoinSymbol = false,
+                    )
+                },
+                showRowsDuringProcessing = true,
+            )
+        }
+
+        assertFactsDisplayed()
+        compose.runOnIdle { phase = PaymentStatusPhase.Success }
+        assertFactsDisplayed()
+        compose.runOnIdle { phase = PaymentStatusPhase.Failure }
+        assertFactsDisplayed()
+    }
+
+    private fun assertFactsDisplayed() {
+        compose.onNodeWithText("Method").assertIsDisplayed()
+        compose.onNodeWithText("BOLT11").assertIsDisplayed()
+        compose.onNodeWithText("Amount").assertIsDisplayed()
+        compose.onNodeWithText("21 sat").assertIsDisplayed()
+        compose.onNodeWithText("Network fee").assertIsDisplayed()
+        compose.onNodeWithText("Up to 3 sat").assertIsDisplayed()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/PaymentStatusScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/PaymentStatusScreen.kt
@@ -56,8 +56,9 @@ enum class PaymentStatusPhase { Processing, Success, Failure }
  * beat — a single bounce and a blur-to-sharp materialize; nothing else
  * springs, and failure stays deliberately still.
  * Success/failure require an explicit Done tap; processing shows no actions.
- * Terminal states may pass [rows] (InspectorRow metadata — Amount/Fee/Mint,
- * the iOS success detail rows) rendered under the title block.
+ * Callers may pass [rows] (InspectorRow metadata — Amount/Fee/Mint, the iOS
+ * payment detail rows). Set [showRowsDuringProcessing] when the row set must
+ * stay anchored across processing, success, and failure.
  */
 @Composable
 fun PaymentStatusScreen(
@@ -68,6 +69,7 @@ fun PaymentStatusScreen(
     doneLabel: String = "Done",
     onDone: (() -> Unit)? = null,
     rows: (@Composable ColumnScope.() -> Unit)? = null,
+    showRowsDuringProcessing: Boolean = false,
 ) {
     val haptics = LocalHapticFeedback.current
     LaunchedEffect(phase) {
@@ -92,10 +94,10 @@ fun PaymentStatusScreen(
         animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
         label = "status-entrance-scale",
     )
-    // Terminal details (title is crossfaded; rows + Done fade in) arrive with
-    // the glyph morph instead of popping. animateFloatAsState starts at its
-    // target, so screens mounted directly in a terminal phase skip the fade.
-    val detailsAlpha by animateFloatAsState(
+    // Opted-in rows stay visible across every phase. The action arrives with the
+    // terminal glyph morph; animateFloatAsState starts at its target for screens
+    // mounted directly in a terminal phase.
+    val terminalAlpha by animateFloatAsState(
         targetValue = if (phase != PaymentStatusPhase.Processing) 1f else 0f,
         animationSpec = tween(durationMillis = 220, delayMillis = 120),
         label = "status-details-alpha",
@@ -200,14 +202,16 @@ fun PaymentStatusScreen(
                     textAlign = TextAlign.Center,
                 )
             }
-            // Metadata rows (iOS PaymentStatusView detail rows) sit under the
-            // title block; only terminal phases pass them so processing stays bare.
-            if (rows != null && phase != PaymentStatusPhase.Processing) {
+            // Opted-in payment flows keep the same metadata slot throughout
+            // processing and terminal outcomes.
+            if (rows != null && (phase != PaymentStatusPhase.Processing || showRowsDuringProcessing)) {
                 Spacer(Modifier.height(CashuTheme.spacing.section))
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .graphicsLayer { alpha = detailsAlpha },
+                        .graphicsLayer {
+                            alpha = if (showRowsDuringProcessing) 1f else terminalAlpha
+                        },
                 ) { rows() }
             }
         }
@@ -220,7 +224,7 @@ fun PaymentStatusScreen(
                     .padding(horizontal = CashuTheme.spacing.comfortable)
                     .navigationBarsPadding()
                     .padding(bottom = CashuTheme.spacing.comfortable)
-                    .graphicsLayer { alpha = detailsAlpha },
+                    .graphicsLayer { alpha = terminalAlpha },
             )
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendPaymentDetails.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendPaymentDetails.kt
@@ -1,0 +1,303 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.CashuPaymentRequestRoute
+import com.cashu.me.Core.PaymentRequestDecodeResult
+import com.cashu.me.Models.MeltPaymentResult
+import com.cashu.me.Models.MeltQuoteInfo
+import com.cashu.me.Models.MeltSettlement
+import com.cashu.me.Models.MintInfo
+import java.net.URI
+
+/** The rail the unified destination field locked onto. */
+internal sealed interface LockedRail {
+    val raw: String
+
+    data class Melt(
+        override val raw: String,
+        val decoded: PaymentRequestDecodeResult,
+        val knownAmount: Long?,
+    ) : LockedRail
+
+    data class Creq(
+        override val raw: String,
+        val decoded: PaymentRequestDecodeResult.CashuPaymentRequest,
+        val knownAmount: Long?,
+        // Arrived pre-formed (scan/deep link) vs. typed/pasted — iOS shows the
+        // raw request string only in the latter case (mirrors UnifiedSendView).
+        val fromScan: Boolean = false,
+    ) : LockedRail
+}
+
+/** Stable identity and order for facts shown throughout a payment attempt. */
+internal enum class SendPaymentDetailKey {
+    Method,
+    Destination,
+    Amount,
+    NetworkFee,
+    InputFee,
+    Mint,
+    Memo,
+    Route,
+}
+
+/** Typed values prevent unresolved fees from being formatted as zero. */
+internal sealed interface SendPaymentDetailValue {
+    data class Text(val text: String) : SendPaymentDetailValue
+    data class Sats(
+        val amount: Long,
+        val isUpperBound: Boolean = false,
+    ) : SendPaymentDetailValue
+    data object Pending : SendPaymentDetailValue
+    data object Unavailable : SendPaymentDetailValue
+}
+
+internal data class SendPaymentDetailRow(
+    val key: SendPaymentDetailKey,
+    val label: String,
+    val value: SendPaymentDetailValue,
+    val valueMonospaced: Boolean = false,
+)
+
+/**
+ * Immutable payment-fact snapshot carried by processing, success, and failure.
+ *
+ * The row keys are fixed when Pay is tapped. Values may become more precise
+ * (a pending fallback fee can resolve, or a settled melt can replace its fee
+ * upper bound with the actual fee), but rows are never inserted or removed
+ * between terminal phases.
+ */
+internal data class SendPaymentDetails(
+    val rows: List<SendPaymentDetailRow>,
+) {
+    init {
+        require(rows.map { it.key }.distinct().size == rows.size) {
+            "Payment detail keys must be unique."
+        }
+    }
+
+    val keys: List<SendPaymentDetailKey> get() = rows.map { it.key }
+
+    fun withNetworkFeeUpperBound(amountSats: Long): SendPaymentDetails =
+        replacing(SendPaymentDetailKey.NetworkFee, SendPaymentDetailValue.Sats(amountSats, isUpperBound = true))
+
+    fun withMintName(name: String): SendPaymentDetails =
+        replacing(SendPaymentDetailKey.Mint, SendPaymentDetailValue.Text(name))
+
+    fun withMeltResult(result: MeltPaymentResult): SendPaymentDetails {
+        val feeValue = if (result.settlement == MeltSettlement.Pending) {
+            SendPaymentDetailValue.Sats(result.feePaid, isUpperBound = true)
+        } else {
+            SendPaymentDetailValue.Sats(result.feePaid)
+        }
+        return replacing(SendPaymentDetailKey.NetworkFee, feeValue)
+    }
+
+    fun resolvingFailed(): SendPaymentDetails = copy(
+        rows = rows.map { row ->
+            if (row.value == SendPaymentDetailValue.Pending) {
+                row.copy(value = SendPaymentDetailValue.Unavailable)
+            } else {
+                row
+            }
+        },
+    )
+
+    private fun replacing(
+        key: SendPaymentDetailKey,
+        value: SendPaymentDetailValue,
+    ): SendPaymentDetails {
+        if (rows.none { it.key == key }) return this
+        return copy(rows = rows.map { row -> if (row.key == key) row.copy(value = value) else row })
+    }
+}
+
+/**
+ * Documents the unified Send terminal row contract:
+ *
+ * - Melt rails: Method, on-chain Destination when applicable, Amount,
+ *   Network fee, and Mint.
+ * - Cashu Request: Method, Amount, Input/Network fee context, Mint when known,
+ *   Memo when supplied, and a Route row when payment changes rails or adds a mint.
+ */
+internal fun buildSendPaymentDetails(
+    rail: LockedRail,
+    cashuRoute: CashuPaymentRequestRoute?,
+    amountSats: Long,
+    mint: MintInfo?,
+    meltQuote: MeltQuoteInfo?,
+    cashuInputFeeSats: Long? = null,
+): SendPaymentDetails {
+    val rows = when (rail) {
+        is LockedRail.Melt -> buildMeltDetails(
+            rail = rail,
+            amountSats = amountSats,
+            mint = mint,
+            quote = meltQuote,
+        )
+        is LockedRail.Creq -> buildCashuRequestDetails(
+            rail = rail,
+            route = cashuRoute,
+            amountSats = amountSats,
+            mint = mint,
+            inputFeeSats = cashuInputFeeSats,
+        )
+    }
+    return SendPaymentDetails(rows)
+}
+
+private fun buildMeltDetails(
+    rail: LockedRail.Melt,
+    amountSats: Long,
+    mint: MintInfo?,
+    quote: MeltQuoteInfo?,
+): List<SendPaymentDetailRow> = buildList {
+    add(textRow(SendPaymentDetailKey.Method, "Method", meltMethodName(rail, quote)))
+    if (rail.decoded is PaymentRequestDecodeResult.Onchain) {
+        add(
+            textRow(
+                SendPaymentDetailKey.Destination,
+                "To",
+                rail.decoded.address,
+                valueMonospaced = true,
+            ),
+        )
+    }
+    add(satsRow(SendPaymentDetailKey.Amount, "Amount", quote?.amount ?: amountSats))
+    add(
+        SendPaymentDetailRow(
+            key = SendPaymentDetailKey.NetworkFee,
+            label = "Network fee",
+            value = quote?.let {
+                SendPaymentDetailValue.Sats(it.feeReserve, isUpperBound = true)
+            } ?: SendPaymentDetailValue.Pending,
+            valueMonospaced = true,
+        ),
+    )
+    val quoteMintUrl = quote?.mintUrl?.takeIf { it.isNotBlank() }
+    val mintName = if (quoteMintUrl != null) {
+        mint
+            ?.takeIf { sameMintUrl(it.url, quoteMintUrl) }
+            ?.name
+            ?.takeIf { it.isNotBlank() }
+            ?: mintDisplayName(quoteMintUrl)
+    } else {
+        mint?.name?.takeIf { it.isNotBlank() }
+    }
+    if (mintName != null) {
+        add(textRow(SendPaymentDetailKey.Mint, "Mint", mintName))
+    }
+}
+
+private fun buildCashuRequestDetails(
+    rail: LockedRail.Creq,
+    route: CashuPaymentRequestRoute?,
+    amountSats: Long,
+    mint: MintInfo?,
+    inputFeeSats: Long?,
+): List<SendPaymentDetailRow> = buildList {
+    add(textRow(SendPaymentDetailKey.Method, "Method", "Cashu Request"))
+    add(satsRow(SendPaymentDetailKey.Amount, "Amount", amountSats))
+
+    val fallback = route is CashuPaymentRequestRoute.PayBolt11Fallback
+    add(
+        SendPaymentDetailRow(
+            key = if (fallback) SendPaymentDetailKey.NetworkFee else SendPaymentDetailKey.InputFee,
+            label = if (fallback) "Network fee" else "Input fee",
+            value = if (fallback) {
+                SendPaymentDetailValue.Pending
+            } else {
+                inputFeeSats
+                    ?.let(SendPaymentDetailValue::Sats)
+                    ?: SendPaymentDetailValue.Unavailable
+            },
+            valueMonospaced = true,
+        ),
+    )
+
+    cashuRequestMintValue(route, mint)?.let {
+        add(
+            SendPaymentDetailRow(
+                key = SendPaymentDetailKey.Mint,
+                label = "Mint",
+                value = it,
+            ),
+        )
+    }
+    rail.decoded.summary.description
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { add(textRow(SendPaymentDetailKey.Memo, "Memo", it)) }
+    cashuRequestRouteName(route)?.let {
+        add(textRow(SendPaymentDetailKey.Route, "Route", it))
+    }
+}
+
+private fun meltMethodName(
+    rail: LockedRail.Melt,
+    quote: MeltQuoteInfo?,
+): String = quote?.paymentMethod?.displayName ?: when (rail.decoded) {
+    is PaymentRequestDecodeResult.Bolt12 -> "BOLT12"
+    is PaymentRequestDecodeResult.Onchain -> "On-chain"
+    is PaymentRequestDecodeResult.Bolt11,
+    is PaymentRequestDecodeResult.LightningAddress -> "BOLT11"
+    is PaymentRequestDecodeResult.CashuPaymentRequest,
+    PaymentRequestDecodeResult.Unrecognized -> "Payment"
+}
+
+private fun cashuRequestMintValue(
+    route: CashuPaymentRequestRoute?,
+    mint: MintInfo?,
+): SendPaymentDetailValue? = when (route) {
+    is CashuPaymentRequestRoute.PayWithEcash ->
+        SendPaymentDetailValue.Text(route.mint.name)
+    is CashuPaymentRequestRoute.AddMintToPay ->
+        route.mintUrls.firstOrNull()?.let(::mintDisplayName)?.let(SendPaymentDetailValue::Text)
+    is CashuPaymentRequestRoute.NeedsExternalTopUp ->
+        route.mintUrl?.let(::mintDisplayName)?.let(SendPaymentDetailValue::Text)
+    is CashuPaymentRequestRoute.PayBolt11Fallback -> SendPaymentDetailValue.Pending
+    is CashuPaymentRequestRoute.UnsupportedUnit,
+    CashuPaymentRequestRoute.MissingAmount,
+    null -> mint?.name?.takeIf { it.isNotBlank() }?.let(SendPaymentDetailValue::Text)
+}
+
+private fun cashuRequestRouteName(route: CashuPaymentRequestRoute?): String? = when (route) {
+    is CashuPaymentRequestRoute.PayBolt11Fallback -> "Lightning fallback"
+    is CashuPaymentRequestRoute.AddMintToPay -> "Add requested mint"
+    is CashuPaymentRequestRoute.NeedsExternalTopUp -> "Top up target mint"
+    is CashuPaymentRequestRoute.PayWithEcash,
+    is CashuPaymentRequestRoute.UnsupportedUnit,
+    CashuPaymentRequestRoute.MissingAmount,
+    null -> null
+}
+
+private fun mintDisplayName(url: String): String =
+    runCatching { URI(url).host }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+        ?: url
+
+private fun sameMintUrl(left: String, right: String): Boolean =
+    left.trim().trimEnd('/').lowercase() == right.trim().trimEnd('/').lowercase()
+
+private fun textRow(
+    key: SendPaymentDetailKey,
+    label: String,
+    value: String,
+    valueMonospaced: Boolean = false,
+) = SendPaymentDetailRow(
+    key = key,
+    label = label,
+    value = SendPaymentDetailValue.Text(value),
+    valueMonospaced = valueMonospaced,
+)
+
+private fun satsRow(
+    key: SendPaymentDetailKey,
+    label: String,
+    value: Long,
+) = SendPaymentDetailRow(
+    key = key,
+    label = label,
+    value = SendPaymentDetailValue.Sats(value),
+    valueMonospaced = true,
+)

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.style.TextOverflow
@@ -70,6 +72,7 @@ import com.cashu.me.Core.Wallet.WalletMessage
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.Wallet.walletMessage
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.normalizedMintUrlForSelection
 import com.cashu.me.Core.routeForCashuPaymentRequest
 import com.cashu.me.Models.MeltPaymentResult
 import com.cashu.me.Models.MeltQuoteInfo
@@ -106,30 +109,18 @@ private const val TYPE_DEBOUNCE_MS = 400L
 
 private enum class SendStep { Input, Amount, Confirm }
 
-/** The rail the destination locked onto. */
-private sealed interface LockedRail {
-    val raw: String
+internal sealed interface SendStatus {
+    val details: SendPaymentDetails
 
-    data class Melt(
-        override val raw: String,
-        val decoded: PaymentRequestDecodeResult,
-        val knownAmount: Long?,
-    ) : LockedRail
-
-    data class Creq(
-        override val raw: String,
-        val decoded: PaymentRequestDecodeResult.CashuPaymentRequest,
-        val knownAmount: Long?,
-        // Arrived pre-formed (scan/deep link) vs. typed/pasted — iOS shows the
-        // raw request string only in the latter case (mirrors UnifiedSendView).
-        val fromScan: Boolean = false,
-    ) : LockedRail
-}
-
-private sealed interface SendStatus {
-    data object Sending : SendStatus
-    data class Sent(val result: MeltPaymentResult?) : SendStatus
-    data class Failed(val message: WalletMessage) : SendStatus
+    data class Sending(override val details: SendPaymentDetails) : SendStatus
+    data class Sent(
+        override val details: SendPaymentDetails,
+        val result: MeltPaymentResult?,
+    ) : SendStatus
+    data class Failed(
+        override val details: SendPaymentDetails,
+        val message: WalletMessage,
+    ) : SendStatus
 }
 
 /**
@@ -265,15 +256,23 @@ fun UnifiedSendScreen(
 
     fun pay() {
         val rail = locked ?: return
+        var paymentDetails = buildSendPaymentDetails(
+            rail = rail,
+            cashuRoute = cashuRoute,
+            amountSats = confirmAmount,
+            mint = activeMint,
+            meltQuote = meltQuote,
+        )
         confirmError = null
-        status = SendStatus.Sending
+        status = SendStatus.Sending(paymentDetails)
         scope.launch {
             try {
                 when (rail) {
                     is LockedRail.Melt -> {
                         val quote = meltQuote ?: error("No quote.")
                         val result = walletManager.meltTokens(quote.id, activeMintUrl)
-                        status = SendStatus.Sent(result)
+                        paymentDetails = paymentDetails.withMeltResult(result)
+                        status = SendStatus.Sent(paymentDetails, result)
                     }
                     is LockedRail.Creq -> {
                         when (val route = cashuRoute) {
@@ -286,8 +285,17 @@ fun UnifiedSendScreen(
                                     amountSats = null,
                                     preferredMintURL = activeMintUrl,
                                 )
+                                paymentDetails = paymentDetails.withNetworkFeeUpperBound(quote.feeReserve)
+                                    .withMintName(
+                                        walletState.mints.firstOrNull {
+                                            normalizedMintUrlForSelection(it.url) ==
+                                                normalizedMintUrlForSelection(quote.mintUrl)
+                                        }?.name ?: quote.mintUrl,
+                                    )
+                                status = SendStatus.Sending(paymentDetails)
                                 val result = walletManager.meltTokens(quote.id, activeMintUrl)
-                                status = SendStatus.Sent(result)
+                                paymentDetails = paymentDetails.withMeltResult(result)
+                                status = SendStatus.Sent(paymentDetails, result)
                                 return@launch
                             }
                             is CashuPaymentRequestRoute.AddMintToPay -> {
@@ -312,13 +320,13 @@ fun UnifiedSendScreen(
                                 walletManager.payCashuPaymentRequest(rail.raw, confirmAmount, activeMintUrl)
                             }
                         }
-                        status = SendStatus.Sent(null)
+                        status = SendStatus.Sent(paymentDetails, null)
                     }
                 }
             } catch (cancellation: CancellationException) {
                 throw cancellation
             } catch (t: Throwable) {
-                status = SendStatus.Failed(t.walletMessage)
+                status = SendStatus.Failed(paymentDetails.resolvingFailed(), t.walletMessage)
             }
         }
     }
@@ -382,11 +390,11 @@ fun UnifiedSendScreen(
 
     // Block sheet dismissal while the melt is in flight — a stray swipe must
     // not tear down the coroutine mid-payment.
-    LaunchedEffect(status) { onDismissLockChanged(status == SendStatus.Sending) }
+    LaunchedEffect(status) { onDismissLockChanged(status is SendStatus.Sending) }
 
     // System back mirrors the header chevron: unwind Confirm → Amount → Input;
     // swallow back entirely while sending. From Input the sheet handles it.
-    BackHandler(enabled = status == SendStatus.Sending || (status == null && step != SendStep.Input)) {
+    BackHandler(enabled = status is SendStatus.Sending || (status == null && step != SendStep.Input)) {
         if (status == null) goBack()
     }
 
@@ -404,16 +412,15 @@ fun UnifiedSendScreen(
     ) {
         // Status terminal replaces the whole body (iOS PaymentStatusView slot).
         when (val current = status) {
-            SendStatus.Sending -> Box(Modifier.weight(1f).fillMaxWidth()) {
-                PaymentStatusScreen(phase = PaymentStatusPhase.Processing, title = "Sending payment…")
+            is SendStatus.Sending -> Box(Modifier.weight(1f).fillMaxWidth()) {
+                PaymentStatusScreen(
+                    phase = PaymentStatusPhase.Processing,
+                    title = "Sending payment…",
+                    rows = { SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol) },
+                    showRowsDuringProcessing = true,
+                )
             }
             is SendStatus.Sent -> Box(Modifier.weight(1f).fillMaxWidth()) {
-                // Amount/Fee/Mint metadata rows (iOS PaymentStatusView success
-                // rows). Melt carries its own result; creq falls back to the
-                // confirmed amount and active mint.
-                val sentAmount = current.result?.amount ?: confirmAmount
-                val sentFee = current.result?.feePaid ?: 0L
-                val sentMint = current.result?.mintUrl ?: activeMintUrl
                 // An async-accepted (NUT-05) melt — typical for on-chain — isn't
                 // settled yet: the mint took the payment and pays out in the
                 // background, so say "processing", not "sent" (iOS parity).
@@ -423,29 +430,7 @@ fun UnifiedSendScreen(
                     title = if (settlementPending) "Payment processing" else "Payment sent",
                     onDone = onClose,
                     rows = {
-                        if (sentAmount > 0L) {
-                            InspectorRow(
-                                label = "Amount",
-                                value = formatter.formatWalletSats(sentAmount, settings.useBitcoinSymbol),
-                                leadingIcon = Icons.Outlined.Payments,
-                            )
-                        }
-                        if (sentFee > 0L) {
-                            CanvasDivider(leadingInset = 16.dp)
-                            InspectorRow(
-                                label = "Fee",
-                                value = formatter.formatWalletSats(sentFee, settings.useBitcoinSymbol),
-                                leadingIcon = Icons.Outlined.Receipt,
-                            )
-                        }
-                        if (sentMint != null) {
-                            CanvasDivider(leadingInset = 16.dp)
-                            InspectorRow(
-                                label = "Mint",
-                                value = sentMint,
-                                leadingIcon = Icons.Outlined.AccountBalance,
-                            )
-                        }
+                        SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol)
                     },
                 )
             }
@@ -460,6 +445,7 @@ fun UnifiedSendScreen(
                     onDone = {
                         if (current.message.isTerminal) onClose() else status = null
                     },
+                    rows = { SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol) },
                 )
             }
             null -> {
@@ -613,6 +599,57 @@ fun UnifiedSendScreen(
         )
     }
 }
+
+@Composable
+internal fun SendPaymentDetailRows(
+    details: SendPaymentDetails,
+    formatter: AmountFormatter,
+    useBitcoinSymbol: Boolean,
+) {
+    details.rows.forEachIndexed { index, row ->
+        if (index > 0) CanvasDivider(leadingInset = 16.dp)
+        val loading = row.value == SendPaymentDetailValue.Pending
+        val value = when (val detailValue = row.value) {
+            SendPaymentDetailValue.Pending -> ""
+            SendPaymentDetailValue.Unavailable -> "Unavailable"
+            is SendPaymentDetailValue.Text -> detailValue.text
+            is SendPaymentDetailValue.Sats -> {
+                val formatted = formatter.formatWalletSats(detailValue.amount, useBitcoinSymbol)
+                when {
+                    row.key in FeeDetailKeys && detailValue.amount == 0L -> "No fee"
+                    detailValue.isUpperBound -> "Up to $formatted"
+                    else -> formatted
+                }
+            }
+        }
+        InspectorRow(
+            label = row.label,
+            value = value,
+            modifier = if (loading) {
+                Modifier.semantics { stateDescription = "Loading" }
+            } else {
+                Modifier
+            },
+            leadingIcon = when (row.key) {
+                SendPaymentDetailKey.Method,
+                SendPaymentDetailKey.Amount,
+                SendPaymentDetailKey.Route -> Icons.Outlined.Payments
+                SendPaymentDetailKey.NetworkFee,
+                SendPaymentDetailKey.InputFee,
+                SendPaymentDetailKey.Memo -> Icons.Outlined.Receipt
+                SendPaymentDetailKey.Mint -> Icons.Outlined.AccountBalance
+                SendPaymentDetailKey.Destination -> null
+            },
+            valueMonospaced = row.valueMonospaced,
+            loading = loading,
+        )
+    }
+}
+
+private val FeeDetailKeys = setOf(
+    SendPaymentDetailKey.NetworkFee,
+    SendPaymentDetailKey.InputFee,
+)
 
 @Composable
 private fun InputFace(

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendPaymentDetailsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendPaymentDetailsTest.kt
@@ -1,0 +1,368 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.CashuPaymentRequestRoute
+import com.cashu.me.Core.CashuPaymentRequestSummary
+import com.cashu.me.Core.PaymentRequestDecodeResult
+import com.cashu.me.Core.Wallet.WalletMessage
+import com.cashu.me.Models.MeltPaymentResult
+import com.cashu.me.Models.MeltQuoteInfo
+import com.cashu.me.Models.MeltQuoteState
+import com.cashu.me.Models.MeltSettlement
+import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.PaymentMethodKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SendPaymentDetailsTest {
+    @Test
+    fun everyMeltRailKeepsItsDocumentedRowsThroughProcessingSuccessAndFailure() {
+        val rails = listOf(
+            MeltCase(
+                rail = LockedRail.Melt(
+                    raw = "lnbc1invoice",
+                    decoded = PaymentRequestDecodeResult.Bolt11(21, "Coffee"),
+                    knownAmount = 21,
+                ),
+                method = PaymentMethodKind.Bolt11,
+                expectedKeys = StandardMeltKeys,
+                expectedMethod = "BOLT11",
+            ),
+            MeltCase(
+                rail = LockedRail.Melt(
+                    raw = "lno1offer",
+                    decoded = PaymentRequestDecodeResult.Bolt12(21, "Coffee"),
+                    knownAmount = 21,
+                ),
+                method = PaymentMethodKind.Bolt12,
+                expectedKeys = StandardMeltKeys,
+                expectedMethod = "BOLT12",
+            ),
+            MeltCase(
+                rail = LockedRail.Melt(
+                    raw = "alice@example.com",
+                    decoded = PaymentRequestDecodeResult.LightningAddress("alice@example.com"),
+                    knownAmount = null,
+                ),
+                method = PaymentMethodKind.Bolt11,
+                expectedKeys = StandardMeltKeys,
+                expectedMethod = "BOLT11",
+            ),
+            MeltCase(
+                rail = LockedRail.Melt(
+                    raw = "bitcoin:bc1qrecipient?amount=0.00000021",
+                    decoded = PaymentRequestDecodeResult.Onchain("bc1qrecipient"),
+                    knownAmount = null,
+                ),
+                method = PaymentMethodKind.Onchain,
+                expectedKeys = listOf(
+                    SendPaymentDetailKey.Method,
+                    SendPaymentDetailKey.Destination,
+                    SendPaymentDetailKey.Amount,
+                    SendPaymentDetailKey.NetworkFee,
+                    SendPaymentDetailKey.Mint,
+                ),
+                expectedMethod = "On-chain",
+            ),
+        )
+
+        rails.forEachIndexed { index, case ->
+            val quote = meltQuote(method = case.method, id = "quote-$index")
+            val details = buildSendPaymentDetails(
+                rail = case.rail,
+                cashuRoute = null,
+                amountSats = 21,
+                mint = Mint,
+                meltQuote = quote,
+            )
+            val result = meltResult(method = case.method)
+
+            assertStableTerminalKeys(
+                processing = SendStatus.Sending(details),
+                success = SendStatus.Sent(details.withMeltResult(result), result),
+                failure = SendStatus.Failed(details.resolvingFailed(), WalletMessage("Mint unavailable.")),
+                expected = case.expectedKeys,
+            )
+            assertEquals(
+                SendPaymentDetailValue.Text(case.expectedMethod),
+                details.value(SendPaymentDetailKey.Method),
+            )
+            assertEquals(SendPaymentDetailValue.Sats(21), details.value(SendPaymentDetailKey.Amount))
+            assertEquals(
+                SendPaymentDetailValue.Sats(3, isUpperBound = true),
+                details.value(SendPaymentDetailKey.NetworkFee),
+            )
+            assertEquals(
+                SendPaymentDetailValue.Text("Minibits"),
+                details.value(SendPaymentDetailKey.Mint),
+            )
+        }
+
+        val onchain = buildSendPaymentDetails(
+            rail = rails.last().rail,
+            cashuRoute = null,
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = meltQuote(PaymentMethodKind.Onchain),
+        )
+        assertEquals(
+            SendPaymentDetailValue.Text("bc1qrecipient"),
+            onchain.value(SendPaymentDetailKey.Destination),
+        )
+    }
+
+    @Test
+    fun cashuRequestKeepsAmountMethodMintInputFeeAndMemoThroughErrors() {
+        val rail = cashuRail(memo = "Dinner")
+        val route = CashuPaymentRequestRoute.PayWithEcash(Mint, amountSats = 21)
+        val details = buildSendPaymentDetails(
+            rail = rail,
+            cashuRoute = route,
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = null,
+            cashuInputFeeSats = 2,
+        )
+        val expected = listOf(
+            SendPaymentDetailKey.Method,
+            SendPaymentDetailKey.Amount,
+            SendPaymentDetailKey.InputFee,
+            SendPaymentDetailKey.Mint,
+            SendPaymentDetailKey.Memo,
+        )
+
+        assertStableTerminalKeys(
+            processing = SendStatus.Sending(details),
+            success = SendStatus.Sent(details, null),
+            failure = SendStatus.Failed(details.resolvingFailed(), WalletMessage("Request rejected.")),
+            expected = expected,
+        )
+        assertEquals(
+            SendPaymentDetailValue.Text("Cashu Request"),
+            details.value(SendPaymentDetailKey.Method),
+        )
+        assertEquals(SendPaymentDetailValue.Sats(2), details.value(SendPaymentDetailKey.InputFee))
+        assertEquals(SendPaymentDetailValue.Text("Dinner"), details.value(SendPaymentDetailKey.Memo))
+    }
+
+    @Test
+    fun unknownCashuInputFeeIsUnavailableInsteadOfZero() {
+        val details = buildSendPaymentDetails(
+            rail = cashuRail(),
+            cashuRoute = CashuPaymentRequestRoute.PayWithEcash(Mint, amountSats = 21),
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = null,
+        )
+
+        assertEquals(
+            SendPaymentDetailValue.Unavailable,
+            details.value(SendPaymentDetailKey.InputFee),
+        )
+        assertTrue(details.rows.none { it.value == SendPaymentDetailValue.Sats(0) })
+    }
+
+    @Test
+    fun cashuLightningFallbackReservesFeeAndRouteRowsAcrossQuoteFailureAndSuccess() {
+        val initial = buildSendPaymentDetails(
+            rail = cashuRail(memo = "Dinner"),
+            cashuRoute = CashuPaymentRequestRoute.PayBolt11Fallback("lnbc1fallback"),
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = null,
+        )
+        val quoted = initial
+            .withNetworkFeeUpperBound(4)
+            .withMintName("Minibits")
+        val result = meltResult(PaymentMethodKind.Bolt11, feePaid = 2)
+        val settled = quoted.withMeltResult(result)
+        val expected = listOf(
+            SendPaymentDetailKey.Method,
+            SendPaymentDetailKey.Amount,
+            SendPaymentDetailKey.NetworkFee,
+            SendPaymentDetailKey.Mint,
+            SendPaymentDetailKey.Memo,
+            SendPaymentDetailKey.Route,
+        )
+
+        assertStableTerminalKeys(
+            processing = SendStatus.Sending(initial),
+            success = SendStatus.Sent(settled, result),
+            failure = SendStatus.Failed(initial.resolvingFailed(), WalletMessage("Quote failed.")),
+            expected = expected,
+        )
+        assertEquals(SendPaymentDetailValue.Pending, initial.value(SendPaymentDetailKey.NetworkFee))
+        assertEquals(SendPaymentDetailValue.Pending, initial.value(SendPaymentDetailKey.Mint))
+        assertEquals(
+            SendPaymentDetailValue.Unavailable,
+            initial.resolvingFailed().value(SendPaymentDetailKey.NetworkFee),
+        )
+        assertEquals(
+            SendPaymentDetailValue.Unavailable,
+            initial.resolvingFailed().value(SendPaymentDetailKey.Mint),
+        )
+        assertEquals(SendPaymentDetailValue.Sats(2), settled.value(SendPaymentDetailKey.NetworkFee))
+        assertEquals(SendPaymentDetailValue.Text("Minibits"), settled.value(SendPaymentDetailKey.Mint))
+        assertEquals(
+            SendPaymentDetailValue.Text("Lightning fallback"),
+            initial.value(SendPaymentDetailKey.Route),
+        )
+    }
+
+    @Test
+    fun cashuAddMintRouteUsesRequestedMintIdentityWithoutClaimingAnUnknownName() {
+        val details = buildSendPaymentDetails(
+            rail = cashuRail(),
+            cashuRoute = CashuPaymentRequestRoute.AddMintToPay(
+                mintUrls = listOf("https://requested.example/path"),
+                amountSats = 21,
+            ),
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = null,
+        )
+
+        assertEquals(
+            SendPaymentDetailValue.Text("requested.example"),
+            details.value(SendPaymentDetailKey.Mint),
+        )
+        assertEquals(
+            SendPaymentDetailValue.Text("Add requested mint"),
+            details.value(SendPaymentDetailKey.Route),
+        )
+    }
+
+    @Test
+    fun pendingOnchainSettlementKeepsTheFeeMarkedAsAnUpperBound() {
+        val details = buildSendPaymentDetails(
+            rail = LockedRail.Melt(
+                raw = "bc1qrecipient",
+                decoded = PaymentRequestDecodeResult.Onchain("bc1qrecipient"),
+                knownAmount = null,
+            ),
+            cashuRoute = null,
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = meltQuote(PaymentMethodKind.Onchain),
+        )
+        val pending = details.withMeltResult(
+            meltResult(
+                method = PaymentMethodKind.Onchain,
+                feePaid = 3,
+                settlement = MeltSettlement.Pending,
+            ),
+        )
+
+        assertEquals(
+            SendPaymentDetailValue.Sats(3, isUpperBound = true),
+            pending.value(SendPaymentDetailKey.NetworkFee),
+        )
+    }
+
+    @Test
+    fun meltUsesTheQuotedMintInsteadOfMislabelingARejectedPreference() {
+        val details = buildSendPaymentDetails(
+            rail = LockedRail.Melt(
+                raw = "lnbc1invoice",
+                decoded = PaymentRequestDecodeResult.Bolt11(21, null),
+                knownAmount = 21,
+            ),
+            cashuRoute = null,
+            amountSats = 21,
+            mint = Mint,
+            meltQuote = meltQuote(
+                method = PaymentMethodKind.Bolt11,
+                mintUrl = "https://selected.example/path",
+            ),
+        )
+
+        assertEquals(
+            SendPaymentDetailValue.Text("selected.example"),
+            details.value(SendPaymentDetailKey.Mint),
+        )
+    }
+
+    private fun assertStableTerminalKeys(
+        processing: SendStatus,
+        success: SendStatus,
+        failure: SendStatus,
+        expected: List<SendPaymentDetailKey>,
+    ) {
+        assertEquals(expected, processing.details.keys)
+        assertEquals(expected, success.details.keys)
+        assertEquals(expected, failure.details.keys)
+        assertEquals(
+            processing.details.rows.map { it.label },
+            success.details.rows.map { it.label },
+        )
+        assertEquals(
+            processing.details.rows.map { it.label },
+            failure.details.rows.map { it.label },
+        )
+    }
+
+    private fun SendPaymentDetails.value(key: SendPaymentDetailKey): SendPaymentDetailValue? =
+        rows.firstOrNull { it.key == key }?.value
+
+    private fun cashuRail(memo: String? = null) = LockedRail.Creq(
+        raw = "creqArequest",
+        decoded = PaymentRequestDecodeResult.CashuPaymentRequest(
+            CashuPaymentRequestSummary(
+                encoded = "creqArequest",
+                amount = 21,
+                unit = "sat",
+                description = memo,
+                mints = listOf(Mint.url),
+            ),
+        ),
+        knownAmount = 21,
+    )
+
+    private fun meltQuote(
+        method: PaymentMethodKind,
+        id: String = "quote",
+        mintUrl: String = Mint.url,
+    ) = MeltQuoteInfo(
+        id = id,
+        mintUrl = mintUrl,
+        amount = 21,
+        feeReserve = 3,
+        paymentMethod = method,
+        state = MeltQuoteState.Unpaid,
+        expiryEpochSeconds = null,
+    )
+
+    private fun meltResult(
+        method: PaymentMethodKind,
+        feePaid: Long = 1,
+        settlement: MeltSettlement = MeltSettlement.Settled,
+    ) = MeltPaymentResult(
+        preimage = "preimage",
+        amount = 21,
+        feePaid = feePaid,
+        mintUrl = Mint.url,
+        paymentMethod = method,
+        settlement = settlement,
+    )
+
+    private data class MeltCase(
+        val rail: LockedRail.Melt,
+        val method: PaymentMethodKind,
+        val expectedKeys: List<SendPaymentDetailKey>,
+        val expectedMethod: String,
+    )
+
+    private companion object {
+        val Mint = MintInfo(
+            url = "https://mint.example",
+            name = "Minibits",
+            balance = 100,
+        )
+        val StandardMeltKeys = listOf(
+            SendPaymentDetailKey.Method,
+            SendPaymentDetailKey.Amount,
+            SendPaymentDetailKey.NetworkFee,
+            SendPaymentDetailKey.Mint,
+        )
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -50,7 +50,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Show the Cashu Request fee estimate before payment.** iOS calculates the input fee and shows loading, no-fee, amount, or unavailable state; Android omits a fee row from Cashu Request confirmation. **Done when:** Android reserves and fills a fee row before the Pay action and does not present an unknown estimate as zero.
 
-- [ ] **[P1 · iOS → Android] Preserve relevant payment facts through terminal states.** Android’s processing, success, and failure screen can drop facts shown during confirmation. **Done when:** each rail has a documented stable row set across processing, success, and failure: amount and method; mint when applicable; destination for on-chain; network/input fees when applicable; and Cashu Request memo, route, or fee context when applicable.
+- [x] **[P1 · iOS → Android] Preserve relevant payment facts through terminal states.** Android’s processing, success, and failure screen can drop facts shown during confirmation. **Done when:** each rail has a documented stable row set across processing, success, and failure: amount and method; mint when applicable; destination for on-chain; network/input fees when applicable; and Cashu Request memo, route, or fee context when applicable.
 
 - [ ] **[P1 · Android → iOS] Explain rail-changing fallback and recovery routes.** Android explicitly identifies Lightning fallback, adding a requested mint, or topping up the target mint; iOS can rely only on a mint row or CTA wording. **Done when:** iOS names a route whenever it materially changes how the request will be paid or what recovery will occur. The ordinary compatible-mint route does not need a duplicate “Pay from” label.
 


### PR DESCRIPTION
## What changed

- add a typed immutable Android Send payment-detail contract
- preserve stable method, amount, mint, destination, fee, memo, and route rows as applicable
- use the same detail set across processing, success, and failure
- cover BOLT11, BOLT12, Lightning address, on-chain, and Cashu Request routes
- keep pending and unknown values explicit instead of presenting them as zero
- mark the matching parity checklist item complete

## Why

Unified Send confirmation knew payment facts that could be dropped when the flow moved into processing, success, or failure. Terminal screens therefore provided less context precisely when users needed to understand or recover a payment.

## User impact

Users retain the relevant payment context throughout every terminal phase, including on-chain destinations and Cashu Request memo, route, mint, and fee information.

## Validation

- focused Send detail tests: 7/7 passed
- full `:app:testDebugUnitTest`: passed
- `:app:assembleDebug`: passed
- `:app:compileDebugAndroidTestKotlin`: passed
- Compose terminal-state test: 1/1 passed twice
- `git diff --check`: passed

A later shared-AVD retry failed before test execution because package/activity services were unavailable; zero tests ran and there was no assertion failure.
