### PR TITLE
Use payment language for manual Lightning check

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
@@ -176,7 +176,7 @@ fun LightningScreen(
             Spacer(Modifier.height(CashuTheme.spacing.comfortable))
             Column(modifier = Modifier.fillMaxWidth().padding(horizontal = CashuTheme.spacing.comfortable)) {
                 PrimaryButton(
-                    text = if (npcState.isCheckingPayments) "Checking…" else "Check for paid quotes now",
+                    text = if (npcState.isCheckingPayments) "Checking…" else "Check for payments",
                     onClick = { npcService.checkAndClaimPayments() },
                     enabled = npcState.isEnabled && !npcState.isCheckingPayments,
                     loading = npcState.isCheckingPayments,

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -172,7 +172,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Add initialization and setup feedback.** iOS distinguishes active setup from “Wallet not fully initialized”; Android collapses both into an empty address message. **Done when:** Android communicates progress separately from a recoverable initialization problem and gives an actionable recovery.
 
-- [ ] **[P2 · iOS → Android] Rename “Check for paid quotes now.”** iOS uses “Check for payments”; Android exposes quote jargon. **Done when:** both use payment language in the primary action.
+- [x] **[P2 · iOS → Android] Rename “Check for paid quotes now.”** iOS uses “Check for payments”; Android exposes quote jargon. **Done when:** both use payment language in the primary action.
 
 - [ ] **[P1 · iOS → Android] Expose Lightning-address connection state accessibly.** iOS combines the address with Connected, Connecting, or error text; Android encodes state only in a colored dot. **Done when:** TalkBack announces the address and current state, and color is never the only signal.
 


### PR DESCRIPTION
## What changed

- rename Android’s manual Lightning-address check action from “Check for paid quotes now” to “Check for payments”
- mark the corresponding iOS/Android parity checklist item complete

## Why

iOS already uses user-facing payment language for this action. Android exposed internal Cashu quote terminology for the same behavior.

## Impact

The two platforms now present the same plain-language primary action. Runtime behavior is unchanged.

## Validation

- verified the current iOS and Android implementations on `origin/main`
- `git diff --check`
- `./gradlew --no-daemon :app:assembleDebug --stacktrace`
