### PR TITLE
Preview custom mint info during onboarding

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -292,6 +292,7 @@ fun OnboardingScreen(
                 busy = finishing,
                 addingMintUrl = addingMintUrl,
                 errorText = firstMintError,
+                walletManager = walletManager,
                 onContinue = { urls -> finishCreate(current.mnemonic, urls) },
                 onSkip = { finishCreate(current.mnemonic, emptyList()) },
             )
@@ -779,14 +780,17 @@ private fun FirstMintFace(
     busy: Boolean,
     addingMintUrl: String?,
     errorText: String?,
+    walletManager: WalletManager,
     onContinue: (List<String>) -> Unit,
     onSkip: () -> Unit,
 ) {
     val haptics = LocalHapticFeedback.current
     val appeared = rememberAppeared()
+    val scope = rememberCoroutineScope()
 
     var selected by remember { mutableStateOf(setOf<String>()) }
     var customUrls by remember { mutableStateOf(listOf<String>()) }
+    val customPreviews = remember { mutableStateMapOf<String, MintInfo>() }
     var customInputOpen by remember { mutableStateOf(false) }
     var customDraft by remember { mutableStateOf(FirstMintUrlDraft()) }
     val clipboard = LocalClipboardManager.current
@@ -804,6 +808,11 @@ private fun FirstMintFace(
         customUrls = customUrls + normalized
         selected = selected + normalized
         customInputOpen = false
+        scope.launch {
+            runCatching { walletManager.fetchLiveMintInfo(normalized) }
+                .getOrNull()
+                ?.let { customPreviews[normalized] = it }
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize()) {
@@ -834,7 +843,9 @@ private fun FirstMintFace(
                 .padding(top = CashuTheme.spacing.snug),
         ) {
             val rows = RecommendedMints.map { Triple(it.name, it.url, it.iconUrl) } +
-                customUrls.map { Triple(shortenMintUrl(it), it, null) }
+                customUrls.map {
+                    Triple(customPreviews[it]?.name ?: shortenMintUrl(it), it, customPreviews[it]?.iconUrl)
+                }
             rows.forEachIndexed { index, (name, url, iconUrl) ->
                 if (index > 0) CanvasDivider()
                 MintSelectRow(

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -898,10 +898,13 @@ struct OnboardingView: View {
             }
         }) {
             HStack(spacing: 12) {
-                MintAvatarView(iconUrl: recommended?.iconUrl, name: recommended?.name ?? shortenUrl(url))
+                MintAvatarView(
+                    iconUrl: recommended?.iconUrl ?? stagedMintIconUrls[url],
+                    name: recommended?.name ?? stagedMintNames[url] ?? shortenUrl(url)
+                )
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(recommended?.name ?? shortenUrl(url))
+                    Text(recommended?.name ?? stagedMintNames[url] ?? shortenUrl(url))
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(.primary)
                         .lineLimit(1)
@@ -988,6 +991,7 @@ struct OnboardingView: View {
             customMintInput = ""
             showCustomMintInput = false
         }
+        fetchStagedMintInfo(normalized)
     }
 
     private func continueFromFirstMint() {


### PR DESCRIPTION
Custom mint URLs in onboarding never got a name/icon preview like restore staging does - just a shortened URL and monogram. This wires up the same fetch restore already uses on both platforms so the row updates once it loads. Doesn't block Continue if it's slow or fails.
 #177
