### PR TITLE
Preserve receive-later token memos

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/WalletJourneyRobot.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/WalletJourneyRobot.kt
@@ -79,6 +79,18 @@ class WalletJourneyRobot(
         return this
     }
 
+    fun awaitTextWithinTag(
+        parentTag: String,
+        text: String,
+        substring: Boolean = false,
+    ): WalletJourneyRobot {
+        val matcher = hasText(text, substring = substring)
+            .and(hasAnyAncestor(hasTestTag(parentTag)))
+        await(matcher, DefaultTimeout)
+        compose.onNode(matcher, useUnmergedTree = true).assertIsDisplayed()
+        return this
+    }
+
     fun scrollToText(containerTag: String, text: String): WalletJourneyRobot {
         compose.onNodeWithTag(containerTag, useUnmergedTree = true)
             .performScrollToNode(hasText(text))

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -388,6 +388,8 @@ class FakeWalletGateway(
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
         const val DeterministicToken =
             "cashuAeyJ0b2tlbiI6W3sicHJvb2ZzIjpbXSwibWludCI6Imh0dHBzOi8vbWludC5taW5pYml0cy5jYXNoIn1dfQ"
+        const val MemoDeterministicToken =
+            "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vbWludC5taW5pYml0cy5jYXNoIiwicHJvb2ZzIjpbXX1dLCJ1bml0Ijoic2F0IiwibWVtbyI6IkNvZmZlZSBmcm9tIEFsaWNlIn0"
     }
 }
 

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
@@ -120,6 +120,33 @@ class FunctionalWalletJourneyTest {
     }
 
     @Test
