### PR TITLE
Support fiat-primary entry for ecash

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashAmountEntry.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashAmountEntry.kt
@@ -1,0 +1,64 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.UnitAmountEntry
+
+/**
+ * Amount-entry policy for Create Ecash.
+ *
+ * Sat-denominated ecash follows the saved sats/fiat primary unit and crosses
+ * into wallet operations only after conversion back to sats. Other mint units
+ * remain native base-unit entry and never pass through the BTC price.
+ */
+internal data class SendEcashEntryContext(
+    val isSatUnit: Boolean,
+    val unitDecimals: Int,
+    val satEntry: UnifiedSendEntryContext,
+) {
+    val isFiatEntry: Boolean
+        get() = isSatUnit && satEntry.primary == AmountDisplayPrimary.Fiat
+
+    val keypadDecimals: Int
+        get() = if (isFiatEntry) 2 else unitDecimals
+
+    fun amountBaseUnits(raw: String): Long =
+        if (isSatUnit) {
+            UnifiedSendAmountEntry.amountSats(raw, satEntry)
+        } else {
+            UnitAmountEntry.baseUnits(raw, unitDecimals)
+        }
+
+    fun maxRawForBalance(balance: Long): String =
+        if (isSatUnit) {
+            UnifiedSendAmountEntry.maxRawForBalance(balance, satEntry)
+        } else {
+            UnitAmountEntry.entryString(balance, unitDecimals)
+        }
+}
+
+internal object SendEcashAmountEntry {
+    fun context(
+        unit: String,
+        unitDecimals: Int,
+        preferredPrimary: String,
+        btcPrice: Double,
+    ): SendEcashEntryContext = SendEcashEntryContext(
+        isSatUnit = unit.equals("sat", ignoreCase = true),
+        unitDecimals = unitDecimals,
+        satEntry = UnifiedSendAmountEntry.context(preferredPrimary, btcPrice),
+    )
+
+    /**
+     * Re-express a live sat amount only when its effective entry unit changes.
+     * Unit-picker changes clear the entry separately, so native mint-unit
+     * amounts are deliberately never reinterpreted as sats or fiat.
+     */
+    fun convert(
+        raw: String,
+        from: SendEcashEntryContext,
+        to: SendEcashEntryContext,
+    ): String {
+        if (!from.isSatUnit || !to.isSatUnit) return raw
+        return UnifiedSendAmountEntry.convert(raw, from.satEntry, to.satEntry)
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -51,6 +52,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -66,6 +68,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -74,7 +78,6 @@ import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
-import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
@@ -166,7 +169,14 @@ fun SendEcashScreen(
     }
     val currency = CurrencyRegistry.currencyForMintUnit(effectiveUnit)
     val isSatUnit = effectiveUnit.equals("sat", ignoreCase = true)
-    val amountValue = UnitAmountEntry.baseUnits(amount, currency.decimals)
+    val amountEntryContext = SendEcashAmountEntry.context(
+        unit = effectiveUnit,
+        unitDecimals = currency.decimals,
+        preferredPrimary = settings.amountDisplayPrimary,
+        btcPrice = priceState.btcPrice,
+    )
+    var previousAmountEntryContext by remember { mutableStateOf(amountEntryContext) }
+    val amountValue = amountEntryContext.amountBaseUnits(amount)
 
     // Per-(mint, unit) spendable balance. Sat answers from cache; non-sat loads
     // through the CDK unit wallet on demand.
@@ -178,6 +188,17 @@ fun SendEcashScreen(
     }
     val mintBalance = if (isSatUnit) activeMint?.balance ?: 0L else nonSatBalance ?: 0L
     val balanceLoading = !isSatUnit && nonSatBalance == null
+
+    // Re-express a live sat amount when fiat entry becomes available or the
+    // saved primary changes. The conversion boundary preserves its sat value.
+    LaunchedEffect(amountEntryContext) {
+        amount = SendEcashAmountEntry.convert(
+            raw = amount,
+            from = previousAmountEntryContext,
+            to = amountEntryContext,
+        )
+        previousAmountEntryContext = amountEntryContext
+    }
 
     // Normalize and validate the P2PK input only when the lock is on.
     val validatedP2pkPubkey: String? = remember(p2pkOn, p2pkInput) {
@@ -284,7 +305,7 @@ fun SendEcashScreen(
                     onPickMint = { pickerOpen = true },
                     onUseMax = {
                         if (mintBalance > 0L) {
-                            amount = UnitAmountEntry.entryString(mintBalance, currency.decimals)
+                            amount = amountEntryContext.maxRawForBalance(mintBalance)
                         }
                     },
                     canUseMax = mintBalance > 0L,
@@ -298,11 +319,18 @@ fun SendEcashScreen(
                         isSatUnit -> formatter.formatWalletSats(mintBalance, settings.useBitcoinSymbol)
                         else -> CurrencyAmount(mintBalance, currency).formatted()
                     },
-                    isSat = isSatUnit,
-                    unit = effectiveUnit,
+                    isSat = isSatUnit && !amountEntryContext.isFiatEntry,
+                    unit = if (amountEntryContext.isFiatEntry) {
+                        priceState.currencyCode
+                    } else {
+                        effectiveUnit
+                    },
                     useBitcoinSymbol = settings.useBitcoinSymbol,
                     formatter = formatter,
-                    decimals = currency.decimals,
+                    decimals = amountEntryContext.keypadDecimals,
+                    fiatCurrencyCode = priceState.currencyCode.takeIf {
+                        amountEntryContext.isFiatEntry
+                    },
                     sending = sending,
                     errorText = errorText,
                     p2pkOn = p2pkOn,
@@ -369,23 +397,24 @@ fun SendEcashScreen(
                     result = current.result,
                     mintUrl = current.mintUrl,
                     unit = current.unit,
-                    amountSats = current.amount,
                     pollingEnabled = settings.checkSentTokens,
-                    amountLabel = if (current.unit.equals("sat", ignoreCase = true)) {
-                        formatter.formatWalletSats(current.amount, settings.useBitcoinSymbol)
-                    } else {
-                        CurrencyAmount(
-                            current.amount,
-                            CurrencyRegistry.currencyForMintUnit(current.unit),
-                        ).formatted()
-                    },
+                    amountPresentation = paymentConfirmationAmountPresentation(
+                        amount = current.amount,
+                        unit = current.unit,
+                        preferredPrimary = settings.amountDisplayPrimary,
+                        showFiat = settings.showFiatBalance,
+                        btcPrice = priceState.btcPrice,
+                        currencyCode = priceState.currencyCode,
+                        useBitcoinSymbol = settings.useBitcoinSymbol,
+                        formatter = formatter,
+                    ),
                     fiatLabel = if (current.unit.equals("sat", ignoreCase = true) &&
                         settings.showFiatBalance && priceState.btcPrice > 0
                     ) {
                         formatter.formatFiat(
                             current.amount,
                             priceState.btcPrice,
-                            settings.bitcoinPriceCurrency,
+                            priceState.currencyCode,
                         )
                     } else {
                         null
@@ -445,6 +474,7 @@ private fun InputFace(
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
     decimals: Int,
+    fiatCurrencyCode: String?,
     sending: Boolean,
     errorText: String?,
     p2pkOn: Boolean,
@@ -505,6 +535,7 @@ private fun InputFace(
             decimals = decimals,
             useBitcoinSymbol = useBitcoinSymbol,
             formatter = formatter,
+            fiatCurrencyCode = fiatCurrencyCode,
             color = amountColor,
         )
 
@@ -626,9 +657,8 @@ private fun GeneratedFace(
     result: SendTokenResult,
     mintUrl: String,
     unit: String,
-    amountSats: Long,
     pollingEnabled: Boolean,
-    amountLabel: String,
+    amountPresentation: PaymentConfirmationAmountPresentation,
     fiatLabel: String?,
     onDone: () -> Unit,
 ) {
@@ -675,7 +705,7 @@ private fun GeneratedFace(
             rows = {
                 com.cashu.me.ui.components.InspectorRow(
                     label = "Amount",
-                    value = amountLabel,
+                    value = amountPresentation.primary,
                     leadingIcon = Icons.Outlined.Payments,
                 )
                 com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
@@ -708,11 +738,7 @@ private fun GeneratedFace(
                 content = result.token,
                 shareSubject = "Cashu token",
             )
-            Text(
-                text = amountLabel,
-                style = MaterialTheme.typography.headlineMedium.withMonoDigits(),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
+            GeneratedEcashAmount(presentation = amountPresentation)
             ClaimStatusRow(claimState = claimState)
             // Detail rows: Fee -> Unit -> Fiat (sat-only) -> Mint (iOS order).
             Column(modifier = Modifier.fillMaxWidth()) {
@@ -764,6 +790,41 @@ private fun GeneratedFace(
             ),
         )
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+    }
+}
+
+@Composable
+private fun GeneratedEcashAmount(
+    presentation: PaymentConfirmationAmountPresentation,
+) {
+    Column(
+        modifier = Modifier.clearAndSetSemantics {
+            contentDescription = presentation.talkBackDescription
+        },
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+    ) {
+        Text(
+            text = presentation.primary,
+            style = MaterialTheme.typography.headlineMedium.withMonoDigits(),
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        presentation.alternate?.let { alternate ->
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ) {
+                Text(
+                    text = alternate,
+                    modifier = Modifier.padding(
+                        horizontal = CashuTheme.spacing.default,
+                        vertical = CashuTheme.spacing.micro,
+                    ),
+                    style = MaterialTheme.typography.labelLarge.withMonoDigits(),
+                )
+            }
+        }
     }
 }
 

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendEcashAmountEntryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendEcashAmountEntryTest.kt
@@ -1,0 +1,125 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.AmountFormatter
+import java.util.Locale
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SendEcashAmountEntryTest {
+    @Test
+    fun savedFiatPrimaryDrivesSatEcashEntryAndValidation() {
+        val context = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            btcPrice = 50_000.0,
+        )
+
+        assertTrue(context.isFiatEntry)
+        assertEquals(2, context.keypadDecimals)
+        assertEquals(25_000L, context.amountBaseUnits("12.50"))
+        assertEquals(
+            UnifiedSendAmountValidation.Valid,
+            UnifiedSendAmountEntry.validation(context.amountBaseUnits("12.50"), 25_000L),
+        )
+        assertEquals(
+            UnifiedSendAmountValidation.InsufficientBalance,
+            UnifiedSendAmountEntry.validation(context.amountBaseUnits("12.51"), 25_000L),
+        )
+    }
+
+    @Test
+    fun fiatSendMaxNeverExceedsTheAvailableSats() {
+        val context = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            btcPrice = 50_000.0,
+        )
+
+        val raw = context.maxRawForBalance(12_350L)
+
+        assertEquals("6.17", raw)
+        assertEquals(12_340L, context.amountBaseUnits(raw))
+        assertTrue(context.amountBaseUnits(raw) <= 12_350L)
+    }
+
+    @Test
+    fun savedSatsPrimaryKeepsExactSatEntryAndSendMax() {
+        val context = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
+            btcPrice = 50_000.0,
+        )
+
+        assertFalse(context.isFiatEntry)
+        assertEquals(0, context.keypadDecimals)
+        assertEquals(12_350L, context.amountBaseUnits("12350"))
+        assertEquals("12350", context.maxRawForBalance(12_350L))
+    }
+
+    @Test
+    fun changingTheSavedPrimaryReexpressesTheEntryWithoutChangingSats() {
+        val sats = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Sats.rawValue,
+            btcPrice = 50_000.0,
+        )
+        val fiat = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            btcPrice = 50_000.0,
+        )
+
+        val converted = SendEcashAmountEntry.convert("25000", sats, fiat)
+
+        assertEquals("12.50", converted)
+        assertEquals(25_000L, fiat.amountBaseUnits(converted))
+    }
+
+    @Test
+    fun nonSatMintUnitRemainsNativeInsteadOfUsingTheBitcoinPrice() {
+        val context = SendEcashAmountEntry.context(
+            unit = "usd",
+            unitDecimals = 2,
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            btcPrice = 50_000.0,
+        )
+
+        assertFalse(context.isFiatEntry)
+        assertEquals(1_250L, context.amountBaseUnits("12.50"))
+        assertEquals("12.50", context.maxRawForBalance(1_250L))
+    }
+
+    @Test
+    fun generatedEcashLeadsWithFiatButKeepsTheConvertedSatAmount() {
+        val entry = SendEcashAmountEntry.context(
+            unit = "sat",
+            unitDecimals = 0,
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            btcPrice = 50_000.0,
+        )
+        val amountSats = entry.amountBaseUnits("12.50")
+
+        val presentation = paymentConfirmationAmountPresentation(
+            amount = amountSats,
+            unit = "sat",
+            preferredPrimary = AmountDisplayPrimary.Fiat.rawValue,
+            showFiat = true,
+            btcPrice = 50_000.0,
+            currencyCode = "USD",
+            useBitcoinSymbol = false,
+            formatter = AmountFormatter(Locale.US),
+        )
+
+        assertEquals(25_000L, amountSats)
+        assertEquals("$12.50", presentation.primary)
+        assertEquals("25,000 sat", presentation.alternate)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -58,7 +58,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Send — ecash and locked ecash
 
-- [ ] **[P1 · iOS → Android] Support fiat-primary entry when creating ecash.** iOS allows sat-denominated ecash to be entered in the preferred fiat unit; Android’s ecash keypad always uses sats. **Done when:** Android entry, validation, Send Max, and the generated amount honor the saved primary unit.
+- [x] **[P1 · iOS → Android] Support fiat-primary entry when creating ecash.** iOS allows sat-denominated ecash to be entered in the preferred fiat unit; Android’s ecash keypad always uses sats. **Done when:** Android entry, validation, Send Max, and the generated amount honor the saved primary unit.
 
 - [ ] **[P1 · iOS → Android] Add scanning for a P2PK recipient key.** iOS can scan a public key and validate it before locking; Android only provides manual entry and “Lock to my key.” **Done when:** Android can scan, paste, or type a recipient key through one validation path with equivalent error handling.
 


### PR DESCRIPTION
## What changed

- Make sat-denominated Create Ecash entry follow the saved fiat/sats primary unit when a BTC price is available.
- Convert fiat keypad cents back to sats before balance validation and token generation.
- Make Send Max produce the closest fiat entry that never exceeds the available sat balance.
- Show the generated ecash amount with the saved primary value and its alternate, while retaining the exact converted sat amount used to create the token.
- Keep explicit non-sat mint units in their native base-unit entry path.
- Mark the corresponding iOS/Android parity checklist item complete.

## Why

Users who selected fiat as their primary amount unit still had to create ecash by entering sats on Android, unlike iOS.

## Root cause

Android's ecash screen parsed the keypad directly with the selected mint unit's decimals. For sat wallets that always meant integer sats, so it bypassed the saved primary-unit conversion already used by unified Send. The generated-token screen likewise always led with sats.

## Impact

Users who prefer fiat can now enter, validate, max, and review sat-denominated ecash in their selected fiat currency. Wallet operations still receive sats, and sats-primary plus non-sat mint-unit behavior remains unchanged.

## Checks

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.send.SendEcashAmountEntryTest --stacktrace`
- `./gradlew --no-daemon :app:testDebugUnitTest --stacktrace`
- `./gradlew --no-daemon :app:assembleDebug --stacktrace`
