### PR TITLE
Surface Nostr identity mutation failures

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/NostrService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrService.kt
@@ -48,7 +48,7 @@ data class NostrState(
 
 class NostrService(
     private val secureStorage: SecureStorage,
-    private val settingsStore: SettingsStore,
+    private val settingsStore: NostrSignerSettings,
 ) {
     private val mutableState = MutableStateFlow(NostrState(signerType = NostrSignerType.fromRaw(settingsStore.nostrSignerType)))
     val state: StateFlow<NostrState> = mutableState.asStateFlow()
@@ -64,10 +64,10 @@ class NostrService(
         seedPrivateKeyBytes = seedKey.takeIf { isValidSecret(it) }?.copyOf()
         val customKey = secureStorage.loadString(StorageKeys.secureNostrPrivateKey)
         return if (NostrSignerType.fromRaw(settingsStore.nostrSignerType) == NostrSignerType.PrivateKey && customKey != null) {
-            setPrivateKey(hexToBytes(customKey), NostrSignerType.PrivateKey, persistCustomKey = false)
+            setPrivateKey(hexToBytes(customKey), NostrSignerType.PrivateKey)
         } else {
             settingsStore.nostrSignerType = NostrSignerType.Seed.rawValue
-            setPrivateKey(seedKey, NostrSignerType.Seed, persistCustomKey = false)
+            setPrivateKey(seedKey, NostrSignerType.Seed)
         }
     }
 
@@ -76,7 +76,7 @@ class NostrService(
     fun importNsec(nsec: String): NostrState {
         val key = Bech32.decode("nsec", nsec)
         require(key.size == 32) { "Invalid nsec private key length." }
-        return setPrivateKey(key, NostrSignerType.PrivateKey, persistCustomKey = true)
+        return setPrivateKey(key, NostrSignerType.PrivateKey, CustomKeyMutation.Save)
     }
 
     fun generateRandomKeypair(): NostrState {
@@ -84,14 +84,12 @@ class NostrService(
         do {
             secureRandom.nextBytes(key)
         } while (!isValidSecret(key))
-        return setPrivateKey(key, NostrSignerType.PrivateKey, persistCustomKey = true)
+        return setPrivateKey(key, NostrSignerType.PrivateKey, CustomKeyMutation.Save)
     }
 
     fun resetToSeedKey(): NostrState {
         val seed = currentSeed ?: throw IllegalStateException("No wallet seed is available for Nostr reset.")
-        secureStorage.delete(StorageKeys.secureNostrPrivateKey)
-        settingsStore.nostrSignerType = NostrSignerType.Seed.rawValue
-        return setPrivateKey(seed.copyOfRange(0, 32), NostrSignerType.Seed, persistCustomKey = false)
+        return setPrivateKey(seed.copyOfRange(0, 32), NostrSignerType.Seed, CustomKeyMutation.Delete)
     }
 
     fun switchSignerType(type: NostrSignerType): NostrState = when (type) {
@@ -100,7 +98,7 @@ class NostrService(
             val customKey = requireStoredCustomKey(
                 secureStorage.loadString(StorageKeys.secureNostrPrivateKey),
             )
-            setPrivateKey(hexToBytes(customKey), NostrSignerType.PrivateKey, persistCustomKey = false)
+            setPrivateKey(hexToBytes(customKey), NostrSignerType.PrivateKey, CustomKeyMutation.Keep)
         }
     }
 
@@ -158,19 +156,54 @@ class NostrService(
         mutableState.value = NostrState(signerType = NostrSignerType.Seed)
     }
 
-    private fun setPrivateKey(key: ByteArray, signerType: NostrSignerType, persistCustomKey: Boolean): NostrState {
+    private enum class CustomKeyMutation { Keep, Save, Delete }
+
+    private fun setPrivateKey(
+        key: ByteArray,
+        signerType: NostrSignerType,
+        customKeyMutation: CustomKeyMutation = CustomKeyMutation.Keep,
+    ): NostrState {
+        // Prepare the complete replacement before changing persistence or the
+        // observable identity. A malformed key can therefore never partially
+        // apply a signer change or reset.
         require(key.size == 32 && isValidSecret(key)) { "Invalid Nostr private key." }
-        if (persistCustomKey) secureStorage.saveString(StorageKeys.secureNostrPrivateKey, key.toHex())
-        settingsStore.nostrSignerType = signerType.rawValue
-        privateKeyBytes = key.copyOf()
         val publicKey = publicKeyXOnly(key)
-        return NostrState(
+        val nextState = NostrState(
             publicKeyHex = publicKey.toHex(),
             npub = Bech32.encode("npub", publicKey),
             nsec = Bech32.encode("nsec", key),
             isInitialized = true,
             signerType = signerType,
-        ).also { mutableState.value = it }
+        )
+
+        val previousCustomKey = secureStorage.loadString(StorageKeys.secureNostrPrivateKey)
+        val previousSignerType = settingsStore.nostrSignerType
+        try {
+            when (customKeyMutation) {
+                CustomKeyMutation.Keep -> Unit
+                CustomKeyMutation.Save -> secureStorage.saveString(StorageKeys.secureNostrPrivateKey, key.toHex())
+                CustomKeyMutation.Delete -> secureStorage.delete(StorageKeys.secureNostrPrivateKey)
+            }
+            settingsStore.nostrSignerType = signerType.rawValue
+        } catch (error: Exception) {
+            // Secure-storage implementations can throw after performing their
+            // write. Restore both persisted values best-effort, while retaining
+            // the original failure for the caller and UI.
+            runCatching {
+                if (previousCustomKey == null) {
+                    secureStorage.delete(StorageKeys.secureNostrPrivateKey)
+                } else {
+                    secureStorage.saveString(StorageKeys.secureNostrPrivateKey, previousCustomKey)
+                }
+            }.exceptionOrNull()?.let(error::addSuppressed)
+            runCatching { settingsStore.nostrSignerType = previousSignerType }
+                .exceptionOrNull()?.let(error::addSuppressed)
+            throw error
+        }
+
+        privateKeyBytes = key.copyOf()
+        mutableState.value = nextState
+        return nextState
     }
 
     companion object {

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -15,10 +15,14 @@ import kotlinx.serialization.json.longOrNull
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Models.P2PKKeyInfo
 
+interface NostrSignerSettings {
+    var nostrSignerType: String
+}
+
 class SettingsStore(
     context: Context,
     storeName: String = "settings_store",
-) {
+) : NostrSignerSettings {
     companion object {
         val defaultNostrRelays = listOf(
             "wss://relay.damus.io",
@@ -94,7 +98,7 @@ class SettingsStore(
         get() = store.boolean(StorageKeys.settingsPeriodicallyCheckIncomingInvoices, true)
         set(value) = store.putBoolean(StorageKeys.settingsPeriodicallyCheckIncomingInvoices, value)
 
-    var nostrSignerType: String
+    override var nostrSignerType: String
         get() = store.string(StorageKeys.settingsNostrSignerType) ?: "SEED"
         set(value) = store.putString(StorageKeys.settingsNostrSignerType, value)
 

--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -512,7 +512,7 @@ fun NostrScreen(
                         mutation = NostrIdentityMutation.GenerateKey,
                         operation = { nostrService.generateRandomKeypair() },
                     )
-                }) { Text("Generate") }
+                })
             },
             dismissButton = {
                 TextButton(onClick = { showGenerateConfirm = false }) { Text("Cancel") }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,7 +71,11 @@ import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.security.rememberWalletAuthenticationLauncher
 import com.cashu.me.ui.theme.CashuTheme
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private const val NsecCopiedFeedbackMillis = 2_000L
 internal const val NostrPrivateKeyWarningText =
@@ -83,6 +88,22 @@ internal fun NostrPrivateKeyWarning(modifier: Modifier = Modifier) {
         modifier = modifier,
         severity = NoticeSeverity.Warning,
     )
+}
+
+internal enum class NostrIdentityMutation(
+    val progressMessage: String,
+    private val failureAction: String,
+) {
+    SwitchSigner("Updating Nostr key source…", "switch the Nostr key source"),
+    ImportKey("Importing Nostr key…", "import the Nostr key"),
+    GenerateKey("Generating a new Nostr key…", "generate a new Nostr key"),
+    ResetKey("Resetting to the wallet seed…", "reset the Nostr key"),
+    ;
+
+    fun failureMessage(error: Throwable): String {
+        val detail = error.message?.trim()?.takeIf(String::isNotEmpty) ?: "Please try again."
+        return "Couldn’t $failureAction. Your current identity was not changed. $detail"
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -100,6 +121,7 @@ fun NostrScreen(
     val nwcState by nwcManager.state.collectAsState()
     val clipboard = LocalClipboardManager.current
     val authenticate = rememberWalletAuthenticationLauncher(appLockManager)
+    val scope = rememberCoroutineScope()
     // Keep the authenticated value tied to this key. Replacing/importing/resetting
     // the Nostr key creates fresh hidden state, even if the previous key was visible.
     var revealedNsec by remember(nostrState.nsec) { mutableStateOf<String?>(null) }
@@ -117,6 +139,31 @@ fun NostrScreen(
     var showMissingCustomKeyChoice by remember { mutableStateOf(false) }
     var showGenerateConfirm by remember { mutableStateOf(false) }
     var showResetConfirm by remember { mutableStateOf(false) }
+    var identityMutation by remember { mutableStateOf<NostrIdentityMutation?>(null) }
+    var identityMutationError by remember { mutableStateOf<String?>(null) }
+
+    fun performIdentityMutation(
+        mutation: NostrIdentityMutation,
+        operation: () -> Unit,
+        onSuccess: () -> Unit = {},
+        onFailure: (String) -> Unit = { identityMutationError = it },
+    ) {
+        if (identityMutation != null) return
+        identityMutation = mutation
+        identityMutationError = null
+        scope.launch {
+            try {
+                withContext(Dispatchers.Default) { operation() }
+                onSuccess()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                onFailure(mutation.failureMessage(error))
+            } finally {
+                identityMutation = null
+            }
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -150,6 +197,7 @@ fun NostrScreen(
                                 count = NostrSignerType.entries.size,
                             ),
                             selected = kind == nostrState.signerType,
+                            enabled = identityMutation == null,
                             onClick = {
                                 when (
                                     nostrSignerSelectionAction(
@@ -163,7 +211,10 @@ fun NostrScreen(
                                         showMissingCustomKeyChoice = true
                                     }
                                     NostrSignerSelectionAction.Switch -> {
-                                        runCatching { nostrService.switchSignerType(kind) }
+                                        performIdentityMutation(
+                                            mutation = NostrIdentityMutation.SwitchSigner,
+                                            operation = { nostrService.switchSignerType(kind) },
+                                        )
                                     }
                                 }
                             },
@@ -261,18 +312,28 @@ fun NostrScreen(
                 PrimaryButton(
                     text = "Generate new key",
                     onClick = { showGenerateConfirm = true },
+                    enabled = identityMutation == null,
+                    loading = identityMutation == NostrIdentityMutation.GenerateKey,
                 )
                 GhostButton(
                     text = "Import nsec…",
                     onClick = { showImport = true },
                     modifier = Modifier.fillMaxWidth(),
+                    enabled = identityMutation == null,
                 )
                 GhostButton(
                     text = "Reset to wallet seed",
                     onClick = { showResetConfirm = true },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = nostrState.signerType != NostrSignerType.Seed,
+                    enabled = nostrState.signerType != NostrSignerType.Seed && identityMutation == null,
                 )
+                identityMutation?.let {
+                    InlineNotice(
+                        text = it.progressMessage,
+                        severity = NoticeSeverity.Info,
+                    )
+                }
+                identityMutationError?.let { InlineNotice(text = it) }
             }
 
             SectionHeader("Relays")
@@ -387,7 +448,12 @@ fun NostrScreen(
     if (showImport) {
         var input by remember { mutableStateOf("") }
         AlertDialog(
-            onDismissRequest = { showImport = false; importError = null },
+            onDismissRequest = {
+                if (identityMutation != NostrIdentityMutation.ImportKey) {
+                    showImport = false
+                    importError = null
+                }
+            },
             title = { Text("Import nsec") },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug)) {
@@ -405,14 +471,26 @@ fun NostrScreen(
                 }
             },
             confirmButton = {
-                TextButton(onClick = {
-                    runCatching { nostrService.importNsec(input.trim()) }
-                        .onSuccess { showImport = false; importError = null }
-                        .onFailure { importError = it.message ?: "Could not import." }
-                }) { Text("Import") }
+                TextButton(
+                    enabled = identityMutation == null,
+                    onClick = {
+                        importError = null
+                        performIdentityMutation(
+                            mutation = NostrIdentityMutation.ImportKey,
+                            operation = { nostrService.importNsec(input.trim()) },
+                            onSuccess = { showImport = false; importError = null },
+                            onFailure = { importError = it },
+                        )
+                    },
+                ) {
+                    Text(if (identityMutation == NostrIdentityMutation.ImportKey) "Importing…" else "Import")
+                }
             },
             dismissButton = {
-                TextButton(onClick = { showImport = false; importError = null }) { Text("Cancel") }
+                TextButton(
+                    enabled = identityMutation != NostrIdentityMutation.ImportKey,
+                    onClick = { showImport = false; importError = null },
+                ) { Text("Cancel") }
             },
         )
     }
@@ -430,8 +508,11 @@ fun NostrScreen(
             confirmButton = {
                 DestructiveTextButton(text = "Generate", onClick = {
                     showGenerateConfirm = false
-                    runCatching { nostrService.generateRandomKeypair() }
-                })
+                    performIdentityMutation(
+                        mutation = NostrIdentityMutation.GenerateKey,
+                        operation = { nostrService.generateRandomKeypair() },
+                    )
+                }) { Text("Generate") }
             },
             dismissButton = {
                 TextButton(onClick = { showGenerateConfirm = false }) { Text("Cancel") }
@@ -452,7 +533,10 @@ fun NostrScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showResetConfirm = false
-                    runCatching { nostrService.resetToSeedKey() }
+                    performIdentityMutation(
+                        mutation = NostrIdentityMutation.ResetKey,
+                        operation = { nostrService.resetToSeedKey() },
+                    )
                 }) {
                     Text("Reset", color = MaterialTheme.colorScheme.error)
                 }

--- a/android/app/src/test/java/com/cashu/me/Core/NostrServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NostrServiceTest.kt
@@ -3,9 +3,13 @@ package com.cashu.me.Core
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertThrows
+import org.junit.Assert.fail
 import org.junit.Test
+import com.cashu.me.Core.Protocols.SecureStorage
+import com.cashu.me.Core.Protocols.StorageKeys
 
 class NostrServiceTest {
     @Test
@@ -49,6 +53,57 @@ class NostrServiceTest {
         val storedKey = "01".repeat(32)
 
         assertEquals(storedKey, NostrService.requireStoredCustomKey(storedKey))
+    }
+
+    @Test
+    fun failedGenerationRestoresStoredKeySignerAndObservableIdentity() {
+        val storage = FailingSecureStorage()
+        val settings = FakeNostrSignerSettings()
+        val service = NostrService(storage, settings)
+        val initial = service.deriveKeypairFromSeed(privateKey(1))
+        storage.failAfterNextSave = true
+
+        assertFails { service.generateRandomKeypair() }
+
+        assertEquals(initial, service.state.value)
+        assertEquals(initial.nsec, Bech32.encode("nsec", NostrService.hexToBytes(service.currentPrivateKey()!!)))
+        assertEquals(NostrSignerType.Seed.rawValue, settings.nostrSignerType)
+        assertNull(storage.loadString(StorageKeys.secureNostrPrivateKey))
+    }
+
+    @Test
+    fun failedResetRestoresCustomKeySignerAndObservableIdentity() {
+        val storage = FailingSecureStorage()
+        val settings = FakeNostrSignerSettings()
+        val service = NostrService(storage, settings)
+        service.deriveKeypairFromSeed(privateKey(1))
+        val customNsec = Bech32.encode("nsec", privateKey(2))
+        val initial = service.importNsec(customNsec)
+        val storedCustomKey = storage.loadString(StorageKeys.secureNostrPrivateKey)
+        storage.failAfterNextDelete = true
+
+        assertFails { service.resetToSeedKey() }
+
+        assertEquals(initial, service.state.value)
+        assertEquals(NostrSignerType.PrivateKey.rawValue, settings.nostrSignerType)
+        assertEquals(storedCustomKey, storage.loadString(StorageKeys.secureNostrPrivateKey))
+    }
+
+    @Test
+    fun failedSignerChangeRestoresSignerAndObservableIdentity() {
+        val storage = FailingSecureStorage(
+            mutableMapOf(StorageKeys.secureNostrPrivateKey to privateKey(2).toHexString()),
+        )
+        val settings = FakeNostrSignerSettings()
+        val service = NostrService(storage, settings)
+        val initial = service.deriveKeypairFromSeed(privateKey(1))
+        settings.failAfterNextSet = true
+
+        assertFails { service.switchSignerType(NostrSignerType.PrivateKey) }
+
+        assertEquals(initial, service.state.value)
+        assertEquals(NostrSignerType.Seed.rawValue, settings.nostrSignerType)
+        assertEquals(privateKey(2).toHexString(), storage.loadString(StorageKeys.secureNostrPrivateKey))
     }
 
     @Test
@@ -122,5 +177,60 @@ class NostrServiceTest {
             json,
         )
         assertFalse(json.contains("""\/"""))
+    }
+
+    private fun privateKey(value: Int): ByteArray = ByteArray(32).also { it[31] = value.toByte() }
+
+    private fun ByteArray.toHexString(): String = joinToString("") { "%02x".format(it) }
+
+    private fun assertFails(block: () -> Unit) {
+        try {
+            block()
+            fail("Expected operation to fail")
+        } catch (_: IllegalStateException) {
+            // Expected injected persistence failure.
+        }
+    }
+
+    private class FakeNostrSignerSettings : NostrSignerSettings {
+        private var value = NostrSignerType.Seed.rawValue
+        var failAfterNextSet = false
+
+        override var nostrSignerType: String
+            get() = value
+            set(newValue) {
+                value = newValue
+                if (failAfterNextSet) {
+                    failAfterNextSet = false
+                    throw IllegalStateException("Signer settings unavailable")
+                }
+            }
+    }
+
+    private class FailingSecureStorage(
+        private val values: MutableMap<String, String> = mutableMapOf(),
+    ) : SecureStorage {
+        var failAfterNextSave = false
+        var failAfterNextDelete = false
+
+        override fun loadString(key: String): String? = values[key]
+
+        override fun saveString(key: String, value: String) {
+            values[key] = value
+            if (failAfterNextSave) {
+                failAfterNextSave = false
+                throw IllegalStateException("Secure storage write failed")
+            }
+        }
+
+        override fun delete(key: String) {
+            values.remove(key)
+            if (failAfterNextDelete) {
+                failAfterNextDelete = false
+                throw IllegalStateException("Secure storage delete failed")
+            }
+        }
+
+        override fun contains(key: String): Boolean = values.containsKey(key)
     }
 }

--- a/android/app/src/test/java/com/cashu/me/ui/settings/NostrIdentityMutationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/settings/NostrIdentityMutationTest.kt
@@ -1,0 +1,16 @@
+package com.cashu.me.ui.settings
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NostrIdentityMutationTest {
+    @Test
+    fun everyMutationFailureNamesTheActionAndPromisesUnchangedIdentity() {
+        NostrIdentityMutation.entries.forEach { mutation ->
+            val message = mutation.failureMessage(IllegalStateException("Storage unavailable"))
+
+            assertTrue(message, message.contains("current identity was not changed"))
+            assertTrue(message, message.contains("Storage unavailable"))
+        }
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -180,7 +180,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Add the Nostr feature introduction.** iOS explains that Nostr powers the Lightning address, npub.cash requests, encrypted backups, and Wallet Connect; Android starts with signer controls. **Done when:** Android provides equivalent user context before technical key management.
 
-- [ ] **[P0 · iOS → Android] Do not silently fail signer changes or key generation/reset.** iOS catches and renders errors; Android wraps several operations in `runCatching` and discards failures. **Done when:** every Android identity mutation has progress where needed, visible user-facing failure feedback, and unchanged state on failure.
+- [x] **[P0 · iOS → Android] Do not silently fail signer changes or key generation/reset.** iOS catches and renders errors; Android wraps several operations in `runCatching` and discards failures. **Done when:** every Android identity mutation has progress where needed, visible user-facing failure feedback, and unchanged state on failure.
 
 - [x] **[P0 · iOS → Android] Require an explicit choice before switching to a missing custom key.** Android automatically generates a new identity when the user selects Custom Key without one; iOS prompts to generate or import. **Done when:** selecting Custom Key never creates or replaces an identity implicitly and asks the user to generate or import before the signer changes.
 


### PR DESCRIPTION
## What changed

- run every Android Nostr identity mutation with in-context progress and disable competing mutation controls
- surface action-specific errors for signer changes, imports, generation, and reset
- prepare identity replacements before persistence and roll back secure storage/settings after persistence failures
- add failure-injection tests proving the observable and persisted identity stays unchanged
- mark the verified parity checklist item complete

## Why

Android discarded failures from signer changes, key generation, and reset while iOS rendered those errors. Reset also deleted the custom key before validating and preparing the seed-derived replacement.

## User impact

Users now see when an identity operation is running and receive a clear error if it fails. Failed mutations retain the current Nostr identity instead of partially applying a replacement.

## Validation

`./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.Core.NostrServiceTest --tests com.cashu.me.ui.settings.NostrIdentityMutationTest --stacktrace`
