### PR TITLE
Honor preferred unit on generated invoice details

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/receive/GeneratedInvoiceAmountComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/receive/GeneratedInvoiceAmountComposeTest.kt
@@ -1,0 +1,85 @@
+package com.cashu.me.ui.receive
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GeneratedInvoiceAmountComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun bolt11SatsPrimaryLeadsAndExposesFiatAlternativeAccessibly() {
+        compose.setCashuContent {
+            GeneratedInvoiceAmount(
+                amount = 100_000_000,
+                amountLabel = "100,000,000 sat",
+                unit = "sat",
+                paymentMethod = PaymentMethodKind.Bolt11,
+                primary = AmountDisplayPrimary.Sats,
+                onFlipPrimary = {},
+                btcPrice = 20_000.0,
+                currencyCode = "USD",
+                useBitcoinSymbol = false,
+            )
+        }
+
+        assertPrimaryAboveAlternate(
+            primary = "100,000,000 sat",
+            alternate = "$20,000.00",
+        )
+        compose.onNodeWithContentDescription(
+            "Alternate amount: $20,000.00. Tap to make it primary.",
+        )
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun fixedBolt12FiatPrimaryLeadsAndExposesSatsAlternativeAccessibly() {
+        compose.setCashuContent {
+            GeneratedInvoiceAmount(
+                amount = 100_000_000,
+                amountLabel = "100,000,000 sat",
+                unit = "sat",
+                paymentMethod = PaymentMethodKind.Bolt12,
+                primary = AmountDisplayPrimary.Fiat,
+                onFlipPrimary = {},
+                btcPrice = 20_000.0,
+                currencyCode = "USD",
+                useBitcoinSymbol = false,
+            )
+        }
+
+        assertPrimaryAboveAlternate(
+            primary = "$20,000.00",
+            alternate = "100,000,000 sat",
+        )
+        compose.onNodeWithContentDescription(
+            "Alternate amount: 100,000,000 sat. Tap to make it primary.",
+        )
+            .assertIsDisplayed()
+            .assertHasClickAction()
+    }
+
+    private fun assertPrimaryAboveAlternate(primary: String, alternate: String) {
+        val primaryNode = compose.onNodeWithText(primary).assertIsDisplayed().fetchSemanticsNode()
+        val alternateNode = compose.onNodeWithText(alternate).assertIsDisplayed().fetchSemanticsNode()
+
+        assertTrue(
+            "Expected preferred amount '$primary' above alternate '$alternate'",
+            primaryNode.boundsInRoot.top < alternateNode.boundsInRoot.top,
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/AmountFlipDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/AmountFlipDisplay.kt
@@ -27,6 +27,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountFormatter
@@ -55,6 +60,8 @@ fun AmountFlipDisplay(
     currencyCode: String,
     useBitcoinSymbol: Boolean,
     modifier: Modifier = Modifier,
+    primaryTextStyle: TextStyle? = null,
+    primaryAccessibilityPrefix: String? = null,
 ) {
     val haptics = LocalHapticFeedback.current
     val formatter = remember { AmountFormatter() }
@@ -93,7 +100,14 @@ fun AmountFlipDisplay(
             )
             AmountText(
                 text = stateDisplay.primary,
-                style = MaterialTheme.typography.displayMedium.withMonoDigits(),
+                modifier = if (primaryAccessibilityPrefix != null) {
+                    Modifier.semantics {
+                        contentDescription = "$primaryAccessibilityPrefix: ${stateDisplay.primary}"
+                    }
+                } else {
+                    Modifier
+                },
+                style = (primaryTextStyle ?: MaterialTheme.typography.displayMedium).withMonoDigits(),
             )
         }
         val secondary = display.secondary
@@ -105,6 +119,8 @@ fun AmountFlipDisplay(
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null,
+                        role = Role.Button,
+                        onClickLabel = "Make $secondary primary",
                     ) {
                         haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                         onFlip(
@@ -114,6 +130,10 @@ fun AmountFlipDisplay(
                                 AmountDisplayPrimary.Fiat
                             },
                         )
+                    }
+                    .semantics(mergeDescendants = true) {
+                        role = Role.Button
+                        contentDescription = "Alternate amount: $secondary. Tap to make it primary."
                     }
                     .padding(
                         horizontal = CashuTheme.spacing.default,
@@ -138,7 +158,7 @@ fun AmountFlipDisplay(
                 }
                 Icon(
                     imageVector = Icons.Outlined.SwapVert,
-                    contentDescription = "Swap display unit",
+                    contentDescription = null,
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(FlipPillIconSize),
                 )

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -68,11 +68,13 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.CashuRequestStore
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
 import com.cashu.me.Core.OnchainPaymentObservation
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.UnitAmountEntry
@@ -86,6 +88,7 @@ import com.cashu.me.Models.MintQuoteInfo
 import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.ui.components.AmountEntryHero
+import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.ExplorerLinkRow
@@ -124,10 +127,12 @@ fun ReceiveLightningScreen(
     walletManager: WalletManager,
     cashuRequestStore: CashuRequestStore,
     settingsManager: SettingsManager,
+    priceService: PriceService,
     onClose: () -> Unit,
 ) {
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val cashuRequestState by cashuRequestStore.state.collectAsState()
     val formatter = remember { AmountFormatter() }
     val scope = rememberCoroutineScope()
@@ -723,6 +728,17 @@ fun ReceiveLightningScreen(
                             .firstOrNull { it.quoteId == liveQuote.id }
                             ?.createdAtEpochMillis,
                         errorText = errorText,
+                        amountPrimary = AmountDisplayPrimary.fromRaw(settings.amountDisplayPrimary),
+                        onFlipAmountPrimary = {
+                            settingsManager.setAmountDisplayPrimary(it.rawValue)
+                        },
+                        fiatPrice = if (settings.showFiatBalance) {
+                            priceState.btcPrice.takeIf { it > 0 }
+                        } else {
+                            null
+                        },
+                        fiatCurrencyCode = settings.bitcoinPriceCurrency,
+                        useBitcoinSymbol = settings.useBitcoinSymbol,
                         pendingStatusText = when {
                             !isOnchain -> "Waiting for payment…"
                             observation != null -> "${observation.statusText}. Trying to mint…"
@@ -978,6 +994,11 @@ private fun DisplayFace(
     mintName: String?,
     createdAtEpochMillis: Long?,
     errorText: String?,
+    amountPrimary: AmountDisplayPrimary,
+    onFlipAmountPrimary: (AmountDisplayPrimary) -> Unit,
+    fiatPrice: Double?,
+    fiatCurrencyCode: String,
+    useBitcoinSymbol: Boolean,
     pendingStatusText: String,
     explorerLabel: String,
     onCopy: () -> Unit,
@@ -1006,13 +1027,16 @@ private fun DisplayFace(
             Spacer(Modifier.height(CashuTheme.spacing.comfortable))
             QrCard(content = quote.request, shareSubject = "Payment request", staticOnly = true)
             if (amountLabel != null) {
-                // SemiBold headlineMedium (~28sp) — heavier than the old thin
-                // headlineSmall, but still secondary to the QR (iOS 32pt intent).
-                AmountText(
-                    text = amountLabel,
-                    style = MaterialTheme.typography.headlineMedium
-                        .copy(fontWeight = FontWeight.SemiBold)
-                        .withMonoDigits(),
+                GeneratedInvoiceAmount(
+                    amount = quote.amount ?: 0L,
+                    amountLabel = amountLabel,
+                    unit = quote.unit,
+                    paymentMethod = quote.paymentMethod,
+                    primary = amountPrimary,
+                    onFlipPrimary = onFlipAmountPrimary,
+                    btcPrice = fiatPrice,
+                    currencyCode = fiatCurrencyCode,
+                    useBitcoinSymbol = useBitcoinSymbol,
                 )
             }
             if (isReusable) {
@@ -1098,6 +1122,51 @@ private fun DisplayFace(
             )
         }
         Spacer(Modifier.navigationBarsPadding())
+    }
+}
+
+/**
+ * Preferred-unit presentation for fixed Lightning requests. Amountless offers,
+ * on-chain deposits, and non-sat mint units retain their rail-native display.
+ */
+@Composable
+internal fun GeneratedInvoiceAmount(
+    amount: Long,
+    amountLabel: String,
+    unit: String,
+    paymentMethod: PaymentMethodKind,
+    primary: AmountDisplayPrimary,
+    onFlipPrimary: (AmountDisplayPrimary) -> Unit,
+    btcPrice: Double?,
+    currencyCode: String,
+    useBitcoinSymbol: Boolean,
+) {
+    val supportsPreferredUnit = amount > 0L &&
+        unit.equals("sat", ignoreCase = true) &&
+        (paymentMethod == PaymentMethodKind.Bolt11 || paymentMethod == PaymentMethodKind.Bolt12)
+    if (supportsPreferredUnit) {
+        AmountFlipDisplay(
+            amountSats = amount,
+            primary = primary,
+            onFlip = onFlipPrimary,
+            btcPrice = btcPrice,
+            currencyCode = currencyCode,
+            useBitcoinSymbol = useBitcoinSymbol,
+            primaryTextStyle = MaterialTheme.typography.headlineMedium
+                .copy(fontWeight = FontWeight.SemiBold),
+            primaryAccessibilityPrefix = when (paymentMethod) {
+                PaymentMethodKind.Bolt11 -> "Invoice amount"
+                PaymentMethodKind.Bolt12 -> "Offer amount"
+                PaymentMethodKind.Onchain -> "Amount"
+            },
+        )
+    } else {
+        AmountText(
+            text = amountLabel,
+            style = MaterialTheme.typography.headlineMedium
+                .copy(fontWeight = FontWeight.SemiBold)
+                .withMonoDigits(),
+        )
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -530,6 +530,7 @@ private fun AuthenticatedShell(container: AppContainer) {
                 walletManager = container.walletManager,
                 cashuRequestStore = container.cashuRequestStore,
                 settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 onClose = close,
             )
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -90,7 +90,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Support fiat-primary amount entry on Bitcoin receive rails.** iOS lets a sat Lightning invoice be entered in fiat; Android’s receive keypad uses fixed sat entry. **Done when:** Android entry and validation honor the persisted primary display setting without changing the sat-denominated quote.
 
-- [ ] **[P2 · iOS → Android] Honor the preferred unit on generated invoice details.** iOS keeps sats and fiat available under a BOLT11 or fixed BOLT12 QR; Android renders a fixed amount string. **Done when:** Android leads with the saved primary unit and exposes the alternate conversion visually and accessibly through a native presentation.
+- [x] **[P2 · iOS → Android] Honor the preferred unit on generated invoice details.** iOS keeps sats and fiat available under a BOLT11 or fixed BOLT12 QR; Android renders a fixed amount string. **Done when:** Android leads with the saved primary unit and exposes the alternate conversion visually and accessibly through a native presentation.
 
 - [ ] **[P1 · iOS → Android] Make expiry the primary one-shot invoice status.** Android can keep “Waiting for payment” as the main status after expiry while only the small caption says Expired. **Done when:** the primary status, accessibility value, and available actions cannot contradict the expired state.
 


### PR DESCRIPTION
## What changed

- render fixed Android BOLT11 and BOLT12 generated-invoice amounts with the saved primary unit
- expose the alternate sats/fiat value through a native tappable presentation with TalkBack semantics
- preserve amountless, on-chain, and non-sat behavior
- add focused Compose coverage and check off the verified parity item

## Root cause

Android reduced generated invoice amounts to one fixed sat string while iOS retained the preferred primary unit and alternate conversion.

## Impact

Generated Lightning invoice details now lead with the user's saved unit and keep the alternate value visible and accessible.

## Validation

- `:app:testDebugUnitTest`
- `:app:compileDebugAndroidTestKotlin`
- focused Compose tests on API 36 and API 37
- `git diff --check`
