### PR TITLE
Show fees on claimed ecash receipts

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashReceiptDetails.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashReceiptDetails.kt
@@ -1,0 +1,34 @@
+package com.cashu.me.ui.send
+
+import com.cashu.me.Core.Protocols.CurrencyAmount
+import com.cashu.me.Core.Protocols.CurrencyRegistry
+import com.cashu.me.Core.shortenMintUrl
+
+internal data class SendEcashReceiptDetails(
+    val amount: String,
+    val fee: String?,
+    val mint: String,
+)
+
+internal fun buildSendEcashReceiptDetails(
+    amountLabel: String,
+    fee: Long,
+    unit: String,
+    mintUrl: String,
+): SendEcashReceiptDetails = SendEcashReceiptDetails(
+    amount = amountLabel,
+    fee = formatSendEcashFee(fee, unit),
+    mint = shortenMintUrl(mintUrl),
+)
+
+internal fun formatSendEcashFee(fee: Long, unit: String): String? =
+    fee.takeIf { it > 0L }?.let { nonzeroFee ->
+        if (unit.equals("sat", ignoreCase = true)) {
+            "$nonzeroFee sat"
+        } else {
+            CurrencyAmount(
+                nonzeroFee,
+                CurrencyRegistry.currencyForMintUnit(unit),
+            ).formatted()
+        }
+    }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material.icons.outlined.Receipt
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LoadingIndicator
@@ -856,8 +857,14 @@ private fun GeneratedFace(
     }
 
     // Claimed resolves to the shared full-screen terminal (iOS parity), with
-    // Amount/Mint metadata rows under the check.
+    // the same Amount/Fee/Mint facts shown while the token is pending.
     if (claimState == ClaimState.Claimed) {
+        val receipt = buildSendEcashReceiptDetails(
+            amountLabel = amountPresentation.primary,
+            fee = result.fee,
+            unit = unit,
+            mintUrl = mintUrl,
+        )
         com.cashu.me.ui.components.PaymentStatusScreen(
             phase = com.cashu.me.ui.components.PaymentStatusPhase.Success,
             title = "Claimed",
@@ -869,9 +876,18 @@ private fun GeneratedFace(
                     leadingIcon = Icons.Outlined.Payments,
                 )
                 com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
+                receipt.fee?.let { feeLabel ->
+                    com.cashu.me.ui.components.InspectorRow(
+                        label = "Fee",
+                        value = feeLabel,
+                        valueMonospaced = true,
+                        leadingIcon = Icons.Outlined.Receipt,
+                    )
+                    com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)
+                }
                 com.cashu.me.ui.components.InspectorRow(
                     label = "Mint",
-                    value = com.cashu.me.Core.shortenMintUrl(mintUrl),
+                    value = receipt.mint,
                     leadingIcon = Icons.Outlined.AccountBalance,
                 )
             },
@@ -902,14 +918,10 @@ private fun GeneratedFace(
             ClaimStatusRow(claimState = claimState)
             // Detail rows: Fee -> Unit -> Fiat (sat-only) -> Mint (iOS order).
             Column(modifier = Modifier.fillMaxWidth()) {
-                if (result.fee > 0L) {
+                formatSendEcashFee(result.fee, unit)?.let { feeLabel ->
                     com.cashu.me.ui.components.InspectorRow(
                         label = "Fee",
-                        value = if (unit.equals("sat", ignoreCase = true)) {
-                            "${result.fee} sat"
-                        } else {
-                            CurrencyAmount(result.fee, CurrencyRegistry.currencyForMintUnit(unit)).formatted()
-                        },
+                        value = feeLabel,
                         valueMonospaced = true,
                     )
                     com.cashu.me.ui.components.CanvasDivider(leadingInset = 16.dp)

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendEcashReceiptDetailsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendEcashReceiptDetailsTest.kt
@@ -1,0 +1,45 @@
+package com.cashu.me.ui.send
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SendEcashReceiptDetailsTest {
+    @Test
+    fun claimedReceiptPreservesAmountNonzeroSatFeeAndMint() {
+        val receipt = buildSendEcashReceiptDetails(
+            amountLabel = "21 sat",
+            fee = 3,
+            unit = "sat",
+            mintUrl = "https://mint.example.com/",
+        )
+
+        assertEquals("21 sat", receipt.amount)
+        assertEquals("3 sat", receipt.fee)
+        assertEquals("mint.example.com", receipt.mint)
+    }
+
+    @Test
+    fun claimedReceiptFormatsFeeInNativeMintUnit() {
+        val receipt = buildSendEcashReceiptDetails(
+            amountLabel = "$12.34",
+            fee = 25,
+            unit = "usd",
+            mintUrl = "https://mint.example.com",
+        )
+
+        assertEquals("$0.25", receipt.fee)
+    }
+
+    @Test
+    fun claimedReceiptOmitsZeroFee() {
+        val receipt = buildSendEcashReceiptDetails(
+            amountLabel = "21 sat",
+            fee = 0,
+            unit = "sat",
+            mintUrl = "https://mint.example.com",
+        )
+
+        assertNull(receipt.fee)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -68,7 +68,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Provide manual claim-status checking when automatic checks are disabled.** iOS adds “Check Status” to pending-token actions; Android leaves the token at Pending with no equivalent action. **Done when:** Android users can run a one-off spent check without re-enabling background polling.
 
-- [ ] **[P1 · iOS → Android] Include the send fee on the Claimed receipt.** iOS shows the fee when the token-generation swap charged one; Android’s pending view shows it but the full-screen Claimed terminal drops it. **Done when:** Android’s Claimed details preserve Amount, applicable Fee, and Mint.
+- [x] **[P1 · iOS → Android] Include the send fee on the Claimed receipt.** iOS shows the fee when the token-generation swap charged one; Android’s pending view shows it but the full-screen Claimed terminal drops it. **Done when:** Android’s Claimed details preserve Amount, applicable Fee, and Mint.
 
 ### Receive — unified entry and Cashu tokens
 


### PR DESCRIPTION
## What changed

- Preserve the generated ecash send fee on the full-screen **Claimed** receipt.
- Share fee formatting between pending and claimed states, including native non-sat mint units.
- Omit the receipt fee row when no fee was charged.
- Add unit coverage for sat fees, USD-denominated fees, zero-fee receipts, amount, and mint display.
- Mark the corresponding iOS/Android parity checklist item complete.

## Why

The final Android receipt should preserve the same material payment facts shown while a generated ecash token is pending and match the equivalent iOS receipt.

## Root cause

The generated token retained its swap fee and the pending screen rendered it, but the Claimed terminal independently built only Amount and Mint rows. That separate terminal-row path dropped the available fee.

## Impact

When token generation charges a nonzero swap fee, Android users now see Amount, Fee, and Mint on the Claimed receipt. The fee uses the token's native mint unit, while zero-fee receipts remain uncluttered.

## Checks

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.send.SendEcashReceiptDetailsTest --stacktrace`
- `./gradlew --no-daemon :app:testDebugUnitTest :app:assembleDebug --stacktrace`
