### PR TITLE
Improve lock ecash accessibility copy

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/send/LockEcashAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/send/LockEcashAccessibilityComposeTest.kt
@@ -52,6 +52,10 @@ class LockEcashAccessibilityComposeTest {
                 input = "",
                 onInputChange = {},
                 inputError = null,
+                confirmedPubkey = null,
+                recipientIsOwnKey = false,
+                onEditRecipient = {},
+                onRemoveRecipient = {},
                 myKeyHex = "02${"a".repeat(64)}",
                 onUseMyKey = {},
             )

--- a/android/app/src/androidTest/java/com/cashu/me/ui/send/LockEcashAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/send/LockEcashAccessibilityComposeTest.kt
@@ -1,0 +1,83 @@
+package com.cashu.me.ui.send
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LockEcashAccessibilityComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun lockControlAnnouncesPlainLanguageOutcomeForBothStates() {
+        compose.setCashuContent {
+            var locked by remember { mutableStateOf(false) }
+            LockEcashToolbarAction(
+                locked = locked,
+                onToggle = { locked = !locked },
+            )
+        }
+
+        assertLockSemantics(
+            state = "Off. Anyone with the ecash token can claim it.",
+        )
+
+        compose.onNodeWithTag(UiTestTags.LockEcashToggle).performClick()
+
+        assertLockSemantics(
+            state = "On. Only the recipient with the selected key can claim it.",
+        )
+    }
+
+    @Test
+    fun expandedLockSectionLeadsWithOutcomeAndKeepsProtocolNameSupporting() {
+        compose.setCashuContent {
+            P2pkLockSection(
+                input = "",
+                onInputChange = {},
+                inputError = null,
+                myKeyHex = "02${"a".repeat(64)}",
+                onUseMyKey = {},
+            )
+        }
+
+        compose.onNodeWithText(LockEcashCopy.Label).assertIsDisplayed()
+        compose.onNodeWithText(LockEcashCopy.RecipientEffect).assertIsDisplayed()
+        compose.onNodeWithText(LockEcashCopy.RecipientKeyLabel).assertIsDisplayed()
+        compose.onNodeWithText("Lock ecash to my key").assertIsDisplayed()
+    }
+
+    private fun assertLockSemantics(state: String) {
+        val semantics = compose.onNodeWithTag(UiTestTags.LockEcashToggle)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .config
+
+        assertEquals(
+            listOf(LockEcashCopy.Label),
+            semantics[SemanticsProperties.ContentDescription],
+        )
+        assertEquals(state, semantics[SemanticsProperties.StateDescription])
+        assertFalse(
+            semantics[SemanticsProperties.ContentDescription]
+                .any { it.contains("P2PK", ignoreCase = true) },
+        )
+        assertFalse(state.contains("P2PK", ignoreCase = true))
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.TextOverflow
@@ -111,6 +112,20 @@ import com.cashu.me.ui.testing.UiTestTags
 // Inline status icons inside dense rows — smaller than the standard 20dp body icon.
 private val STATUS_ICON_SMALL = 18.dp
 private val CHECKING_PROGRESS_SIZE = 14.dp
+
+internal object LockEcashCopy {
+    const val Label = "Lock ecash"
+    const val RecipientEffect = "Only the recipient with this public key can claim it."
+    const val RecipientKeyLabel = "Recipient public key (P2PK)"
+    const val InvalidRecipientKey =
+        "Enter a valid recipient public key: 64 hex characters, or 66 beginning with 02 or 03."
+
+    fun stateDescription(locked: Boolean): String = if (locked) {
+        "On. Only the recipient with the selected key can claim it."
+    } else {
+        "Off. Anyone with the ecash token can claim it."
+    }
+}
 
 private sealed interface SendFace {
     data object Input : SendFace
@@ -242,7 +257,7 @@ fun SendEcashScreen(
         }
         p2pkInputError = runCatching {
             com.cashu.me.Core.SettingsManager.normalizeP2PKPublicKeyForSend(trimmed)
-        }.exceptionOrNull()?.message
+        }.exceptionOrNull()?.let { LockEcashCopy.InvalidRecipientKey }
     }
 
     // Generation counts as money-in-motion: block sheet dismissal.
