### PR TITLE
Add Lightning address initialization feedback

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/settings/LightningAddressSetupFeedbackComposeTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/settings/LightningAddressSetupFeedbackComposeTest.kt
@@ -1,0 +1,51 @@
+package com.cashu.me.ui.settings
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LightningAddressSetupFeedbackComposeTest {
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun activeSetupHasDedicatedProgressFeedback() {
+        compose.setCashuContent {
+            LightningAddressSetupFeedback(
+                status = LightningAddressSetupStatus.SettingUp,
+                retrying = false,
+                recoveryError = null,
+                onRetry = {},
+            )
+        }
+
+        compose.onNodeWithText("Setting up Lightning address…").assertIsDisplayed()
+    }
+
+    @Test
+    fun incompleteSetupExplainsProblemAndOffersRetry() {
+        var retries = 0
+        compose.setCashuContent {
+            LightningAddressSetupFeedback(
+                status = LightningAddressSetupStatus.NeedsRecovery,
+                retrying = false,
+                recoveryError = null,
+                onRetry = { retries += 1 },
+            )
+        }
+
+        compose.onNodeWithText(
+            "Wallet not fully initialized. Try setup again to finish your Lightning address.",
+        ).assertIsDisplayed()
+        compose.onNodeWithText("Try setup again").performClick()
+        compose.runOnIdle { assertEquals(1, retries) }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
@@ -175,7 +175,10 @@ class NPCService(
                 update {
                     copy(
                         isConnected = false,
-                        errorMessage = if (current.isEnabled) "npub.cash keys are not initialized." else null,
+                        // Key setup follows wallet-runtime initialization. This is a
+                        // readiness state, not a connection failure; the settings UI
+                        // can distinguish active setup from a setup that needs retrying.
+                        errorMessage = null,
                     )
                 }
                 return@withLock

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -175,6 +175,29 @@ class WalletManager(
         }
     }
 
+    /**
+     * Retries only the prerequisites needed by Lightning-address settings.
+     *
+     * A wallet runtime startup failure is retried first. If the runtime is
+     * already healthy but npub.cash key derivation previously failed, avoid
+     * reopening the repository and derive that identity again from the stored
+     * wallet seed.
+     */
+    suspend fun retryLightningAddressSetup() {
+        if (!mutableState.value.isRuntimeReady) initialize()
+        check(mutableState.value.isRuntimeReady) { "Wallet runtime is not ready." }
+        if (npcService.state.value.isInitialized) return
+
+        val mnemonic = withContext(Dispatchers.IO) {
+            checkNotNull(secureStorage.loadString(StorageKeys.secureWalletMnemonic)) {
+                "Stored wallet seed could not be decrypted."
+            }
+        }
+        withContext(Dispatchers.IO) {
+            npcService.initializeWithSeed(walletBip39Seed(mnemonic))
+        }
+    }
+
     private fun startDeferredStartupMaintenance(hasStoredWallet: Boolean) {
         scope.launch(Dispatchers.IO) {
             // Give Compose a scheduling opportunity to render cached state before

--- a/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.QrCode2
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +35,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import com.cashu.me.Core.NPCService
 import com.cashu.me.Core.NPCState
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.WalletState
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.InlineNotice
@@ -58,6 +61,26 @@ import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.ToggleRow
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.theme.CashuTheme
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+internal enum class LightningAddressSetupStatus {
+    Ready,
+    Empty,
+    SettingUp,
+    NeedsRecovery,
+}
+
+internal fun lightningAddressSetupStatus(
+    walletState: WalletState,
+    npcState: NPCState,
+): LightningAddressSetupStatus = when {
+    npcState.lightningAddress.isNotBlank() -> LightningAddressSetupStatus.Ready
+    !npcState.isEnabled -> LightningAddressSetupStatus.Empty
+    !walletState.isRuntimeReady && walletState.startupFailure == null ->
+        LightningAddressSetupStatus.SettingUp
+    else -> LightningAddressSetupStatus.NeedsRecovery
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -69,9 +92,12 @@ fun LightningScreen(
     val walletState by walletManager.state.collectAsState()
     val npcState by npcService.state.collectAsState()
     val clipboard = LocalClipboardManager.current
+    val scope = rememberCoroutineScope()
 
     var mintPickerOpen by remember { mutableStateOf(false) }
     var addressQrOpen by remember { mutableStateOf(false) }
+    var retryingSetup by remember { mutableStateOf(false) }
+    var setupRecoveryError by remember { mutableStateOf<String?>(null) }
 
     Scaffold(
         topBar = {
@@ -120,14 +146,26 @@ fun LightningScreen(
                         )
                     }
                 } else {
-                    Text(
-                        text = "No Lightning address configured. Enable below to receive at an @ address.",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(
-                            horizontal = CashuTheme.spacing.comfortable,
-                            vertical = CashuTheme.spacing.snug,
-                        ),
+                    LightningAddressSetupFeedback(
+                        status = lightningAddressSetupStatus(walletState, npcState),
+                        retrying = retryingSetup,
+                        recoveryError = setupRecoveryError,
+                        onRetry = {
+                            scope.launch {
+                                retryingSetup = true
+                                setupRecoveryError = null
+                                try {
+                                    walletManager.retryLightningAddressSetup()
+                                } catch (cancellation: CancellationException) {
+                                    throw cancellation
+                                } catch (_: Throwable) {
+                                    setupRecoveryError =
+                                        "Lightning address setup couldn't finish. Try again or restart the app."
+                                } finally {
+                                    retryingSetup = false
+                                }
+                            }
+                        },
                     )
                 }
             }
@@ -229,6 +267,59 @@ fun LightningScreen(
                 )
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
             }
+        }
+    }
+}
+
+@Composable
+internal fun LightningAddressSetupFeedback(
+    status: LightningAddressSetupStatus,
+    retrying: Boolean,
+    recoveryError: String?,
+    onRetry: () -> Unit,
+) {
+    val contentModifier = Modifier.padding(
+        horizontal = CashuTheme.spacing.comfortable,
+        vertical = CashuTheme.spacing.snug,
+    )
+    when (status) {
+        LightningAddressSetupStatus.Ready -> Unit
+        LightningAddressSetupStatus.Empty -> Text(
+            text = "No Lightning address configured. Enable below to receive at an @ address.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = contentModifier,
+        )
+        LightningAddressSetupStatus.SettingUp -> Row(
+            modifier = contentModifier,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(CashuTheme.spacing.loose),
+                strokeWidth = 2.dp,
+            )
+            Text(
+                text = "Setting up Lightning address…",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        LightningAddressSetupStatus.NeedsRecovery -> Column(
+            modifier = contentModifier,
+            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+        ) {
+            InlineNotice(
+                text = recoveryError
+                    ?: "Wallet not fully initialized. Try setup again to finish your Lightning address.",
+            )
+            PrimaryButton(
+                text = "Try setup again",
+                onClick = onRetry,
+                loading = retrying,
+                enabled = !retrying,
+                modifier = Modifier.fillMaxWidth(),
+            )
         }
     }
 }

--- a/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSetupStatusTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSetupStatusTest.kt
@@ -1,0 +1,57 @@
+package com.cashu.me.ui.settings
+
+import com.cashu.me.Core.NPCState
+import com.cashu.me.Core.WalletStartupFailure
+import com.cashu.me.Core.WalletState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LightningAddressSetupStatusTest {
+    @Test
+    fun enabledAddressShowsProgressWhileWalletRuntimeIsStarting() {
+        assertEquals(
+            LightningAddressSetupStatus.SettingUp,
+            lightningAddressSetupStatus(
+                walletState = WalletState(isInitialized = true, isRuntimeReady = false),
+                npcState = NPCState(isEnabled = true),
+            ),
+        )
+    }
+
+    @Test
+    fun startupFailureOffersRecoveryInsteadOfIndefiniteProgress() {
+        assertEquals(
+            LightningAddressSetupStatus.NeedsRecovery,
+            lightningAddressSetupStatus(
+                walletState = WalletState(
+                    isInitialized = true,
+                    isRuntimeReady = false,
+                    startupFailure = WalletStartupFailure("The saved wallet couldn't be opened."),
+                ),
+                npcState = NPCState(isEnabled = true),
+            ),
+        )
+    }
+
+    @Test
+    fun missingAddressAfterRuntimeReadyOffersSetupRecovery() {
+        assertEquals(
+            LightningAddressSetupStatus.NeedsRecovery,
+            lightningAddressSetupStatus(
+                walletState = WalletState(isInitialized = true, isRuntimeReady = true),
+                npcState = NPCState(isEnabled = true),
+            ),
+        )
+    }
+
+    @Test
+    fun disabledFeatureKeepsNeutralEmptyState() {
+        assertEquals(
+            LightningAddressSetupStatus.Empty,
+            lightningAddressSetupStatus(
+                walletState = WalletState(isInitialized = true, isRuntimeReady = true),
+                npcState = NPCState(isEnabled = false),
+            ),
+        )
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -170,7 +170,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · iOS → Android] Gate Lightning settings by feature state.** iOS shows disabled explanation, setup progress, initialization warning, or live controls as appropriate; Android always renders the empty address card and all preference/check controls. **Done when:** Android shows only actions meaningful in the current state.
 
-- [ ] **[P1 · iOS → Android] Add initialization and setup feedback.** iOS distinguishes active setup from “Wallet not fully initialized”; Android collapses both into an empty address message. **Done when:** Android communicates progress separately from a recoverable initialization problem and gives an actionable recovery.
+- [x] **[P1 · iOS → Android] Add initialization and setup feedback.** iOS distinguishes active setup from “Wallet not fully initialized”; Android collapses both into an empty address message. **Done when:** Android communicates progress separately from a recoverable initialization problem and gives an actionable recovery.
 
 - [ ] **[P2 · iOS → Android] Rename “Check for paid quotes now.”** iOS uses “Check for payments”; Android exposes quote jargon. **Done when:** both use payment language in the primary action.
 


### PR DESCRIPTION
## What changed

- distinguish active Lightning-address setup from an incomplete wallet setup on Android
- offer an actionable retry that reopens a failed wallet runtime or re-derives only the Lightning-address identity when the runtime is already healthy
- avoid treating pending key setup as a connection error
- add targeted presentation-state and Compose UI coverage
- mark only the matching parity-checklist item complete

## Why

iOS already communicates setup progress separately from a recoverable initialization problem. Android previously collapsed both states into the same empty-address message, leaving users without meaningful progress or recovery feedback.

## Validation

- `./gradlew --no-daemon :app:testDebugUnitTest --tests com.cashu.me.ui.settings.LightningAddressSetupStatusTest --stacktrace`
- `./gradlew --no-daemon :app:compileDebugAndroidTestKotlin --stacktrace`
- `git diff --check`
