### PR TITLE
Let onboarding headlines wrap; align Android add-mint row with iOS; swap Coinos for Chorus

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/Buttons.kt
@@ -210,6 +210,7 @@ fun GhostButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    leadingIcon: ImageVector? = null,
     trailingIcon: ImageVector? = null,
     textStyle: TextStyle = MaterialTheme.typography.labelLarge,
     contentColor: Color = Color.Unspecified,
@@ -227,6 +228,14 @@ fun GhostButton(
             ButtonDefaults.textButtonColors()
         },
     ) {
+        if (leadingIcon != null) {
+            Icon(
+                imageVector = leadingIcon,
+                contentDescription = null,
+                modifier = Modifier.size(GhostButtonIconSize),
+            )
+            Spacer(Modifier.width(CashuTheme.spacing.tight))
+        }
         Text(text = text, style = textStyle)
         if (trailingIcon != null) {
             Spacer(Modifier.width(CashuTheme.spacing.micro))

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -119,7 +119,7 @@ private data class RecommendedMint(val name: String, val url: String, val iconUr
 // Mirrors iOS RecommendedMint.suggested (ActivityOrbView.swift).
 private val RecommendedMints = listOf(
     RecommendedMint("Minibits", "https://mint.minibits.cash/Bitcoin", "https://minibits.cash/icon-192.png"),
-    RecommendedMint("Coinos", "https://mint.coinos.io", "https://coinos.io/images/icon.png"),
+    RecommendedMint("Chorus OFF Mint", "https://mint.chorus.community", "https://chorus.community/apple-touch-icon.png"),
     RecommendedMint("Macadamia", "https://mint.macadamia.cash", "https://cypherbase.cc/images/logo_w256.png"),
 )
 
@@ -383,7 +383,7 @@ internal fun WelcomeFace(
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
         ) {
             Text(
-                text = "Private cash.\nIn your pocket.",
+                text = "Private cash. In your pocket.",
                 style = onboardingTitleStyle(),
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -459,7 +459,7 @@ private fun EcashConceptSheet(onDismiss: () -> Unit) {
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
         ) {
             Text(
-                text = "Ecash is bearer cash\nfor Bitcoin.",
+                text = "Ecash is bearer cash for Bitcoin.",
                 style = MaterialTheme.typography.headlineMedium.copy(
                     fontWeight = FontWeight.ExtraBold,
                     letterSpacing = (-0.3).sp,
@@ -524,7 +524,7 @@ private fun ShowMnemonicFace(
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
         ) {
             Text(
-                text = "Your Seed\nPhrase.",
+                text = "Your Seed Phrase.",
                 style = onboardingTitleStyle(),
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -825,7 +825,7 @@ private fun FirstMintFace(
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
         ) {
             Text(
-                text = "Pick your\nfirst mint.",
+                text = "Pick your first mint.",
                 style = onboardingTitleStyle(),
                 color = MaterialTheme.colorScheme.onSurface,
             )
@@ -858,27 +858,20 @@ private fun FirstMintFace(
                 )
             }
             if (!customInputOpen) {
-                Row(
+                // iOS routes both this and "Skip for now" through
+                // `.textLinkButton()`; GhostButton is that style's analog, so the
+                // two stay centered and share press feedback on both platforms.
+                GhostButton(
+                    text = "Add custom mint URL",
+                    onClick = { customInputOpen = true },
+                    enabled = !busy,
+                    leadingIcon = Icons.Outlined.Add,
+                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable(enabled = !busy) { customInputOpen = true }
-                        .testTag(UiTestTags.AddCustomMint)
-                        .padding(vertical = CashuTheme.spacing.default),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Add,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(WarningIconSize),
-                    )
-                    Text(
-                        text = "Add custom mint URL",
-                        style = MaterialTheme.typography.labelLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                }
+                        .padding(top = CashuTheme.spacing.micro)
+                        .testTag(UiTestTags.AddCustomMint),
+                )
             } else {
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
                 CashuTextField(

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -43,7 +43,9 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -453,41 +455,58 @@ internal fun WelcomeFace(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun EcashConceptSheet(onDismiss: () -> Unit) {
-    ModalBottomSheet(onDismissRequest = onDismiss) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        // Skip the partially-expanded detent. At that height a short viewport
+        // (360x800dp) or a large font scale pushed "Got it" past the sheet edge,
+        // where it was clipped and the gesture pill drew across it.
+        sheetState = rememberBottomSheetState(
+            initialValue = SheetValue.Hidden,
+            enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+        ),
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = HeaderPadding)
                 .padding(bottom = CashuTheme.spacing.comfortable)
                 .navigationBarsPadding(),
-            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
         ) {
-            Text(
-                text = "Ecash is bearer cash for Bitcoin.",
-                style = MaterialTheme.typography.headlineMedium.copy(
-                    fontWeight = FontWeight.ExtraBold,
-                    letterSpacing = (-0.3).sp,
-                ),
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            Column(verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default)) {
+            // Prose scrolls; the CTA stays pinned below it. iOS gets the same
+            // shape from a Spacer() ahead of the button in `conceptSheet`.
+            Column(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+            ) {
                 Text(
-                    text = "Whoever holds it, owns it. Your balance stays on this device, hidden from everyone else.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    text = "Ecash is bearer cash for Bitcoin.",
+                    style = MaterialTheme.typography.headlineMedium.copy(
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = (-0.3).sp,
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
-                Text(
-                    text = "Mints hold the Bitcoin behind your ecash. You can use several at once.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-                Text(
-                    text = "Send instantly. Cash out to Lightning anytime.",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default)) {
+                    Text(
+                        text = "Whoever holds it, owns it. Your balance stays on this device, hidden from everyone else.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "Mints hold the Bitcoin behind your ecash. You can use several at once.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "Send instantly. Cash out to Lightning anytime.",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
-            Spacer(Modifier.height(CashuTheme.spacing.snug))
+            Spacer(Modifier.height(CashuTheme.spacing.comfortable))
             PrimaryButton(text = "Got it", onClick = onDismiss)
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -382,8 +382,12 @@ internal fun WelcomeFace(
                 .riseIn(appeared, 0),
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
         ) {
+            // The only headline that keeps a hardcoded break. Left to wrap
+            // naturally it wraps after "In" — "Private cash. In" / "your
+            // pocket." — splitting the second sentence. Breaking at the
+            // sentence boundary is the deliberate exception.
             Text(
-                text = "Private cash. In your pocket.",
+                text = "Private cash.\nIn your pocket.",
                 style = onboardingTitleStyle(),
                 color = MaterialTheme.colorScheme.onSurface,
             )

--- a/ios/CashuWallet/Views/Components/ActivityOrbView.swift
+++ b/ios/CashuWallet/Views/Components/ActivityOrbView.swift
@@ -251,7 +251,7 @@ struct RecommendedMint: Identifiable {
     /// The curated shortlist offered when a user has no mints to type from memory.
     static let suggested: [RecommendedMint] = [
         RecommendedMint(name: "Minibits", url: "https://mint.minibits.cash/Bitcoin", iconUrl: "https://minibits.cash/icon-192.png"),
-        RecommendedMint(name: "Coinos", url: "https://mint.coinos.io", iconUrl: "https://coinos.io/images/icon.png"),
+        RecommendedMint(name: "Chorus OFF Mint", url: "https://mint.chorus.community", iconUrl: "https://chorus.community/apple-touch-icon.png"),
         RecommendedMint(name: "Macadamia", url: "https://mint.macadamia.cash", iconUrl: "https://cypherbase.cc/images/logo_w256.png")
     ]
 }

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -189,7 +189,7 @@ struct OnboardingView: View {
 
             stagger(appeared: welcomeAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Private cash.\nIn your pocket.")
+                    Text("Private cash. In your pocket.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
                         .foregroundStyle(.primary)
@@ -268,10 +268,11 @@ struct OnboardingView: View {
 
     private var conceptSheet: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("Ecash is bearer cash\nfor Bitcoin.")
+            Text("Ecash is bearer cash for Bitcoin.")
                 .font(.title.weight(.heavy))
                 .tracking(-0.3)
                 .lineSpacing(-1)
+                .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 8)
 
             VStack(alignment: .leading, spacing: 16) {
@@ -619,7 +620,7 @@ struct OnboardingView: View {
 
             stagger(appeared: mnemonicAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Your Seed\nPhrase.")
+                    Text("Your Seed Phrase.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
                         .foregroundStyle(.primary)
@@ -778,7 +779,7 @@ struct OnboardingView: View {
         VStack(spacing: 16) {
             stagger(appeared: firstMintAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Pick your\nfirst mint.")
+                    Text("Pick your first mint.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
                         .fixedSize(horizontal: false, vertical: true)

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -189,7 +189,11 @@ struct OnboardingView: View {
 
             stagger(appeared: welcomeAppeared, index: 0) {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Private cash. In your pocket.")
+                    // The only headline that keeps a hardcoded break. Left to
+                    // wrap naturally it wraps after "In" — "Private cash. In" /
+                    // "your pocket." — splitting the second sentence. Breaking
+                    // at the sentence boundary is the deliberate exception.
+                    Text("Private cash.\nIn your pocket.")
                         .font(.largeTitle.weight(.heavy))
                         .tracking(-0.5)
                         .foregroundStyle(.primary)

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -34,6 +34,10 @@ struct OnboardingView: View {
 
     // First-mint state (create path)
     @State private var showConceptSheet = false
+    /// Measured height of `conceptSheet`, so the sheet hugs its content instead
+    /// of sitting at a fixed `.medium` detent. Seeded with a plausible value so
+    /// the first layout pass is close; corrected on measure.
+    @State private var conceptSheetHeight: CGFloat = 360
     @State private var selectedMintUrls: Set<String> = []
     @State private var customMintUrls: [String] = []
     @State private var showCustomMintInput = false
@@ -288,8 +292,6 @@ struct OnboardingView: View {
             .foregroundStyle(.secondary)
             .fixedSize(horizontal: false, vertical: true)
 
-            Spacer()
-
             Button(action: {
                 HapticFeedback.selection()
                 showConceptSheet = false
@@ -297,10 +299,23 @@ struct OnboardingView: View {
                 Text("Got it")
             }
             .glassButton()
-            .padding(.bottom, 8)
+            .padding(.top, 4)
         }
         .padding(28)
-        .presentationDetents([.medium, .large])
+        // Size the sheet to its content. A `.medium` detent is a fraction of the
+        // screen, not of the copy, so a `Spacer()` above the button used to
+        // absorb the leftover — leaving a gap that grew with device height
+        // (~107pt on iPhone 17e, ~134pt on iPhone 11) rather than a designed
+        // value. Measuring keeps the copy-to-button gap a constant 20pt and
+        // matches Android, whose sheet already hugs its content.
+        .onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { height in
+            conceptSheetHeight = height
+        }
+        // `.large` stays available so very large accessibility text can still
+        // expand past the measured height rather than clip.
+        .presentationDetents([.height(conceptSheetHeight), .large])
         .presentationDragIndicator(.visible)
     }
 


### PR DESCRIPTION
## What

Four onboarding fixes, plus one deliberate exception.

**1. Stop hardcoding headline line breaks.** Every onboarding hero headline embedded a literal `\n`, freezing the break regardless of screen width, locale, or the user's Dynamic Type / font-scale setting. `Pick your first mint.` measures ~319pt against 334–384pt of available width across the shipping iPhone lineup — it was being broken with room to spare. On iPhone 11 (414pt, the largest iPhone viewport bucket) the forced break wasted an entire line with ~100pt unused.

Three of the four now wrap naturally. **The welcome headline keeps its break as a deliberate, commented exception**: left to the layout engine it breaks after "In" — `Private cash. In` / `your pocket.` — splitting the second sentence, confirmed by capture on a mainstream device at default text size.

**2. Android "Add custom mint URL" now matches iOS.** It had diverged six ways: leading vs centered, inset vs full-width, 12dp vs 14pt padding, 4dp vs 6pt icon gap, and it borrowed a constant named `WarningIconSize` for its plus glyph. The root cause was structural — iOS routes both this and "Skip for now" through `.textLinkButton()`, while Android hand-rolled a bare `Row`. Fixed by giving `GhostButton` (Android's existing analog of that style, already used for "Skip for now" on the same screen) an optional `leadingIcon` and routing the row through it. It picks up centering, a full-width tap target, and the 0.6 pressed-alpha it previously had **no press feedback at all** for. The new param is default-null, so the other 14 call sites are unaffected.

**3. Coinos → Chorus OFF Mint** (`https://mint.chorus.community`) in the curated first-mint shortlist. The mint's self-declared `icon_url` is unusable — a 642×650 JPEG last modified 2017 on an unrelated CDN — so the icon is hand-picked from `chorus.community`, matching how the other entries are sourced. On iOS this list also feeds `SuggestedMintsSection` in the seed-restore flow, so the swap surfaces there too.

**4. The ecash concept sheet no longer clips its "Got it" CTA on Android.** Its content was a plain top-down `Column` with no scroll and no bottom anchoring, inside a `ModalBottomSheet` opening at its partially-expanded detent. Once headline + three paragraphs + button stacked taller than that detent, the button landed outside the sheet's visible bounds and the system gesture pill drew across it. Reproduced at 360×800dp and at 411×914dp with `font_scale 1.3`; 393×873dp at 1.0 had just enough room to hide it. iOS never had the bug because `conceptSheet` puts a `Spacer()` ahead of the button. Android now gets the same shape — prose scrolls inside a weighted child, CTA pinned below — and the sheet skips the partial detent via `rememberBottomSheetState`'s `enabledValues` (the `skipPartiallyExpanded` overload is deprecated in Material3 1.5).

This one is a **pre-existing defect**, not caused by the headline change: before the fix, the CTA band was byte-identical across the first two commits of this branch.

**5. The ecash concept sheet now sizes to its content on iOS.** It sat at a fixed `.medium` detent — a fraction of the *screen*, not of the copy — with a `Spacer()` above the CTA absorbing the remainder. The gap between the last paragraph and "Got it" was therefore residue that grew with device height (~107pt on iPhone 17e, ~115pt on iPhone 17, ~134pt on iPhone 11) rather than a designed value. Measuring the content to drive a `.height()` detent makes the sheet hug its copy: measured sheet height went from **479pt / 459pt** (iPhone 11 / iPhone 17, tracking the screen) to **381.0pt / 380.7pt** (tracking the content), and the copy-to-button gap is now 24pt by construction everywhere. `.large` stays in the detent set so very large accessibility sizes expand rather than clip. This also closes a parity gap that fix #4 opened, since the Android sheet already hugged its content.

## Notes for review

- The concept-sheet headline was the one of four without `.fixedSize(horizontal:false, vertical:true)` — line 284 sits on the sibling body-text stack, not the headline — so it gained one to avoid vertical truncation now that it wraps.
- Chorus OFF Mint self-reports `"The Chorus mint for the Oslo Freedom Forum 2024"` on Nutshell 0.20.0. Flagged as a product decision, not a code one.
- Pre-existing parity gaps found but **not** fixed here: Android's two onboarding text links differ in colour from each other (`primary` vs `onSurfaceVariant`) where iOS's match; Android has no equivalent of iOS's `SuggestedMintsSection` in the restore flow; and at large accessibility text Android headlines don't grow (Android 14+ non-linear font scaling) while iOS Dynamic Type re-wraps them.

## Testing

- Android: `:app:testDebugUnitTest` 442 tests, 0 failures; `:app:lintDebug` and `:app:validateDebugScreenshotTest` clean. The one lint warning in `OnboardingScreen.kt` (`UseOfNonLambdaOffsetOverload`, in the `riseIn` helper) is pre-existing on `main`.
- iOS: builds clean. `CashuWalletTests` shows 28 failures, all in `CDKIntegrationTests`/`NutshellIntegrationTests` which need local mints on :3338/:3339 — `main` produces the identical 28, so pre-existing and environmental.
- Visual evidence in the comment below: 32 matched before/after pairs across 3 iOS and 3 Android viewports plus large-text rows, manifest-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