@@ -286,15 +301,10 @@ fun SendEcashScreen(
                     }
                 } else if (current is SendFace.Input) {
                     // iOS toolbar order: lock, then unit (unit sits to the lock's right).
-                    IconButton(onClick = { p2pkOn = !p2pkOn }) {
-                        ToolbarIcon(
-                            imageVector = if (p2pkOn) Icons.Filled.Lock
-                            else Icons.Outlined.LockOpen,
-                            contentDescription = if (p2pkOn) "P2PK locked" else "P2PK off",
-                            tint = if (p2pkOn) MaterialTheme.colorScheme.onSurface
-                            else MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
+                    LockEcashToolbarAction(
+                        locked = p2pkOn,
+                        onToggle = { p2pkOn = !p2pkOn },
+                    )
                     if (activeMint?.supportsMultipleUnits == true) {
                         androidx.compose.material3.TextButton(onClick = { unitPickerOpen = true }) {
                             Text(
@@ -387,7 +397,7 @@ fun SendEcashScreen(
                             return@InputFace
                         }
                         if (p2pkOn && validatedP2pkPubkey == null) {
-                            errorText = p2pkInputError ?: "Enter a valid P2PK pubkey."
+                            errorText = p2pkInputError ?: LockEcashCopy.InvalidRecipientKey
                             return@InputFace
                         }
                         sending = true
@@ -657,6 +667,28 @@ internal fun isOwnP2pkRecipient(
 }
 
 @Composable
+internal fun LockEcashToolbarAction(
+    locked: Boolean,
+    onToggle: () -> Unit,
+) {
+    IconButton(
+        onClick = onToggle,
+        modifier = Modifier
+            .testTag(UiTestTags.LockEcashToggle)
+            .semantics {
+                stateDescription = LockEcashCopy.stateDescription(locked)
+            },
+    ) {
+        ToolbarIcon(
+            imageVector = if (locked) Icons.Filled.Lock else Icons.Outlined.LockOpen,
+            contentDescription = LockEcashCopy.Label,
+            tint = if (locked) MaterialTheme.colorScheme.onSurface
+            else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
 internal fun P2pkLockSection(
     input: String,
     onInputChange: (String) -> Unit,
@@ -738,12 +770,22 @@ internal fun P2pkLockSection(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.tight),
     ) {
+        Text(
+            text = LockEcashCopy.Label,
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Text(
+            text = LockEcashCopy.RecipientEffect,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         CashuTextField(
             value = input,
             onValueChange = onInputChange,
             modifier = Modifier.fillMaxWidth(),
-            label = "Recipient P2PK pubkey",
-            placeholder = "02… or 64-char hex",
+            label = LockEcashCopy.RecipientKeyLabel,
+            placeholder = "02… or 64-character hex",
             singleLine = true,
             keyboardOptions = KeyboardOptions(
                 capitalization = androidx.compose.ui.text.input.KeyboardCapitalization.None,
@@ -762,7 +804,7 @@ internal fun P2pkLockSection(
         }
         if (myKeyHex != null) {
             com.cashu.me.ui.components.GhostButton(
-                text = "Lock to my key",
+                text = "Lock ecash to my key",
                 onClick = onUseMyKey,
             )
         }

--- a/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
@@ -41,6 +41,7 @@ object UiTestTags {
     const val SendPaymentSubmit = "cashu.send.payment.submit"
     const val SendEcashScreen = "cashu.sheet.send-ecash"
     const val SendEcashSubmit = "cashu.send.ecash.submit"
+    const val LockEcashToggle = "cashu.send.ecash.lock-toggle"
     const val AddMintSheet = "cashu.sheet.add-mint"
     const val AddMintUrl = "cashu.sheet.add-mint.url"
     const val AddMintSubmit = "cashu.sheet.add-mint.submit"

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -64,7 +64,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P2 · iOS → Android] Show a clear confirmed P2PK recipient state.** Android leaves the full technical input field in the amount layout after validation; iOS replaces it with a compact confirmation. **Done when:** Android clearly identifies the validated recipient, distinguishes “your key” where applicable, and provides accessible edit and remove actions. The exact iOS chip treatment is not required.
 
-- [ ] **[P2 · iOS → Android] Replace protocol jargon in lock accessibility copy.** Android announces “P2PK off” and “P2PK locked”; iOS describes the user outcome. **Done when:** Android’s visible and assistive copy leads with “Lock ecash” and the recipient effect, with P2PK only as optional supporting terminology.
+- [x] **[P2 · iOS → Android] Replace protocol jargon in lock accessibility copy.** Android announces “P2PK off” and “P2PK locked”; iOS describes the user outcome. **Done when:** Android’s visible and assistive copy leads with “Lock ecash” and the recipient effect, with P2PK only as optional supporting terminology.
 
 - [ ] **[P1 · iOS → Android] Provide manual claim-status checking when automatic checks are disabled.** iOS adds “Check Status” to pending-token actions; Android leaves the token at Pending with no equivalent action. **Done when:** Android users can run a one-off spent check without re-enabling background polling.
 


### PR DESCRIPTION
## What changed

- Replace the Android lock toolbar's `P2PK off` and `P2PK locked` announcements with a stable `Lock ecash` label and plain-language state descriptions.
- Lead the expanded lock section with the recipient outcome, keep P2PK as supporting terminology, and use plain-language validation and quick-action copy.
- Add Compose accessibility coverage for both toggle states and the visible expanded-section copy.
- Mark the matching iOS/Android parity checklist item complete.

## Why

The lock control exposed protocol jargon instead of explaining what enabling the lock means for the recipient. This made the action and its current state unclear, especially with TalkBack.

## Root cause

The toolbar icon's content description was derived directly from the internal P2PK state. The expanded form likewise led with the protocol name rather than the claim restriction users are choosing.

## User impact

TalkBack now announces `Lock ecash` and whether anyone with the token or only the selected recipient can claim it. Sighted users see the same outcome-led explanation when the lock section is open.

## Checks

- `./gradlew --no-daemon :app:compileDebugAndroidTestKotlin :app:testDebugUnitTest :app:assembleDebug --stacktrace`
- `./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.ui.send.LockEcashAccessibilityComposeTest --stacktrace`
- `./gradlew --no-daemon :app:compileDebugKotlin :app:testDebugUnitTest --stacktrace`
- `git diff --check`
