### PR TITLE
Search transaction and request memos on iOS

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -102,7 +102,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### History and transaction details
 
-- [ ] **[P1 · Android → iOS] Search transaction and request memos.** Android includes memos in History search; iOS searches titles and numeric amounts only. **Done when:** iOS matches memo text case-insensitively for both item types.
+- [x] **[P1 · Android → iOS] Search transaction and request memos.** Android includes memos in History search; iOS searches titles and numeric amounts only. **Done when:** iOS matches memo text case-insensitively for both item types.
 
 - [ ] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
 

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000D /* CashuRequestRouteExplanationTests.swift */; };
 		C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */; };
 		T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000E /* CrashReportSanitizerTests.swift */; };
+		T2B000000000000F /* HistorySearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000F /* HistorySearchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -297,6 +298,7 @@
 		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
 		C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestPaymentObservationTests.swift; path = CashuWalletTests/CashuRequestPaymentObservationTests.swift; sourceTree = "<group>"; };
 		T1B000000000000E /* CrashReportSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrashReportSanitizerTests.swift; path = CashuWalletTests/CrashReportSanitizerTests.swift; sourceTree = "<group>"; };
+		T1B000000000000F /* HistorySearchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistorySearchTests.swift; path = CashuWalletTests/HistorySearchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -351,6 +353,7 @@
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
 				T1B000000000000E /* CrashReportSanitizerTests.swift */,
+				T1B000000000000F /* HistorySearchTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -896,6 +899,7 @@
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
 				T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */,
