### PR TITLE
Add manual sent ecash status checks

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/PendingTokenClaim.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PendingTokenClaim.kt
@@ -1,0 +1,66 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Wallet.WalletMessage
+import com.cashu.me.Core.Wallet.walletMessage
+import com.cashu.me.Models.PendingToken
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Result of a user-initiated spent-status probe.
+ *
+ * "Not claimed" is a successful response from the mint, distinct from a
+ * transport or wallet failure. Keeping those outcomes separate lets the UI
+ * acknowledge a completed check while still offering a safe retry on errors.
+ */
+internal sealed interface PendingTokenClaimCheckResult {
+    data object Claimed : PendingTokenClaimCheckResult
+    data object NotClaimed : PendingTokenClaimCheckResult
+    data class Failed(val message: WalletMessage) : PendingTokenClaimCheckResult
+}
+
+internal suspend fun runPendingTokenClaimCheck(
+    check: suspend () -> Boolean,
+): PendingTokenClaimCheckResult =
+    try {
+        if (check()) {
+            PendingTokenClaimCheckResult.Claimed
+        } else {
+            PendingTokenClaimCheckResult.NotClaimed
+        }
+    } catch (cancellation: CancellationException) {
+        throw cancellation
+    } catch (error: Throwable) {
+        PendingTokenClaimCheckResult.Failed(error.walletMessage)
+    }
+
+/**
+ * Resolve the local pending-token record behind a History row.
+ *
+ * CDK transaction IDs can replace the local token ID during history merging,
+ * so the encoded token is the stable first choice and the ID is a legacy
+ * fallback.
+ */
+internal fun pendingSentTokenFor(
+    transaction: WalletTransaction,
+    pendingTokens: List<PendingToken>,
+): PendingToken? {
+    if (
+        transaction.type != TransactionType.Outgoing ||
+        transaction.kind != TransactionKind.Ecash ||
+        transaction.status != TransactionStatus.Pending ||
+        !transaction.isPendingToken
+    ) {
+        return null
+    }
+    return pendingTokens.firstOrNull { it.token == transaction.token }
+        ?: pendingTokens.firstOrNull { it.tokenId == transaction.id }
+}
+
+internal fun shouldOfferManualClaimCheck(
+    automaticChecksEnabled: Boolean,
+    pendingToken: PendingToken?,
+): Boolean = !automaticChecksEnabled && pendingToken != null

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -32,22 +32,33 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.PendingTokenClaimCheckResult
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
 import com.cashu.me.Core.ReceiveConfirmationOwner
+import com.cashu.me.Core.pendingSentTokenFor
 import com.cashu.me.Core.resolveTransactionForDetail
+import com.cashu.me.Core.runPendingTokenClaimCheck
 import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.shouldOfferManualClaimCheck
 import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Models.TransactionKind
@@ -60,6 +71,8 @@ import com.cashu.me.ui.components.DetailActionFooter
 import com.cashu.me.ui.components.EmptyState
 import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.InspectorRow
