### PR TITLE
Audit and sanitize crash reports

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/AppLogger.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AppLogger.kt
@@ -7,6 +7,15 @@ object AppLogger {
     private val nostrSecretPattern = Regex("""\bnsec1[023456789acdefghjklmnpqrstuvwxyz]+\b""", RegexOption.IGNORE_CASE)
     private val nwcUriPattern = Regex("""\bnostr\+walletconnect://[^\s,;)"']+""", RegexOption.IGNORE_CASE)
     private val cashuTokenPattern = Regex("""\bcashu[ab][a-z0-9_\-=]{16,}\b""", RegexOption.IGNORE_CASE)
+    private val cashuRequestPattern = Regex("""\bcreq(?:a|b1)[a-z0-9_\-=]{8,}\b""", RegexOption.IGNORE_CASE)
+    private val lightningPayloadPattern = Regex(
+        """\b(?:lnbc|lntb|lnbcrt|lno|lni|lnr|lnurl)[a-z0-9]{16,}\b""",
+        RegexOption.IGNORE_CASE,
+    )
+    private val bitcoinUriPattern = Regex("""\bbitcoin:(?://)?[^\s,;)"']+""", RegexOption.IGNORE_CASE)
+    private val bech32BitcoinAddressPattern = Regex("""\b(?:bc1|tb1|bcrt1)[a-z0-9]{20,}\b""", RegexOption.IGNORE_CASE)
+    private val base58BitcoinAddressPattern = Regex("""\b[13mn2][a-km-zA-HJ-NP-Z1-9]{25,34}\b""")
+    private val emailPattern = Regex("""\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b""", RegexOption.IGNORE_CASE)
     private val urlPattern = Regex("""https?://[^\s,;)"']+""", RegexOption.IGNORE_CASE)
     private val localPathPattern = Regex("""(?<![A-Za-z0-9])/(?:Users|private|data|var|tmp|storage|sdcard)/[^\s,;)"']+""")
     private val labeledSecretPattern = Regex(
@@ -42,6 +51,12 @@ object AppLogger {
             .replace(nostrSecretPattern, "<redacted-nsec>")
             .replace(nwcUriPattern, "<redacted-nwc-uri>")
             .replace(cashuTokenPattern, "<redacted-cashu-token>")
+            .replace(cashuRequestPattern, "<redacted-cashu-request>")
+            .replace(lightningPayloadPattern, "<redacted-lightning-payload>")
+            .replace(bitcoinUriPattern, "<redacted-bitcoin-uri>")
+            .replace(bech32BitcoinAddressPattern, "<redacted-bitcoin-address>")
+            .replace(base58BitcoinAddressPattern, "<redacted-bitcoin-address>")
+            .replace(emailPattern, "<redacted-email>")
             .replace(urlPattern, "<redacted-url>")
             .replace(localPathPattern, "<redacted-path>")
             .replace(labeledSecretPattern) { match ->

--- a/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
@@ -128,8 +128,8 @@ fun PrivacyScreen(
 
             SectionHeader("Diagnostics")
             ToggleRow(
-                title = "Send anonymous crash reports",
-                subtitle = "Opt-in. Screenshots and view hierarchy are never attached, and no Sentry PII is collected.",
+                title = "Send crash reports",
+                subtitle = "Opt-in. Screenshots and view hierarchy are not attached. Reports can include technical error details and recent wallet actions.",
                 checked = settings.sentryEnabled,
                 onCheckedChange = settingsManager::setSentryEnabled,
             )

--- a/android/app/src/test/java/com/cashu/me/Core/AppLoggerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/AppLoggerTest.kt
@@ -50,6 +50,22 @@ class AppLoggerTest {
     }
 
     @Test
+    fun privacySafeMessageRedactsPaymentPayloadsAndContactDetails() {
+        val message = AppLogger.privacySafeMessage(
+            "request creqAabcdefghijklmnopqrstuvwxyz0123456789 " +
+                "invoice lnbc1abcdefghijklmnopqrstuvwxyz0123456789 " +
+                "offer lno1abcdefghijklmnopqrstuvwxyz0123456789 " +
+                "bitcoin:bc1qexamplewalletaddress0123456789 and alice@example.com",
+        )
+
+        assertEquals(
+            "request <redacted-cashu-request> invoice <redacted-lightning-payload> " +
+                "offer <redacted-lightning-payload> <redacted-bitcoin-uri> and <redacted-email>",
+            message,
+        )
+    }
+
+    @Test
     fun privacySafeThrowableRedactsMessageButKeepsStack() {
         val error = IllegalStateException("failed token cashuAabcdefghijklmnopqrstuvwxyz0123456789")
         error.stackTrace = arrayOf(StackTraceElement("Example", "method", "Example.kt", 12))

--- a/docs/product/crash-report-data-audit.md
+++ b/docs/product/crash-report-data-audit.md
@@ -1,0 +1,43 @@
+# Crash-report data audit
+
+Last audited: 2026-08-01
+
+Crash reporting is opt-in and off by default on both platforms. Enabling it starts Sentry;
+disabling it closes the SDK. Both SDK configurations disable default PII collection,
+screenshots, and view-hierarchy attachments, and enable session tracking and 10% performance
+trace sampling.
+
+## iOS inventory
+
+- Explicit captures: wallet load/creation failure, wallet deletion failure, and Nostr-NPC
+  quote failure. These errors now cross `CrashReportSanitizer`, which keeps the error type and
+  code but discards arbitrary `NSError.userInfo` and redacts the description.
+- Explicit breadcrumbs: token sent/received; mint added/restored/removed; wallet
+  loaded/created/restored/deleted; Lightning mint, send, and asynchronous settlement states;
+  and Nostr-NPC quote minting. These are static action labels without amounts, token material,
+  quote IDs, mint URLs, or addresses. The Sentry boundary still sanitizes every explicit
+  breadcrumb message.
+- SDK diagnostics: unhandled crash diagnostics, automatic SDK breadcrumbs, session state, and
+  sampled performance traces may be collected while reporting is enabled. They are not covered
+  by a promise of anonymity or of containing no personal data.
+
+## Android inventory
+
+- Explicit captures and wallet breadcrumbs: none currently emitted by production call sites.
+  `SentryService.capture` and `breadcrumb` remain sanitized and tested boundaries for future
+  call sites.
+- SDK diagnostics: unhandled crash diagnostics, automatic Android/Sentry breadcrumbs, session
+  state, and sampled performance traces may be collected while reporting is enabled. They are
+  not covered by a promise of anonymity or of containing no personal data.
+
+## Redaction contract
+
+The shared platform policy redacts known high-risk values from explicit wallet captures and
+breadcrumbs: Nostr private keys, Nostr Wallet Connect URIs, Cashu tokens and requests,
+Lightning payment payloads, Bitcoin URIs and addresses, email/Lightning addresses, HTTP(S)
+URLs, local filesystem paths, and values labeled as mnemonic, seed phrase, private key, or
+secret. Tests on both platforms cover the crash-report boundary and these payload classes.
+
+The Settings text deliberately promises only enforced SDK configuration: reporting is opt-in,
+screenshots and view hierarchy are not attached, and reports can include technical error details
+and recent wallet actions.

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -246,7 +246,7 @@ These items may improve efficiency or discoverability but are not required for f
 
 These are important, but they belong in dedicated security/privacy, design-system, or style/tooling backlogs rather than the release parity gate.
 
-- [ ] **[P0 · Security/privacy] Audit crash-report data and narrow the displayed privacy promise.** **Done when:** captures and breadcrumbs are inventoried on both platforms, sensitive wallet payloads are sanitized, redaction is tested, and displayed promises are limited to guarantees the implementation enforces.
+- [x] **[P0 · Security/privacy] Audit crash-report data and narrow the displayed privacy promise.** **Done when:** captures and breadcrumbs are inventoried on both platforms, sensitive wallet payloads are sanitized, redaction is tested, and displayed promises are limited to guarantees the implementation enforces.
 
 - [ ] **[P2 · Design system] Define an accessible currency-row avatar rule.** **Done when:** the design system documents a neutral currency code or monogram rule instead of country flags or ambiguous symbols, while retaining ISO code and localized currency name in text.
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000B /* ReceiveAutoPasteTests.swift */; };
 		T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000C /* HomeActionAccessibilityTests.swift */; };
 		T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000D /* CashuRequestRouteExplanationTests.swift */; };
+		T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000E /* CrashReportSanitizerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -293,6 +294,7 @@
 		T1B000000000000B /* ReceiveAutoPasteTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReceiveAutoPasteTests.swift; path = CashuWalletTests/ReceiveAutoPasteTests.swift; sourceTree = "<group>"; };
 		T1B000000000000C /* HomeActionAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HomeActionAccessibilityTests.swift; path = CashuWalletTests/HomeActionAccessibilityTests.swift; sourceTree = "<group>"; };
 		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
+		T1B000000000000E /* CrashReportSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrashReportSanitizerTests.swift; path = CashuWalletTests/CrashReportSanitizerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -345,6 +347,7 @@
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
 				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
+				T1B000000000000E /* CrashReportSanitizerTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -888,6 +891,7 @@
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
 				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
+				T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Core/SentryService.swift
+++ b/ios/CashuWallet/Core/SentryService.swift
@@ -24,15 +24,74 @@ enum SentryService {
 
     static func capture(_ error: Error) {
         guard SettingsStore.shared.sentryEnabled else { return }
-        SentrySDK.capture(error: error)
+        SentrySDK.capture(error: CrashReportSanitizer.error(error))
     }
 
     static func breadcrumb(_ message: String, category: String = "wallet") {
         guard SettingsStore.shared.sentryEnabled else { return }
         let crumb = Breadcrumb()
-        crumb.message = message
+        crumb.message = CrashReportSanitizer.message(message)
         crumb.category = category
         crumb.level = .info
         SentrySDK.addBreadcrumb(crumb)
+    }
+}
+
+/// Removes known wallet secrets and payment payloads at the explicit crash-report boundary.
+///
+/// Keep this independent of Sentry so the redaction contract can be unit tested without
+/// starting the SDK. Unknown error metadata is intentionally discarded: `NSError.userInfo`
+/// may contain the same request data that caused the failure.
+enum CrashReportSanitizer {
+    private struct Replacement {
+        let expression: NSRegularExpression
+        let template: String
+
+        init(_ pattern: String, template: String, caseInsensitive: Bool = true) {
+            expression = try! NSRegularExpression(
+                pattern: pattern,
+                options: caseInsensitive ? [.caseInsensitive] : []
+            )
+            self.template = template
+        }
+    }
+
+    private static let replacements = [
+        Replacement(#"\bnostr\+walletconnect://[^\s,;)\"']+"#, template: "<redacted-nwc-uri>"),
+        Replacement(#"\bnsec1[023456789acdefghjklmnpqrstuvwxyz]+\b"#, template: "<redacted-nsec>"),
+        Replacement(#"\bcashu[ab][a-z0-9_\-=]{16,}\b"#, template: "<redacted-cashu-token>"),
+        Replacement(#"\bcreq(?:a|b1)[a-z0-9_\-=]{8,}\b"#, template: "<redacted-cashu-request>"),
+        Replacement(#"\b(?:lnbc|lntb|lnbcrt|lno|lni|lnr|lnurl)[a-z0-9]{16,}\b"#, template: "<redacted-lightning-payload>"),
+        Replacement(#"\bbitcoin:(?://)?[^\s,;)\"']+"#, template: "<redacted-bitcoin-uri>"),
+        Replacement(#"\b(?:bc1|tb1|bcrt1)[a-z0-9]{20,}\b"#, template: "<redacted-bitcoin-address>"),
+        Replacement(#"\b[13mn2][a-km-zA-HJ-NP-Z1-9]{25,34}\b"#, template: "<redacted-bitcoin-address>", caseInsensitive: false),
+        Replacement(#"\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b"#, template: "<redacted-email>"),
+        Replacement(#"https?://[^\s,;)\"']+"#, template: "<redacted-url>"),
+        Replacement(#"(?<![A-Za-z0-9])/(?:Users|private|data|var|tmp|storage|sdcard)/[^\s,;)\"']+"#, template: "<redacted-path>", caseInsensitive: false),
+        Replacement(
+            #"\b(mnemonic|seed phrase|private key|secret)\s*[:=]\s*([^\s,;]+(?:\s+[^\s,;]+){0,23})"#,
+            template: "$1=<redacted>"
+        ),
+    ]
+
+    static func message(_ message: String) -> String {
+        replacements.reduce(message) { result, replacement in
+            let range = NSRange(result.startIndex..<result.endIndex, in: result)
+            return replacement.expression.stringByReplacingMatches(
+                in: result,
+                range: range,
+                withTemplate: replacement.template
+            )
+        }
+    }
+
+    static func error(_ error: Error) -> NSError {
+        let original = error as NSError
+        let typeName = String(reflecting: type(of: error))
+        return NSError(
+            domain: "CashuWallet.SanitizedError",
+            code: original.code,
+            userInfo: [NSLocalizedDescriptionKey: "\(typeName): \(message(original.localizedDescription))"]
+        )
     }
 }

--- a/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
@@ -56,8 +56,8 @@ struct PrivacySettingsSection: View {
 
                 Toggle(isOn: $settings.sentryEnabled) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Send anonymous crash reports")
-                        Text("Helps improve the app. No personal data, wallet addresses, or amounts are ever sent.")
+                        Text("Send crash reports")
+                        Text("Opt-in. Screenshots and view hierarchy are not attached. Reports can include technical error details and recent wallet actions.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }

--- a/ios/CashuWalletTests/CrashReportSanitizerTests.swift
+++ b/ios/CashuWalletTests/CrashReportSanitizerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import CashuWallet
+
+final class CrashReportSanitizerTests: XCTestCase {
+    func testMessageRedactsWalletSecretsUrlsAndPaths() {
+        let message = CrashReportSanitizer.message(
+            "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq " +
+                "nostr+walletconnect://service?relay=wss%3A%2F%2Frelay.example&secret=client " +
+                "cashuAabcdefghijklmnopqrstuvwxyz0123456789 at https://mint.example.com " +
+                "/private/var/mobile/wallet.db"
+        )
+
+        XCTAssertEqual(
+            message,
+            "<redacted-nsec> <redacted-nwc-uri> <redacted-cashu-token> at <redacted-url> " +
+                "<redacted-path>"
+        )
+    }
+
+    func testMessageRedactsPaymentPayloadsAndContactDetails() {
+        let message = CrashReportSanitizer.message(
+            "request creqAabcdefghijklmnopqrstuvwxyz0123456789 " +
+                "invoice lnbc1abcdefghijklmnopqrstuvwxyz0123456789 " +
+                "offer lno1abcdefghijklmnopqrstuvwxyz0123456789 " +
+                "bitcoin:bc1qexamplewalletaddress0123456789 and alice@example.com"
+        )
+
+        XCTAssertEqual(
+            message,
+            "request <redacted-cashu-request> invoice <redacted-lightning-payload> " +
+                "offer <redacted-lightning-payload> <redacted-bitcoin-uri> and <redacted-email>"
+        )
+    }
+
+    func testSanitizedErrorDropsUserInfoAndKeepsOnlySafeDescriptionAndCode() {
+        let original = NSError(
+            domain: "RemoteWalletError",
+            code: 42,
+            userInfo: [
+                NSLocalizedDescriptionKey: "failed cashuAabcdefghijklmnopqrstuvwxyz0123456789",
+                "rawResponse": "secret=correct horse battery staple",
+            ]
+        )
+
+        let safe = CrashReportSanitizer.error(original)
+
+        XCTAssertEqual(safe.domain, "CashuWallet.SanitizedError")
+        XCTAssertEqual(safe.code, 42)
+        XCTAssertEqual(
+            safe.localizedDescription,
+            "NSError: failed <redacted-cashu-token>"
+        )
+        XCTAssertNil(safe.userInfo["rawResponse"])
+    }
+}


### PR DESCRIPTION
## What changed

- inventory iOS and Android crash captures, breadcrumbs, and SDK diagnostics
- sanitize explicit iOS errors and breadcrumbs before they reach Sentry
- expand both platforms' redaction coverage for Cashu requests, Lightning payloads, Bitcoin destinations, and email/Lightning addresses
- replace the unsupported "anonymous" privacy claim with wording limited to enforced SDK settings
- add cross-platform redaction tests and mark the parity checklist item complete

## Root cause

iOS sent raw `Error` values through its explicit Sentry capture boundary, while Android already sanitized that path. The two settings screens also made broader privacy promises than their SDK configuration can enforce for automatic crash diagnostics.

## Impact

Known wallet secrets and payment payloads are removed from explicit wallet captures and breadcrumbs. Users now see an accurate description of what opt-in reporting excludes and what reports can contain.

## Validation

- Android `AppLoggerTest` and `SentryServiceTest`
- iOS `CrashReportSanitizerTests`
- Xcode project plist validation
- whitespace validation