+				T2B000000000000F /* HistorySearchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -432,19 +432,15 @@ struct HistoryView: View {
     }
 
     private func matchesSearch(_ item: HistoryItem) -> Bool {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return true }
         switch item {
         case .transaction(let tx):
-            if rowTitle(for: tx).lowercased().contains(query) { return true }
-            if "\(tx.amount)".contains(query) { return true }
-            return false
+            return HistorySearch.matches(query: searchText, transaction: tx)
         case .request(let req):
-            if req.displayTitle.lowercased().contains(query) { return true }
-            if let amount = req.amount, "\(amount)".contains(query) { return true }
-            let received = totalReceived(for: req)
-            if received > 0, "\(received)".contains(query) { return true }
-            return false
+            return HistorySearch.matches(
+                query: searchText,
+                request: req,
+                receivedTotal: totalReceived(for: req)
+            )
         }
     }
 
@@ -657,6 +653,35 @@ struct HistoryView: View {
         return (sameYear ? Self.sameYearDateFormatter : Self.otherYearDateFormatter).string(from: date)
     }
 
+}
+
+/// History search matching, extracted from HistoryView so it is unit-testable.
+/// Title and memo match case-insensitively; amounts match as substrings of the
+/// raw value (Android `unifiedFiltered` parity — memos included for both
+/// transactions and Cashu Requests).
+enum HistorySearch {
+    static func matches(query: String, transaction: WalletTransaction) -> Bool {
+        let query = normalized(query)
+        guard !query.isEmpty else { return true }
+        if transaction.displayTitle.lowercased().contains(query) { return true }
+        if "\(transaction.amount)".contains(query) { return true }
+        if let memo = transaction.memo, memo.lowercased().contains(query) { return true }
+        return false
+    }
+
+    static func matches(query: String, request: CashuRequest, receivedTotal: UInt64) -> Bool {
+        let query = normalized(query)
+        guard !query.isEmpty else { return true }
+        if request.displayTitle.lowercased().contains(query) { return true }
+        if let amount = request.amount, "\(amount)".contains(query) { return true }
+        if receivedTotal > 0, "\(receivedTotal)".contains(query) { return true }
+        if let memo = request.memo, memo.lowercased().contains(query) { return true }
+        return false
+    }
+
+    private static func normalized(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
 }
 
 /// Mounts system `.searchable` only while History search is active. Keeping it

--- a/ios/CashuWalletTests/HistorySearchTests.swift
+++ b/ios/CashuWalletTests/HistorySearchTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import CashuWallet
+
+final class HistorySearchTests: XCTestCase {
+
+    private func makeTransaction(
+        amount: UInt64 = 210,
+        memo: String? = nil
+    ) -> WalletTransaction {
+        WalletTransaction(
+            id: "tx-1",
+            amount: amount,
+            type: .incoming,
+            kind: .ecash,
+            date: Date(),
+            memo: memo,
+            status: .completed
+        )
+    }
+
+    private func makeRequest(
+        amount: UInt64? = 500,
+        memo: String? = nil
+    ) -> CashuRequest {
+        CashuRequest(
+            encoded: "creqAtest",
+            amount: amount,
+            memo: memo
+        )
+    }
+
+    func testTransactionMatchesMemoCaseInsensitively() {
+        let tx = makeTransaction(memo: "Coffee with Alice")
+        XCTAssertTrue(HistorySearch.matches(query: "coffee", transaction: tx))
+        XCTAssertTrue(HistorySearch.matches(query: "ALICE", transaction: tx))
+        XCTAssertTrue(HistorySearch.matches(query: "  With Alice  ", transaction: tx))
+    }
+
+    func testTransactionWithoutMemoDoesNotMatchMemoQuery() {
+        let tx = makeTransaction(memo: nil)
+        XCTAssertFalse(HistorySearch.matches(query: "coffee", transaction: tx))
+    }
+
+    func testTransactionStillMatchesTitleAndAmount() {
+        let tx = makeTransaction(amount: 210, memo: nil)
+        XCTAssertTrue(HistorySearch.matches(query: "ecash", transaction: tx))
+        XCTAssertTrue(HistorySearch.matches(query: "21", transaction: tx))
+    }
+
+    func testRequestMatchesMemoCaseInsensitively() {
+        let req = makeRequest(memo: "Dinner split Friday")
+        XCTAssertTrue(HistorySearch.matches(query: "dinner", request: req, receivedTotal: 0))
+        XCTAssertTrue(HistorySearch.matches(query: "FRIDAY", request: req, receivedTotal: 0))
+    }
+
+    func testRequestWithoutMemoDoesNotMatchMemoQuery() {
+        let req = makeRequest(memo: nil)
+        XCTAssertFalse(HistorySearch.matches(query: "dinner", request: req, receivedTotal: 0))
+    }
+
+    func testRequestStillMatchesTitleAndAmounts() {
+        let req = makeRequest(amount: 500, memo: nil)
+        XCTAssertTrue(HistorySearch.matches(query: "cashu", request: req, receivedTotal: 0))
+        XCTAssertTrue(HistorySearch.matches(query: "50", request: req, receivedTotal: 0))
+        XCTAssertTrue(HistorySearch.matches(query: "42", request: req, receivedTotal: 420))
+    }
+
+    func testBlankQueryMatchesEverything() {
+        let tx = makeTransaction(memo: nil)
+        let req = makeRequest(amount: nil, memo: nil)
+        XCTAssertTrue(HistorySearch.matches(query: "", transaction: tx))
+        XCTAssertTrue(HistorySearch.matches(query: "   ", transaction: tx))
+        XCTAssertTrue(HistorySearch.matches(query: "", request: req, receivedTotal: 0))
+        XCTAssertTrue(HistorySearch.matches(query: "   ", request: req, receivedTotal: 0))
+    }
+}


### PR DESCRIPTION
## Parity gap

Android's History search matches memo text case-insensitively for both item types; iOS only searched row titles and numeric amounts.

- Android (`android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt`, `unifiedFiltered`): matches `tx.memo` and `request.memo` with `ignoreCase = true` alongside title/amount.
- iOS (`ios/CashuWallet/Views/History/HistoryView.swift`, `matchesSearch`): title + amount only — no memo matching.

Checks off the **Search transaction and request memos** item in `docs/product/ios-android-parity-checklist.md`.

## Fix

- Extracted the search predicate from `HistoryView.matchesSearch` into a testable `HistorySearch` enum (same pattern as `HomeActionAccessibility`/`SendPaymentCopy`), adding case-insensitive memo matching for both `WalletTransaction` and `CashuRequest`. Existing title/amount/received-total matching is unchanged; blank queries still match everything.

## Verification

- `xcodebuild build` on iPhone 17 Pro simulator: succeeded.
- New `HistorySearchTests` (7 tests, all passing): memo matches case-insensitively for transactions and Cashu Requests, nil memos don't match memo queries, title/amount matching preserved, blank query matches all.
- Re-ran `HomeActionAccessibilityTests`, `CashuRequestRouteExplanationTests`, `CashuRequestPaymentObservationTests`: all pass.