### PR TITLE
Confirm P2PK recipients on Android

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveActualFeeComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveActualFeeComposeTest.kt
@@ -29,7 +29,7 @@ class ReceiveActualFeeComposeTest {
                 proofCount = 1,
             ),
             fee = 3,
-            locked = false,
+            p2pkLock = P2PKLockState.Unlocked,
         )
         val claimed = settledTokenClaim(review, creditedAmount = 93)
 

--- a/android/app/src/androidTest/java/com/cashu/me/ui/send/P2pkRecipientConfirmationComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/send/P2pkRecipientConfirmationComposeTest.kt
@@ -1,0 +1,80 @@
+package com.cashu.me.ui.send
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.settings.P2PKKeyDisplay
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class P2pkRecipientConfirmationComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    private val recipient = "02${"a".repeat(64)}"
+
+    @Test
+    fun ownRecipientConfirmationIsCompactAndActionsAreAccessible() {
+        var editClicks = 0
+        var removeClicks = 0
+        compose.setCashuContent {
+            P2pkLockSection(
+                input = recipient,
+                onInputChange = {},
+                inputError = null,
+                confirmedPubkey = recipient,
+                recipientIsOwnKey = true,
+                onEditRecipient = { editClicks += 1 },
+                onRemoveRecipient = { removeClicks += 1 },
+                myKeyHex = recipient,
+                onUseMyKey = {},
+            )
+        }
+
+        compose.onNodeWithText("Locked to").assertIsDisplayed()
+        compose.onNodeWithText("Your key").assertIsDisplayed()
+        compose.onNodeWithText("Recipient P2PK pubkey").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Locked ecash recipient: Your key")
+            .assertIsDisplayed()
+        compose.onNodeWithContentDescription("Edit locked ecash recipient")
+            .assertIsDisplayed()
+            .performClick()
+        compose.onNodeWithContentDescription("Remove locked ecash recipient")
+            .assertIsDisplayed()
+            .performClick()
+
+        compose.runOnIdle {
+            assertEquals(1, editClicks)
+            assertEquals(1, removeClicks)
+        }
+    }
+
+    @Test
+    fun externalRecipientUsesTruncatedPublicKeyIdentity() {
+        val label = P2PKKeyDisplay.shortLabel(recipient)
+        compose.setCashuContent {
+            P2pkLockSection(
+                input = recipient,
+                onInputChange = {},
+                inputError = null,
+                confirmedPubkey = recipient,
+                recipientIsOwnKey = false,
+                onEditRecipient = {},
+                onRemoveRecipient = {},
+                myKeyHex = null,
+                onUseMyKey = {},
+            )
+        }
+
+        compose.onNodeWithText(label).assertIsDisplayed()
+        compose.onNodeWithContentDescription("Locked ecash recipient: $label")
+            .assertIsDisplayed()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
@@ -42,6 +43,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.outlined.AccountBalance
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.Payments
@@ -70,7 +72,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -97,6 +102,7 @@ import com.cashu.me.ui.components.TwoFaceScreen
 import com.cashu.me.ui.components.UnitPickerSheet
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.components.ToolbarIcon
+import com.cashu.me.ui.settings.P2PKKeyDisplay
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.rememberReducedMotion
 import com.cashu.me.ui.theme.withMonoDigits
@@ -147,6 +153,7 @@ fun SendEcashScreen(
     var p2pkOn by remember { mutableStateOf(false) }
     var p2pkInput by remember { mutableStateOf("") }
     var p2pkInputError by remember { mutableStateOf<String?>(null) }
+    var p2pkEditing by remember { mutableStateOf(true) }
 
     val activeMintUrl = selectedMintUrl ?: walletState.activeMint?.url
     val activeMint = walletState.mints.firstOrNull { it.url == activeMintUrl } ?: walletState.activeMint
@@ -206,6 +213,22 @@ fun SendEcashScreen(
         else runCatching {
             com.cashu.me.Core.SettingsManager.normalizeP2PKPublicKeyForSend(p2pkInput)
         }.getOrNull()
+    }
+    val primaryP2pkPublicKey = settingsManager.primaryP2PKKeyInfo()?.publicKey
+    val p2pkRecipientIsOwnKey = validatedP2pkPubkey?.let { recipient ->
+        isOwnP2pkRecipient(
+            recipient = recipient,
+            ownPublicKeys = buildList {
+                primaryP2pkPublicKey?.let(::add)
+                addAll(settings.p2pkKeys.map { it.publicKey })
+            },
+        )
+    } == true
+    LaunchedEffect(p2pkOn, validatedP2pkPubkey) {
+        when {
+            !p2pkOn -> p2pkEditing = true
+            validatedP2pkPubkey != null -> p2pkEditing = false
+        }
     }
     LaunchedEffect(p2pkOn, p2pkInput) {
         if (!p2pkOn) {
@@ -337,13 +360,20 @@ fun SendEcashScreen(
                     p2pkInput = p2pkInput,
                     onP2pkInputChange = { p2pkInput = it },
                     p2pkInputError = p2pkInputError,
+                    confirmedP2pkPubkey = validatedP2pkPubkey?.takeUnless { p2pkEditing },
+                    p2pkRecipientIsOwnKey = p2pkRecipientIsOwnKey,
+                    onEditP2pkRecipient = { p2pkEditing = true },
+                    onRemoveP2pkRecipient = {
+                        p2pkInput = ""
+                        p2pkOn = false
+                    },
                     // iOS "Lock to my key" shortcut: opt-in via the Locked Ecash
                     // toggle, and it targets the seed-derived primary key.
                     p2pkMyKeyHex = if (settings.showP2PKButtonInDrawer) {
-                        settingsManager.primaryP2PKKeyInfo()?.publicKey
+                        primaryP2pkPublicKey
                     } else null,
                     onUseMyP2pkKey = {
-                        settingsManager.primaryP2PKKeyInfo()?.let { p2pkInput = it.publicKey }
+                        primaryP2pkPublicKey?.let { p2pkInput = it }
                     },
                     canSendWithP2pk = !p2pkOn || validatedP2pkPubkey != null,
                     onSend = {
@@ -481,6 +511,10 @@ private fun InputFace(
     p2pkInput: String,
     onP2pkInputChange: (String) -> Unit,
     p2pkInputError: String?,
+    confirmedP2pkPubkey: String?,
+    p2pkRecipientIsOwnKey: Boolean,
+    onEditP2pkRecipient: () -> Unit,
+    onRemoveP2pkRecipient: () -> Unit,
     p2pkMyKeyHex: String?,
     onUseMyP2pkKey: () -> Unit,
     canSendWithP2pk: Boolean,
@@ -544,6 +578,10 @@ private fun InputFace(
                 input = p2pkInput,
                 onInputChange = onP2pkInputChange,
                 inputError = p2pkInputError,
+                confirmedPubkey = confirmedP2pkPubkey,
+                recipientIsOwnKey = p2pkRecipientIsOwnKey,
+                onEditRecipient = onEditP2pkRecipient,
+                onRemoveRecipient = onRemoveP2pkRecipient,
                 myKeyHex = p2pkMyKeyHex,
                 onUseMyKey = onUseMyP2pkKey,
             )
@@ -608,14 +646,94 @@ private fun InputFace(
     }
 }
 
+internal fun isOwnP2pkRecipient(
+    recipient: String,
+    ownPublicKeys: Iterable<String>,
+): Boolean {
+    val comparableRecipient = SettingsManager.normalizeP2PKPublicKeyForComparison(recipient)
+    return ownPublicKeys.any { ownKey ->
+        SettingsManager.normalizeP2PKPublicKeyForComparison(ownKey) == comparableRecipient
+    }
+}
+
 @Composable
-private fun P2pkLockSection(
+internal fun P2pkLockSection(
     input: String,
     onInputChange: (String) -> Unit,
     inputError: String?,
+    confirmedPubkey: String?,
+    recipientIsOwnKey: Boolean,
+    onEditRecipient: () -> Unit,
+    onRemoveRecipient: () -> Unit,
     myKeyHex: String?,
     onUseMyKey: () -> Unit,
 ) {
+    if (confirmedPubkey != null) {
+        val recipientLabel = if (recipientIsOwnKey) {
+            "Your key"
+        } else {
+            P2PKKeyDisplay.shortLabel(confirmedPubkey)
+        }
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics {
+                    contentDescription = "Locked ecash recipient: $recipientLabel"
+                },
+            shape = MaterialTheme.shapes.medium,
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 56.dp)
+                    .padding(start = CashuTheme.spacing.default, end = CashuTheme.spacing.micro),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.tight),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.CheckCircle,
+                    contentDescription = null,
+                    tint = CashuTheme.colors.received,
+                    modifier = Modifier.size(CashuTheme.spacing.comfortable),
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Locked to",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = recipientLabel,
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = if (recipientIsOwnKey) {
+                                FontFamily.Default
+                            } else {
+                                FontFamily.Monospace
+                            },
+                        ),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.MiddleEllipsis,
+                    )
+                }
+                IconButton(onClick = onEditRecipient) {
+                    Icon(
+                        imageVector = Icons.Outlined.Edit,
+                        contentDescription = "Edit locked ecash recipient",
+                    )
+                }
+                IconButton(onClick = onRemoveRecipient) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = "Remove locked ecash recipient",
+                    )
+                }
+            }
+        }
+        return
+    }
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.tight),

