### PR TITLE
Make animated QR frame advance 10x faster

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Views/Components/QRCodeView.kt
+++ b/android/app/src/main/java/com/cashu/me/Views/Components/QRCodeView.kt
@@ -33,9 +33,9 @@ import com.gorunjinian.bcur.UREncoder
 import kotlinx.coroutines.delay
 
 enum class QRSpeed(val label: String, val intervalMillis: Long) {
-    Fast("F", 100),
-    Medium("M", 300),
-    Slow("S", 500);
+    Fast("F", 10),
+    Medium("M", 30),
+    Slow("S", 50);
 
     fun next(): QRSpeed = when (this) {
         Fast -> Medium

--- a/ios/CashuWallet/Views/Components/QRCodeView.swift
+++ b/ios/CashuWallet/Views/Components/QRCodeView.swift
@@ -13,9 +13,9 @@ enum QRSpeed: String, CaseIterable {
     
     var interval: Double {
         switch self {
-        case .fast: return 0.1
-        case .medium: return 0.3
-        case .slow: return 0.5
+        case .fast: return 0.01
+        case .medium: return 0.03
+        case .slow: return 0.05
         }
     }
     


### PR DESCRIPTION
## Summary
- Cut animated QR `QRSpeed` frame intervals by 10× on iOS and Android (Fast 100→10ms, Medium 300→30ms, Slow 500→50ms).
- Keeps existing speed toggle labels and cycle order; default remains Fast.

## Test plan
- [ ] Send a long ecash token and confirm the animated QR rotates visibly faster than before
- [ ] Cycle SPEED F/M/S and confirm relative speeds still feel ordered
- [ ] Scan the faster animated QR with another cashu.me-native device and confirm UR reassembly still succeeds
- [ ] Confirm short/static payloads (Lightning invoice, on-chain) still render as a single static QR