### PR TITLE
Give key generation destructive semantics

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/components/DestructiveTextButtonAccessibilityComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/components/DestructiveTextButtonAccessibilityComposeTest.kt
@@ -1,0 +1,40 @@
+package com.cashu.me.ui.components
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DestructiveTextButtonAccessibilityComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun destructiveActionExposesButtonRoleAndAccessibleWarning() {
+        compose.setCashuContent {
+            DestructiveTextButton(
+                text = "Generate",
+                onClick = {},
+            )
+        }
+
+        val semantics = compose.onNodeWithText("Generate")
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+            .config
+
+        assertEquals(Role.Button, semantics[SemanticsProperties.Role])
+        assertEquals(
+            "Destructive action",
+            semantics[SemanticsProperties.StateDescription],
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -65,6 +67,7 @@ private val GhostButtonIconSize = 16.dp
 private const val PressedScale = 0.97f
 // iOS TextLinkButtonStyle: text links dim to 0.6 while pressed.
 private const val TextLinkPressedAlpha = 0.6f
+private const val DestructiveActionStateDescription = "Destructive action"
 
 @Composable
 private fun rememberPressScale(interactionSource: MutableInteractionSource): Float {
@@ -281,7 +284,13 @@ fun CircularMethodButton(
     }
 }
 
-/** Destructive inline action (Delete Wallet, Remove Mint). */
+/**
+ * Destructive inline action (Delete Wallet, Remove Mint).
+ *
+ * Material's error color communicates the action visually. The state description
+ * gives accessibility services the equivalent destructive announcement while the
+ * underlying [TextButton] continues to expose the native button role.
+ */
 @Composable
 fun DestructiveTextButton(
     text: String,
@@ -293,7 +302,9 @@ fun DestructiveTextButton(
     val alpha = rememberPressAlpha(interactionSource)
     TextButton(
         onClick = onClick,
-        modifier = modifier.graphicsLayer { this.alpha = alpha },
+        modifier = modifier
+            .semantics { stateDescription = DestructiveActionStateDescription }
+            .graphicsLayer { this.alpha = alpha },
         enabled = enabled,
         interactionSource = interactionSource,
         colors = ButtonDefaults.textButtonColors(

--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -56,6 +56,7 @@ import com.cashu.me.Core.NwcManager
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.CashuTextField
+import com.cashu.me.ui.components.DestructiveTextButton
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.IconSwap
 import com.cashu.me.ui.components.InlineNotice
@@ -362,10 +363,10 @@ fun NostrScreen(
                 )
             },
             confirmButton = {
-                TextButton(onClick = {
+                DestructiveTextButton(text = "Generate", onClick = {
                     showGenerateConfirm = false
                     runCatching { nostrService.generateRandomKeypair() }
-                }) { Text("Generate") }
+                })
             },
             dismissButton = {
                 TextButton(onClick = { showGenerateConfirm = false }) { Text("Cancel") }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -190,7 +190,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P0 · Converge] Make every identity-replacement warning complete.** Current generate/reset warnings split consequences between platforms, while import and signer-change paths do not consistently confirm replacement. **Done when:** generate, import, reset, and signer-change paths warn as applicable that the Lightning address changes, Nostr apps/messages use a different identity, and the old key is replaced before destructive confirmation.
 
-- [ ] **[P2 · iOS → Android] Give key generation native destructive semantics.** Android’s Generate action is visually neutral even though it replaces an identity; iOS uses a destructive confirmation role. **Done when:** Android uses the platform’s destructive semantic role and accessible announcement for the replacement action. It need not copy iOS styling.
+- [x] **[P2 · iOS → Android] Give key generation native destructive semantics.** Android’s Generate action is visually neutral even though it replaces an identity; iOS uses a destructive confirmation role. **Done when:** Android uses the platform’s destructive semantic role and accessible announcement for the replacement action. It need not copy iOS styling.
 
 - [ ] **[P2 · iOS → Android] Add the relay-purpose explanation.** iOS explains that relays synchronize npub.cash-compatible data and backups; Android lists relays without that context. **Done when:** Android explains why changing the relay list affects wallet features.
 


### PR DESCRIPTION
## What changed

- Style the Android Nostr key-generation confirmation with the shared Material destructive action.
- Expose an accessibility state description so screen readers announce that the Generate button is destructive.
- Add focused Compose semantics coverage and mark the parity checklist item complete.

## Why

iOS already marks Generate with a destructive confirmation role, while Android presented the identity-replacing action as a neutral text button.

## Validation

- `:app:compileDebugKotlin`
- `:app:compileDebugAndroidTestKotlin`
- `git diff --check`