--- a/android/app/src/test/java/com/cashu/me/ui/send/P2pkRecipientIdentityTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/P2pkRecipientIdentityTest.kt
@@ -1,0 +1,39 @@
+package com.cashu.me.ui.send
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class P2pkRecipientIdentityTest {
+    private val xOnlyKey = "a".repeat(64)
+
+    @Test
+    fun primaryCompressedKeyIsRecognizedAsOwnRecipient() {
+        assertTrue(
+            isOwnP2pkRecipient(
+                recipient = "02$xOnlyKey",
+                ownPublicKeys = listOf("02$xOnlyKey"),
+            ),
+        )
+    }
+
+    @Test
+    fun storedXOnlyKeyIsRecognizedAsOwnRecipient() {
+        assertTrue(
+            isOwnP2pkRecipient(
+                recipient = "03$xOnlyKey",
+                ownPublicKeys = listOf(xOnlyKey),
+            ),
+        )
+    }
+
+    @Test
+    fun externalKeyIsNotMarkedAsOwnRecipient() {
+        assertFalse(
+            isOwnP2pkRecipient(
+                recipient = "02${"b".repeat(64)}",
+                ownPublicKeys = listOf("02$xOnlyKey", "c".repeat(64)),
+            ),
+        )
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -62,7 +62,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Add scanning for a P2PK recipient key.** iOS can scan a public key and validate it before locking; Android only provides manual entry and “Lock to my key.” **Done when:** Android can scan, paste, or type a recipient key through one validation path with equivalent error handling.
 
-- [ ] **[P2 · iOS → Android] Show a clear confirmed P2PK recipient state.** Android leaves the full technical input field in the amount layout after validation; iOS replaces it with a compact confirmation. **Done when:** Android clearly identifies the validated recipient, distinguishes “your key” where applicable, and provides accessible edit and remove actions. The exact iOS chip treatment is not required.
+- [x] **[P2 · iOS → Android] Show a clear confirmed P2PK recipient state.** Android leaves the full technical input field in the amount layout after validation; iOS replaces it with a compact confirmation. **Done when:** Android clearly identifies the validated recipient, distinguishes “your key” where applicable, and provides accessible edit and remove actions. The exact iOS chip treatment is not required.
 
 - [ ] **[P2 · iOS → Android] Replace protocol jargon in lock accessibility copy.** Android announces “P2PK off” and “P2PK locked”; iOS describes the user outcome. **Done when:** Android’s visible and assistive copy leads with “Lock ecash” and the recipient effect, with P2PK only as optional supporting terminology.
 


### PR DESCRIPTION
## What changed

- Replace the full P2PK public-key field with a compact confirmed-recipient surface once validation succeeds.
- Show `Your key` for the wallet's primary or stored device keys; otherwise show the shared middle-truncated public-key identity.
- Add 48dp Edit and Remove actions with explicit accessibility labels.
- Add JVM ownership-matching tests and Compose tests for own/external recipient rendering and action semantics.
- Mark the corresponding iOS/Android parity checklist item complete.

## Why

Users need a clear, compact confirmation of who can claim locked ecash before they send it.

## Root cause

The Android lock section had a single rendering mode. Validation enabled sending, but the full technical input remained in the amount layout, so users had no concise confirmation of the lock target and no explicit edit or remove controls.

## Impact

After a recipient key validates, Android now clearly identifies the lock target without keeping the technical field prominent. Users can distinguish wallet-owned keys from external recipients and can edit or remove the recipient through accessible controls.

## Checks

- `./gradlew --no-daemon :app:testDebugUnitTest` — 387 tests passed
- `./gradlew --no-daemon :app:assembleDebug`
- `./gradlew --no-daemon :app:compileDebugAndroidTestKotlin`
- Focused `P2pkRecipientConfirmationComposeTest` on an API 36 emulator — 2/2 tests passed