+import com.cashu.me.ui.components.InlineNotice
+import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.ToolbarIcon
@@ -68,6 +81,7 @@ import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withMonoDigits
+import com.cashu.me.ui.testing.UiTestTags
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,6 +98,7 @@ fun TransactionDetailScreen(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val formatter = remember { AmountFormatter() }
+    val scope = rememberCoroutineScope()
 
     // Pending mint-quote rows use id == quoteId; after mint CDK swaps in a new
     // transaction id with the same quoteId. Keep the open-time identity so the
@@ -102,6 +117,10 @@ fun TransactionDetailScreen(
     val transaction = resolved ?: openSnapshot
 
     var copied by remember { mutableStateOf(false) }
+    var checkingClaim by remember(transactionId) { mutableStateOf(false) }
+    var manualCheckResult: PendingTokenClaimCheckResult? by remember(transactionId) {
+        mutableStateOf(null)
+    }
     LaunchedEffect(copied) {
         if (copied) {
             delay(2000)
@@ -181,8 +200,15 @@ fun TransactionDetailScreen(
                 transaction.type == TransactionType.Incoming &&
                 transaction.status == TransactionStatus.Pending
         }
+        val pendingSentToken = pendingSentTokenFor(transaction, walletState.pendingTokens)
+        val offersManualClaimCheck = shouldOfferManualClaimCheck(
+            automaticChecksEnabled = settings.checkSentTokens,
+            pendingToken = pendingSentToken,
+        )
         val hasPrimaryAction =
-            (pendingReceiveToken != null && onClaimReceiveToken != null) || copyableContent != null
+            (pendingReceiveToken != null && onClaimReceiveToken != null) ||
+                offersManualClaimCheck ||
+                copyableContent != null
 
         Column(
             modifier = Modifier
@@ -263,6 +289,26 @@ fun TransactionDetailScreen(
                         ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
                     }
                 }
+                if (offersManualClaimCheck) {
+                    when (val outcome = manualCheckResult) {
+                        PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                            text = "Status checked",
+                            detail = "This token has not been claimed yet.",
+                            severity = NoticeSeverity.Info,
+                            modifier = Modifier.semantics {
+                                liveRegion = LiveRegionMode.Polite
+                            },
+                        )
+                        is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                            text = "Couldn't check status",
+                            detail = outcome.message.text,
+                            modifier = Modifier.semantics {
+                                liveRegion = LiveRegionMode.Polite
+                            },
+                        )
+                        PendingTokenClaimCheckResult.Claimed, null -> Unit
+                    }
+                }
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
             }
 
@@ -273,18 +319,52 @@ fun TransactionDetailScreen(
                             text = "Receive",
                             onClick = { onClaimReceiveToken(pendingReceiveToken) },
                         )
-                    } else if (copyableContent != null) {
-                        // Copy is a secondary convenience, not a primary action —
-                        // quiet neutral tonal fill (matches Home's Send/Receive)
-                        // rather than the loud inverted-ink primary.
-                        PrimaryButton(
-                            text = if (copied) "Copied" else "Copy",
-                            onClick = {
-                                clipboard.setText(AnnotatedString(copyableContent))
-                                copied = true
-                            },
-                            colors = neutralActionButtonColors(),
-                        )
+                    } else {
+                        if (offersManualClaimCheck && pendingSentToken != null) {
+                            PrimaryButton(
+                                text = if (checkingClaim) "Checking…" else "Check Status",
+                                onClick = {
+                                    checkingClaim = true
+                                    manualCheckResult = null
+                                    scope.launch {
+                                        try {
+                                            manualCheckResult = runPendingTokenClaimCheck {
+                                                walletManager.checkPendingTokenStatus(pendingSentToken)
+                                            }
+                                        } finally {
+                                            checkingClaim = false
+                                        }
+                                    }
+                                },
+                                loading = checkingClaim,
+                                modifier = Modifier
+                                    .testTag(UiTestTags.HistoryCheckTokenStatus)
+                                    .semantics {
+                                        contentDescription = if (checkingClaim) {
+                                            "Checking claim status"
+                                        } else {
+                                            "Check Status"
+                                        }
+                                        liveRegion = LiveRegionMode.Polite
+                                    },
+                            )
+                        }
+                        if (offersManualClaimCheck && copyableContent != null) {
+                            Spacer(Modifier.height(CashuTheme.spacing.tight))
+                        }
+                        if (copyableContent != null) {
+                            // Copy is a secondary convenience, not a primary action —
+                            // quiet neutral tonal fill (matches Home's Send/Receive)
+                            // rather than the loud inverted-ink primary.
+                            PrimaryButton(
+                                text = if (copied) "Copied" else "Copy",
+                                onClick = {
+                                    clipboard.setText(AnnotatedString(copyableContent))
+                                    copied = true
+                                },
+                                colors = neutralActionButtonColors(),
+                            )
+                        }
                     }
                 }
             }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -320,7 +320,23 @@ fun TransactionDetailScreen(
                             onClick = { onClaimReceiveToken(pendingReceiveToken) },
                         )
                     } else {
+                        if (copyableContent != null) {
+                            // Copy is a secondary convenience, not a primary action —
+                            // quiet neutral tonal fill (matches Home's Send/Receive)
+                            // rather than the loud inverted-ink primary.
+                            PrimaryButton(
+                                text = if (copied) "Copied" else "Copy",
+                                onClick = {
+                                    clipboard.setText(AnnotatedString(copyableContent))
+                                    copied = true
+                                },
+                                colors = neutralActionButtonColors(),
+                            )
+                        }
                         if (offersManualClaimCheck && pendingSentToken != null) {
+                            if (copyableContent != null) {
+                                Spacer(Modifier.height(CashuTheme.spacing.tight))
+                            }
                             PrimaryButton(
                                 text = if (checkingClaim) "Checking…" else "Check Status",
                                 onClick = {
@@ -347,22 +363,6 @@ fun TransactionDetailScreen(
                                         }
                                         liveRegion = LiveRegionMode.Polite
                                     },
-                            )
-                        }
-                        if (offersManualClaimCheck && copyableContent != null) {
-                            Spacer(Modifier.height(CashuTheme.spacing.tight))
-                        }
-                        if (copyableContent != null) {
-                            // Copy is a secondary convenience, not a primary action —
-                            // quiet neutral tonal fill (matches Home's Send/Receive)
-                            // rather than the loud inverted-ink primary.
-                            PrimaryButton(
-                                text = if (copied) "Copied" else "Copy",
-                                onClick = {
-                                    clipboard.setText(AnnotatedString(copyableContent))
-                                    copied = true
-                                },
-                                colors = neutralActionButtonColors(),
                             )
                         }
                     }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -1066,29 +1066,6 @@ private fun GeneratedFace(
             GeneratedEcashAmount(presentation = amountPresentation)
             ClaimStatusRow(claimState = claimState)
             if (!pollingEnabled) {
-                GhostButton(
-                    text = if (claimState == ClaimState.Checking) "Checking…" else "Check Status",
-                    onClick = {
-                        claimState = ClaimState.Checking
-                        manualCheckResult = null
-                        scope.launch {
-                            val outcome = checkGeneratedTokenClaim(
-                                walletManager = walletManager,
-                                token = result.token,
-                                mintUrl = mintUrl,
-                            )
-                            manualCheckResult = outcome
-                            claimState = if (outcome == PendingTokenClaimCheckResult.Claimed) {
-                                ClaimState.Claimed
-                            } else {
-                                ClaimState.Pending
-                            }
-                        }
-                    },
-                    enabled = claimState != ClaimState.Checking,
-                    trailingIcon = if (claimState == ClaimState.Checking) null else Icons.Outlined.Refresh,
-                    modifier = Modifier.testTag(UiTestTags.SendEcashCheckStatus),
-                )
                 when (val outcome = manualCheckResult) {
                     PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
                         text = "Status checked",
@@ -1137,22 +1114,52 @@ private fun GeneratedFace(
                 )
             }
         }
-        // Gray tonal fill instead of the inverted-ink primary — the analog of
-        // iOS's non-prominent glass capsule; adapts to light/dark.
-        PrimaryButton(
-            text = if (copied) "Copied" else "Copy",
-            onClick = {
-                clipboard.setText(AnnotatedString(result.token))
-                copied = true
-            },
-            colors = neutralActionButtonColors(),
+        Column(
             modifier = Modifier.padding(
                 start = CashuTheme.spacing.comfortable,
                 end = CashuTheme.spacing.comfortable,
                 top = CashuTheme.spacing.micro,
                 bottom = CashuTheme.spacing.comfortable,
             ),
-        )
+        ) {
+            // Gray tonal fill instead of the inverted-ink primary — the analog of
+            // iOS's non-prominent glass capsule; adapts to light/dark.
+            PrimaryButton(
+                text = if (copied) "Copied" else "Copy",
+                onClick = {
+                    clipboard.setText(AnnotatedString(result.token))
+                    copied = true
+                },
+                colors = neutralActionButtonColors(),
+            )
+            if (!pollingEnabled) {
+                Spacer(Modifier.height(CashuTheme.spacing.tight))
+                // Keep manual status checks with the pinned actions, rather
+                // than inline beneath the QR code.
+                PrimaryButton(
+                    text = if (claimState == ClaimState.Checking) "Checking…" else "Check Status",
+                    onClick = {
+                        claimState = ClaimState.Checking
+                        manualCheckResult = null
+                        scope.launch {
+                            val outcome = checkGeneratedTokenClaim(
+                                walletManager = walletManager,
+                                token = result.token,
+                                mintUrl = mintUrl,
+                            )
+                            manualCheckResult = outcome
+                            claimState = if (outcome == PendingTokenClaimCheckResult.Claimed) {
+                                ClaimState.Claimed
+                            } else {
+                                ClaimState.Pending
+                            }
+                        }
+                    },
+                    loading = claimState == ClaimState.Checking,
+                    modifier = Modifier.testTag(UiTestTags.SendEcashCheckStatus),
+                )
+            }
+        }
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.LockOpen
 import androidx.compose.material.icons.outlined.Payments
 import androidx.compose.material.icons.outlined.Receipt
+import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LoadingIndicator
@@ -76,10 +77,12 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.AccessibilityAction
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.AnnotatedString
@@ -98,12 +101,15 @@ import com.cashu.me.Core.rememberWalletHaptics
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.PendingTokenClaimCheckResult
+import com.cashu.me.Core.runPendingTokenClaimCheck
 import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Models.SendTokenResult
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.CashuTextField
+import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.MintPickerSheet
@@ -959,8 +965,12 @@ private fun GeneratedFace(
     onDone: () -> Unit,
 ) {
     val clipboard = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
     var copied by remember { mutableStateOf(false) }
     var claimState: ClaimState by remember(result.token) { mutableStateOf(ClaimState.Pending) }
+    var manualCheckResult: PendingTokenClaimCheckResult? by remember(result.token) {
+        mutableStateOf(null)
+    }
     LaunchedEffect(copied) {
         if (copied) {
             delay(2000)
@@ -972,19 +982,23 @@ private fun GeneratedFace(
     // (flipping Pending↔Checking per probe made the row flicker), intervals
     // back off 5s → 15s, and after 10 checks the row rests at Pending.
     LaunchedEffect(result.token, mintUrl, pollingEnabled) {
-        if (!pollingEnabled) return@LaunchedEffect
+        if (!pollingEnabled) {
+            if (claimState != ClaimState.Claimed) claimState = ClaimState.Pending
+            return@LaunchedEffect
+        }
         claimState = ClaimState.Checking
         var interval = 5_000L
         repeat(10) {
             delay(interval)
-            // checkTokenSpent returns true once any proof is spent (redeemed);
-            // null means the check failed — keep watching, never fake a claim.
-            val spent = runCatching {
-                walletManager.checkTokenSpent(result.token, mintUrl)
-            }.getOrNull()
-            if (spent == true) {
-                claimState = ClaimState.Claimed
-                return@LaunchedEffect
+            // A spent proof moves the tracked token to Claimed. Probe failures
+            // stay Pending and the automatic watcher keeps trying.
+            when (checkGeneratedTokenClaim(walletManager, result.token, mintUrl)) {
+                PendingTokenClaimCheckResult.Claimed -> {
+                    claimState = ClaimState.Claimed
+                    return@LaunchedEffect
+                }
+                PendingTokenClaimCheckResult.NotClaimed -> Unit
+                is PendingTokenClaimCheckResult.Failed -> Unit
             }
             interval = (interval + 1_000L).coerceAtMost(15_000L)
         }
@@ -1051,6 +1065,49 @@ private fun GeneratedFace(
             )
             GeneratedEcashAmount(presentation = amountPresentation)
             ClaimStatusRow(claimState = claimState)
+            if (!pollingEnabled) {
+                GhostButton(
+                    text = if (claimState == ClaimState.Checking) "Checking…" else "Check Status",
+                    onClick = {
+                        claimState = ClaimState.Checking
+                        manualCheckResult = null
+                        scope.launch {
+                            val outcome = checkGeneratedTokenClaim(
+                                walletManager = walletManager,
+                                token = result.token,
+                                mintUrl = mintUrl,
+                            )
+                            manualCheckResult = outcome
+                            claimState = if (outcome == PendingTokenClaimCheckResult.Claimed) {
+                                ClaimState.Claimed
+                            } else {
+                                ClaimState.Pending
+                            }
+                        }
+                    },
+                    enabled = claimState != ClaimState.Checking,
+                    trailingIcon = if (claimState == ClaimState.Checking) null else Icons.Outlined.Refresh,
+                    modifier = Modifier.testTag(UiTestTags.SendEcashCheckStatus),
+                )
+                when (val outcome = manualCheckResult) {
+                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                        text = "Status checked",
+                        detail = "This token has not been claimed yet.",
+                        severity = NoticeSeverity.Info,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                        },
+                    )
+                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                        text = "Couldn't check status",
+                        detail = outcome.message.text,
+                        modifier = Modifier.semantics {
+                            liveRegion = LiveRegionMode.Polite
+                        },
+                    )
+                    PendingTokenClaimCheckResult.Claimed, null -> Unit
+                }
+            }
             // Detail rows: Fee -> Unit -> Fiat (sat-only) -> Mint (iOS order).
             Column(modifier = Modifier.fillMaxWidth()) {
                 formatSendEcashFee(result.fee, unit)?.let { feeLabel ->
@@ -1138,9 +1195,13 @@ private fun GeneratedEcashAmount(
 private enum class ClaimState { Pending, Checking, Claimed }
 
 @Composable
-private fun ClaimStatusRow(claimState: ClaimState) {
+private fun ClaimStatusRow(
+    claimState: ClaimState,
+    modifier: Modifier = Modifier,
+) {
     AnimatedContent(
         targetState = claimState,
+        modifier = modifier.semantics { liveRegion = LiveRegionMode.Polite },
         transitionSpec = { fadeIn(tween(220)) togetherWith fadeOut(tween(220)) },
         label = "claim-state",
     ) { state ->
@@ -1192,6 +1253,29 @@ private fun ClaimStatusRow(claimState: ClaimState) {
                 }
             }
             ClaimState.Claimed -> Unit
+        }
+    }
+}
+
+private suspend fun checkGeneratedTokenClaim(
+    walletManager: WalletManager,
+    token: String,
+    mintUrl: String,
+): PendingTokenClaimCheckResult = runPendingTokenClaimCheck {
+    val walletState = walletManager.state.value
+    when {
+        walletState.claimedTokens.any { it.token == token } -> true
+        else -> {
+            val pending = walletState.pendingTokens.firstOrNull { it.token == token }
+            if (pending != null) {
+                // This path both checks the mint and moves the local History
+                // record from Pending to Claimed when a proof is spent.
+                walletManager.checkPendingTokenStatus(pending)
+            } else {
+                // Defensive fallback for a legacy/generated token with no local
+                // pending record. New sends always take the tracked path above.
+                walletManager.checkTokenSpent(token, mintUrl)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/testing/UiTestTags.kt
@@ -42,11 +42,13 @@ object UiTestTags {
     const val SendEcashScreen = "cashu.sheet.send-ecash"
     const val SendEcashSubmit = "cashu.send.ecash.submit"
     const val LockEcashToggle = "cashu.send.ecash.lock-toggle"
-    const val P2pkRecipientConfirmation = "cashu.send.ecash.p2pk-recipient"
+const val P2pkRecipientConfirmation = "cashu.send.ecash.p2pk-recipient"
+    const val SendEcashCheckStatus = "cashu.send.ecash.check-status"
     const val AddMintSheet = "cashu.sheet.add-mint"
     const val AddMintUrl = "cashu.sheet.add-mint.url"
     const val AddMintSubmit = "cashu.sheet.add-mint.submit"
     const val HistorySearch = "cashu.history.search"
+    const val HistoryCheckTokenStatus = "cashu.history.check-token-status"
 
     fun mintRow(url: String): String = "cashu.mint.${url.hashCode().toUInt().toString(16)}"
 

--- a/android/app/src/test/java/com/cashu/me/Core/PendingTokenClaimTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PendingTokenClaimTest.kt
@@ -1,0 +1,102 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.PendingToken
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PendingTokenClaimTest {
+    @Test
+    fun manualCheckIsOnlyOfferedForPendingTokenWhenAutomaticChecksAreDisabled() {
+        val pending = pendingToken()
+
+        assertTrue(shouldOfferManualClaimCheck(automaticChecksEnabled = false, pending))
+        assertFalse(shouldOfferManualClaimCheck(automaticChecksEnabled = true, pending))
+        assertFalse(shouldOfferManualClaimCheck(automaticChecksEnabled = false, pendingToken = null))
+    }
+
+    @Test
+    fun resolvesMergedHistoryRowByEncodedTokenWhenCdkReplacesItsId() {
+        val pending = pendingToken()
+        val mergedRow = pendingTransaction(id = "cdk-transaction-id", token = pending.token)
+
+        assertEquals(pending, pendingSentTokenFor(mergedRow, listOf(pending)))
+    }
+
+    @Test
+    fun doesNotResolveIncomingOrCompletedEcashRows() {
+        val pending = pendingToken()
+
+        assertEquals(
+            null,
+            pendingSentTokenFor(
+                pendingTransaction(token = pending.token).copy(type = TransactionType.Incoming),
+                listOf(pending),
+            ),
+        )
+        assertEquals(
+            null,
+            pendingSentTokenFor(
+                pendingTransaction(token = pending.token).copy(status = TransactionStatus.Completed),
+                listOf(pending),
+            ),
+        )
+    }
+
+    @Test
+    fun distinguishesClaimedNotClaimedAndRetryableFailure() = runBlocking {
+        assertSame(
+            PendingTokenClaimCheckResult.Claimed,
+            runPendingTokenClaimCheck { true },
+        )
+        assertSame(
+            PendingTokenClaimCheckResult.NotClaimed,
+            runPendingTokenClaimCheck { false },
+        )
+
+        val failed = runPendingTokenClaimCheck {
+            throw IllegalStateException("network connection failed")
+        } as PendingTokenClaimCheckResult.Failed
+        assertEquals("Couldn't reach the mint. Check your connection and try again.", failed.message.text)
+        assertTrue(failed.message.isRetryable)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun cancellationIsNotConvertedIntoARetryMessage() {
+        runBlocking {
+            runPendingTokenClaimCheck { throw CancellationException("screen closed") }
+        }
+    }
+
+    private fun pendingToken() = PendingToken(
+        tokenId = "local-pending-id",
+        token = "cashuBpending",
+        amount = 42,
+        fee = 1,
+        dateEpochMillis = 100,
+        mintUrl = "https://mint.example.com",
+    )
+
+    private fun pendingTransaction(
+        id: String = "local-pending-id",
+        token: String,
+    ) = WalletTransaction(
+        id = id,
+        amount = 42,
+        type = TransactionType.Outgoing,
+        kind = TransactionKind.Ecash,
+        dateEpochMillis = 100,
+        status = TransactionStatus.Pending,
+        mintUrl = "https://mint.example.com",
+        token = token,
+        isPendingToken = true,
+    )
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -66,7 +66,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P2 · iOS → Android] Replace protocol jargon in lock accessibility copy.** Android announces “P2PK off” and “P2PK locked”; iOS describes the user outcome. **Done when:** Android’s visible and assistive copy leads with “Lock ecash” and the recipient effect, with P2PK only as optional supporting terminology.
 
-- [x] **[P1 · iOS → Android] Provide manual claim-status checking when automatic checks are disabled.** iOS adds “Check Status” to pending-token actions; Android’s pending-token view previously had no per-token equivalent. **Done when:** Android users can run a one-off spent check on a pending token without re-enabling background polling.
+- [x] **[P1 · Converge] Provide manual claim-status checking when automatic checks are disabled.** Both generated-token screens and pending outgoing ecash details expose “Check Status,” distinguish claimed, unclaimed, and failed checks, and keep errors retryable. **Done when:** users on either platform can run a one-off spent check without re-enabling background polling.
 
 - [x] **[P1 · iOS → Android] Include the send fee on the Claimed receipt.** iOS shows the fee when the token-generation swap charged one; Android’s pending view shows it but the full-screen Claimed terminal drops it. **Done when:** Android’s Claimed details preserve Amount, applicable Fee, and Mint.
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -66,7 +66,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P2 · iOS → Android] Replace protocol jargon in lock accessibility copy.** Android announces “P2PK off” and “P2PK locked”; iOS describes the user outcome. **Done when:** Android’s visible and assistive copy leads with “Lock ecash” and the recipient effect, with P2PK only as optional supporting terminology.
 
-- [ ] **[P1 · iOS → Android] Provide manual claim-status checking when automatic checks are disabled.** iOS adds “Check Status” to pending-token actions; Android’s pending-token view has no per-token equivalent. (Android users can force a global re-check of all pending sent tokens via pull-to-refresh on Home and History, but there is no per-token action.) **Done when:** Android users can run a one-off spent check on a pending token without re-enabling background polling.
+- [x] **[P1 · iOS → Android] Provide manual claim-status checking when automatic checks are disabled.** iOS adds “Check Status” to pending-token actions; Android’s pending-token view previously had no per-token equivalent. **Done when:** Android users can run a one-off spent check on a pending token without re-enabling background polling.
 
 - [x] **[P1 · iOS → Android] Include the send fee on the Claimed receipt.** iOS shows the fee when the token-generation swap charged one; Android’s pending view shows it but the full-screen Claimed terminal drops it. **Done when:** Android’s Claimed details preserve Amount, applicable Fee, and Mint.
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		D200000000000108 /* WalletManager+Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000108 /* WalletManager+Backup.swift */; };
 		D200000000000109 /* WalletErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000109 /* WalletErrors.swift */; };
 		D20000000000010A /* WalletManager+PendingMelts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010A /* WalletManager+PendingMelts.swift */; };
+		D20000000000010C /* PendingTokenClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010C /* PendingTokenClaim.swift */; };
 		D200000000000201 /* PaymentMethodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000201 /* PaymentMethodKind.swift */; };
 		D200000000000202 /* PaymentRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000202 /* PaymentRequestParser.swift */; };
 		D200000000000203 /* OnchainExplorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000203 /* OnchainExplorer.swift */; };
@@ -244,6 +245,7 @@
 		D100000000000108 /* WalletManager+Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+Backup.swift"; sourceTree = "<group>"; };
 		D100000000000109 /* WalletErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletErrors.swift; sourceTree = "<group>"; };
 		D10000000000010A /* WalletManager+PendingMelts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+PendingMelts.swift"; sourceTree = "<group>"; };
+		D10000000000010C /* PendingTokenClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTokenClaim.swift; sourceTree = "<group>"; };
 		D100000000000201 /* PaymentMethodKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodKind.swift; sourceTree = "<group>"; };
 		D100000000000202 /* PaymentRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRequestParser.swift; sourceTree = "<group>"; };
 		D100000000000203 /* OnchainExplorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainExplorer.swift; sourceTree = "<group>"; };
@@ -634,6 +636,7 @@
 				D10000000000010B /* MintQuoteCheckBackoff.swift */,
 				D100000000000108 /* WalletManager+Backup.swift */,
 				D100000000000109 /* WalletErrors.swift */,
+				D10000000000010C /* PendingTokenClaim.swift */,
 			);
 			path = Wallet;
 			sourceTree = "<group>";
@@ -919,6 +922,7 @@
 				D20000000000010B /* MintQuoteCheckBackoff.swift in Sources */,
 				D200000000000108 /* WalletManager+Backup.swift in Sources */,
 				D200000000000109 /* WalletErrors.swift in Sources */,
+				D20000000000010C /* PendingTokenClaim.swift in Sources */,
 				D200000000000201 /* PaymentMethodKind.swift in Sources */,
 				D200000000000202 /* PaymentRequestParser.swift in Sources */,
 				D200000000000203 /* OnchainExplorer.swift in Sources */,

--- a/ios/CashuWallet/Core/Services/TokenService.swift
+++ b/ios/CashuWallet/Core/Services/TokenService.swift
@@ -302,24 +302,32 @@ class TokenService: ObservableObject {
     /// decoded from a token created under an IDv2 keyset may carry a short/legacy
     /// keyset ID and CDK's `checkProofsSpent` will throw:
     ///   "Short keyset id does not match any of the provided IDv2s"
+    func checkTokenSpent(token: String, mintUrl: String) async throws -> Bool {
+        guard let repo = walletRepository() else {
+            throw WalletError.notInitialized
+        }
+
+        let tokenObj = try Token.decode(encodedToken: token)
+        let mintUrlObj = MintUrl(url: mintUrl)
+        let tokenUnit = tokenObj.unit() ?? .sat
+
+        let wallet = try await repo.getWallet(mintUrl: mintUrlObj, unit: tokenUnit)
+        let keysets = try await wallet.getMintKeysets(filter: .all)
+        let proofs = try tokenObj.proofs(mintKeysets: keysets)
+        let spentStates = try await wallet.checkProofsSpent(proofs: proofs)
+
+        // If any proofs are spent, the token has been redeemed.
+        return spentStates.contains(true)
+    }
+
+    /// Passive checks keep their historical non-throwing contract. Interactive
+    /// checks call `checkTokenSpent` so failures can be shown instead of being
+    /// misreported as a definitive "not claimed" result.
     func checkTokenSpendable(token: String, mintUrl: String) async -> Bool {
-        guard let repo = walletRepository() else { return false }
-
         do {
-            let tokenObj = try Token.decode(encodedToken: token)
-            let mintUrlObj = MintUrl(url: mintUrl)
-            let tokenUnit = tokenObj.unit() ?? .sat
-
-            let wallet = try await repo.getWallet(mintUrl: mintUrlObj, unit: tokenUnit)
-            let keysets = try await wallet.getMintKeysets(filter: .all)
-            let proofs = try tokenObj.proofs(mintKeysets: keysets)
-
-            let spentStates = try await wallet.checkProofsSpent(proofs: proofs)
-
-            // If any proofs are spent, the token has been redeemed
-            return spentStates.contains(true)
+            return try await checkTokenSpent(token: token, mintUrl: mintUrl)
         } catch {
-            print("Error checking token spendable: \(error)")
+            AppLogger.wallet.error("Error checking token spent status: \(error)")
             return false
         }
     }

--- a/ios/CashuWallet/Core/Wallet/PendingTokenClaim.swift
+++ b/ios/CashuWallet/Core/Wallet/PendingTokenClaim.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Result of a user-initiated spent-status probe.
+///
+/// A successful mint response that reports unspent proofs is distinct from a
+/// transport or wallet failure so the UI can acknowledge the completed check
+/// without hiding a retryable error.
+enum PendingTokenClaimCheckResult {
+    case claimed
+    case notClaimed
+    case failed(WalletMessage)
+}
+
+/// Run one status probe while preserving structured task cancellation.
+func runPendingTokenClaimCheck(
+    check: () async throws -> Bool
+) async throws -> PendingTokenClaimCheckResult {
+    do {
+        return try await check() ? .claimed : .notClaimed
+    } catch {
+        if error is CancellationError || Task.isCancelled {
+            throw CancellationError()
+        }
+        return .failed(error.walletMessage)
+    }
+}
+
+/// Resolve the local pending-token record behind a History row.
+///
+/// CDK transaction IDs can replace the local token ID during History merging,
+/// so the encoded token is the stable first choice and the ID is a legacy
+/// fallback.
+func pendingSentTokenFor(
+    transaction: WalletTransaction,
+    pendingTokens: [PendingToken]
+) -> PendingToken? {
+    guard transaction.type == .outgoing,
+          transaction.kind == .ecash,
+          transaction.status == .pending,
+          transaction.isPendingToken else {
+        return nil
+    }
+
+    if let token = transaction.token,
+       let matchingToken = pendingTokens.first(where: { $0.token == token }) {
+        return matchingToken
+    }
+
+    return pendingTokens.first(where: { $0.tokenId == transaction.id })
+}
+
+func shouldOfferManualClaimCheck(
+    automaticChecksEnabled: Bool,
+    pendingToken: PendingToken?
+) -> Bool {
+    !automaticChecksEnabled && pendingToken != nil
+}

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -212,11 +212,21 @@ extension WalletManager {
         return await tokenService.checkTokenSpendable(token: token, mintUrl: resolvedMintUrl)
     }
 
-    func checkPendingTokenStatus(pendingToken: PendingToken) async {
-        let isSpent = await checkTokenSpendable(token: pendingToken.token, mintUrl: pendingToken.mintUrl)
+    func checkTokenSpent(token: String, mintUrl: String) async throws -> Bool {
+        try await tokenService.checkTokenSpent(token: token, mintUrl: mintUrl)
+    }
+
+    @discardableResult
+    func checkPendingTokenStatus(pendingToken: PendingToken) async throws -> Bool {
+        let isSpent = try await checkTokenSpent(
+            token: pendingToken.token,
+            mintUrl: pendingToken.mintUrl
+        )
         if isSpent {
             transactionService.markTokenAsClaimed(token: pendingToken.token)
+            await loadTransactions()
         }
+        return isSpent
     }
 
     func checkAllPendingTokens() async {
@@ -225,7 +235,19 @@ extension WalletManager {
         guard !pendingTokens.isEmpty else { return }
 
         for token in pendingTokens {
-            await checkPendingTokenStatus(pendingToken: token)
+            do {
+                let isSpent = try await tokenService.checkTokenSpent(
+                    token: token.token,
+                    mintUrl: token.mintUrl
+                )
+                if isSpent {
+                    transactionService.markTokenAsClaimed(token: token.token)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                AppLogger.wallet.error("Pending token status check failed: \(error)")
+            }
         }
         await loadTransactions()
     }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -13,6 +13,9 @@ struct TransactionDetailView: View {
     /// Label of the row whose value was just copied — drives the doc.on.doc →
     /// green checkmark swap on tap-to-copy rows (Address / Transaction ID / …).
     @State private var copiedRowLabel: String?
+    @State private var isCheckingClaim = false
+    @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
+    @State private var manualClaimCheckTask: Task<Void, Never>?
 
     init(transaction: WalletTransaction) {
         self.seed = transaction
@@ -45,6 +48,20 @@ struct TransactionDetailView: View {
         if showsQR { return qrContent }
         if transaction.kind == .ecash, let token = transaction.token { return token }
         return nil
+    }
+
+    private var pendingSentToken: PendingToken? {
+        pendingSentTokenFor(
+            transaction: transaction,
+            pendingTokens: walletManager.pendingTokens
+        )
+    }
+
+    private var offersManualClaimCheck: Bool {
+        shouldOfferManualClaimCheck(
+            automaticChecksEnabled: settings.checkSentTokens,
+            pendingToken: pendingSentToken
+        )
     }
 
     /// A reusable BOLT12 offer — its bech32 human-readable prefix is `lno`.
@@ -150,25 +167,62 @@ struct TransactionDetailView: View {
                         }
                         .padding(.top, 8)
                         .padding(.horizontal, 4)
+
+                        if offersManualClaimCheck {
+                            switch manualClaimCheckResult {
+                            case .notClaimed:
+                                InlineNotice(
+                                    message: "This token has not been claimed yet.",
+                                    title: "Status checked",
+                                    severity: .info,
+                                    tinted: true
+                                )
+                            case .failed(let message):
+                                InlineNotice(
+                                    message: message.text,
+                                    title: "Couldn't check status",
+                                    severity: message.severity,
+                                    tinted: true
+                                )
+                            case .claimed, nil:
+                                EmptyView()
+                            }
+                        }
                     }
                     .padding(.horizontal)
                 }
 
-                // Single primary action — Copy. Appears for an actionable
-                // artifact (unclaimed token / pending or reusable invoice /
-                // on-chain address) and, as a receipt, for a settled ecash token.
-                // Share stays top-right in the toolbar, gated on `showsQR`, so a
-                // spent token is never re-presented as a shareable payment code.
-                // See DESIGN.md → Share-At-Top Rule + settled-ecash receipt carve-out.
-                if let content = copyableContent {
-                    Button(action: { copyContent(content) }) {
-                        Text(copyButtonText)
+                // Pending outgoing ecash gains the same one-off status action as
+                // the generated-token screen when automatic checks are disabled.
+                // Copy remains the quiet convenience action underneath.
+                if offersManualClaimCheck || copyableContent != nil {
+                    VStack(spacing: 12) {
+                        if offersManualClaimCheck, let pendingToken = pendingSentToken {
+                            Button(action: { startManualClaimCheck(pendingToken) }) {
+                                if isCheckingClaim {
+                                    ProgressView()
+                                } else {
+                                    Text("Check Status")
+                                }
+                            }
+                            .glassButton()
+                            .disabled(isCheckingClaim)
+                            .accessibilityIdentifier("cashu.history.check-token-status")
+                            .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                            .accessibilityInputLabels(["Check Status"])
+                        }
+
+                        if let content = copyableContent {
+                            Button(action: { copyContent(content) }) {
+                                Text(copyButtonText)
+                            }
+                            .glassButton()
+                            .accessibilityLabel(copyButtonText == "Copied" ? "Copied" : "Copy \(qrContentTypeLabel)")
+                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
+                        }
                     }
-                    .glassButton()
                     .padding(.horizontal)
                     .padding(.bottom, 16)
-                    .accessibilityLabel(copyButtonText == "Copied" ? "Copied" : "Copy \(qrContentTypeLabel)")
-                    .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
@@ -203,6 +257,9 @@ struct TransactionDetailView: View {
             .task(id: seed.id) {
                 guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
                 _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
+            }
+            .onDisappear {
+                manualClaimCheckTask?.cancel()
             }
         }
     }
@@ -454,5 +511,41 @@ struct TransactionDetailView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             copyButtonText = "Copy"
         }
+    }
+
+    private func startManualClaimCheck(_ pendingToken: PendingToken) {
+        manualClaimCheckTask?.cancel()
+        manualClaimCheckTask = Task {
+            isCheckingClaim = true
+            manualClaimCheckResult = nil
+            defer { isCheckingClaim = false }
+
+            do {
+                let outcome = try await runPendingTokenClaimCheck {
+                    try await walletManager.checkPendingTokenStatus(pendingToken: pendingToken)
+                }
+                guard !Task.isCancelled else { return }
+
+                manualClaimCheckResult = outcome
+                announceClaimCheckResult(outcome)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func announceClaimCheckResult(_ outcome: PendingTokenClaimCheckResult) {
+        let announcement: String
+        switch outcome {
+        case .claimed:
+            announcement = "Token claimed."
+        case .notClaimed:
+            announcement = "Status checked. This token has not been claimed yet."
+        case .failed(let message):
+            announcement = "Couldn't check status. \(message.text)"
+        }
+        AccessibilityNotification.Announcement(announcement).post()
     }
 }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -194,9 +194,18 @@ struct TransactionDetailView: View {
 
                 // Pending outgoing ecash gains the same one-off status action as
                 // the generated-token screen when automatic checks are disabled.
-                // Copy remains the quiet convenience action underneath.
+                // Keep it after Copy so the two surfaces share the same action order.
                 if offersManualClaimCheck || copyableContent != nil {
                     VStack(spacing: 12) {
+                        if let content = copyableContent {
+                            Button(action: { copyContent(content) }) {
+                                Text(copyButtonText)
+                            }
+                            .glassButton()
+                            .accessibilityLabel(copyButtonText == "Copied" ? "Copied" : "Copy \(qrContentTypeLabel)")
+                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
+                        }
+
                         if offersManualClaimCheck, let pendingToken = pendingSentToken {
                             Button(action: { startManualClaimCheck(pendingToken) }) {
                                 if isCheckingClaim {
@@ -210,15 +219,6 @@ struct TransactionDetailView: View {
                             .accessibilityIdentifier("cashu.history.check-token-status")
                             .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
                             .accessibilityInputLabels(["Check Status"])
-                        }
-
-                        if let content = copyableContent {
-                            Button(action: { copyContent(content) }) {
-                                Text(copyButtonText)
-                            }
-                            .glassButton()
-                            .accessibilityLabel(copyButtonText == "Copied" ? "Copied" : "Copy \(qrContentTypeLabel)")
-                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                         }
                     }
                     .padding(.horizontal)

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -37,6 +37,7 @@ struct SendView: View {
     @State private var isCheckingClaim = false
     @State private var tokenClaimed = false
     @State private var checkingTask: Task<Void, Never>?
+    @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
 
     // Copy button feedback
     @State private var copyButtonText = "Copy"
@@ -620,13 +621,6 @@ struct SendView: View {
                             Button(action: { showShareSheet = true }) {
                                 Label("Share", systemImage: "square.and.arrow.up")
                             }
-                            if !settings.checkSentTokens {
-                                Button(action: {
-                                    Task { await checkTokenClaimNow(token: token) }
-                                }) {
-                                    Label("Check Status", systemImage: "arrow.clockwise")
-                                }
-                            }
                         }
 
                     // Amount — sats keep the fiat-flip display; a non-sat token
@@ -681,6 +675,47 @@ struct SendView: View {
                     .animation(reduceMotion ? .easeInOut(duration: 0.2) : .spring(response: 0.5, dampingFraction: 0.7), value: tokenClaimed)
                     .animation(.easeInOut(duration: 0.2), value: isCheckingClaim)
 
+                    if !settings.checkSentTokens {
+                        Button(action: { startManualClaimCheck(token: token) }) {
+                            Label {
+                                Text(isCheckingClaim ? "Checking…" : "Check Status")
+                            } icon: {
+                                if isCheckingClaim {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                } else {
+                                    Image(systemName: "arrow.clockwise")
+                                }
+                            }
+                        }
+                        .textLinkButton()
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                        .disabled(isCheckingClaim)
+                        .accessibilityIdentifier("cashu.send.ecash.check-status")
+                        .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                        .accessibilityInputLabels(["Check Status"])
+
+                        switch manualClaimCheckResult {
+                        case .notClaimed:
+                            InlineNotice(
+                                message: "This token has not been claimed yet.",
+                                title: "Status checked",
+                                severity: .info,
+                                tinted: true
+                            )
+                        case .failed(let message):
+                            InlineNotice(
+                                message: message.text,
+                                title: "Couldn't check status",
+                                severity: message.severity,
+                                tinted: true
+                            )
+                        case .claimed, nil:
+                            EmptyView()
+                        }
+                    }
+
                     // Detail rows on canvas with hairline dividers — same
                     // pattern as the Lightning Invoice screen.
                     VStack(spacing: 0) {
@@ -720,8 +755,9 @@ struct SendView: View {
             .padding(.bottom, 16)
         }
         .onAppear {
-            guard settings.checkSentTokens else { return }
-            startClaimPolling(token: token)
+            guard settings.checkSentTokens,
+                  let mintUrl = generatedTokenMintURL else { return }
+            startClaimPolling(token: token, mintUrl: mintUrl)
         }
     }
 
@@ -938,7 +974,7 @@ struct SendView: View {
 
     // MARK: - Token Claim Detection
 
-    private func startClaimPolling(token: String) {
+    private func startClaimPolling(token: String, mintUrl: String) {
         // Cancel any existing task
         checkingTask?.cancel()
 
@@ -946,60 +982,99 @@ struct SendView: View {
 
         checkingTask = Task {
             let maxChecks = 10
-            let maxInterval: UInt64 = 15_000_000_000
+            let maxInterval = 15
             var checkCount = 0
-            var interval: UInt64 = 5_000_000_000
+            var interval = 5
 
             while !Task.isCancelled && !tokenClaimed && checkCount < maxChecks {
-                try? await Task.sleep(nanoseconds: interval)
+                do {
+                    try await Task.sleep(for: .seconds(interval))
+                } catch {
+                    break
+                }
 
-                guard !Task.isCancelled else { break }
+                let outcome: PendingTokenClaimCheckResult
+                do {
+                    outcome = try await runPendingTokenClaimCheck {
+                        try await checkGeneratedTokenClaim(token: token, mintUrl: mintUrl)
+                    }
+                } catch {
+                    break
+                }
 
-                // Check if token has been spent
-                let isSpent = await walletManager.checkTokenSpendable(token: token)
-
-                if isSpent {
+                if case .claimed = outcome {
                     // Flipping `tokenClaimed` swaps the body to the full-screen
                     // success (owns its own success haptic on appear, so don't
                     // buzz here). It stays until the user taps Done.
-                    await MainActor.run {
-                        tokenClaimed = true
-                        isCheckingClaim = false
-                    }
-
-                    // Remove from pending and reload transactions so HistoryView updates
-                    // We need to find the pending token ID - it's stored when we create the token
-                    await walletManager.markTokenAsClaimed(token: token)
+                    tokenClaimed = true
+                    isCheckingClaim = false
                     break
                 }
 
                 checkCount += 1
-                interval = min(interval + 1_000_000_000, maxInterval)
+                interval = min(interval + 1, maxInterval)
             }
 
-            await MainActor.run {
-                isCheckingClaim = false
+            isCheckingClaim = false
+        }
+    }
+
+    private func startManualClaimCheck(token: String) {
+        guard let mintUrl = generatedTokenMintURL else {
+            let message = WalletError.notInitialized.walletMessage
+            manualClaimCheckResult = .failed(message)
+            announceClaimCheckResult(.failed(message))
+            return
+        }
+
+        checkingTask?.cancel()
+        checkingTask = Task {
+            isCheckingClaim = true
+            manualClaimCheckResult = nil
+            defer { isCheckingClaim = false }
+
+            do {
+                let outcome = try await runPendingTokenClaimCheck {
+                    try await checkGeneratedTokenClaim(token: token, mintUrl: mintUrl)
+                }
+                guard !Task.isCancelled else { return }
+
+                manualClaimCheckResult = outcome
+                if case .claimed = outcome {
+                    tokenClaimed = true
+                }
+                announceClaimCheckResult(outcome)
+            } catch is CancellationError {
+                return
+            } catch {
+                return
             }
         }
     }
 
-    private func checkTokenClaimNow(token: String) async {
-        await MainActor.run {
-            isCheckingClaim = true
+    private func checkGeneratedTokenClaim(token: String, mintUrl: String) async throws -> Bool {
+        if let pendingToken = walletManager.pendingTokens.first(where: { $0.token == token }) {
+            return try await walletManager.checkPendingTokenStatus(pendingToken: pendingToken)
         }
 
-        let isSpent = await walletManager.checkTokenSpendable(token: token)
+        let isSpent = try await walletManager.checkTokenSpent(token: token, mintUrl: mintUrl)
         if isSpent {
-            // Full-screen success owns the screen + its haptic; stays until Done.
-            await MainActor.run {
-                tokenClaimed = true
-            }
             await walletManager.markTokenAsClaimed(token: token)
         }
+        return isSpent
+    }
 
-        await MainActor.run {
-            isCheckingClaim = false
+    private func announceClaimCheckResult(_ outcome: PendingTokenClaimCheckResult) {
+        let announcement: String
+        switch outcome {
+        case .claimed:
+            announcement = "Token claimed."
+        case .notClaimed:
+            announcement = "Status checked. This token has not been claimed yet."
+        case .failed(let message):
+            announcement = "Couldn't check status. \(message.text)"
         }
+        AccessibilityNotification.Announcement(announcement).post()
     }
 }
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -676,26 +676,6 @@ struct SendView: View {
                     .animation(.easeInOut(duration: 0.2), value: isCheckingClaim)
 
                     if !settings.checkSentTokens {
-                        Button(action: { startManualClaimCheck(token: token) }) {
-                            Label {
-                                Text(isCheckingClaim ? "Checking…" : "Check Status")
-                            } icon: {
-                                if isCheckingClaim {
-                                    ProgressView()
-                                        .controlSize(.small)
-                                } else {
-                                    Image(systemName: "arrow.clockwise")
-                                }
-                            }
-                        }
-                        .textLinkButton()
-                        .frame(minHeight: 44)
-                        .contentShape(Rectangle())
-                        .disabled(isCheckingClaim)
-                        .accessibilityIdentifier("cashu.send.ecash.check-status")
-                        .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
-                        .accessibilityInputLabels(["Check Status"])
-
                         switch manualClaimCheckResult {
                         case .notClaimed:
                             InlineNotice(
@@ -747,10 +727,27 @@ struct SendView: View {
                 .padding(.horizontal)
             }
 
-            Button(action: { copyToken(token) }) {
-                Text(copyButtonText)
+            VStack(spacing: 12) {
+                Button(action: { copyToken(token) }) {
+                    Text(copyButtonText)
+                }
+                .glassButton()
+
+                if !settings.checkSentTokens {
+                    Button(action: { startManualClaimCheck(token: token) }) {
+                        if isCheckingClaim {
+                            ProgressView()
+                        } else {
+                            Text("Check Status")
+                        }
+                    }
+                    .glassButton()
+                    .disabled(isCheckingClaim)
+                    .accessibilityIdentifier("cashu.send.ecash.check-status")
+                    .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                    .accessibilityInputLabels(["Check Status"])
+                }
             }
-            .glassButton()
             .padding(.horizontal)
             .padding(.bottom, 16)
         }

--- a/ios/CashuWalletTests/TransactionServiceTests.swift
+++ b/ios/CashuWalletTests/TransactionServiceTests.swift
@@ -245,6 +245,113 @@ final class TransactionServiceTests: XCTestCase {
         XCTAssertEqual(service.pendingTokens.count, 1, "Unrelated pending token should remain")
     }
 
+    // MARK: - Manual pending-token claim checks
+
+    func testManualClaimCheckIsOnlyOfferedWhenAutomaticChecksAreDisabled() {
+        let pending = pendingToken(id: "manual", amount: 42)
+
+        XCTAssertTrue(
+            shouldOfferManualClaimCheck(
+                automaticChecksEnabled: false,
+                pendingToken: pending
+            )
+        )
+        XCTAssertFalse(
+            shouldOfferManualClaimCheck(
+                automaticChecksEnabled: true,
+                pendingToken: pending
+            )
+        )
+        XCTAssertFalse(
+            shouldOfferManualClaimCheck(
+                automaticChecksEnabled: false,
+                pendingToken: nil
+            )
+        )
+    }
+
+    func testPendingSentTokenResolvesMergedHistoryRowByEncodedToken() {
+        let pending = pendingToken(id: "local-pending-id", amount: 42)
+        var mergedRow = transaction(
+            id: "cdk-transaction-id",
+            status: .pending,
+            date: pending.date
+        )
+        mergedRow.isPendingToken = true
+        mergedRow.token = pending.token
+
+        let resolved = pendingSentTokenFor(
+            transaction: mergedRow,
+            pendingTokens: [pending]
+        )
+
+        XCTAssertEqual(resolved?.tokenId, pending.tokenId)
+    }
+
+    func testPendingSentTokenRejectsIncomingAndCompletedRows() {
+        let pending = pendingToken(id: "local-pending-id", amount: 42)
+        var incoming = transaction(
+            id: pending.tokenId,
+            status: .pending,
+            date: pending.date,
+            type: .incoming
+        )
+        incoming.isPendingToken = true
+        incoming.token = pending.token
+
+        var completed = transaction(
+            id: pending.tokenId,
+            status: .completed,
+            date: pending.date
+        )
+        completed.isPendingToken = true
+        completed.token = pending.token
+
+        XCTAssertNil(
+            pendingSentTokenFor(transaction: incoming, pendingTokens: [pending])
+        )
+        XCTAssertNil(
+            pendingSentTokenFor(transaction: completed, pendingTokens: [pending])
+        )
+    }
+
+    func testPendingTokenClaimCheckDistinguishesAllOutcomes() async throws {
+        let claimed = try await runPendingTokenClaimCheck { true }
+        guard case .claimed = claimed else {
+            return XCTFail("Expected claimed result")
+        }
+
+        let notClaimed = try await runPendingTokenClaimCheck { false }
+        guard case .notClaimed = notClaimed else {
+            return XCTFail("Expected not-claimed result")
+        }
+
+        let failed = try await runPendingTokenClaimCheck {
+            throw WalletError.networkError("network connection failed")
+        }
+        guard case .failed(let message) = failed else {
+            return XCTFail("Expected failed result")
+        }
+        XCTAssertEqual(
+            message.text,
+            "Couldn't reach the mint. Check your connection and try again."
+        )
+        XCTAssertEqual(message.recoverability, .retryable)
+    }
+
+    func testPendingTokenClaimCheckPreservesCancellation() async {
+        do {
+            _ = try await runPendingTokenClaimCheck {
+                throw CancellationError()
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected: leaving the screen must cancel instead of showing an error.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
     // MARK: - Pending Receive Tokens
 
     func testPendingReceiveTokensEmptyInitially() {


### PR DESCRIPTION
## What changed

- add a visible one-off **Check Status** action to newly generated pending ecash when automatic sent-token checks are disabled
- add the same action to pending outgoing ecash transaction details in History
- persist a Claimed result through the existing single-token status path
- show checking progress, explicit still-pending feedback, retryable wallet errors, and polite accessibility announcements
- cover claim-result handling, action visibility, merged History-row resolution, and cancellation with unit tests
- mark the corresponding iOS/Android parity checklist item complete

## Why

Turning off automatic sent-token checks left Android users with no way to determine whether a pending ecash token had been redeemed. iOS already offered a one-off check without changing the background preference.

## Root cause

Android's generated-token UI only launched the automatic polling effect when the preference was enabled, while its pending History detail exposed Copy but no per-token status action. The lower-level single-token check already existed but was not reachable from either UI.

## Impact

Users who opt out of background sent-token polling can now check one token on demand. The action does not re-enable or modify the automatic-check setting. Successful checks update the token to Claimed; unclaimed and error outcomes remain safe to retry.

## Checks

- `:app:testDebugUnitTest --tests com.cashu.me.Core.PendingTokenClaimTest`
- `:app:testDebugUnitTest`
- `:app:assembleDebug`
- `:app:compileDebugAndroidTestKotlin`
- `:app:lintDebug`
