### PR TITLE
Fix receive-later memo test compilation

### DIFF
--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveLaterMemoTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveLaterMemoTest.kt
@@ -19,7 +19,7 @@ class ReceiveLaterMemoTest {
                     proofCount = 0,
                 ),
                 fee = 0,
-                locked = false,
+                p2pkLock = P2PKLockState.Unlocked,
             ),
         )
 
@@ -40,7 +40,7 @@ class ReceiveLaterMemoTest {
                     proofCount = 1,
                 ),
                 fee = 0,
-                locked = false,
+                p2pkLock = P2PKLockState.Unlocked,
             ),
         )
 


### PR DESCRIPTION
## Summary

- update `ReceiveLaterMemoTest` to use the typed `P2PKLockState.Unlocked` constructor argument
- keep the receive-later memo coverage aligned with the current `TokenReview` model

## Root cause

`TokenReview.locked: Boolean` was replaced by `TokenReview.p2pkLock: P2PKLockState`, but the subsequently added memo tests still used the removed named argument. As a result, `:app:compileDebugUnitTestKotlin` failed on `main` before any unit tests could run.

## Impact

Restores Android unit-test compilation and CI. This changes test fixtures only; production behavior is unchanged.

## Testing

- `./gradlew --no-daemon :app:testDebugUnitTest --stacktrace`
