### PR TITLE
Unify Cashu Request Nostr readiness

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -72,10 +72,9 @@ class CashuRequestListener(
             )
             return
         }
-        val relays = settingsManager.state.value.nostrRelays
-            .map(String::trim)
-            .filter { it.startsWith("ws://") || it.startsWith("wss://") }
-            .distinct()
+        val relays = CashuRequestNostrReadiness.normalizedRelays(
+            settingsManager.state.value.nostrRelays,
+        )
         if (relays.isEmpty()) {
             mutableState.value = mutableState.value.copy(
                 isRunning = false,

--- a/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
@@ -1,5 +1,6 @@
 package com.cashu.me.Core
 
+import java.net.URI
 import java.util.Base64
 
 object PaymentRequestBuilder {
@@ -93,6 +94,72 @@ object PaymentRequestBuilder {
     }
 }
 
+sealed interface CashuRequestNostrReadiness {
+    data class Ready(
+        val publicKeyHex: String,
+        val relays: List<String>,
+    ) : CashuRequestNostrReadiness
+
+    data class Blocked(
+        val recoveryMessage: String,
+    ) : CashuRequestNostrReadiness
+
+    companion object {
+        const val NOSTR_KEY_RECOVERY =
+            "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again."
+        const val RELAY_RECOVERY =
+            "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again."
+        const val LISTENER_RECOVERY =
+            "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again."
+
+        fun current(
+            nostrService: NostrService,
+            settingsManager: SettingsManager,
+        ): CashuRequestNostrReadiness {
+            val nostr = nostrService.state.value
+            val settings = settingsManager.state.value
+            return evaluate(
+                isIdentityInitialized = nostr.isInitialized,
+                publicKeyHex = nostr.publicKeyHex,
+                privateKeyHex = nostrService.currentPrivateKey(),
+                relays = settings.nostrRelays,
+                listenerEnabled = settings.enablePaymentRequests,
+            )
+        }
+
+        internal fun evaluate(
+            isIdentityInitialized: Boolean,
+            publicKeyHex: String,
+            privateKeyHex: String?,
+            relays: List<String>,
+            listenerEnabled: Boolean,
+        ): CashuRequestNostrReadiness {
+            if (!isIdentityInitialized ||
+                !publicKeyHex.isHexKey() ||
+                privateKeyHex?.isHexKey() != true
+            ) {
+                return Blocked(NOSTR_KEY_RECOVERY)
+            }
+            val usableRelays = normalizedRelays(relays)
+            if (usableRelays.isEmpty()) return Blocked(RELAY_RECOVERY)
+            if (!listenerEnabled) return Blocked(LISTENER_RECOVERY)
+            return Ready(publicKeyHex = publicKeyHex, relays = usableRelays)
+        }
+
+        internal fun normalizedRelays(relays: List<String>): List<String> =
+            relays.map(String::trim)
+                .filter { relay ->
+                    runCatching { URI(relay) }.getOrNull()?.let { uri ->
+                        uri.scheme?.lowercase() in setOf("ws", "wss") && !uri.host.isNullOrBlank()
+                    } == true
+                }
+                .distinct()
+
+        private fun String.isHexKey(): Boolean =
+            length == 64 && all { it in '0'..'9' || it.lowercaseChar() in 'a'..'f' }
+    }
+}
+
 /**
  * Builds the "receive locked ecash" artifact: a NUT-18 Cashu payment request that
  * locks any payment to the wallet's primary (seed-derived) P2PK key and routes the
@@ -105,9 +172,9 @@ object LockedReceiveRequest {
         settingsManager: SettingsManager,
         amount: Long? = null,
     ): String? {
-        val nostrPubkey = nostrService.state.value.publicKeyHex.takeIf { it.isNotBlank() } ?: return null
+        val readiness = CashuRequestNostrReadiness.current(nostrService, settingsManager)
+        if (readiness !is CashuRequestNostrReadiness.Ready) return null
         val primary = settingsManager.primaryP2PKKeyInfo() ?: return null
-        val relays = settingsManager.state.value.nostrRelays.takeIf { it.isNotEmpty() } ?: return null
         return runCatching {
             PaymentRequestBuilder.build(
                 id = com.cashu.me.Models.CashuRequest.newId(),
@@ -115,8 +182,8 @@ object LockedReceiveRequest {
                 unit = "sat",
                 mints = emptyList(),
                 description = null,
-                nostrPubkeyHex = nostrPubkey,
-                relays = relays,
+                nostrPubkeyHex = readiness.publicKeyHex,
+                relays = readiness.relays,
                 p2pkPubkeyHex = primary.publicKey,
             )
         }.getOrNull()

--- a/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PaymentRequestBuilder.kt
@@ -95,6 +95,16 @@ object PaymentRequestBuilder {
 }
 
 sealed interface CashuRequestNostrReadiness {
+    data class RequestConfiguration(
+        val publicKeyHex: String,
+        val relays: List<String>,
+    )
+
+    data class DeliveryNotice(
+        val title: String,
+        val message: String,
+    )
+
     data class Ready(
         val publicKeyHex: String,
         val relays: List<String>,
@@ -102,7 +112,36 @@ sealed interface CashuRequestNostrReadiness {
 
     data class Blocked(
         val recoveryMessage: String,
+        val requestConfiguration: RequestConfiguration? = null,
     ) : CashuRequestNostrReadiness
+
+    fun requestConfigurationOrNull(): RequestConfiguration? = when (this) {
+        is Ready -> RequestConfiguration(publicKeyHex = publicKeyHex, relays = relays)
+        is Blocked -> requestConfiguration
+    }
+
+    /**
+     * Contextual copy for an already-created request. It avoids the "try again"
+     * wording used for creation errors because the QR remains shareable while
+     * the wallet's receive path is unavailable.
+     */
+    fun deliveryNoticeOrNull(): DeliveryNotice? {
+        val recoveryMessage = (this as? Blocked)?.recoveryMessage ?: return null
+        return when (recoveryMessage) {
+            NOSTR_KEY_RECOVERY -> DeliveryNotice(
+                title = "Nostr key unavailable",
+                message = "This wallet can't receive payments for this request. Check Settings → Nostr → Nostr key.",
+            )
+            RELAY_RECOVERY -> DeliveryNotice(
+                title = "No usable relay",
+                message = "This wallet can't receive payments for this request. Add a ws:// or wss:// relay in Settings → Nostr → Relays.",
+            )
+            else -> DeliveryNotice(
+                title = "Payment requests are off",
+                message = "You can share this request, but this wallet won't receive payments until you turn on Settings → Privacy → Listen for payment requests.",
+            )
+        }
+    }
 
     companion object {
         const val NOSTR_KEY_RECOVERY =
@@ -142,7 +181,11 @@ sealed interface CashuRequestNostrReadiness {
             }
             val usableRelays = normalizedRelays(relays)
             if (usableRelays.isEmpty()) return Blocked(RELAY_RECOVERY)
-            if (!listenerEnabled) return Blocked(LISTENER_RECOVERY)
+            val requestConfiguration = RequestConfiguration(
+                publicKeyHex = publicKeyHex,
+                relays = usableRelays,
+            )
+            if (!listenerEnabled) return Blocked(LISTENER_RECOVERY, requestConfiguration)
             return Ready(publicKeyHex = publicKeyHex, relays = usableRelays)
         }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -53,6 +53,7 @@ import java.util.Date
 import kotlinx.coroutines.delay
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.CashuRequestStore
+import com.cashu.me.Core.CashuRequestNostrReadiness
 import com.cashu.me.Core.NostrService
 import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
 import com.cashu.me.Core.NfcReceive.NfcReceivePhase
@@ -129,12 +130,12 @@ fun CashuRequestDetailScreen(
     ) {
         if (nfcReceiveCoordinator.state.value.phase.isNfcTransferActive()) return
         val req = request ?: return
-        val nostr = nostrService.state.value
-        val relays = settings.nostrRelays
-        if (nostr.publicKeyHex.isBlank() || relays.isEmpty()) {
-            regenerateError = "Nostr isn't ready — check your relays in Settings."
+        val readiness = CashuRequestNostrReadiness.current(nostrService, settingsManager)
+        if (readiness is CashuRequestNostrReadiness.Blocked) {
+            regenerateError = readiness.recoveryMessage
             return
         }
+        readiness as CashuRequestNostrReadiness.Ready
         val resolvedUnit = walletState.mints.firstOrNull { it.url == nextMints.firstOrNull() }
             ?.resolvedMintUnit(nextUnit ?: req.unit) ?: (nextUnit ?: req.unit)
         // A stored integer means something different after a unit change; clear
@@ -147,8 +148,8 @@ fun CashuRequestDetailScreen(
                 unit = resolvedUnit,
                 mints = nextMints,
                 description = req.memo,
-                nostrPubkeyHex = nostr.publicKeyHex,
-                relays = relays,
+                nostrPubkeyHex = readiness.publicKeyHex,
+                relays = readiness.relays,
             )
         }.onSuccess { encoded ->
             cashuRequestStore.update(

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -71,10 +71,12 @@ import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.DetailActionFooter
 import com.cashu.me.ui.components.GhostButton
+import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InlineNoticeHost
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.MintPickerSheet
 import com.cashu.me.ui.components.NumberPadFooter
+import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
 import com.cashu.me.ui.components.QrCard
@@ -105,12 +107,16 @@ fun CashuRequestDetailScreen(
     val storeState by cashuRequestStore.state.collectAsState()
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val nostrState by nostrService.state.collectAsState()
     val nfcState by nfcReceiveCoordinator.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
 
     val request = storeState.requests.firstOrNull { it.id == requestId }
+    val requestReadiness = remember(settings, nostrState) {
+        CashuRequestNostrReadiness.current(nostrService, settingsManager)
+    }
     var copied by remember { mutableStateOf(false) }
     var mintPickerOpen by remember { mutableStateOf(false) }
     var amountPickerOpen by remember { mutableStateOf(false) }
@@ -131,11 +137,11 @@ fun CashuRequestDetailScreen(
         if (nfcReceiveCoordinator.state.value.phase.isNfcTransferActive()) return
         val req = request ?: return
         val readiness = CashuRequestNostrReadiness.current(nostrService, settingsManager)
-        if (readiness is CashuRequestNostrReadiness.Blocked) {
-            regenerateError = readiness.recoveryMessage
+        val configuration = readiness.requestConfigurationOrNull()
+        if (configuration == null) {
+            regenerateError = (readiness as? CashuRequestNostrReadiness.Blocked)?.recoveryMessage
             return
         }
-        readiness as CashuRequestNostrReadiness.Ready
         val resolvedUnit = walletState.mints.firstOrNull { it.url == nextMints.firstOrNull() }
             ?.resolvedMintUnit(nextUnit ?: req.unit) ?: (nextUnit ?: req.unit)
         // A stored integer means something different after a unit change; clear
@@ -148,8 +154,8 @@ fun CashuRequestDetailScreen(
                 unit = resolvedUnit,
                 mints = nextMints,
                 description = req.memo,
-                nostrPubkeyHex = readiness.publicKeyHex,
-                relays = readiness.relays,
+                nostrPubkeyHex = configuration.publicKeyHex,
+                relays = configuration.relays,
             )
         }.onSuccess { encoded ->
             cashuRequestStore.update(
@@ -330,10 +336,19 @@ fun CashuRequestDetailScreen(
                     NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
                 }
 
-                StatusBlock(
-                    received = request.receivedPayments.isNotEmpty(),
-                    paymentCount = paymentCount,
-                )
+                val deliveryNotice = requestReadiness.deliveryNoticeOrNull()
+                if (request.isEcashRequest && request.receivedPayments.isEmpty() && deliveryNotice != null) {
+                    InlineNotice(
+                        text = deliveryNotice.title,
+                        detail = deliveryNotice.message,
+                        severity = NoticeSeverity.Warning,
+                    )
+                } else {
+                    StatusBlock(
+                        received = request.receivedPayments.isNotEmpty(),
+                        paymentCount = paymentCount,
+                    )
+                }
 
                 Column(modifier = Modifier.fillMaxWidth()) {
                     val activeMintUrl = request.mints.firstOrNull()

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import com.cashu.me.Core.CashuRequestStore
+import com.cashu.me.Core.CashuRequestNostrReadiness
 import com.cashu.me.Core.NostrService
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TokenParser
@@ -111,19 +112,21 @@ fun ReceiveEcashScreen(
     // Keep it mint-agnostic even when an active mint exists; the request detail
     // screen lets the user opt into a specific mint later.
     fun createNewRequest() {
-        val nostr = nostrService.state.value
-        val relays = settings.nostrRelays
-        if (nostr.publicKeyHex.isBlank() || relays.isEmpty()) {
-            inputHint = "Nostr isn't ready — check your relays in Settings."
+        val readiness = CashuRequestNostrReadiness.current(nostrService, settingsManager)
+        if (readiness is CashuRequestNostrReadiness.Blocked) {
+            inputHint = readiness.recoveryMessage
             return
         }
+        readiness as CashuRequestNostrReadiness.Ready
         inputHint = null
         runCatching {
             val id = com.cashu.me.Models.CashuRequest.newId()
             cashuRequestStore.createNostrCashuRequest(
                 id = id,
-                nostrPubkeyHex = nostr.publicKeyHex,
-                relays = relays,
+                amount = null,
+                unit = "sat",
+                nostrPubkeyHex = readiness.publicKeyHex,
+                relays = readiness.relays,
             )
         }.onSuccess { request ->
             onOpenRequest(request.id)

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
@@ -113,11 +113,11 @@ fun ReceiveEcashScreen(
     // screen lets the user opt into a specific mint later.
     fun createNewRequest() {
         val readiness = CashuRequestNostrReadiness.current(nostrService, settingsManager)
-        if (readiness is CashuRequestNostrReadiness.Blocked) {
-            inputHint = readiness.recoveryMessage
+        val configuration = readiness.requestConfigurationOrNull()
+        if (configuration == null) {
+            inputHint = (readiness as? CashuRequestNostrReadiness.Blocked)?.recoveryMessage
             return
         }
-        readiness as CashuRequestNostrReadiness.Ready
         inputHint = null
         runCatching {
             val id = com.cashu.me.Models.CashuRequest.newId()
@@ -125,8 +125,8 @@ fun ReceiveEcashScreen(
                 id = id,
                 amount = null,
                 unit = "sat",
-                nostrPubkeyHex = readiness.publicKeyHex,
-                relays = readiness.relays,
+                nostrPubkeyHex = configuration.publicKeyHex,
+                relays = configuration.relays,
             )
         }.onSuccess { request ->
             onOpenRequest(request.id)

--- a/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
@@ -142,7 +142,7 @@ class PaymentRequestBuilderTest {
     }
 
     @Test
-    fun nostrReadinessNamesListenerSettingWhenListeningIsOff() {
+    fun nostrReadinessKeepsRequestBuildableWhenListeningIsOff() {
         val readiness = CashuRequestNostrReadiness.evaluate(
             isIdentityInitialized = true,
             publicKeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
@@ -154,8 +154,31 @@ class PaymentRequestBuilderTest {
         assertEquals(
             CashuRequestNostrReadiness.Blocked(
                 "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again.",
+                requestConfiguration = CashuRequestNostrReadiness.RequestConfiguration(
+                    publicKeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+                    relays = listOf("wss://relay.example"),
+                ),
             ),
             readiness,
+        )
+    }
+
+    @Test
+    fun listenerDisabledReadinessUsesRequestDetailNotice() {
+        val readiness = CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized = true,
+            publicKeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+            privateKeyHex = PRIVATE_KEY_HEX,
+            relays = listOf("wss://relay.example"),
+            listenerEnabled = false,
+        )
+
+        assertEquals(
+            CashuRequestNostrReadiness.DeliveryNotice(
+                title = "Payment requests are off",
+                message = "You can share this request, but this wallet won't receive payments until you turn on Settings → Privacy → Listen for payment requests.",
+            ),
+            readiness.deliveryNoticeOrNull(),
         )
     }
 

--- a/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PaymentRequestBuilderTest.kt
@@ -79,6 +79,86 @@ class PaymentRequestBuilderTest {
         )
     }
 
+    @Test
+    fun nostrReadinessReturnsNormalizedDeliverableConfiguration() {
+        val publicKey = NostrService.publicKeyHex(PRIVATE_KEY_HEX)
+
+        val readiness = CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized = true,
+            publicKeyHex = publicKey,
+            privateKeyHex = PRIVATE_KEY_HEX,
+            relays = listOf(
+                " https://not-a-relay.example ",
+                " wss://relay.example ",
+                "wss://relay.example",
+                "ws://localhost:7777",
+            ),
+            listenerEnabled = true,
+        )
+
+        assertEquals(
+            CashuRequestNostrReadiness.Ready(
+                publicKeyHex = publicKey,
+                relays = listOf("wss://relay.example", "ws://localhost:7777"),
+            ),
+            readiness,
+        )
+    }
+
+    @Test
+    fun nostrReadinessNamesNostrKeySettingForMissingKeyMaterial() {
+        val readiness = CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized = true,
+            publicKeyHex = "not-a-key",
+            privateKeyHex = null,
+            relays = listOf("wss://relay.example"),
+            listenerEnabled = true,
+        )
+
+        assertEquals(
+            CashuRequestNostrReadiness.Blocked(
+                "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again.",
+            ),
+            readiness,
+        )
+    }
+
+    @Test
+    fun nostrReadinessNamesRelaySettingWhenNoUsableRelayExists() {
+        val readiness = CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized = true,
+            publicKeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+            privateKeyHex = PRIVATE_KEY_HEX,
+            relays = listOf("", "https://relay.example", "wss://"),
+            listenerEnabled = true,
+        )
+
+        assertEquals(
+            CashuRequestNostrReadiness.Blocked(
+                "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again.",
+            ),
+            readiness,
+        )
+    }
+
+    @Test
+    fun nostrReadinessNamesListenerSettingWhenListeningIsOff() {
+        val readiness = CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized = true,
+            publicKeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+            privateKeyHex = PRIVATE_KEY_HEX,
+            relays = listOf("wss://relay.example"),
+            listenerEnabled = false,
+        )
+
+        assertEquals(
+            CashuRequestNostrReadiness.Blocked(
+                "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again.",
+            ),
+            readiness,
+        )
+    }
+
     private companion object {
         private const val PRIVATE_KEY_HEX = "0000000000000000000000000000000000000000000000000000000000000001"
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -74,7 +74,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · iOS → Android] Create new ecash requests as any-mint requests by default.** iOS creates a NUT-18 request with no mint restriction; Android silently inserts the active mint, changing who can pay. **Done when:** Android leaves the mint list empty unless the user explicitly selects a mint, and tests cover request creation with and without a restriction.
 
-- [ ] **[P1 · Converge] Use one Nostr-readiness rule and recovery message.** Android requires both a public key and relays and says “check your relays”; iOS checks initialized identity and points broadly to Settings → Nostr. **Done when:** both validate every prerequisite needed for a deliverable request and name the exact setting that needs attention.
+- [x] **[P1 · Converge] Use one Nostr-readiness rule and recovery message.** Android requires both a public key and relays and says “check your relays”; iOS checks initialized identity and points broadly to Settings → Nostr. **Done when:** both validate every prerequisite needed for a deliverable request and name the exact setting that needs attention.
 
 - [x] **[P0 · iOS → Android] Warn before receiving from an unknown mint.** iOS identifies that receiving will add a new mint and asks the user to continue only if they trust it; Android has no equivalent trust warning. **Done when:** Android displays the normalized mint host and explains that the mint will be added; claim remains one-tap after the user has seen the caution (iOS parity).
 

--- a/ios/CashuWallet/Core/CashuRequestListener.swift
+++ b/ios/CashuWallet/Core/CashuRequestListener.swift
@@ -54,7 +54,9 @@ final class CashuRequestListener: ObservableObject {
             AppLogger.wallet.error("CashuRequestListener: NostrService not initialized")
             return
         }
-        let relays = SettingsManager.shared.nostrRelays
+        let relays = CashuRequestNostrReadiness.normalizedRelays(
+            SettingsManager.shared.nostrRelays
+        )
         guard !relays.isEmpty else {
             AppLogger.wallet.error("CashuRequestListener: no Nostr relays configured — cannot receive Cashu Request payments")
             return

--- a/ios/CashuWallet/Core/PaymentRequestBuilder.swift
+++ b/ios/CashuWallet/Core/PaymentRequestBuilder.swift
@@ -88,6 +88,79 @@ enum PaymentRequestBuilder {
     }
 }
 
+enum CashuRequestNostrReadiness: Equatable {
+    case ready(publicKeyHex: String, relays: [String])
+    case blocked(recoveryMessage: String)
+
+    static let nostrKeyRecovery =
+        "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again."
+    static let relayRecovery =
+        "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again."
+    static let listenerRecovery =
+        "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again."
+
+    var recoveryMessage: String? {
+        guard case .blocked(let recoveryMessage) = self else { return nil }
+        return recoveryMessage
+    }
+
+    @MainActor
+    static func current() -> CashuRequestNostrReadiness {
+        let nostr = NostrService.shared
+        let settings = SettingsManager.shared
+        return evaluate(
+            isIdentityInitialized: nostr.isInitialized,
+            publicKeyHex: nostr.publicKeyHex,
+            privateKeyHex: nostr.getPrivateKeyHex(),
+            relays: settings.nostrRelays,
+            listenerEnabled: settings.enablePaymentRequests
+        )
+    }
+
+    static func evaluate(
+        isIdentityInitialized: Bool,
+        publicKeyHex: String,
+        privateKeyHex: String?,
+        relays: [String],
+        listenerEnabled: Bool
+    ) -> CashuRequestNostrReadiness {
+        guard isIdentityInitialized,
+              isHexKey(publicKeyHex),
+              privateKeyHex.map(isHexKey) == true else {
+            return .blocked(recoveryMessage: nostrKeyRecovery)
+        }
+        let usableRelays = normalizedRelays(relays)
+        guard !usableRelays.isEmpty else {
+            return .blocked(recoveryMessage: relayRecovery)
+        }
+        guard listenerEnabled else {
+            return .blocked(recoveryMessage: listenerRecovery)
+        }
+        return .ready(publicKeyHex: publicKeyHex, relays: usableRelays)
+    }
+
+    static func normalizedRelays(_ relays: [String]) -> [String] {
+        var seen: Set<String> = []
+        return relays.compactMap { relay -> String? in
+            let trimmed = relay.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let components = URLComponents(string: trimmed),
+                  let scheme = components.scheme?.lowercased(),
+                  ["ws", "wss"].contains(scheme),
+                  components.host?.isEmpty == false,
+                  seen.insert(trimmed).inserted else {
+                return nil
+            }
+            return trimmed
+        }
+    }
+
+    private static func isHexKey(_ value: String) -> Bool {
+        value.count == 64 && value.unicodeScalars.allSatisfy {
+            CharacterSet(charactersIn: "0123456789abcdefABCDEF").contains($0)
+        }
+    }
+}
+
 // MARK: - Locked Receive Request
 
 /// Builds the "receive locked ecash" artifact: a NUT-18 Cashu payment request that
@@ -97,19 +170,15 @@ enum PaymentRequestBuilder {
 enum LockedReceiveRequest {
     @MainActor
     static func build(amount: UInt64? = nil) -> String? {
-        let nostr = NostrService.shared
-        guard nostr.isInitialized,
-              !nostr.publicKeyHex.isEmpty,
+        guard case let .ready(publicKeyHex, relays) = CashuRequestNostrReadiness.current(),
               let pubkey = SettingsManager.shared.primaryP2PKPublicKey else { return nil }
-        let relays = SettingsManager.shared.nostrRelays
-        guard !relays.isEmpty else { return nil }
         return try? PaymentRequestBuilder.build(
             id: CashuRequest.newId(),
             amount: amount,
             unit: "sat",
             mints: [],
             description: nil,
-            nostrPubkeyHex: nostr.publicKeyHex,
+            nostrPubkeyHex: publicKeyHex,
             relays: relays,
             p2pkPubkeyHex: pubkey
         )

--- a/ios/CashuWallet/Core/PaymentRequestBuilder.swift
+++ b/ios/CashuWallet/Core/PaymentRequestBuilder.swift
@@ -89,8 +89,18 @@ enum PaymentRequestBuilder {
 }
 
 enum CashuRequestNostrReadiness: Equatable {
-    case ready(publicKeyHex: String, relays: [String])
-    case blocked(recoveryMessage: String)
+    struct RequestConfiguration: Equatable {
+        let publicKeyHex: String
+        let relays: [String]
+    }
+
+    struct DeliveryNotice: Equatable {
+        let title: String
+        let message: String
+    }
+
+    case ready(configuration: RequestConfiguration)
+    case blocked(recoveryMessage: String, requestConfiguration: RequestConfiguration?)
 
     static let nostrKeyRecovery =
         "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again."
@@ -100,8 +110,44 @@ enum CashuRequestNostrReadiness: Equatable {
         "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again."
 
     var recoveryMessage: String? {
-        guard case .blocked(let recoveryMessage) = self else { return nil }
+        guard case .blocked(let recoveryMessage, _) = self else { return nil }
         return recoveryMessage
+    }
+
+    /// The key and relay data needed to encode a request. A listener-disabled
+    /// wallet still has a valid configuration, so request creation can continue
+    /// while the detail screen explains that receiving is currently unavailable.
+    var requestConfiguration: RequestConfiguration? {
+        switch self {
+        case .ready(let configuration):
+            return configuration
+        case .blocked(_, let requestConfiguration):
+            return requestConfiguration
+        }
+    }
+
+    /// Contextual copy for an already-created request. This deliberately avoids
+    /// the "try again" language used by creation errors because the QR is valid
+    /// and remains shareable while the wallet's receive path is unavailable.
+    var deliveryNotice: DeliveryNotice? {
+        guard let recoveryMessage else { return nil }
+        switch recoveryMessage {
+        case Self.nostrKeyRecovery:
+            return DeliveryNotice(
+                title: "Nostr key unavailable",
+                message: "This wallet can't receive payments for this request. Check Settings → Nostr → Nostr key."
+            )
+        case Self.relayRecovery:
+            return DeliveryNotice(
+                title: "No usable relay",
+                message: "This wallet can't receive payments for this request. Add a ws:// or wss:// relay in Settings → Nostr → Relays."
+            )
+        default:
+            return DeliveryNotice(
+                title: "Payment requests are off",
+                message: "You can share this request, but this wallet won't receive payments until you turn on Settings → Privacy → Listen for payment requests."
+            )
+        }
     }
 
     @MainActor
@@ -127,16 +173,29 @@ enum CashuRequestNostrReadiness: Equatable {
         guard isIdentityInitialized,
               isHexKey(publicKeyHex),
               privateKeyHex.map(isHexKey) == true else {
-            return .blocked(recoveryMessage: nostrKeyRecovery)
+            return .blocked(
+                recoveryMessage: nostrKeyRecovery,
+                requestConfiguration: nil
+            )
         }
         let usableRelays = normalizedRelays(relays)
         guard !usableRelays.isEmpty else {
-            return .blocked(recoveryMessage: relayRecovery)
+            return .blocked(
+                recoveryMessage: relayRecovery,
+                requestConfiguration: nil
+            )
         }
+        let configuration = RequestConfiguration(
+            publicKeyHex: publicKeyHex,
+            relays: usableRelays
+        )
         guard listenerEnabled else {
-            return .blocked(recoveryMessage: listenerRecovery)
+            return .blocked(
+                recoveryMessage: listenerRecovery,
+                requestConfiguration: configuration
+            )
         }
-        return .ready(publicKeyHex: publicKeyHex, relays: usableRelays)
+        return .ready(configuration: configuration)
     }
 
     static func normalizedRelays(_ relays: [String]) -> [String] {
@@ -170,7 +229,7 @@ enum CashuRequestNostrReadiness: Equatable {
 enum LockedReceiveRequest {
     @MainActor
     static func build(amount: UInt64? = nil) -> String? {
-        guard case let .ready(publicKeyHex, relays) = CashuRequestNostrReadiness.current(),
+        guard case let .ready(configuration) = CashuRequestNostrReadiness.current(),
               let pubkey = SettingsManager.shared.primaryP2PKPublicKey else { return nil }
         return try? PaymentRequestBuilder.build(
             id: CashuRequest.newId(),
@@ -178,8 +237,8 @@ enum LockedReceiveRequest {
             unit: "sat",
             mints: [],
             description: nil,
-            nostrPubkeyHex: publicKeyHex,
-            relays: relays,
+            nostrPubkeyHex: configuration.publicKeyHex,
+            relays: configuration.relays,
             p2pkPubkeyHex: pubkey
         )
     }

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -15,6 +15,7 @@ struct CashuRequestDetailView: View {
     @State private var showMintPicker = false
     @State private var showAmountPicker = false
     @State private var showUnitPicker = false
+    @State private var regenerationError: String?
     @State private var receiveBaselineBalance: UInt64?
     @State private var didAutoComplete = false
     /// Amount of the payment that just landed, for the shared success screen.
@@ -209,6 +210,10 @@ struct CashuRequestDetailView: View {
 
                     statusBadge
 
+                    if let regenerationError {
+                        InlineNotice(message: regenerationError, severity: .error)
+                    }
+
                     VStack(spacing: 0) {
                         // Only the ecash NUT-18 request can re-mint its Mint /
                         // Amount in place (that's what `regenerate` rebuilds).
@@ -401,9 +406,12 @@ struct CashuRequestDetailView: View {
     /// second entry for the same receive intent.
     private func regenerate(amount: UInt64?? = nil, unit: String? = nil, mints: [String]? = nil) {
         HapticFeedback.selection()
-        let nostr = NostrService.shared
-        guard nostr.isInitialized, !nostr.publicKeyHex.isEmpty,
-              let existing = request else { return }
+        guard let existing = request else { return }
+        let readiness = CashuRequestNostrReadiness.current()
+        guard case let .ready(publicKeyHex, relays) = readiness else {
+            regenerationError = readiness.recoveryMessage
+            return
+        }
         let nextMints = mints ?? existing.mints
         // Validate the unit against the (possibly newly chosen) mint: keep the
         // requested/existing unit when that mint supports it, else fall back to
@@ -429,12 +437,14 @@ struct CashuRequestDetailView: View {
                 unit: nextUnit,
                 mints: nextMints,
                 description: existing.memo,
-                nostrPubkeyHex: nostr.publicKeyHex,
-                relays: SettingsManager.shared.nostrRelays
+                nostrPubkeyHex: publicKeyHex,
+                relays: relays
             )
             store.update(id: existing.id, amount: nextAmount, unit: nextUnit, mints: nextMints, encoded: encoded)
+            regenerationError = nil
         } catch {
             AppLogger.wallet.error("Could not regenerate request: \(String(describing: error))")
+            regenerationError = "Couldn't update the request. Please try again."
         }
     }
 

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -6,6 +6,7 @@ struct CashuRequestDetailView: View {
     @EnvironmentObject var walletManager: WalletManager
     @ObservedObject private var store = CashuRequestStore.shared
     @ObservedObject private var settings = SettingsManager.shared
+    @ObservedObject private var nostr = NostrService.shared
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let onClose: (() -> Void)?
@@ -208,7 +209,7 @@ struct CashuRequestDetailView: View {
                         }
                     }
 
-                    statusBadge
+                    deliveryStatus(for: request)
 
                     if let regenerationError {
                         InlineNotice(message: regenerationError, severity: .error)
@@ -313,6 +314,23 @@ struct CashuRequestDetailView: View {
         .animation(.easeInOut(duration: 0.2), value: paymentCount)
     }
 
+    @ViewBuilder
+    private func deliveryStatus(for request: CashuRequest) -> some View {
+        if paymentCount > 0 || request.rail != .ecash {
+            statusBadge
+        } else if let notice = CashuRequestNostrReadiness.current().deliveryNotice {
+            InlineNotice(
+                message: notice.message,
+                title: notice.title,
+                severity: .caution,
+                tinted: true
+            )
+            .transition(reduceMotion ? .opacity : .opacity.combined(with: .scale(scale: 0.98)))
+        } else {
+            statusBadge
+        }
+    }
+
     // MARK: - Detail rows
 
     private func detailRow(icon: String, label: String, value: String) -> some View {
@@ -408,7 +426,7 @@ struct CashuRequestDetailView: View {
         HapticFeedback.selection()
         guard let existing = request else { return }
         let readiness = CashuRequestNostrReadiness.current()
-        guard case let .ready(publicKeyHex, relays) = readiness else {
+        guard let configuration = readiness.requestConfiguration else {
             regenerationError = readiness.recoveryMessage
             return
         }
@@ -437,8 +455,8 @@ struct CashuRequestDetailView: View {
                 unit: nextUnit,
                 mints: nextMints,
                 description: existing.memo,
-                nostrPubkeyHex: publicKeyHex,
-                relays: relays
+                nostrPubkeyHex: configuration.publicKeyHex,
+                relays: configuration.relays
             )
             store.update(id: existing.id, amount: nextAmount, unit: nextUnit, mints: nextMints, encoded: encoded)
             regenerationError = nil

--- a/ios/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveView.swift
@@ -435,7 +435,7 @@ struct UnifiedReceiveView: View {
     private func createNewRequest() {
         HapticFeedback.selection()
         let readiness = CashuRequestNostrReadiness.current()
-        guard case let .ready(publicKeyHex, relays) = readiness else {
+        guard let configuration = readiness.requestConfiguration else {
             inputHint = readiness.recoveryMessage
             return
         }
@@ -447,8 +447,8 @@ struct UnifiedReceiveView: View {
                 unit: "sat",
                 mints: [],
                 description: nil,
-                nostrPubkeyHex: publicKeyHex,
-                relays: relays
+                nostrPubkeyHex: configuration.publicKeyHex,
+                relays: configuration.relays
             )
             let request = CashuRequestStore.shared.createNew(
                 id: id,
@@ -642,7 +642,7 @@ struct ReceiveEcashView: View {
     private func createNewRequest() {
         HapticFeedback.selection()
         let readiness = CashuRequestNostrReadiness.current()
-        guard case let .ready(publicKeyHex, relays) = readiness else {
+        guard let configuration = readiness.requestConfiguration else {
             errorMessage = readiness.recoveryMessage
             return
         }
@@ -654,8 +654,8 @@ struct ReceiveEcashView: View {
                 unit: "sat",
                 mints: [],
                 description: nil,
-                nostrPubkeyHex: publicKeyHex,
-                relays: relays
+                nostrPubkeyHex: configuration.publicKeyHex,
+                relays: configuration.relays
             )
             let request = CashuRequestStore.shared.createNew(
                 id: id,

--- a/ios/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveView.swift
@@ -135,13 +135,15 @@ struct ReceiveView: View {
     }
 
     private var lockedKeyUnavailable: some View {
-        VStack(spacing: 12) {
+        let recoveryMessage = CashuRequestNostrReadiness.current().recoveryMessage
+            ?? "Set up your primary key in Settings → Locked Ecash, then try again."
+        return VStack(spacing: 12) {
             Image(systemName: "key.slash")
                 .font(.largeTitle)
                 .foregroundStyle(.secondary)
             Text("Couldn't create a request")
                 .font(.headline)
-            Text("This needs your wallet set up with a Nostr relay. Check Settings → Nostr, then try again.")
+            Text(recoveryMessage)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -432,9 +434,9 @@ struct UnifiedReceiveView: View {
     /// builder + store as the legacy `ReceiveEcashView.createNewRequest`.
     private func createNewRequest() {
         HapticFeedback.selection()
-        let nostr = NostrService.shared
-        guard nostr.isInitialized, !nostr.publicKeyHex.isEmpty else {
-            inputHint = "Your Nostr identity isn't ready yet. Check Settings → Nostr, then try again."
+        let readiness = CashuRequestNostrReadiness.current()
+        guard case let .ready(publicKeyHex, relays) = readiness else {
+            inputHint = readiness.recoveryMessage
             return
         }
         let id = CashuRequest.newId()
@@ -445,8 +447,8 @@ struct UnifiedReceiveView: View {
                 unit: "sat",
                 mints: [],
                 description: nil,
-                nostrPubkeyHex: nostr.publicKeyHex,
-                relays: SettingsManager.shared.nostrRelays
+                nostrPubkeyHex: publicKeyHex,
+                relays: relays
             )
             let request = CashuRequestStore.shared.createNew(
                 id: id,
@@ -639,9 +641,9 @@ struct ReceiveEcashView: View {
 
     private func createNewRequest() {
         HapticFeedback.selection()
-        let nostr = NostrService.shared
-        guard nostr.isInitialized, !nostr.publicKeyHex.isEmpty else {
-            errorMessage = "Your Nostr identity isn't ready yet. Check Settings → Nostr, then try again."
+        let readiness = CashuRequestNostrReadiness.current()
+        guard case let .ready(publicKeyHex, relays) = readiness else {
+            errorMessage = readiness.recoveryMessage
             return
         }
         let id = CashuRequest.newId()
@@ -652,8 +654,8 @@ struct ReceiveEcashView: View {
                 unit: "sat",
                 mints: [],
                 description: nil,
-                nostrPubkeyHex: nostr.publicKeyHex,
-                relays: SettingsManager.shared.nostrRelays
+                nostrPubkeyHex: publicKeyHex,
+                relays: relays
             )
             let request = CashuRequestStore.shared.createNew(
                 id: id,

--- a/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
@@ -62,8 +62,10 @@ final class CashuRequestNostrReadinessTests: XCTestCase {
                 ]
             ),
             .ready(
-                publicKeyHex: publicKeyHex,
-                relays: ["wss://relay.example", "ws://localhost:7777"]
+                configuration: .init(
+                    publicKeyHex: publicKeyHex,
+                    relays: ["wss://relay.example", "ws://localhost:7777"]
+                )
             )
         )
     }
@@ -79,7 +81,8 @@ final class CashuRequestNostrReadinessTests: XCTestCase {
             ),
             .blocked(
                 recoveryMessage:
-                    "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again."
+                    "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again.",
+                requestConfiguration: nil
             )
         )
     }
@@ -89,17 +92,32 @@ final class CashuRequestNostrReadinessTests: XCTestCase {
             evaluate(relays: ["", "https://relay.example", "wss://"]),
             .blocked(
                 recoveryMessage:
-                    "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again."
+                    "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again.",
+                requestConfiguration: nil
             )
         )
     }
 
-    func testDisabledListenerNamesExactPrivacySetting() {
+    func testDisabledListenerKeepsRequestBuildableAndNamesExactPrivacySetting() {
         XCTAssertEqual(
             evaluate(listenerEnabled: false),
             .blocked(
                 recoveryMessage:
-                    "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again."
+                    "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again.",
+                requestConfiguration: .init(
+                    publicKeyHex: publicKeyHex,
+                    relays: ["wss://relay.example"]
+                )
+            )
+        )
+    }
+
+    func testDisabledListenerUsesContextualDetailNotice() {
+        XCTAssertEqual(
+            evaluate(listenerEnabled: false).deliveryNotice,
+            .init(
+                title: "Payment requests are off",
+                message: "You can share this request, but this wallet won't receive payments until you turn on Settings → Privacy → Listen for payment requests."
             )
         )
     }

--- a/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
@@ -46,3 +46,74 @@ final class CashuRequestRouteExplanationTests: XCTestCase {
         )
     }
 }
+
+final class CashuRequestNostrReadinessTests: XCTestCase {
+    private let publicKeyHex = String(repeating: "1", count: 64)
+    private let privateKeyHex = String(repeating: "2", count: 64)
+
+    func testReadyConfigurationKeepsOnlyNormalizedWebSocketRelays() {
+        XCTAssertEqual(
+            evaluate(
+                relays: [
+                    " https://not-a-relay.example ",
+                    " wss://relay.example ",
+                    "wss://relay.example",
+                    "ws://localhost:7777",
+                ]
+            ),
+            .ready(
+                publicKeyHex: publicKeyHex,
+                relays: ["wss://relay.example", "ws://localhost:7777"]
+            )
+        )
+    }
+
+    func testMissingKeyMaterialNamesExactNostrKeySetting() {
+        XCTAssertEqual(
+            CashuRequestNostrReadiness.evaluate(
+                isIdentityInitialized: true,
+                publicKeyHex: "not-a-key",
+                privateKeyHex: nil,
+                relays: ["wss://relay.example"],
+                listenerEnabled: true
+            ),
+            .blocked(
+                recoveryMessage:
+                    "Your Nostr key isn't ready. Check Settings → Nostr → Nostr key, then try again."
+            )
+        )
+    }
+
+    func testNoUsableRelayNamesExactRelaySetting() {
+        XCTAssertEqual(
+            evaluate(relays: ["", "https://relay.example", "wss://"]),
+            .blocked(
+                recoveryMessage:
+                    "No usable Nostr relay is configured. Add a ws:// or wss:// relay in Settings → Nostr → Relays, then try again."
+            )
+        )
+    }
+
+    func testDisabledListenerNamesExactPrivacySetting() {
+        XCTAssertEqual(
+            evaluate(listenerEnabled: false),
+            .blocked(
+                recoveryMessage:
+                    "Cashu Request listening is off. Turn on Settings → Privacy → Listen for payment requests, then try again."
+            )
+        )
+    }
+
+    private func evaluate(
+        relays: [String] = ["wss://relay.example"],
+        listenerEnabled: Bool = true
+    ) -> CashuRequestNostrReadiness {
+        CashuRequestNostrReadiness.evaluate(
+            isIdentityInitialized: true,
+            publicKeyHex: publicKeyHex,
+            privateKeyHex: privateKeyHex,
+            relays: relays,
+            listenerEnabled: listenerEnabled
+        )
+    }
+}


### PR DESCRIPTION
## Root cause

iOS and Android were checking different subsets of the Nostr prerequisites needed to deliver a NUT-18 Cashu Request. The first version of this PR then treated every missing prerequisite as a request-construction failure. The visual review showed that this made iOS block the Ecash action inside the compact Receive sheet when **Listen for payment requests** was off, even though the wallet still had enough key and relay data to encode a valid request.

Request construction and active receiving are separate states: a valid key and usable relay are required to build the request, while the listener setting determines whether the wallet can currently receive its response.

## Changes

- Keep one platform-equivalent Cashu Request Nostr-readiness classifier that validates:
  - an initialized identity
  - valid 64-character hexadecimal public and available private keys
  - at least one normalized `ws://` or `wss://` relay with a host
  - the listener state, separately from construction prerequisites
- Reuse normalized relay validation in both platforms' request and listener paths.
- Keep missing key material or usable relays as construction blockers because a valid Nostr transport cannot be encoded without them.
- Allow iOS and Android to create and regenerate a Cashu Request when only the payment-request listener is disabled.
- Move the listener warning from the compact Receive sheet to the Cashu Request detail sheet on both platforms.
- Replace the misleading **Waiting for payment…** state with a titled, tinted, Dynamic Type-friendly caution card that explains the request is shareable and names **Settings → Privacy → Listen for payment requests**.
- Use the same listener-disabled detail-screen hint on both platforms.
- Add focused unit coverage for the ready configuration, every recovery branch, listener-disabled request buildability, and the contextual detail-sheet notice.
- Mark only the completed “Use one Nostr-readiness rule and recovery message” parity-checklist item.

## Impact

iOS and Android users can still create and share a Cashu Request when listening is disabled. The QR screen clearly communicates that this wallet will not receive payments until the listener is enabled. The compact Receive sheet stays uncluttered. Missing key or relay data still blocks construction with an actionable settings path.

## Validation

### Android focused unit tests

```sh
./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.Core.PaymentRequestBuilderTest --stacktrace
```

Result: `BUILD SUCCESSFUL`; 9 tests passed, including listener-disabled buildability and contextual detail-notice coverage.

### Android debug build

```sh
./gradlew --no-daemon :app:assembleDebug --stacktrace
```

Result from the original PR validation: `BUILD SUCCESSFUL`.

### iOS focused simulator tests

```sh
xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -configuration Debug \
  -destination 'id=8ED87EF5-4E5A-4DB2-8407-C60EC7F43079' \
  -derivedDataPath /private/tmp/wallet-receive-nostr-derived \
  -clonedSourcePackagesDirPath /private/tmp/wallet-receive-nostr-sourcepackages \
  -disableAutomaticPackageResolution -skipPackagePluginValidation \
  -only-testing:CashuWalletTests/CashuRequestNostrReadinessTests test
```

Result: `TEST SUCCEEDED`; all 5 readiness tests passed, including listener-disabled buildability and contextual detail notice coverage.

### iOS syntax parse

```sh
xcrun swiftc -frontend -parse \
  ios/CashuWallet/Core/PaymentRequestBuilder.swift \
  ios/CashuWallet/Views/Receive/ReceiveView.swift \
  ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift \
  ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
```

Result: passed with no parse errors.

### Diff hygiene

```sh
git diff --cached --check
```

Result: passed with no whitespace errors.
