### PR TITLE
fix: commit pending custom mint URL on onboarding Continue

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -815,6 +815,17 @@ private fun FirstMintFace(
         }
     }
 
+    fun handleContinue() {
+        if (customDraft.input.isNotBlank()) {
+            commitCustomUrl()
+            if (customDraft.error != null) return
+        }
+        if (selected.isEmpty()) return
+        // Preserve display order: recommended first, then customs.
+        val ordered = (RecommendedMints.map { it.url } + customUrls).filter { it in selected }
+        onContinue(ordered)
+    }
+
     Column(modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
@@ -936,12 +947,8 @@ private fun FirstMintFace(
         ) {
             PrimaryButton(
                 text = "Continue",
-                onClick = {
-                    // Preserve display order: recommended first, then customs.
-                    val ordered = (RecommendedMints.map { it.url } + customUrls).filter { it in selected }
-                    onContinue(ordered)
-                },
-                enabled = selected.isNotEmpty() && !busy,
+                onClick = ::handleContinue,
+                enabled = (selected.isNotEmpty() || customDraft.input.isNotBlank()) && !busy,
                 loading = busy,
                 modifier = Modifier.testTag(UiTestTags.ContinueWithMint),
             )

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -860,8 +860,8 @@ struct OnboardingView: View {
                         }
                     }
                     .glassButton()
-                    .disabled(selectedMintUrls.isEmpty || isAddingFirstMints)
-                    .animation(.easeOut(duration: 0.2), value: selectedMintUrls.isEmpty)
+                    .disabled((selectedMintUrls.isEmpty && customMintInput.isEmpty) || isAddingFirstMints)
+                    .animation(.easeOut(duration: 0.2), value: selectedMintUrls.isEmpty && customMintInput.isEmpty)
                     .accessibilityIdentifier("onboarding-continue")
 
                     Button(action: skipFirstMint) {
@@ -995,6 +995,10 @@ struct OnboardingView: View {
     }
 
     private func continueFromFirstMint() {
+        if !customMintInput.isEmpty {
+            commitCustomMintInput()
+            guard customMintInput.isEmpty else { return }
+        }
         guard !selectedMintUrls.isEmpty else { return }
         isAddingFirstMints = true
         firstMintError = nil


### PR DESCRIPTION
Fixes #176

If you type a mint URL in onboarding but tap Continue instead of the Add arrow, the mint gets silently dropped — Continue only used already-committed mints, never the pending input text.

Fix: Continue now commits pending input first (reusing the existing Add validation), on both iOS and Android. Also enabled Continue when there's valid pending text, not just after Add is tapped.
