### PR TITLE
fix(android): report settled receive fee

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveActualFeeComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/ReceiveActualFeeComposeTest.kt
@@ -1,0 +1,52 @@
+package com.cashu.me.ui.receive
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Models.TokenInfo
+import com.cashu.me.ui.setCashuContent
+import java.util.Locale
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReceiveActualFeeComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun receiptDisplaysSettledFeeInsteadOfPreview() {
+        val review = TokenReview(
+            token = "cashu-token",
+            info = TokenInfo(
+                amount = 100,
+                mint = "https://mint.example.com",
+                unit = "sat",
+                memo = null,
+                proofCount = 1,
+            ),
+            fee = 3,
+            locked = false,
+        )
+        val claimed = settledTokenClaim(review, creditedAmount = 93)
+
+        compose.setCashuContent {
+            TokenClaimTerminal(
+                status = claimed,
+                formatter = AmountFormatter(Locale.US),
+                useBitcoinSymbol = false,
+                onDone = {},
+                onRetry = {},
+            )
+        }
+
+        compose.onNodeWithText("Amount").assertIsDisplayed()
+        compose.onNodeWithText("93 sat").assertIsDisplayed()
+        compose.onNodeWithText("Fee").assertIsDisplayed()
+        compose.onNodeWithText("7 sat").assertIsDisplayed()
+        compose.onNodeWithText("3 sat").assertDoesNotExist()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -92,6 +92,29 @@ internal sealed interface TokenClaimStatus {
     data class Failed(val message: WalletMessage) : TokenClaimStatus
 }
 
+/**
+ * Reconciles the receive preview with CDK's settled credit.
+ *
+ * The decoded token amount is gross while [creditedAmount] is the exact net
+ * amount added to the wallet. Clamp only for the subtraction so a malformed
+ * value cannot produce a negative fee; the receipt still reports the
+ * non-negative credited amount returned by settlement.
+ */
+internal fun settledTokenClaim(
+    review: TokenReview,
+    creditedAmount: Long,
+): TokenClaimStatus.Claimed {
+    val grossAmount = review.info.amount.coerceAtLeast(0L)
+    val safeCreditedAmount = creditedAmount.coerceAtLeast(0L)
+    val paidFee = grossAmount - safeCreditedAmount.coerceAtMost(grossAmount)
+    return TokenClaimStatus.Claimed(
+        amount = safeCreditedAmount,
+        fee = paidFee,
+        unit = review.info.unit,
+        mint = review.info.mint,
+    )
+}
+
 // iOS ReceiveTokenDetailView: floor the redeem at 500ms so the "Claiming…"
 // spinner is legible on instant redeems. Not a fake delay — the redeem itself
 // hits the mint; we only pad the *display* of an early result.
@@ -124,20 +147,10 @@ internal suspend fun claimToken(
     val elapsed = System.currentTimeMillis() - startedAt
     if (elapsed < MinClaimingBeatMillis) delay(MinClaimingBeatMillis - elapsed)
     return result.fold(
-        onSuccess = { credited ->
-            TokenClaimStatus.Claimed(
-                // The gateway reports what was actually credited (net of the
-                // receive-swap fee); fall back to the reviewed net amount.
-                amount = if (credited > 0L) {
-                    credited
-                } else {
-                    review.info.amount - review.fee.coerceIn(0L, review.info.amount)
-                },
-                fee = review.fee,
-                unit = review.info.unit,
-                mint = review.info.mint,
-            )
-        },
+        // The gateway's exact net credit supersedes the preview. Reconcile the
+        // receipt from gross − credited so both amount and fee describe the
+        // same settlement.
+        onSuccess = { credited -> settledTokenClaim(review, credited) },
         onFailure = { TokenClaimStatus.Failed(it.walletMessage) },
     )
 }

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -33,6 +33,22 @@ class TransactionDisplayTest {
     }
 
     @Test
+    fun incomingEcashHistoryDisplaysSettledFee() {
+        // Incoming CDK rows carry the fee recorded by settlement. History must
+        // render that value directly rather than any earlier receive preview.
+        val transaction = transaction(
+            kind = TransactionKind.Ecash,
+            type = TransactionType.Incoming,
+            fee = 7,
+        )
+
+        val fields = TransactionDisplay.detailFields(transaction)
+
+        assertTrue(fields.any { it.label == "Fee" && it.value == "7 sat" })
+        assertTrue(fields.none { it.label == "Fee" && it.value == "3 sat" })
+    }
+
+    @Test
     fun unpaidInvoiceTitlesAsInvoiceUntilPaid() {
         val unpaid = transaction(
             kind = TransactionKind.Lightning,

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveActualFeeTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveActualFeeTest.kt
@@ -1,0 +1,73 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Models.TokenInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ReceiveActualFeeTest {
+    @Test
+    fun `settlement difference replaces preview fee`() {
+        val claim = settledTokenClaim(
+            review(grossAmount = 100, previewFee = 3),
+            creditedAmount = 93,
+        )
+
+        assertEquals(93L, claim.amount)
+        assertEquals(7L, claim.fee)
+    }
+
+    @Test
+    fun `matching settlement preserves normal fee`() {
+        val claim = settledTokenClaim(
+            review(grossAmount = 100, previewFee = 7),
+            creditedAmount = 93,
+        )
+
+        assertEquals(93L, claim.amount)
+        assertEquals(7L, claim.fee)
+    }
+
+    @Test
+    fun `full credit reports zero fee even when preview was nonzero`() {
+        val claim = settledTokenClaim(
+            review(grossAmount = 100, previewFee = 4),
+            creditedAmount = 100,
+        )
+
+        assertEquals(100L, claim.amount)
+        assertEquals(0L, claim.fee)
+    }
+
+    @Test
+    fun `credited amount is safely bounded only for fee arithmetic`() {
+        val overCredit = settledTokenClaim(
+            review(grossAmount = 100, previewFee = 4),
+            creditedAmount = 105,
+        )
+        val invalidNegativeCredit = settledTokenClaim(
+            review(grossAmount = 100, previewFee = 4),
+            creditedAmount = -1,
+        )
+
+        assertEquals(105L, overCredit.amount)
+        assertEquals(0L, overCredit.fee)
+        assertEquals(0L, invalidNegativeCredit.amount)
+        assertEquals(100L, invalidNegativeCredit.fee)
+    }
+
+    private fun review(
+        grossAmount: Long,
+        previewFee: Long,
+    ) = TokenReview(
+        token = "cashu-token",
+        info = TokenInfo(
+            amount = grossAmount,
+            mint = "https://mint.example.com",
+            unit = "sat",
+            memo = null,
+            proofCount = 1,
+        ),
+        fee = previewFee,
+        locked = false,
+    )
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -84,7 +84,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Preserve a memo when choosing Receive later.** iOS stores the decoded token memo in the pending receive; Android’s pending-token conversion drops it. **Done when:** the Android History row and later claim retain the original memo.
 
-- [ ] **[P0 · iOS → Android] Report the actually paid receive fee.** iOS derives the final fee from gross token value minus the amount credited; Android carries the preview fee into success even if settlement differs. **Done when:** Android’s receipt reconciles the displayed fee against the credited amount and tests cover a settlement that differs from the preview.
+- [x] **[P0 · iOS → Android] Report the actually paid receive fee.** iOS derives the final fee from gross token value minus the amount credited; Android carries the preview fee into success even if settlement differs. **Done when:** Android’s receipt reconciles the displayed fee against the credited amount and tests cover a settlement that differs from the preview.
 
 ### Receive — Lightning, reusable invoices, on-chain, and Cashu Requests
 


### PR DESCRIPTION
## Root cause

Android used CDK's settled net credit for the success receipt amount, but copied the earlier receive-fee preview into the receipt unchanged. When settlement differed from the preview, the Amount and Fee rows described different calculations. A zero settlement was also replaced with the previewed net amount.

## Changes

- Reconcile a successful token claim from the decoded gross token value and CDK's exact credited amount.
- Derive the paid fee as `gross - min(credited, gross)` with non-negative input handling, matching iOS.
- Keep the existing transaction-history source of truth: incoming CDK transaction fees are settled values, not receive previews.
- Add focused reconciliation, history-presentation, and emulator-rendered receipt coverage.
- Mark only “Report the actually paid receive fee” complete in the parity checklist.

## Impact

After a token is claimed, Android now reports an internally consistent receipt: the displayed amount is the actual wallet credit and the displayed fee is the actual difference from the token's gross value. A stale preview can no longer survive into success.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.receive.ReceiveActualFeeTest --tests com.cashu.me.Core.TransactionDisplayTest --stacktrace`
- `ANDROID_SERIAL=emulator-5554 ./gradlew --no-daemon :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.ui.receive.ReceiveActualFeeComposeTest --stacktrace`
- `./gradlew --no-daemon :app:testDebugUnitTest :app:assembleDebug --stacktrace`
- `./gradlew --no-daemon :app:testDebugUnitTest :app:lintDebug :app:assembleRelease --stacktrace`

All checks passed.
