### PR TITLE
Correlate Cashu Request success to linked payments

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -96,7 +96,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · Android → iOS] Add Total received to reusable-invoice details.** Android shows a cumulative total after BOLT12 payments; iOS only changes the status badge. **Done when:** iOS exposes the unit-correct cumulative amount.
 
-- [ ] **[P1 · Android → iOS] Correlate an open Cashu Request success to a new payment record.** Android watches the request’s received-payment IDs; iOS has a fallback that treats any balance increase while the receive sheet is open as payment for that request. **Done when:** iOS cannot show request success for an unrelated balance increase, with regression coverage for concurrent balance changes.
+- [x] **[P1 · Android → iOS] Correlate an open Cashu Request success to a new payment record.** Android watches the request’s received-payment IDs; iOS has a fallback that treats any balance increase while the receive sheet is open as payment for that request. **Done when:** iOS cannot show request success for an unrelated balance increase, with regression coverage for concurrent balance changes.
 
 - [ ] **[P2 · Android → iOS] Show Total received in Cashu Request details.** Android adds the aggregate after one or more payments; iOS shows only the status count and original request amount. **Done when:** iOS includes a unit-correct aggregate row without confusing it with the requested amount.
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000B /* ReceiveAutoPasteTests.swift */; };
 		T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000C /* HomeActionAccessibilityTests.swift */; };
 		T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000D /* CashuRequestRouteExplanationTests.swift */; };
