### PR TITLE
Use user-facing Lightning address language

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
@@ -59,6 +59,15 @@ import com.cashu.me.ui.components.ToggleRow
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.theme.CashuTheme
 
+internal object LightningAddressSettingsCopy {
+    const val EnableTitle = "Enable Lightning Address"
+    const val EnableSubtitle =
+        "Receive Lightning payments to your wallet using a Lightning address."
+    const val AutomaticClaimTitle = "Auto-claim payments"
+    const val AutomaticClaimSubtitle =
+        "Add incoming payments to your wallet without confirmation."
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LightningScreen(
@@ -134,15 +143,15 @@ fun LightningScreen(
 
             SectionHeader("Settings")
             ToggleRow(
-                title = "Enable Nostr-NPC bridge",
-                subtitle = "Route Lightning payments through the NPC quote handler",
+                title = LightningAddressSettingsCopy.EnableTitle,
+                subtitle = LightningAddressSettingsCopy.EnableSubtitle,
                 checked = npcState.isEnabled,
                 onCheckedChange = { npcService.setEnabled(it) },
             )
             CanvasDivider(leadingInset = 16.dp)
             ToggleRow(
-                title = "Automatic claim",
-                subtitle = "Mint paid quotes without confirmation",
+                title = LightningAddressSettingsCopy.AutomaticClaimTitle,
+                subtitle = LightningAddressSettingsCopy.AutomaticClaimSubtitle,
                 checked = npcState.automaticClaim,
                 onCheckedChange = { npcService.setAutomaticClaim(it) },
                 enabled = npcState.isEnabled,

--- a/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSettingsCopyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSettingsCopyTest.kt
@@ -1,0 +1,37 @@
+package com.cashu.me.ui.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class LightningAddressSettingsCopyTest {
+    @Test
+    fun enableControlLeadsWithTheUserOutcome() {
+        assertEquals(
+            "Enable Lightning Address",
+            LightningAddressSettingsCopy.EnableTitle,
+        )
+        assertEquals(
+            "Receive Lightning payments to your wallet using a Lightning address.",
+            LightningAddressSettingsCopy.EnableSubtitle,
+        )
+    }
+
+    @Test
+    fun primarySettingsCopyDoesNotExposeImplementationTerms() {
+        val primaryCopy = listOf(
+            LightningAddressSettingsCopy.EnableTitle,
+            LightningAddressSettingsCopy.EnableSubtitle,
+            LightningAddressSettingsCopy.AutomaticClaimTitle,
+            LightningAddressSettingsCopy.AutomaticClaimSubtitle,
+        )
+        val implementationTerms = listOf("Nostr", "NPC", "bridge", "quote", "handler")
+
+        implementationTerms.forEach { term ->
+            assertFalse(
+                "Primary Lightning address copy must not expose '$term'",
+                primaryCopy.any { it.contains(term, ignoreCase = true) },
+            )
+        }
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -166,7 +166,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Settings — Lightning address
 
-- [ ] **[P1 · iOS → Android] Replace “Enable Nostr-NPC bridge” with user-facing language.** iOS says “Enable Lightning Address”; Android exposes internal protocol/component names such as “NPC quote handler.” **Done when:** Android leads with the user outcome and moves implementation terminology to optional technical help.
+- [x] **[P1 · iOS → Android] Replace “Enable Nostr-NPC bridge” with user-facing language.** iOS says “Enable Lightning Address”; Android exposes internal protocol/component names such as “NPC quote handler.” **Done when:** Android leads with the user outcome and moves implementation terminology to optional technical help.
 
 - [ ] **[P1 · iOS → Android] Gate Lightning settings by feature state.** iOS shows disabled explanation, setup progress, initialization warning, or live controls as appropriate; Android always renders the empty address card and all preference/check controls. **Done when:** Android shows only actions meaningful in the current state.
 


### PR DESCRIPTION
## What changed

- rename Android’s Lightning address enable control to lead with the user outcome
- replace NPC/quote-handler terminology in adjacent primary settings copy with payment language
- add focused regression coverage that rejects implementation terminology in those primary labels
- mark the assigned parity-checklist item complete

## Why

iOS presents this feature as “Enable Lightning Address,” while Android exposed internal Nostr-NPC and quote-handler terminology. The Android labels now describe what users enable and what automatic claiming does.

## Validation

- `:app:testDebugUnitTest --tests com.cashu.me.ui.settings.LightningAddressSettingsCopyTest`
- `:app:assembleDebug`
- `git diff --check`
