### PR TITLE
Show the actual P2PK target during Android receive

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveP2PKLockReviewComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveP2PKLockReviewComposeTest.kt
@@ -1,0 +1,76 @@
+package com.cashu.me.ui.receive
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Models.TokenInfo
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReceiveP2PKLockReviewComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun heldKeyShowsRecipientAndClaimableStatus() {
+        val state = p2pkLockState(P2PK_TOKEN) { targets ->
+            targets == listOf(P2PK_TARGET)
+        }
+        val locked = state as P2PKLockState.Locked
+        assertEquals(listOf(P2PK_TARGET), locked.targets)
+        assertTrue(locked.claimable)
+        setLockContent(locked)
+
+        compose.onNodeWithText("Locked to").assertIsDisplayed()
+        compose.onNodeWithText(P2PK_TARGET_LABEL).assertIsDisplayed()
+        compose.onNodeWithText("Status").assertIsDisplayed()
+        compose.onNodeWithText("Claimable · Your key").assertIsDisplayed()
+    }
+
+    @Test
+    fun unheldKeyShowsSameRecipientAndUnclaimableStatus() {
+        val state = p2pkLockState(P2PK_TOKEN) { false }
+        val locked = state as P2PKLockState.Locked
+        assertEquals(listOf(P2PK_TARGET), locked.targets)
+        assertFalse(locked.claimable)
+        setLockContent(locked)
+
+        compose.onNodeWithText("Locked to").assertIsDisplayed()
+        compose.onNodeWithText(P2PK_TARGET_LABEL).assertIsDisplayed()
+        compose.onNodeWithText("Status").assertIsDisplayed()
+        compose.onNodeWithText("Unclaimable · Key unavailable").assertIsDisplayed()
+    }
+
+    private fun setLockContent(lock: P2PKLockState.Locked) {
+        compose.setCashuContent {
+            TokenInspectorRows(
+                info = TokenInfo(
+                    amount = 1,
+                    mint = "https://mint.example",
+                    unit = "sat",
+                    memo = null,
+                    proofCount = 1,
+                ),
+                fee = 0,
+                p2pkLock = lock,
+            )
+        }
+    }
+
+    private companion object {
+        const val P2PK_TARGET =
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        const val P2PK_TARGET_LABEL = "0279be667ef9…815b16f81798"
+
+        // Cashu V3 fixture with one proof whose secret is locked to P2PK_TARGET.
+        const val P2PK_TOKEN =
+            "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vbWludC5leGFtcGxlIiwicHJvb2ZzIjpbeyJpZCI6IjAwYmZhNzMzMDJkMTJmZmQiLCJhbW91bnQiOjEsInNlY3JldCI6IltcIlAyUEtcIix7XCJub25jZVwiOlwiMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMFwiLFwiZGF0YVwiOlwiMDI3OWJlNjY3ZWY5ZGNiYmFjNTVhMDYyOTVjZTg3MGIwNzAyOWJmY2RiMmRjZTI4ZDk1OWYyODE1YjE2ZjgxNzk4XCJ9XSIsIkMiOiIwMjc5YmU2NjdlZjlkY2JiYWM1NWEwNjI5NWNlODcwYjA3MDI5YmZjZGIyZGNlMjhkOTU5ZjI4MTViMTZmODE3OTgifV19XX0="
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
@@ -246,7 +246,7 @@ private fun ConfirmContent(
         TokenInspectorRows(
             info = info,
             fee = fee,
-            locked = review?.locked == true,
+            p2pkLock = review?.p2pkLock,
             modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
         )
         Spacer(Modifier.weight(FooterWeight))
@@ -261,7 +261,7 @@ private fun ConfirmContent(
                 onClick = onReceive,
                 // Disabled until the fee/lock preview lands (net amount must be
                 // known before committing) and while P2PK-locked to foreign keys.
-                enabled = review != null && !review.locked,
+                enabled = review?.canClaim == true,
                 // The app's one inverted-ink CTA — mirrors iOS's sole
                 // .glassButton(prominent: true) on the receive commit
                 // (ReceiveView.swift); every other bottom CTA is neutral gray.

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountBalance
+import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material.icons.outlined.Payments
 import androidx.compose.material.icons.outlined.Receipt
+import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -26,6 +28,8 @@ import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.PaymentStatusPhase
 import com.cashu.me.ui.components.PaymentStatusScreen
+import com.cashu.me.ui.settings.P2PKKeyDisplay
+import com.cashu.me.ui.theme.CashuTheme
 
 /**
  * Shared review/claim core for ecash tokens — one implementation behind both
@@ -41,7 +45,34 @@ internal data class TokenReview(
     val token: String,
     val info: TokenInfo,
     val fee: Long,
-    val locked: Boolean,
+    val p2pkLock: P2PKLockState,
+) {
+    val canClaim: Boolean
+        get() = p2pkLock !is P2PKLockState.Locked || p2pkLock.claimable
+}
+
+/**
+ * Explicit P2PK review state. Keeping the public targets is important: a
+ * claimability boolean alone cannot tell the user who the token was locked to.
+ */
+internal sealed interface P2PKLockState {
+    data object Unlocked : P2PKLockState
+
+    data class Locked(
+        val targets: List<String>,
+        val claimable: Boolean,
+    ) : P2PKLockState {
+        init {
+            require(targets.isNotEmpty()) { "A locked token must identify a P2PK target." }
+        }
+    }
+}
+
+/** Display-safe projection shared by the Compose rows and focused UI tests. */
+internal data class P2PKLockPresentation(
+    val targetLabels: List<String>,
+    val statusText: String,
+    val claimable: Boolean,
 )
 
 internal sealed interface TokenParseOutcome {
@@ -61,6 +92,51 @@ internal fun parseToken(raw: String): TokenParseOutcome {
 }
 
 /**
+ * Parses the token's public P2PK targets and resolves whether this wallet has a
+ * usable signing key. The callback boundary keeps private key material out of
+ * the review state and makes held/unheld behavior independently testable.
+ */
+internal fun p2pkLockState(
+    token: String,
+    hasSigningKey: (List<String>) -> Boolean,
+): P2PKLockState = p2pkLockStateForTargets(
+    targets = TokenParser.p2pkPubkeys(token),
+    hasSigningKey = hasSigningKey,
+)
+
+/** Pure state seam used to verify held/unheld behavior without native CDK I/O. */
+internal fun p2pkLockStateForTargets(
+    targets: List<String>,
+    hasSigningKey: (List<String>) -> Boolean,
+): P2PKLockState {
+    val canonicalTargets = targets
+        .map(P2PKKeyDisplay::canonical)
+        .filter(String::isNotEmpty)
+        .distinctBy(SettingsManager::normalizeP2PKPublicKeyForComparison)
+    return if (canonicalTargets.isEmpty()) {
+        P2PKLockState.Unlocked
+    } else {
+        P2PKLockState.Locked(
+            targets = canonicalTargets,
+            claimable = hasSigningKey(canonicalTargets),
+        )
+    }
+}
+
+internal fun P2PKLockState.presentation(): P2PKLockPresentation? = when (this) {
+    P2PKLockState.Unlocked -> null
+    is P2PKLockState.Locked -> P2PKLockPresentation(
+        targetLabels = targets.map(P2PKKeyDisplay::shortLabel),
+        statusText = if (claimable) {
+            "Claimable · Your key"
+        } else {
+            "Unclaimable · Key unavailable"
+        },
+        claimable = claimable,
+    )
+}
+
+/**
  * Async half of validation: receive-swap fee preview + P2PK lock check.
  * Fee failures degrade to 0 (matching the historical sheet behavior); the
  * redeem itself is the source of truth.
@@ -72,13 +148,15 @@ internal suspend fun tokenReviewDetails(
     settingsManager: SettingsManager,
 ): TokenReview {
     val fee = runCatching { walletManager.calculateReceiveFee(token) }.getOrDefault(0L)
-    val locks = TokenParser.p2pkPubkeys(token)
-    val unlocked = if (locks.isEmpty()) {
-        true
-    } else {
-        settingsManager.p2pkSigningKeysFor(locks).isNotEmpty()
+    val p2pkLock = p2pkLockState(token) { targets ->
+        // p2pkSigningKeysFor deliberately throws when no usable matching key is
+        // held. Convert that expected guard into stable review state so an
+        // unclaimable token can still identify its recipient before action.
+        runCatching {
+            settingsManager.p2pkSigningKeysFor(targets).isNotEmpty()
+        }.getOrDefault(false)
     }
-    return TokenReview(token = token, info = info, fee = fee, locked = !unlocked)
+    return TokenReview(token = token, info = info, fee = fee, p2pkLock = p2pkLock)
 }
 
 /**
@@ -162,11 +240,12 @@ internal fun pendingReceiveTokenFrom(review: TokenReview): PendingReceiveToken =
 internal fun TokenInspectorRows(
     info: TokenInfo,
     fee: Long?,
-    locked: Boolean,
+    p2pkLock: P2PKLockState?,
     modifier: Modifier = Modifier,
 ) {
     val isSatToken = info.unit.equals("sat", ignoreCase = true)
     val tokenCurrency = CurrencyRegistry.currencyForMintUnit(info.unit)
+    val lockPresentation = p2pkLock?.presentation()
     Column(modifier = modifier.fillMaxWidth()) {
         InspectorRow(
             label = "Fee",
@@ -185,12 +264,32 @@ internal fun TokenInspectorRows(
             value = info.mint,
             leadingIcon = Icons.Outlined.AccountBalance,
         )
-        if (locked) {
+        lockPresentation?.let { lock ->
+            lock.targetLabels.forEachIndexed { index, target ->
+                CanvasDivider(leadingInset = 16.dp)
+                InspectorRow(
+                    label = if (index == 0) "Locked to" else "Also locked to",
+                    value = target,
+                    leadingIcon = Icons.Outlined.Lock,
+                    valueMonospaced = true,
+                )
+            }
             CanvasDivider(leadingInset = 16.dp)
+            val statusColor = if (lock.claimable) {
+                CashuTheme.colors.received
+            } else {
+                CashuTheme.colors.pending
+            }
             InspectorRow(
-                label = "P2PK",
-                value = "Requires your key",
-                leadingIcon = Icons.Outlined.Lock,
+                label = "Status",
+                value = lock.statusText,
+                trailingIcon = if (lock.claimable) {
+                    Icons.Outlined.CheckCircle
+                } else {
+                    Icons.Outlined.WarningAmber
+                },
+                trailingIconTint = statusColor,
+                valueColor = statusColor,
             )
         }
         if (info.memo != null) {

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveP2PKLockReviewTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveP2PKLockReviewTest.kt
@@ -1,0 +1,56 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Models.TokenInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReceiveP2PKLockReviewTest {
+    @Test
+    fun heldTargetRemainsIdentifiedAndEnablesClaim() {
+        val state = p2pkLockStateForTargets(listOf(P2PK_TARGET)) { targets ->
+            targets == listOf(P2PK_TARGET)
+        }
+
+        val locked = state as P2PKLockState.Locked
+        val presentation = requireNotNull(locked.presentation())
+        assertEquals(listOf(P2PK_TARGET), locked.targets)
+        assertTrue(locked.claimable)
+        assertEquals(listOf(P2PK_TARGET_LABEL), presentation.targetLabels)
+        assertEquals("Claimable · Your key", presentation.statusText)
+        assertTrue(reviewWith(locked).canClaim)
+    }
+
+    @Test
+    fun unheldTargetRemainsIdentifiedAndDisablesClaim() {
+        val state = p2pkLockStateForTargets(listOf(P2PK_TARGET)) { false }
+
+        val locked = state as P2PKLockState.Locked
+        val presentation = requireNotNull(locked.presentation())
+        assertEquals(listOf(P2PK_TARGET), locked.targets)
+        assertFalse(locked.claimable)
+        assertEquals(listOf(P2PK_TARGET_LABEL), presentation.targetLabels)
+        assertEquals("Unclaimable · Key unavailable", presentation.statusText)
+        assertFalse(reviewWith(locked).canClaim)
+    }
+
+    private fun reviewWith(lock: P2PKLockState): TokenReview = TokenReview(
+        token = "cashuBfixture",
+        info = TokenInfo(
+            amount = 1,
+            mint = "https://mint.example",
+            unit = "sat",
+            memo = null,
+            proofCount = 1,
+        ),
+        fee = 0,
+        p2pkLock = lock,
+    )
+
+    private companion object {
+        const val P2PK_TARGET =
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+        const val P2PK_TARGET_LABEL = "0279be667ef9…815b16f81798"
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -78,7 +78,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P0 · iOS → Android] Warn before receiving from an unknown mint.** iOS identifies that receiving will add a new mint and asks the user to continue only if they trust it; Android has no equivalent trust warning. **Done when:** Android displays the normalized mint host, explains that the mint will be added, and blocks an accidental one-tap claim.
 
-- [ ] **[P1 · iOS → Android] Show the actual P2PK lock target.** Android uses a generic “Requires your key” row only when the key is not held and hides the row when it is held; iOS identifies the recipient. **Done when:** Android always identifies a locked token’s recipient and clearly distinguishes claimable from unclaimable before the user acts.
+- [x] **[P1 · iOS → Android] Show the actual P2PK lock target.** Android uses a generic “Requires your key” row only when the key is not held and hides the row when it is held; iOS identifies the recipient. **Done when:** Android always identifies a locked token’s recipient and clearly distinguishes claimable from unclaimable before the user acts.
 
 - [ ] **[P1 · Android → iOS] Show the token memo during review.** Android includes a Memo row when present; iOS does not. **Done when:** iOS lets the recipient review the sender’s memo before claiming.
 


### PR DESCRIPTION
## Root cause

Android collapsed NUT-11 review metadata into a single locked boolean. That discarded the public recipient target, hid P2PK details whenever the wallet held the key, and showed only generic copy for foreign keys. The unheld-key guard could also throw while building review state, leaving the preview unresolved instead of explaining why the token could not be claimed.

## Changes

- Preserve every canonical public P2PK target in explicit receive-review state.
- Convert missing or unusable signing keys into a stable unclaimable state without exposing private key material.
- Always show a display-safe, middle-truncated recipient identifier.
- Add a separate Claimable · Your key or Unclaimable · Key unavailable status with Material state color and icon.
- Drive Receive CTA eligibility from the explicit claimability state.
- Add held/unheld JVM state tests and on-device Compose tests backed by a real encoded NUT-11 token.
- Mark only the matching parity-checklist item complete.

## Impact

Recipients can verify exactly which public key a locked token targets before acting. Tokens for a key held by the wallet remain claimable; tokens for an unavailable key clearly disable Receive and explain the state instead of failing silently or omitting the recipient.

## Validation

- ./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.receive.ReceiveP2PKLockReviewTest --stacktrace
- ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.ui.receive.ReceiveP2PKLockReviewComposeTest --stacktrace — 2/2 tests passed on API 37
- ./gradlew --no-daemon :app:testDebugUnitTest :app:assembleDebug --stacktrace
- ./gradlew --no-daemon :app:lintDebug :app:assembleRelease --stacktrace
- git diff --check