### PR TITLE
Require a choice for missing custom Nostr keys

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/NostrService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrService.kt
@@ -21,6 +21,23 @@ enum class NostrSignerType(val rawValue: String, val displayName: String) {
     }
 }
 
+internal enum class NostrSignerSelectionAction {
+    NoChange,
+    Switch,
+    ChooseCustomKey,
+}
+
+internal fun nostrSignerSelectionAction(
+    current: NostrSignerType,
+    requested: NostrSignerType,
+    hasCustomKey: Boolean,
+): NostrSignerSelectionAction = when {
+    current == requested -> NostrSignerSelectionAction.NoChange
+    requested == NostrSignerType.PrivateKey && !hasCustomKey ->
+        NostrSignerSelectionAction.ChooseCustomKey
+    else -> NostrSignerSelectionAction.Switch
+}
+
 data class NostrState(
     val publicKeyHex: String = "",
     val npub: String = "",
@@ -80,9 +97,10 @@ class NostrService(
     fun switchSignerType(type: NostrSignerType): NostrState = when (type) {
         NostrSignerType.Seed -> resetToSeedKey()
         NostrSignerType.PrivateKey -> {
-            secureStorage.loadString(StorageKeys.secureNostrPrivateKey)
-                ?.let { setPrivateKey(hexToBytes(it), NostrSignerType.PrivateKey, persistCustomKey = false) }
-                ?: generateRandomKeypair()
+            val customKey = requireStoredCustomKey(
+                secureStorage.loadString(StorageKeys.secureNostrPrivateKey),
+            )
+            setPrivateKey(hexToBytes(customKey), NostrSignerType.PrivateKey, persistCustomKey = false)
         }
     }
 
@@ -156,6 +174,11 @@ class NostrService(
     }
 
     companion object {
+        internal fun requireStoredCustomKey(customKey: String?): String =
+            customKey ?: throw IllegalStateException(
+                "Generate or import a custom key before switching key sources.",
+            )
+
         private val params = SECNamedCurves.getByName("secp256k1")
         private val curve = params.curve
         private val generator = params.g

--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -51,9 +51,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.cashu.me.Core.AppLockManager
 import com.cashu.me.Core.NostrService
+import com.cashu.me.Core.NostrSignerSelectionAction
 import com.cashu.me.Core.NostrSignerType
 import com.cashu.me.Core.NwcManager
 import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.nostrSignerSelectionAction
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.GhostButton
@@ -99,6 +101,7 @@ fun NostrScreen(
     var importError by remember { mutableStateOf<String?>(null) }
     var addRelayOpen by remember { mutableStateOf(false) }
     var addRelayError by remember { mutableStateOf<String?>(null) }
+    var showMissingCustomKeyChoice by remember { mutableStateOf(false) }
     var showGenerateConfirm by remember { mutableStateOf(false) }
     var showResetConfirm by remember { mutableStateOf(false) }
 
@@ -135,7 +138,21 @@ fun NostrScreen(
                             ),
                             selected = kind == nostrState.signerType,
                             onClick = {
-                                runCatching { nostrService.switchSignerType(kind) }
+                                when (
+                                    nostrSignerSelectionAction(
+                                        current = nostrState.signerType,
+                                        requested = kind,
+                                        hasCustomKey = nostrService.hasCustomPrivateKey(),
+                                    )
+                                ) {
+                                    NostrSignerSelectionAction.NoChange -> Unit
+                                    NostrSignerSelectionAction.ChooseCustomKey -> {
+                                        showMissingCustomKeyChoice = true
+                                    }
+                                    NostrSignerSelectionAction.Switch -> {
+                                        runCatching { nostrService.switchSignerType(kind) }
+                                    }
+                                }
                             },
                         ) { Text(kind.displayName) }
                     }
@@ -316,6 +333,36 @@ fun NostrScreen(
             )
             Spacer(Modifier.height(CashuTheme.spacing.section))
         }
+    }
+
+    if (showMissingCustomKeyChoice) {
+        AlertDialog(
+            onDismissRequest = { showMissingCustomKeyChoice = false },
+            title = { Text("Choose a custom key") },
+            text = {
+                Text(
+                    "Generate a new Nostr identity or import an existing nsec before switching to Custom Key.",
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showMissingCustomKeyChoice = false
+                    showGenerateConfirm = true
+                }) { Text("Generate") }
+            },
+            dismissButton = {
+                Row {
+                    TextButton(onClick = { showMissingCustomKeyChoice = false }) {
+                        Text("Cancel")
+                    }
+                    TextButton(onClick = {
+                        showMissingCustomKeyChoice = false
+                        showImport = true
+                    }) { Text("Import") }
+                }
+            },
+        )
     }
 
     if (showImport) {

--- a/android/app/src/test/java/com/cashu/me/Core/NostrServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NostrServiceTest.kt
@@ -4,9 +4,53 @@ import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class NostrServiceTest {
+    @Test
+    fun selectingMissingCustomKeyRequestsAChoiceWithoutSwitching() {
+        assertEquals(
+            NostrSignerSelectionAction.ChooseCustomKey,
+            nostrSignerSelectionAction(
+                current = NostrSignerType.Seed,
+                requested = NostrSignerType.PrivateKey,
+                hasCustomKey = false,
+            ),
+        )
+    }
+
+    @Test
+    fun selectingStoredCustomKeySwitchesSigner() {
+        assertEquals(
+            NostrSignerSelectionAction.Switch,
+            nostrSignerSelectionAction(
+                current = NostrSignerType.Seed,
+                requested = NostrSignerType.PrivateKey,
+                hasCustomKey = true,
+            ),
+        )
+    }
+
+    @Test
+    fun switchingToMissingCustomKeyRequiresExplicitSetup() {
+        val error = assertThrows(IllegalStateException::class.java) {
+            NostrService.requireStoredCustomKey(null)
+        }
+
+        assertEquals(
+            "Generate or import a custom key before switching key sources.",
+            error.message,
+        )
+    }
+
+    @Test
+    fun switchingToExistingCustomKeyUsesStoredIdentity() {
+        val storedKey = "01".repeat(32)
+
+        assertEquals(storedKey, NostrService.requireStoredCustomKey(storedKey))
+    }
+
     @Test
     fun bech32RoundTripsNsecPayload() {
         val key = ByteArray(32) { index -> (index + 1).toByte() }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -182,7 +182,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P0 · iOS → Android] Do not silently fail signer changes or key generation/reset.** iOS catches and renders errors; Android wraps several operations in `runCatching` and discards failures. **Done when:** every Android identity mutation has progress where needed, visible user-facing failure feedback, and unchanged state on failure.
 
-- [ ] **[P0 · iOS → Android] Require an explicit choice before switching to a missing custom key.** Android automatically generates a new identity when the user selects Custom Key without one; iOS prompts to generate or import. **Done when:** selecting Custom Key never creates or replaces an identity implicitly and asks the user to generate or import before the signer changes.
+- [x] **[P0 · iOS → Android] Require an explicit choice before switching to a missing custom key.** Android automatically generates a new identity when the user selects Custom Key without one; iOS prompts to generate or import. **Done when:** selecting Custom Key never creates or replaces an identity implicitly and asks the user to generate or import before the signer changes.
 
 - [ ] **[P1 · iOS → Android] Warn next to private-key reveal and copy.** Android already authenticates reveal/copy but shows masked/reveal/copy controls without nearby consequence text. **Done when:** Android explains that the nsec controls the user’s Nostr identity and Lightning address and must not be shared, before or alongside the authenticated actions.
 


### PR DESCRIPTION
## Summary
- prompt users to generate or import before selecting a missing custom Nostr key
- prevent the Nostr service from implicitly generating an identity during signer changes
- cover both the selection decision and service guard with targeted tests
- mark the verified parity checklist item complete

## Root cause
Android treated selecting Custom Key as a mutation request and generated a key when secure storage had none, while iOS requires a user-confirmed setup action.

## Impact
Selecting Custom Key no longer creates or replaces a Nostr identity without an explicit Generate or Import choice.

## Validation
- `:app:testDebugUnitTest --tests com.cashu.me.Core.NostrServiceTest`
- `git diff --check`