### PR TITLE
Support fiat-primary Bitcoin receive entry

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/BitcoinAmountEntry.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/BitcoinAmountEntry.kt
@@ -1,0 +1,84 @@
+package com.cashu.me.Core
+
+import kotlin.math.roundToLong
+
+internal data class BitcoinAmountEntryContext(
+    val primary: AmountDisplayPrimary,
+    val btcPrice: Double,
+)
+
+/**
+ * Shared conversion boundary for sat-denominated amount-entry surfaces.
+ *
+ * The keypad keeps a unit-native raw string (integer sats or fiat cents), while
+ * quote and payment APIs always receive the represented sat value.
+ */
+internal object BitcoinAmountEntry {
+    fun context(preferredPrimary: String, btcPrice: Double): BitcoinAmountEntryContext {
+        val preferred = AmountDisplayPrimary.fromRaw(preferredPrimary)
+        val effective = if (
+            preferred == AmountDisplayPrimary.Fiat &&
+            btcPrice.isFinite() &&
+            btcPrice > 0.0
+        ) {
+            AmountDisplayPrimary.Fiat
+        } else {
+            AmountDisplayPrimary.Sats
+        }
+        return BitcoinAmountEntryContext(effective, btcPrice)
+    }
+
+    fun amountSats(raw: String, context: BitcoinAmountEntryContext): Long =
+        when (context.primary) {
+            AmountDisplayPrimary.Sats -> raw.toLongOrNull()?.takeIf { it > 0L } ?: 0L
+            AmountDisplayPrimary.Fiat -> fiatCentsToSats(
+                cents = UnitAmountEntry.baseUnits(raw, FIAT_DECIMALS),
+                btcPrice = context.btcPrice,
+            )
+        }
+
+    fun rawForSats(amountSats: Long, context: BitcoinAmountEntryContext): String {
+        if (amountSats <= 0L) return ""
+        return when (context.primary) {
+            AmountDisplayPrimary.Sats -> amountSats.toString()
+            AmountDisplayPrimary.Fiat -> {
+                if (!context.btcPrice.isFinite() || context.btcPrice <= 0.0) return ""
+                val cents = (
+                    amountSats.toDouble() /
+                        SATS_PER_BITCOIN *
+                        context.btcPrice *
+                        CENTS_PER_FIAT
+                    ).roundToLong()
+                if (cents !in 1..MAX_ENTRY_BASE_UNITS) {
+                    ""
+                } else {
+                    UnitAmountEntry.entryString(cents, FIAT_DECIMALS)
+                }
+            }
+        }
+    }
+
+    fun convert(
+        raw: String,
+        from: BitcoinAmountEntryContext,
+        to: BitcoinAmountEntryContext,
+    ): String {
+        if (raw.isEmpty() || from.primary == to.primary) return raw
+        return rawForSats(amountSats(raw, from), to)
+    }
+
+    private fun fiatCentsToSats(cents: Long, btcPrice: Double): Long {
+        if (cents <= 0L || !btcPrice.isFinite() || btcPrice <= 0.0) return 0L
+        val sats = cents.toDouble() /
+            CENTS_PER_FIAT /
+            btcPrice *
+            SATS_PER_BITCOIN
+        if (!sats.isFinite() || sats <= 0.0 || sats > Long.MAX_VALUE.toDouble()) return 0L
+        return sats.roundToLong()
+    }
+
+    private const val FIAT_DECIMALS = 2
+    private const val CENTS_PER_FIAT = 100.0
+    private const val SATS_PER_BITCOIN = 100_000_000.0
+    private const val MAX_ENTRY_BASE_UNITS = 99_999_999_999L
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveAmountEntry.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveAmountEntry.kt
@@ -1,0 +1,84 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.BitcoinAmountEntry
+import com.cashu.me.Core.BitcoinAmountEntryContext
+import com.cashu.me.Core.UnitAmountEntry
+
+internal data class ReceiveAmountEntryContext(
+    val quoteUnit: String,
+    val mintUnitDecimals: Int,
+    val bitcoin: BitcoinAmountEntryContext,
+) {
+    val isSatQuote: Boolean = quoteUnit.equals("sat", ignoreCase = true)
+    val isFiatPrimary: Boolean = isSatQuote && bitcoin.primary == AmountDisplayPrimary.Fiat
+    val entryDecimals: Int = if (isFiatPrimary) FIAT_DECIMALS else mintUnitDecimals
+
+    private companion object {
+        const val FIAT_DECIMALS = 2
+    }
+}
+
+internal enum class ReceiveAmountValidation {
+    Empty,
+    Valid,
+}
+
+/** Amount-entry policy for receive quotes, including unit-preserving validation. */
+internal object ReceiveAmountEntry {
+    fun context(
+        quoteUnit: String,
+        mintUnitDecimals: Int,
+        preferredPrimary: String,
+        btcPrice: Double,
+    ): ReceiveAmountEntryContext = ReceiveAmountEntryContext(
+        quoteUnit = quoteUnit,
+        mintUnitDecimals = mintUnitDecimals,
+        bitcoin = BitcoinAmountEntry.context(preferredPrimary, btcPrice),
+    )
+
+    fun amountBaseUnits(raw: String, context: ReceiveAmountEntryContext): Long =
+        if (context.isSatQuote) {
+            BitcoinAmountEntry.amountSats(raw, context.bitcoin)
+        } else {
+            UnitAmountEntry.baseUnits(raw, context.mintUnitDecimals)
+        }
+
+    fun validation(raw: String, context: ReceiveAmountEntryContext): ReceiveAmountValidation =
+        if (amountBaseUnits(raw, context) > 0L) {
+            ReceiveAmountValidation.Valid
+        } else {
+            ReceiveAmountValidation.Empty
+        }
+
+    fun quoteAmount(
+        raw: String,
+        context: ReceiveAmountEntryContext,
+        amountless: Boolean,
+    ): Long? = if (amountless) {
+        null
+    } else {
+        amountBaseUnits(raw, context).takeIf { it > 0L }
+    }
+
+    fun rawForBaseUnits(amount: Long, context: ReceiveAmountEntryContext): String =
+        if (context.isSatQuote) {
+            BitcoinAmountEntry.rawForSats(amount, context.bitcoin)
+        } else {
+            UnitAmountEntry.entryString(amount, context.mintUnitDecimals)
+        }
+
+    fun convert(
+        raw: String,
+        from: ReceiveAmountEntryContext,
+        to: ReceiveAmountEntryContext,
+    ): String {
+        if (raw.isEmpty()) return raw
+        if (!from.quoteUnit.equals(to.quoteUnit, ignoreCase = true)) return ""
+        return if (from.isSatQuote && to.isSatQuote) {
+            BitcoinAmountEntry.convert(raw, from.bitcoin, to.bitcoin)
+        } else {
+            raw
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -73,9 +73,9 @@ import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
 import com.cashu.me.Core.OnchainPaymentObservation
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.SettingsManager
-import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.mintQuoteDisplayExpiry
@@ -124,10 +124,12 @@ fun ReceiveLightningScreen(
     walletManager: WalletManager,
     cashuRequestStore: CashuRequestStore,
     settingsManager: SettingsManager,
+    priceService: PriceService,
     onClose: () -> Unit,
 ) {
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val cashuRequestState by cashuRequestStore.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
@@ -166,6 +168,14 @@ fun ReceiveLightningScreen(
     }
     val currency = CurrencyRegistry.currencyForMintUnit(effectiveUnit)
     val isSatUnit = effectiveUnit.equals("sat", ignoreCase = true)
+    val amountEntryContext = ReceiveAmountEntry.context(
+        quoteUnit = effectiveUnit,
+        mintUnitDecimals = currency.decimals,
+        preferredPrimary = settings.amountDisplayPrimary,
+        btcPrice = priceState.btcPrice,
+    )
+    var previousAmountEntryContext by remember { mutableStateOf(amountEntryContext) }
+    val amountValidation = ReceiveAmountEntry.validation(amount, amountEntryContext)
     val showsUnitSelector = activeMint?.supportsMultipleMintUnits == true &&
         method != PaymentMethodKind.Onchain
 
@@ -188,9 +198,14 @@ fun ReceiveLightningScreen(
         requestMethod: PaymentMethodKind,
         amountless: Boolean,
         forceNewReusableOffer: Boolean = false,
+        amountOverride: Long? = null,
     ) {
-        val explicit = UnitAmountEntry.baseUnits(amount, currency.decimals)
-            .takeIf { it > 0 }
+        val explicit = amountOverride?.takeIf { it > 0L }
+            ?: ReceiveAmountEntry.quoteAmount(
+                raw = amount,
+                context = amountEntryContext,
+                amountless = false,
+            )
         if (!amountless && requestMethod.requiresMintAmount && explicit == null) {
             errorText = "Enter an amount."
             return
@@ -206,7 +221,11 @@ fun ReceiveLightningScreen(
         errorText = null
         scope.launch {
             try {
-                val requestUnit = if (requestMethod == PaymentMethodKind.Onchain) "sat" else effectiveUnit
+                val requestUnit = if (requestMethod == PaymentMethodKind.Onchain) {
+                    "sat"
+                } else {
+                    amountEntryContext.quoteUnit
+                }
                 val quote = if (
                     requestMethod == PaymentMethodKind.Bolt12 &&
                     amountless &&
@@ -281,10 +300,17 @@ fun ReceiveLightningScreen(
         } else {
             val quoteUnit = (face as? ReceiveLnFace.Display)?.quote?.unit ?: effectiveUnit
             val decimals = CurrencyRegistry.currencyForMintUnit(quoteUnit).decimals
-            amount = UnitAmountEntry.entryString(nextAmount, decimals)
+            val nextContext = ReceiveAmountEntry.context(
+                quoteUnit = quoteUnit,
+                mintUnitDecimals = decimals,
+                preferredPrimary = settings.amountDisplayPrimary,
+                btcPrice = priceState.btcPrice,
+            )
+            amount = ReceiveAmountEntry.rawForBaseUnits(nextAmount, nextContext)
             createMintRequest(
                 requestMethod = PaymentMethodKind.Bolt12,
                 amountless = false,
+                amountOverride = nextAmount,
             )
         }
     }
@@ -311,6 +337,17 @@ fun ReceiveLightningScreen(
             // path, not a keypad that can't create without an amount.
             applyMethodOption(fallback)
         }
+    }
+
+    // Preserve the represented sat amount if a cached price becomes available
+    // or the persisted primary setting changes while this screen is open.
+    LaunchedEffect(amountEntryContext) {
+        amount = ReceiveAmountEntry.convert(
+            raw = amount,
+            from = previousAmountEntryContext,
+            to = amountEntryContext,
+        )
+        previousAmountEntryContext = amountEntryContext
     }
 
     // System back unwinds Display → Input; from Input the sheet handles it.
@@ -522,17 +559,24 @@ fun ReceiveLightningScreen(
                                 formatter.formatWalletSats(it.balance, settings.useBitcoinSymbol)
                             },
                             onPickMint = { mintPickerOpen = true },
-                            isSat = isSatUnit,
-                            unit = effectiveUnit,
+                            isSat = isSatUnit && !amountEntryContext.isFiatPrimary,
+                            unit = if (amountEntryContext.isFiatPrimary) {
+                                priceState.currencyCode
+                            } else {
+                                effectiveUnit
+                            },
                             useBitcoinSymbol = settings.useBitcoinSymbol,
                             formatter = formatter,
-                            decimals = currency.decimals,
+                            decimals = amountEntryContext.entryDecimals,
+                            fiatCurrencyCode = priceState.currencyCode
+                                .takeIf { amountEntryContext.isFiatPrimary },
+                            amountValid = amountValidation == ReceiveAmountValidation.Valid,
                             errorText = errorText,
                             onCreate = {
                                 createMintRequest(
                                     requestMethod = method,
                                     amountless = !method.requiresMintAmount &&
-                                        UnitAmountEntry.baseUnits(amount, currency.decimals) <= 0,
+                                        amountValidation == ReceiveAmountValidation.Empty,
                                 )
                             },
                         )
@@ -795,11 +839,18 @@ fun ReceiveLightningScreen(
         val quoteUnit = displayQuote.unit
         val isSat = quoteUnit.equals("sat", ignoreCase = true)
         val quoteCurrency = CurrencyRegistry.currencyForMintUnit(quoteUnit)
+        val editEntryContext = ReceiveAmountEntry.context(
+            quoteUnit = quoteUnit,
+            mintUnitDecimals = quoteCurrency.decimals,
+            preferredPrimary = settings.amountDisplayPrimary,
+            btcPrice = priceState.btcPrice,
+        )
         ReusableAmountEditSheet(
             initialAmount = displayQuote.amount.takeUnless { displayQuote.isAmountless },
             isSat = isSat,
             unit = quoteUnit,
-            decimals = quoteCurrency.decimals,
+            entryContext = editEntryContext,
+            fiatCurrencyCode = priceState.currencyCode,
             useBitcoinSymbol = settings.useBitcoinSymbol,
             formatter = formatter,
             onDone = { next ->
@@ -853,6 +904,8 @@ private fun InputFace(
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
     decimals: Int,
+    fiatCurrencyCode: String?,
+    amountValid: Boolean,
     errorText: String?,
     onCreate: () -> Unit,
 ) {
@@ -896,6 +949,7 @@ private fun InputFace(
             decimals = decimals,
             useBitcoinSymbol = useBitcoinSymbol,
             formatter = formatter,
+            fiatCurrencyCode = fiatCurrencyCode,
         )
         if (errorText != null) {
             Spacer(Modifier.height(CashuTheme.spacing.default))
@@ -908,7 +962,7 @@ private fun InputFace(
             decimals = decimals,
             buttonText = if (creating) "Creating…" else selectedMethod.createActionTitle,
             onButtonClick = onCreate,
-            buttonEnabled = !creating,
+            buttonEnabled = !creating && (!selectedMethod.requiresMintAmount || amountValid),
             buttonLoading = creating,
         )
     }
@@ -1141,7 +1195,8 @@ private fun ReusableAmountEditSheet(
     initialAmount: Long?,
     isSat: Boolean,
     unit: String,
-    decimals: Int,
+    entryContext: ReceiveAmountEntryContext,
+    fiatCurrencyCode: String,
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
     onDone: (Long?) -> Unit,
@@ -1149,7 +1204,12 @@ private fun ReusableAmountEditSheet(
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     var amount by remember {
-        mutableStateOf(UnitAmountEntry.entryString(initialAmount ?: 0, decimals))
+        mutableStateOf(ReceiveAmountEntry.rawForBaseUnits(initialAmount ?: 0, entryContext))
+    }
+    var previousEntryContext by remember { mutableStateOf(entryContext) }
+    LaunchedEffect(entryContext) {
+        amount = ReceiveAmountEntry.convert(amount, previousEntryContext, entryContext)
+        previousEntryContext = entryContext
     }
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -1171,20 +1231,24 @@ private fun ReusableAmountEditSheet(
             Spacer(Modifier.weight(1f))
             AmountEntryHero(
                 entryRaw = amount,
-                isSat = isSat,
-                unit = unit,
-                decimals = decimals,
+                isSat = isSat && !entryContext.isFiatPrimary,
+                unit = if (entryContext.isFiatPrimary) fiatCurrencyCode else unit,
+                decimals = entryContext.entryDecimals,
                 useBitcoinSymbol = useBitcoinSymbol,
                 formatter = formatter,
+                fiatCurrencyCode = fiatCurrencyCode.takeIf { entryContext.isFiatPrimary },
             )
             Spacer(Modifier.weight(1f))
             NumberPadFooter(
                 amount = amount,
                 onAmountChange = { amount = it },
-                decimals = decimals,
+                decimals = entryContext.entryDecimals,
                 buttonText = "Done",
                 onButtonClick = {
-                    onDone(UnitAmountEntry.baseUnits(amount, decimals).takeIf { it > 0 })
+                    onDone(
+                        ReceiveAmountEntry.amountBaseUnits(amount, entryContext)
+                            .takeIf { it > 0L },
+                    )
                 },
             )
         }

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendAmountEntry.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendAmountEntry.kt
@@ -1,13 +1,11 @@
 package com.cashu.me.ui.send
 
 import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.BitcoinAmountEntry
+import com.cashu.me.Core.BitcoinAmountEntryContext
 import com.cashu.me.Core.UnitAmountEntry
-import kotlin.math.roundToLong
 
-internal data class UnifiedSendEntryContext(
-    val primary: AmountDisplayPrimary,
-    val btcPrice: Double,
-)
+internal typealias UnifiedSendEntryContext = BitcoinAmountEntryContext
 
 internal enum class UnifiedSendAmountValidation {
     Empty,
@@ -22,45 +20,14 @@ internal enum class UnifiedSendAmountValidation {
  * quotes and payments always receive the converted sat value.
  */
 internal object UnifiedSendAmountEntry {
-    fun context(preferredPrimary: String, btcPrice: Double): UnifiedSendEntryContext {
-        val preferred = AmountDisplayPrimary.fromRaw(preferredPrimary)
-        val effective = if (preferred == AmountDisplayPrimary.Fiat && btcPrice.isFinite() && btcPrice > 0.0) {
-            AmountDisplayPrimary.Fiat
-        } else {
-            AmountDisplayPrimary.Sats
-        }
-        return UnifiedSendEntryContext(effective, btcPrice)
-    }
+    fun context(preferredPrimary: String, btcPrice: Double): UnifiedSendEntryContext =
+        BitcoinAmountEntry.context(preferredPrimary, btcPrice)
 
     fun amountSats(raw: String, context: UnifiedSendEntryContext): Long =
-        when (context.primary) {
-            AmountDisplayPrimary.Sats -> raw.toLongOrNull()?.takeIf { it > 0L } ?: 0L
-            AmountDisplayPrimary.Fiat -> fiatCentsToSats(
-                cents = UnitAmountEntry.baseUnits(raw, FIAT_DECIMALS),
-                btcPrice = context.btcPrice,
-            )
-        }
+        BitcoinAmountEntry.amountSats(raw, context)
 
-    fun rawForSats(amountSats: Long, context: UnifiedSendEntryContext): String {
-        if (amountSats <= 0L) return ""
-        return when (context.primary) {
-            AmountDisplayPrimary.Sats -> amountSats.toString()
-            AmountDisplayPrimary.Fiat -> {
-                if (!context.btcPrice.isFinite() || context.btcPrice <= 0.0) return ""
-                val cents = (
-                    amountSats.toDouble() /
-                        SATS_PER_BITCOIN *
-                        context.btcPrice *
-                        CENTS_PER_FIAT
-                    ).roundToLong()
-                if (cents !in 1..MAX_ENTRY_BASE_UNITS) {
-                    ""
-                } else {
-                    UnitAmountEntry.entryString(cents, FIAT_DECIMALS)
-                }
-            }
-        }
-    }
+    fun rawForSats(amountSats: Long, context: UnifiedSendEntryContext): String =
+        BitcoinAmountEntry.rawForSats(amountSats, context)
 
     /**
      * Fiat cents cannot represent every sat balance exactly. Pick the closest
@@ -81,10 +48,7 @@ internal object UnifiedSendAmountEntry {
         raw: String,
         from: UnifiedSendEntryContext,
         to: UnifiedSendEntryContext,
-    ): String {
-        if (raw.isEmpty() || from.primary == to.primary) return raw
-        return rawForSats(amountSats(raw, from), to)
-    }
+    ): String = BitcoinAmountEntry.convert(raw, from, to)
 
     fun validation(amountSats: Long, balanceSats: Long): UnifiedSendAmountValidation =
         when {
@@ -93,18 +57,5 @@ internal object UnifiedSendAmountEntry {
             else -> UnifiedSendAmountValidation.Valid
         }
 
-    private fun fiatCentsToSats(cents: Long, btcPrice: Double): Long {
-        if (cents <= 0L || !btcPrice.isFinite() || btcPrice <= 0.0) return 0L
-        val sats = cents.toDouble() /
-            CENTS_PER_FIAT /
-            btcPrice *
-            SATS_PER_BITCOIN
-        if (!sats.isFinite() || sats <= 0.0 || sats > Long.MAX_VALUE.toDouble()) return 0L
-        return sats.roundToLong()
-    }
-
     private const val FIAT_DECIMALS = 2
-    private const val CENTS_PER_FIAT = 100.0
-    private const val SATS_PER_BITCOIN = 100_000_000.0
-    private const val MAX_ENTRY_BASE_UNITS = 99_999_999_999L
 }

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -530,6 +530,7 @@ private fun AuthenticatedShell(container: AppContainer) {
                 walletManager = container.walletManager,
                 cashuRequestStore = container.cashuRequestStore,
                 settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 onClose = close,
             )
 

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveAmountEntryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveAmountEntryTest.kt
@@ -1,0 +1,81 @@
+package com.cashu.me.ui.receive
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReceiveAmountEntryTest {
+    @Test
+    fun fiatPrimaryConvertsEntryAndKeepsTheQuoteDenominatedInSats() {
+        val context = satContext(preferredPrimary = "fiat", btcPrice = 50_000.0)
+
+        assertTrue(context.isFiatPrimary)
+        assertEquals(2, context.entryDecimals)
+        assertEquals(ReceiveAmountValidation.Valid, ReceiveAmountEntry.validation("12.50", context))
+        assertEquals(25_000L, ReceiveAmountEntry.quoteAmount("12.50", context, amountless = false))
+        assertEquals("sat", context.quoteUnit)
+    }
+
+    @Test
+    fun validationRejectsAnEmptyFiatEntryAfterConversion() {
+        val context = satContext(preferredPrimary = "fiat", btcPrice = 50_000.0)
+
+        assertEquals(ReceiveAmountValidation.Empty, ReceiveAmountEntry.validation("", context))
+        assertEquals(null, ReceiveAmountEntry.quoteAmount("", context, amountless = false))
+    }
+
+    @Test
+    fun unavailablePriceFallsBackToIntegerSatEntry() {
+        val context = satContext(preferredPrimary = "fiat", btcPrice = 0.0)
+
+        assertFalse(context.isFiatPrimary)
+        assertEquals(AmountDisplayPrimary.Sats, context.bitcoin.primary)
+        assertEquals(0, context.entryDecimals)
+        assertEquals(12_500L, ReceiveAmountEntry.quoteAmount("12500", context, amountless = false))
+    }
+
+    @Test
+    fun priceAvailabilityReexpressesExistingSatsWithoutChangingTheQuoteAmount() {
+        val sats = satContext(preferredPrimary = "fiat", btcPrice = 0.0)
+        val fiat = satContext(preferredPrimary = "fiat", btcPrice = 50_000.0)
+
+        val convertedRaw = ReceiveAmountEntry.convert("25000", from = sats, to = fiat)
+
+        assertEquals("12.50", convertedRaw)
+        assertEquals(25_000L, ReceiveAmountEntry.quoteAmount(convertedRaw, fiat, amountless = false))
+    }
+
+    @Test
+    fun nonSatMintUnitsRemainUnitNative() {
+        val context = ReceiveAmountEntry.context(
+            quoteUnit = "usd",
+            mintUnitDecimals = 2,
+            preferredPrimary = "fiat",
+            btcPrice = 50_000.0,
+        )
+
+        assertFalse(context.isFiatPrimary)
+        assertEquals(2, context.entryDecimals)
+        assertEquals(1_250L, ReceiveAmountEntry.quoteAmount("12.50", context, amountless = false))
+        assertEquals("usd", context.quoteUnit)
+    }
+
+    @Test
+    fun amountlessQuotesIgnoreAnyTypedValue() {
+        val context = satContext(preferredPrimary = "fiat", btcPrice = 50_000.0)
+
+        assertEquals(null, ReceiveAmountEntry.quoteAmount("12.50", context, amountless = true))
+    }
+
+    private fun satContext(
+        preferredPrimary: String,
+        btcPrice: Double,
+    ): ReceiveAmountEntryContext = ReceiveAmountEntry.context(
+        quoteUnit = "sat",
+        mintUnitDecimals = 0,
+        preferredPrimary = preferredPrimary,
+        btcPrice = btcPrice,
+    )
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -88,7 +88,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Receive — Lightning, reusable invoices, on-chain, and Cashu Requests
 
-- [ ] **[P1 · iOS → Android] Support fiat-primary amount entry on Bitcoin receive rails.** iOS lets a sat Lightning invoice be entered in fiat; Android’s receive keypad uses fixed sat entry. **Done when:** Android entry and validation honor the persisted primary display setting without changing the sat-denominated quote.
+- [x] **[P1 · iOS → Android] Support fiat-primary amount entry on Bitcoin receive rails.** iOS lets a sat Lightning invoice be entered in fiat; Android’s receive keypad uses fixed sat entry. **Done when:** Android entry and validation honor the persisted primary display setting without changing the sat-denominated quote.
 
 - [ ] **[P2 · iOS → Android] Honor the preferred unit on generated invoice details.** iOS keeps sats and fiat available under a BOLT11 or fixed BOLT12 QR; Android renders a fixed amount string. **Done when:** Android leads with the saved primary unit and exposes the alternate conversion visually and accessibly through a native presentation.
 


### PR DESCRIPTION
## What changed

- honor the saved sats/fiat primary unit on Android Bitcoin receive amount entry
- convert fiat keypad input to the sat-denominated quote amount without changing quote semantics
- preserve unit-native handling for non-sat mints and fall back to sats when no BTC price is available
- add focused regression coverage and check off the verified parity item

## Root cause

The Android receive flow parsed keypad input directly with the mint unit's decimals, so sat-denominated Lightning receive amounts ignored the persisted fiat-primary setting.

## Impact

Users whose primary amount unit is fiat can now enter BOLT11 and fixed BOLT12 receive amounts in fiat while generated quotes remain denominated in sats.

## Validation

- focused receive and unified Send amount-entry tests
- full `:app:testDebugUnitTest :app:lintDebug`
- `git diff --check`