+    fun receiveLaterMemoAppearsInHistoryAndLaterClaimReview() {
+        val fixture = launch(
+            FixtureMode.SeededWithMint,
+            deepLink = "cashu:${FakeWalletGateway.MemoDeterministicToken}",
+        )
+
+        robot.awaitTag(UiTestTags.ReceiveEcashDetail)
+            .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Memo")
+            .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Coffee from Alice")
+            .tapTextWithinTag(UiTestTags.ReceiveEcashDetail, "Receive later")
+            .awaitTag(UiTestTags.WalletScreen)
+
+        val pending = fixture.container.walletManager.state.value.pendingReceiveTokens.single()
+        assertEquals("Coffee from Alice", pending.memo)
+
+        robot.tapText("History")
+            .awaitTag(UiTestTags.HistoryScreen)
+            .tapTag(UiTestTags.transactionRow(pending.tokenId))
+            .awaitText("Memo")
+            .awaitText("Coffee from Alice")
+            .tapText("Receive")
+            .awaitTag(UiTestTags.ReceiveEcashDetail)
+            .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Memo")
+            .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Coffee from Alice")
+    }
+
+    @Test
     fun lightningReceiveTransitionsToPaidSuccessAndHistory() {
         val fixture = launch(FixtureMode.SeededWithMint)
         val fake = checkNotNull(fixture.fakeGateway)

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -283,6 +283,7 @@ class CashuRequestListener(
             unit = info.unit,
             cashuRequestId = payload.requestId,
             processedId = eventId,
+            memo = info.memo,
         )
         return runCatching {
             walletManager.savePendingReceiveToken(pending)

--- a/android/app/src/main/java/com/cashu/me/Core/TokenHistoryTransactions.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TokenHistoryTransactions.kt
@@ -34,6 +34,7 @@ internal fun pendingReceiveTokenTransactions(tokens: List<PendingReceiveToken>):
             type = TransactionType.Incoming,
             kind = TransactionKind.Ecash,
             dateEpochMillis = token.dateEpochMillis,
+            memo = token.memo,
             status = TransactionStatus.Pending,
             mintUrl = token.mintUrl,
             token = token.token,

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -101,6 +101,9 @@ object TransactionDisplay {
             add(TransactionDetailField("Date", formatDetailDate(transaction.dateEpochMillis)))
             if (transaction.fee > 0) add(TransactionDetailField("Fee", formatNativeAmount(transaction.fee, transaction.unit)))
             transaction.mintUrl?.let { add(TransactionDetailField("Mint", mintHost(it))) }
+            transaction.memo
+                ?.takeIf { it.isNotBlank() }
+                ?.let { add(TransactionDetailField("Memo", it)) }
             if (transaction.kind == TransactionKind.Onchain) {
                 // Address/txid are reference blobs — show the decoder's standard
                 // 8…6 short form; tap-to-copy carries the full value.

--- a/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
@@ -33,6 +33,7 @@ data class PendingReceiveToken(
     val unit: String = "sat",
     val cashuRequestId: String? = null,
     val processedId: String? = null,
+    val memo: String? = null,
 ) {
     val id: String get() = tokenId
     val isCashuRequestPayment: Boolean get() = cashuRequestId != null || processedId != null

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -151,6 +151,7 @@ internal fun pendingReceiveTokenFrom(review: TokenReview): PendingReceiveToken =
         mintUrl = review.info.mint,
         dateEpochMillis = System.currentTimeMillis(),
         unit = review.info.unit,
+        memo = review.info.memo,
     )
 
 /**

--- a/android/app/src/test/java/com/cashu/me/Core/TokenHistoryTransactionsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TokenHistoryTransactionsTest.kt
@@ -51,6 +51,7 @@ class TokenHistoryTransactionsTest {
                     dateEpochMillis = 200,
                     mintUrl = MintUrl,
                     unit = "eur",
+                    memo = "Coffee from Alice",
                 ),
             ),
         )
@@ -62,6 +63,7 @@ class TokenHistoryTransactionsTest {
         assertEquals("cashu-receive", row.token)
         assertEquals(0L, row.fee)
         assertEquals("eur", row.unit)
+        assertEquals("Coffee from Alice", row.memo)
         assertTrue(row.isPendingToken)
     }
 

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -134,6 +134,22 @@ class TransactionDisplayTest {
         assertEquals("Ecash token", TransactionDisplay.qrLabel(transaction))
     }
 
+    @Test
+    fun memoAppearsInHistoryDetailsOnlyWhenPresent() {
+        val withMemo = transaction(
+            kind = TransactionKind.Ecash,
+            type = TransactionType.Incoming,
+            memo = "Coffee from Alice",
+        )
+        val withoutMemo = withMemo.copy(memo = null)
+
+        assertTrue(
+            TransactionDisplay.detailFields(withMemo)
+                .any { it.label == "Memo" && it.value == "Coffee from Alice" },
+        )
+        assertTrue(TransactionDisplay.detailFields(withoutMemo).none { it.label == "Memo" })
+    }
+
     private fun transaction(
         kind: TransactionKind,
         type: TransactionType,
@@ -141,6 +157,7 @@ class TransactionDisplayTest {
         invoice: String? = null,
         preimage: String? = null,
         fee: Long = 0,
+        memo: String? = null,
     ) = WalletTransaction(
         id = "tx",
         amount = 10,
@@ -153,5 +170,6 @@ class TransactionDisplayTest {
         token = token,
         invoice = invoice,
         fee = fee,
+        memo = memo,
     )
 }

--- a/android/app/src/test/java/com/cashu/me/Models/PendingReceiveTokenPersistenceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Models/PendingReceiveTokenPersistenceTest.kt
@@ -1,0 +1,52 @@
+package com.cashu.me.Models
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PendingReceiveTokenPersistenceTest {
+    private val json = Json { encodeDefaults = true }
+
+    @Test
+    fun memoSurvivesPersistenceRoundTrip() {
+        val original = pendingReceiveToken(memo = "Coffee from Alice")
+
+        val restored = json.decodeFromString<PendingReceiveToken>(
+            json.encodeToString(original),
+        )
+
+        assertEquals("Coffee from Alice", restored.memo)
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun legacyPendingReceiveWithoutMemoDefaultsToAbsent() {
+        val restored = json.decodeFromString<PendingReceiveToken>(
+            """
+            {
+              "tokenId": "pending",
+              "token": "cashuAtoken",
+              "amount": 21,
+              "dateEpochMillis": 100,
+              "mintUrl": "https://mint.example.com",
+              "unit": "sat"
+            }
+            """.trimIndent(),
+        )
+
+        assertNull(restored.memo)
+    }
+
+    private fun pendingReceiveToken(memo: String?) = PendingReceiveToken(
+        tokenId = "pending",
+        token = "cashuAtoken",
+        amount = 21,
+        dateEpochMillis = 100,
+        mintUrl = "https://mint.example.com",
+        unit = "sat",
+        memo = memo,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveLaterMemoTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveLaterMemoTest.kt
@@ -1,0 +1,54 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Models.TokenInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReceiveLaterMemoTest {
+    @Test
+    fun receiveLaterPreservesMemoForHistoryAndLaterClaim() {
+        val pending = pendingReceiveTokenFrom(
+            TokenReview(
+                token = MemoToken,
+                info = TokenInfo(
+                    amount = 0,
+                    mint = "https://mint.minibits.cash",
+                    unit = "sat",
+                    memo = "Coffee from Alice",
+                    proofCount = 0,
+                ),
+                fee = 0,
+                locked = false,
+            ),
+        )
+
+        assertEquals("Coffee from Alice", pending.memo)
+        assertEquals(MemoToken, pending.token)
+    }
+
+    @Test
+    fun receiveLaterKeepsAbsentMemoAbsent() {
+        val pending = pendingReceiveTokenFrom(
+            TokenReview(
+                token = "cashuAtoken-without-memo",
+                info = TokenInfo(
+                    amount = 21,
+                    mint = "https://mint.example.com",
+                    unit = "sat",
+                    memo = null,
+                    proofCount = 1,
+                ),
+                fee = 0,
+                locked = false,
+            ),
+        )
+
+        assertNull(pending.memo)
+    }
+
+    private companion object {
+        const val MemoToken =
+            "cashuAeyJ0b2tlbiI6W3sibWludCI6Imh0dHBzOi8vbWludC5taW5pYml0cy5jYXNoIiwicHJvb2ZzIjpbXX1dLCJ1bml0Ijoic2F0IiwibWVtbyI6IkNvZmZlZSBmcm9tIEFsaWNlIn0"
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -82,7 +82,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · Android → iOS] Show the token memo during review.** Android includes a Memo row when present; iOS does not. **Done when:** iOS lets the recipient review the sender’s memo before claiming.
 
-- [ ] **[P1 · iOS → Android] Preserve a memo when choosing Receive later.** iOS stores the decoded token memo in the pending receive; Android’s pending-token conversion drops it. **Done when:** the Android History row and later claim retain the original memo.
+- [x] **[P1 · iOS → Android] Preserve a memo when choosing Receive later.** iOS stores the decoded token memo in the pending receive; Android’s pending-token conversion drops it. **Done when:** the Android History row and later claim retain the original memo.
 
 - [ ] **[P0 · iOS → Android] Report the actually paid receive fee.** iOS derives the final fee from gross token value minus the amount credited; Android carries the preview fee into success even if settlement differs. **Done when:** Android’s receipt reconciles the displayed fee against the credited amount and tests cover a settlement that differs from the preview.
 


### PR DESCRIPTION
## Root cause

Android's `PendingReceiveToken` model had no memo field. The Receive-later conversion therefore dropped `TokenInfo.memo`, persistence could not retain it, and the synthesized pending History transaction had no memo to display.

## Changes

- Add a backward-compatible optional memo to `PendingReceiveToken`.
- Carry decoded memos into manual Receive-later and held Cashu-request pending tokens.
- Map pending-token memos into History transactions and show nonblank memos in transaction details.
- Add focused conversion, persistence/legacy-JSON, History mapping, and History presentation tests.
- Add an emulator journey covering memo review → Receive later → History details → later claim review, including destination-scoped UI assertions.
- Mark the corresponding iOS/Android parity checklist item complete.

## User impact

A sender's original memo now survives Receive later, appears in Android History details, and remains visible when the recipient returns to claim the token. Tokens without memos and previously persisted pending-token JSON continue to work unchanged.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.receive.ReceiveLaterMemoTest --tests com.cashu.me.Models.PendingReceiveTokenPersistenceTest --tests com.cashu.me.Core.TokenHistoryTransactionsTest --tests com.cashu.me.Core.TransactionDisplayTest --stacktrace`
  - Passed: 16 focused unit tests.
- `ANDROID_SERIAL=emulator-5554 ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.ui.journeys.FunctionalWalletJourneyTest#receiveLaterMemoAppearsInHistoryAndLaterClaimReview --stacktrace`
  - Passed on the connected API 37 Pixel 8 AVD.
- `./gradlew --no-daemon :app:testDebugUnitTest :app:lintDebug :app:assembleRelease --stacktrace`
  - Passed.
- `git diff --check`
  - Passed.
