### PR TITLE
Explain the purpose of Nostr relays on Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -291,6 +291,9 @@ fun NostrScreen(
                     }
                 }
             }
+            FooterText(
+                "Relays sync your Nostr data for compatible features like npub.cash and backups.",
+            )
             Column(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = CashuTheme.spacing.comfortable),
                 verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -192,7 +192,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Give key generation native destructive semantics.** Android’s Generate action is visually neutral even though it replaces an identity; iOS uses a destructive confirmation role. **Done when:** Android uses the platform’s destructive semantic role and accessible announcement for the replacement action. It need not copy iOS styling.
 
-- [ ] **[P2 · iOS → Android] Add the relay-purpose explanation.** iOS explains that relays synchronize npub.cash-compatible data and backups; Android lists relays without that context. **Done when:** Android explains why changing the relay list affects wallet features.
+- [x] **[P2 · iOS → Android] Add the relay-purpose explanation.** iOS explains that relays synchronize npub.cash-compatible data and backups; Android lists relays without that context. **Done when:** Android explains why changing the relay list affects wallet features.
 
 ### Settings — Wallet Connect and locked-ecash keys
 


### PR DESCRIPTION
## What changed

- add quiet supporting text beside Android's Nostr relay list explaining that relays sync data for npub.cash-compatible features and backups
- mark the verified relay-purpose parity checklist item complete

## Why

iOS already explains why relay configuration affects wallet features, while Android previously listed relay URLs and mutation actions without any product context.

## Impact

Users can understand the consequences of changing their relay list before adding, removing, or resetting relays.

## Validation

- `git diff --check`
- `./gradlew --no-daemon :app:lintDebug --stacktrace` (BUILD SUCCESSFUL)
