### PR TITLE
Authenticate before enabling App Lock

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/AppLockManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AppLockManager.kt
@@ -90,11 +90,37 @@ class AppLockManager(
     suspend fun authenticate(
         activity: FragmentActivity?,
         reason: String = "Unlock your wallet",
+    ): Boolean = authenticate(
+        activity = activity,
+        reason = reason,
+        succeedWhenUnavailable = true,
+    )
+
+    /**
+     * Confirms that the user can satisfy App Lock before the setting is enabled.
+     * Unlike the runtime unlock path, unavailable authentication must fail closed:
+     * persisting an unusable lock would leave the setting enabled without a
+     * successful device-owner challenge.
+     */
+    suspend fun authenticateForAppLockEnablement(
+        activity: FragmentActivity?,
+    ): Boolean = authenticate(
+        activity = activity,
+        reason = "Confirm to enable App Lock",
+        succeedWhenUnavailable = false,
+    )
+
+    private suspend fun authenticate(
+        activity: FragmentActivity?,
+        reason: String,
+        succeedWhenUnavailable: Boolean,
     ): Boolean {
         if (mutableState.value.isAuthenticating) return false
         if (!refreshAvailability()) {
-            applyRuntime(AppLockPolicy.authenticated(runtime))
-            return true
+            if (succeedWhenUnavailable) {
+                applyRuntime(AppLockPolicy.authenticated(runtime))
+            }
+            return succeedWhenUnavailable
         }
         if (activity == null) {
             AppLogger.security.error("Authentication unavailable: no FragmentActivity")

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -234,6 +234,7 @@ fun CashuNavHost(
         composable(Routes.SETTINGS_PRIVACY) {
             PrivacyScreen(
                 settingsManager = container.settingsManager,
+                appLockManager = container.appLockManager,
                 onClose = { navController.popBackStack() },
             )
         }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
@@ -20,22 +20,35 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.cashu.me.Core.AppLockManager
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.ToggleRow
 import com.cashu.me.ui.components.ToolbarIcon
+import com.cashu.me.ui.security.findFragmentActivity
 import com.cashu.me.ui.theme.CashuTheme
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PrivacyScreen(
     settingsManager: SettingsManager,
+    appLockManager: AppLockManager,
     onClose: () -> Unit,
 ) {
     val settings by settingsManager.state.collectAsState()
+    val context = LocalContext.current
+    val activity = remember(context) { context.findFragmentActivity() }
+    val scope = rememberCoroutineScope()
+    var isEnablingAppLock by remember { mutableStateOf(false) }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -62,7 +75,24 @@ fun PrivacyScreen(
                 title = "App Lock",
                 subtitle = "Require device authentication when returning to the wallet",
                 checked = settings.appLockEnabled,
-                onCheckedChange = settingsManager::setAppLockEnabled,
+                onCheckedChange = { enabled ->
+                    if (!enabled) {
+                        settingsManager.setAppLockEnabled(false)
+                    } else {
+                        scope.launch {
+                            isEnablingAppLock = true
+                            try {
+                                enableAppLockAfterAuthentication(
+                                    authenticate = { appLockManager.authenticateForAppLockEnablement(activity) },
+                                    setEnabled = settingsManager::setAppLockEnabled,
+                                )
+                            } finally {
+                                isEnablingAppLock = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isEnablingAppLock,
             )
 
             SectionHeader("Background work")
@@ -136,4 +166,11 @@ fun PrivacyScreen(
 
         }
     }
+}
+
+internal suspend fun enableAppLockAfterAuthentication(
+    authenticate: suspend () -> Boolean,
+    setEnabled: (Boolean) -> Unit,
+) {
+    setEnabled(authenticate())
 }

--- a/android/app/src/test/java/com/cashu/me/ui/settings/AppLockEnablementTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/settings/AppLockEnablementTest.kt
@@ -1,0 +1,41 @@
+package com.cashu.me.ui.settings
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AppLockEnablementTest {
+    @Test
+    fun successfulAuthenticationEnablesAppLockOnlyAfterChallengeCompletes() = runBlocking {
+        val events = mutableListOf<String>()
+        var enabled = false
+
+        enableAppLockAfterAuthentication(
+            authenticate = {
+                events += "authenticated"
+                true
+            },
+            setEnabled = {
+                enabled = it
+                events += "persisted"
+            },
+        )
+
+        assertTrue(enabled)
+        assertEquals(listOf("authenticated", "persisted"), events)
+    }
+
+    @Test
+    fun cancelledOrFailedAuthenticationLeavesAppLockDisabled() = runBlocking {
+        var enabled = false
+
+        enableAppLockAfterAuthentication(
+            authenticate = { false },
+            setEnabled = { enabled = it },
+        )
+
+        assertFalse(enabled)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -144,7 +144,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Make App Lock discoverable in a security-oriented Settings location.** Android currently places the toggle under Privacy even though it controls local device access. **Done when:** App Lock is discoverable under a clear security or backup-and-security destination while privacy/background networking controls remain conceptually separate. The exact iOS hierarchy is not required.
 
-- [ ] **[P0 · iOS → Android] Authenticate before enabling App Lock.** iOS verifies device-owner authentication and reverts with an error if enabling fails; Android directly persists the toggle. **Done when:** Android cannot enable App Lock until a device-owner challenge succeeds, and cancellation or failure leaves it disabled.
+- [x] **[P0 · iOS → Android] Authenticate before enabling App Lock.** iOS verifies device-owner authentication and reverts with an error if enabling fails; Android directly persists the toggle. **Done when:** Android cannot enable App Lock until a device-owner challenge succeeds, and cancellation or failure leaves it disabled.
 
 - [ ] **[P1 · iOS → Android] Explain unavailable App Lock and preserve access.** iOS detects the absence of a device passcode, gives setup guidance, and explains that seed reveal always authenticates; Android exposes no equivalent guidance. Android’s manager currently fails open, so this is not an established lockout bug. **Done when:** Android reports capability state, points to device security setup, states the seed-reveal guarantee, and never presents an unavailable lock as active.
 


### PR DESCRIPTION
## What changed

- require Android device-owner authentication before persisting App Lock as enabled
- leave App Lock disabled when authentication is cancelled, fails, is unavailable, or cannot be presented
- keep the runtime unlock path fail-open when device authentication becomes unavailable
- disable the setting while the native challenge is active
- add focused tests and mark the parity checklist item complete

## Why

Android previously persisted the toggle immediately, unlike iOS, so users could enable App Lock without proving they could satisfy the device-owner challenge.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.settings.AppLockEnablementTest --stacktrace`
- `git diff --check`
