### PR TITLE
Warn before exposing the Nostr private key

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/settings/NostrPrivateKeyWarningComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/settings/NostrPrivateKeyWarningComposeTest.kt
@@ -1,0 +1,34 @@
+package com.cashu.me.ui.settings
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NostrPrivateKeyWarningComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun warningExplainsIdentityAndLightningAddressRiskAccessibly() {
+        compose.setCashuContent {
+            NostrPrivateKeyWarning()
+        }
+
+        val warning = compose.onNodeWithText(NostrPrivateKeyWarningText)
+            .assertIsDisplayed()
+            .fetchSemanticsNode()
+
+        assertEquals(
+            listOf(NostrPrivateKeyWarningText),
+            warning.config[SemanticsProperties.Text].map { it.text },
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NostrScreen.kt
@@ -61,6 +61,7 @@ import com.cashu.me.ui.components.IconSwap
 import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.NavRow
+import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.ToolbarIcon
@@ -69,6 +70,17 @@ import com.cashu.me.ui.theme.CashuTheme
 import kotlinx.coroutines.delay
 
 private const val NsecCopiedFeedbackMillis = 2_000L
+internal const val NostrPrivateKeyWarningText =
+    "Your nsec controls your Nostr identity and Lightning address. Never share it."
+
+@Composable
+internal fun NostrPrivateKeyWarning(modifier: Modifier = Modifier) {
+    InlineNotice(
+        text = NostrPrivateKeyWarningText,
+        modifier = modifier,
+        severity = NoticeSeverity.Warning,
+    )
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -169,6 +181,9 @@ fun NostrScreen(
             )
 
             SectionHeader("Private key")
+            NostrPrivateKeyWarning(
+                modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
+            )
             Row(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -184,7 +184,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P0 · iOS → Android] Require an explicit choice before switching to a missing custom key.** Android automatically generates a new identity when the user selects Custom Key without one; iOS prompts to generate or import. **Done when:** selecting Custom Key never creates or replaces an identity implicitly and asks the user to generate or import before the signer changes.
 
-- [ ] **[P1 · iOS → Android] Warn next to private-key reveal and copy.** Android already authenticates reveal/copy but shows masked/reveal/copy controls without nearby consequence text. **Done when:** Android explains that the nsec controls the user’s Nostr identity and Lightning address and must not be shared, before or alongside the authenticated actions.
+- [x] **[P1 · iOS → Android] Warn next to private-key reveal and copy.** Android already authenticates reveal/copy but shows masked/reveal/copy controls without nearby consequence text. **Done when:** Android explains that the nsec controls the user’s Nostr identity and Lightning address and must not be shared, before or alongside the authenticated actions.
 
 - [ ] **[P1 · iOS → Android] Explain the consequences of nsec import.** Android already validates imports and reports errors; native text editing can provide paste, replace, and clear. The missing gap is product context. **Done when:** Android states that importing replaces the current custom identity and affects the Lightning address and Nostr apps/messages before confirmation, while keeping validation errors user-facing.
 


### PR DESCRIPTION
## What changed

- add an adjacent Android warning before the authenticated Nostr private-key reveal and copy controls
- explain that the nsec controls both the user’s Nostr identity and Lightning address and must never be shared
- add focused Compose accessibility coverage for the complete warning
- mark the assigned parity checklist item complete

## Why

iOS already presents consequence text beside its private-key reveal/copy UI. Android authenticated both actions but provided no nearby explanation of what exposure permits.

## Verification

- `:app:compileDebugAndroidTestKotlin`
- `:app:testDebugUnitTest`
- focused `NostrPrivateKeyWarningComposeTest` on an API 36 emulator
- `git diff --check`
