### PR TITLE
Default Cashu requests to any mint

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestCreation.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestCreation.kt
@@ -1,0 +1,39 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.CashuRequest
+
+/**
+ * Creates a Nostr-delivered NUT-18 request.
+ *
+ * New requests are deliberately unrestricted unless the user explicitly picks
+ * a mint. Keeping that choice in this API prevents ambient wallet state (such
+ * as the active mint) from silently narrowing who can pay the request.
+ */
+internal fun CashuRequestStore.createNostrCashuRequest(
+    id: String = CashuRequest.newId(),
+    amount: Long? = null,
+    unit: String = "sat",
+    selectedMintUrl: String? = null,
+    memo: String? = null,
+    nostrPubkeyHex: String,
+    relays: List<String>,
+): CashuRequest {
+    val mints = listOfNotNull(selectedMintUrl?.trim()?.takeIf { it.isNotEmpty() })
+    val encoded = PaymentRequestBuilder.build(
+        id = id,
+        amount = amount,
+        unit = unit,
+        mints = mints,
+        description = memo,
+        nostrPubkeyHex = nostrPubkeyHex,
+        relays = relays,
+    )
+    return createNew(
+        id = id,
+        amount = amount,
+        unit = unit,
+        mints = mints,
+        memo = memo,
+        encoded = encoded,
+    )
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
@@ -39,10 +39,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import com.cashu.me.Core.CashuRequestStore
 import com.cashu.me.Core.NostrService
-import com.cashu.me.Core.PaymentRequestBuilder
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TokenParser
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.createNostrCashuRequest
 import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.CircularMethodButton
 import com.cashu.me.ui.components.FlowSheetTitle
@@ -120,17 +120,11 @@ fun ReceiveEcashScreen(
         inputHint = null
         runCatching {
             val id = com.cashu.me.Models.CashuRequest.newId()
-            val mints = emptyList<String>()
-            val encoded = PaymentRequestBuilder.build(
+            cashuRequestStore.createNostrCashuRequest(
                 id = id,
-                amount = null,
-                unit = "sat",
-                mints = mints,
-                description = null,
                 nostrPubkeyHex = nostr.publicKeyHex,
                 relays = relays,
             )
-            cashuRequestStore.createNew(id = id, mints = mints, encoded = encoded)
         }.onSuccess { request ->
             onOpenRequest(request.id)
         }.onFailure {

--- a/android/app/src/test/java/com/cashu/me/Core/CashuRequestCreationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuRequestCreationTest.kt
@@ -1,0 +1,56 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.CashuRequest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CashuRequestCreationTest {
+    @Test
+    fun newRequestIsUnrestrictedByDefault() {
+        val request = store().createNostrCashuRequest(
+            id = "unrestricted",
+            nostrPubkeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+            relays = listOf("wss://relay.example"),
+        )
+
+        assertEquals(emptyList<String>(), request.mints)
+        assertEquals(
+            emptyList<String>(),
+            PaymentRequestDecoder.cashuPaymentRequestSummary(request.encoded)?.mints,
+        )
+    }
+
+    @Test
+    fun newRequestUsesExplicitMintRestriction() {
+        val request = store().createNostrCashuRequest(
+            id = "restricted",
+            selectedMintUrl = "https://mint.example",
+            nostrPubkeyHex = NostrService.publicKeyHex(PRIVATE_KEY_HEX),
+            relays = listOf("wss://relay.example"),
+        )
+
+        assertEquals(listOf("https://mint.example"), request.mints)
+        assertEquals(
+            listOf("https://mint.example"),
+            PaymentRequestDecoder.cashuPaymentRequestSummary(request.encoded)?.mints,
+        )
+    }
+
+    private fun store() = CashuRequestStore(MemoryPersistence())
+
+    private class MemoryPersistence : CashuRequestPersistence {
+        private var requests: List<CashuRequest> = emptyList()
+        override var currentCashuRequestId: String? = null
+
+        override fun loadCashuRequests(): List<CashuRequest> = requests
+
+        override fun saveCashuRequests(requests: List<CashuRequest>) {
+            this.requests = requests
+        }
+    }
+
+    private companion object {
+        private const val PRIVATE_KEY_HEX =
+            "0000000000000000000000000000000000000000000000000000000000000001"
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -72,7 +72,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Receive — unified entry and Cashu tokens
 
-- [ ] **[P1 · iOS → Android] Create new ecash requests as any-mint requests by default.** iOS creates a NUT-18 request with no mint restriction; Android silently inserts the active mint, changing who can pay. **Done when:** Android leaves the mint list empty unless the user explicitly selects a mint, and tests cover request creation with and without a restriction.
+- [x] **[P1 · iOS → Android] Create new ecash requests as any-mint requests by default.** iOS creates a NUT-18 request with no mint restriction; Android silently inserts the active mint, changing who can pay. **Done when:** Android leaves the mint list empty unless the user explicitly selects a mint, and tests cover request creation with and without a restriction.
 
 - [ ] **[P1 · Converge] Use one Nostr-readiness rule and recovery message.** Android requires both a public key and relays and says “check your relays”; iOS checks initialized identity and points broadly to Settings → Nostr. **Done when:** both validate every prerequisite needed for a deliverable request and name the exact setting that needs attention.
 


### PR DESCRIPTION
## Root cause

The Receive flow historically copied `walletState.activeMint.url` into both the encoded NUT-18 request and the stored request. That ambient wallet state silently restricted a new request even though the user had not selected a mint. Main recently stopped passing the active mint, but request construction remained inline and the unrestricted-versus-explicitly-restricted behavior had no regression coverage.

## Changes

- Centralize Nostr Cashu request creation in an unrestricted-by-default API.
- Require an explicit `selectedMintUrl` before writing a NUT-18 mint restriction.
- Route the Receive entry point through that API without supplying ambient active-mint state.
- Add focused tests that verify both the stored request and decoded NUT-18 mint list for unrestricted and explicitly restricted creation.
- Mark the matching iOS/Android parity checklist item complete.

## Impact

New ecash requests remain payable from any mint by default. Users can still restrict a request by deliberately selecting a mint in the request editor.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.Core.CashuRequestCreationTest --stacktrace` — **BUILD SUCCESSFUL** (focused unrestricted/restricted regression tests; 26 tasks executed).
- `./gradlew --no-daemon :app:testDebugUnitTest --stacktrace` — **BUILD SUCCESSFUL** (complete Android debug unit-test suite; 26 tasks, 1 executed and 25 up-to-date after the focused run).
- `git diff --cached --check` — clean.