+		C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -293,6 +294,7 @@
 		T1B000000000000B /* ReceiveAutoPasteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiveAutoPasteTests.swift; path = CashuWalletTests/ReceiveAutoPasteTests.swift; sourceTree = "<group>"; };
 		T1B000000000000C /* HomeActionAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeActionAccessibilityTests.swift; path = CashuWalletTests/HomeActionAccessibilityTests.swift; sourceTree = "<group>"; };
 		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
+		C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestPaymentObservationTests.swift; path = CashuWalletTests/CashuRequestPaymentObservationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -345,6 +347,7 @@
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
 				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
+				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -888,6 +891,7 @@
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
 				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
+				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -15,7 +15,7 @@ struct CashuRequestDetailView: View {
     @State private var showMintPicker = false
     @State private var showAmountPicker = false
     @State private var showUnitPicker = false
-    @State private var receiveBaselineBalance: UInt64?
+    @State private var paymentObservation: CashuRequestPaymentObservation
     @State private var didAutoComplete = false
     /// Amount of the payment that just landed, for the shared success screen.
     @State private var receivedAmount: UInt64?
@@ -23,6 +23,9 @@ struct CashuRequestDetailView: View {
 
     init(request: CashuRequest, onClose: (() -> Void)? = nil) {
         self._requestId = State(initialValue: request.id)
+        self._paymentObservation = State(
+            initialValue: CashuRequestPaymentObservation(existingPayments: request.receivedPayments)
+        )
         self.onClose = onClose
     }
 
@@ -99,28 +102,13 @@ struct CashuRequestDetailView: View {
                 .presentationDetents([.medium])
             }
         }
-        .onAppear {
-            // Baseline for the receive-flow balance watcher below.
-            receiveBaselineBalance = walletManager.balance
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .cashuTokenReceived)) { note in
-            guard let source = note.userInfo?["source"] as? String,
-                  source == "cashu-request" else { return }
-            // Ignore a payment that names a *different* request, but if the payer
-            // didn't echo the request id back (common — many wallets omit it),
-            // assume the payment is for the request we're watching.
-            if let paidId = note.userInfo?["requestId"] as? String, paidId != requestId { return }
-            AppLogger.wallet.notice("CashuRequestDetailView: payment via notification")
-            markPaymentReceived(amount: note.userInfo?["amount"] as? UInt64)
-        }
-        .onChange(of: walletManager.balance) { _, newBalance in
-            // Robust fallback: the transient .cashuTokenReceived notification can
-            // be missed, but the listener's redeem always bumps the @Published
-            // balance on the main thread. In the receive flow, any balance
-            // increase while we're watching the QR is the payment landing.
-            guard onClose != nil, let baseline = receiveBaselineBalance, newBalance > baseline else { return }
-            AppLogger.wallet.notice("CashuRequestDetailView: payment via balance bump \(baseline)->\(newBalance)")
-            markPaymentReceived(amount: newBalance - baseline)
+        .onChange(of: request?.receivedPayments) { _, currentPayments in
+            guard let currentPayments,
+                  let payment = paymentObservation.newlyLinkedPayment(in: currentPayments) else { return }
+            AppLogger.wallet.notice(
+                "CashuRequestDetailView: linked payment \(payment.transactionId, privacy: .public)"
+            )
+            markPaymentReceived(amount: payment.amount)
         }
     }
 
@@ -448,5 +436,26 @@ struct CashuRequestDetailView: View {
     /// more than one unit.
     private func unitEditable(for request: CashuRequest) -> Bool {
         request.rail == .ecash && (requestMint(for: request)?.supportsMultipleUnits ?? false)
+    }
+}
+
+/// Tracks the request-specific transaction records that existed when its detail
+/// opened and returns only payments linked afterwards. Wallet balance changes
+/// are intentionally outside this correlation boundary.
+struct CashuRequestPaymentObservation {
+    private var observedTransactionIds: Set<String>
+
+    init(existingPayments: [CashuRequestPayment]) {
+        observedTransactionIds = Set(existingPayments.map(\.transactionId))
+    }
+
+    mutating func newlyLinkedPayment(
+        in currentPayments: [CashuRequestPayment]
+    ) -> CashuRequestPayment? {
+        let payment = currentPayments.last {
+            !observedTransactionIds.contains($0.transactionId)
+        }
+        observedTransactionIds = Set(currentPayments.map(\.transactionId))
+        return payment
     }
 }

--- a/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class CashuRequestPaymentObservationTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var store: CashuRequestStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "CashuRequestPaymentObservationTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        store = CashuRequestStore(userDefaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        store = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testUnrelatedConcurrentBalanceIncreaseDoesNotProduceRequestSuccess() throws {
+        let watchedRequest = store.createNew(id: "watched-request", encoded: "creqAwatched")
+        _ = store.createNew(id: "unrelated-request", encoded: "creqAunrelated")
+        var observation = CashuRequestPaymentObservation(
+            existingPayments: watchedRequest.receivedPayments
+        )
+        var walletBalance: UInt64 = 100
+
+        store.attachPayment(
+            requestId: "unrelated-request",
+            transactionId: "unrelated-payment",
+            amount: 25
+        )
+        walletBalance += 25
+
+        XCTAssertEqual(walletBalance, 125)
+        let watchedPayments = try XCTUnwrap(
+            store.request(withId: "watched-request")?.receivedPayments
+        )
+        XCTAssertNil(observation.newlyLinkedPayment(in: watchedPayments))
+    }
+
+    func testNewlyLinkedRequestPaymentProducesRequestSuccess() throws {
+        let request = store.createNew(id: "watched-request", encoded: "creqAwatched")
+        var observation = CashuRequestPaymentObservation(
+            existingPayments: request.receivedPayments
+        )
+        store.attachPayment(
+            requestId: request.id,
+            transactionId: "request-payment",
+            amount: 21
+        )
+        let linkedPayments = try XCTUnwrap(
+            store.request(withId: request.id)?.receivedPayments
+        )
+        let payment = try XCTUnwrap(linkedPayments.first)
+
+        XCTAssertEqual(
+            observation.newlyLinkedPayment(in: linkedPayments),
+            payment
+        )
+        XCTAssertNil(observation.newlyLinkedPayment(in: linkedPayments))
+    }
+
+    func testExistingRequestPaymentsEstablishBaselineWithoutReplayingSuccess() {
+        let existing = CashuRequestPayment(
+            transactionId: "existing-payment",
+            amount: 13,
+            receivedAt: Date()
+        )
+        var observation = CashuRequestPaymentObservation(existingPayments: [existing])
+
+        XCTAssertNil(observation.newlyLinkedPayment(in: [existing]))
+    }
+}


### PR DESCRIPTION
## What changed

- make iOS Cashu Request success react only to a newly linked payment record for the open request
- remove notification and wallet-balance fallbacks that could attribute unrelated incoming funds to that request
- add regression coverage for unrelated balance changes, legitimate linked payments, and existing-payment baselines
- check off the verified parity item

## Root cause

The open iOS receive sheet treated an uncorrelated Cashu notification or any wallet balance increase as success for the displayed request.

## Impact

Concurrent unrelated incoming payments can no longer produce a false Cashu Request success screen.

## Validation

- focused correlation tests: 3/3 passed
- full `CashuWalletTests` target
- `git diff --check`
