### PR TITLE
Close Android History parity gaps

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/HistoryFilters.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/HistoryFilters.kt
@@ -9,10 +9,10 @@ import java.util.Locale
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.WalletTransaction
 
-enum class HistoryFilter(val label: String) {
-    All("All"),
-    Pending("Pending"),
-    Completed("Completed"),
+enum class HistoryFilter(val label: String, val accessibilityValue: String) {
+    All("All", "All"),
+    Pending("Pending", "Pending only"),
+    Completed("Completed", "Completed only"),
 }
 
 const val HistoryPageSize = 10

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -16,6 +16,30 @@ data class TransactionDetailField(
     val copyValue: String? = null,
 )
 
+/**
+ * Incoming ecash the user hasn't claimed yet — a "Receive later" token or a
+ * NUT-18 payment held for approval (iOS `WalletTransaction.isPendingReceiveToken`).
+ * These synthetic rows use the pending token id as the row id, so History
+ * removal is `WalletManager.removePendingReceiveToken(transaction.id)`.
+ */
+val WalletTransaction.isPendingReceiveToken: Boolean
+    get() = token != null &&
+        isPendingToken &&
+        type == TransactionType.Incoming &&
+        status == TransactionStatus.Pending
+
+/** How the transaction-detail hero amount picks its unit (iOS TransactionDetailView parity). */
+enum class DetailAmountPresentation {
+    /** Sat-denominated Lightning/ecash: the saved primary unit leads; the alternate flips in. */
+    PreferredUnit,
+
+    /** On-chain records always stay in sats — never fiat-converted. */
+    SatsOnly,
+
+    /** Non-sat mint units render natively — never BTC-price converted. */
+    NativeUnit,
+}
+
 object TransactionDisplay {
     // Kind-first, capitalized kind, lowercase verb — single source of truth for
     // rows AND the detail title, so a row and the sheet it opens read identically.
@@ -89,6 +113,18 @@ object TransactionDisplay {
         TransactionKind.Ecash -> "Ecash token"
         TransactionKind.Lightning -> "Payment request"
         TransactionKind.Onchain -> "Bitcoin address"
+    }
+
+    /**
+     * Hero-unit rule for the detail amount (iOS TransactionDetailView parity):
+     * sat-denominated Lightning/ecash records lead with the saved primary unit
+     * and keep the alternate available; on-chain stays in sats; non-sat mint
+     * units render natively with no fiat conversion.
+     */
+    fun amountPresentation(transaction: WalletTransaction): DetailAmountPresentation = when {
+        !transaction.unit.equals("sat", ignoreCase = true) -> DetailAmountPresentation.NativeUnit
+        transaction.kind == TransactionKind.Onchain -> DetailAmountPresentation.SatsOnly
+        else -> DetailAmountPresentation.PreferredUnit
     }
 
     // Detail rows follow the iOS canon: Status first (monochrome), Date, then

--- a/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/TransactionRow.kt
@@ -1,7 +1,8 @@
 package com.cashu.me.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,12 +48,20 @@ data class TransactionRowModel(
  * arrow's orientation, never colour); kind is named in the title. The amount is
  * the ledger signal: received is green with a plus, sent is primary with no
  * sign, and pending/expired is muted with no sign.
+ *
+ * [onLongClick] is the row-level secondary action (iOS swipe-action parity —
+ * e.g. removing an unclaimed incoming token from History); with TalkBack it
+ * surfaces as the standard double-tap-and-hold action, labelled by
+ * [onLongClickLabel].
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TransactionRow(
     model: TransactionRowModel,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
 ) {
     val tx = model.transaction
     val incoming = tx.type == TransactionType.Incoming
@@ -78,7 +87,11 @@ fun TransactionRow(
             .semantics {
                 contentDescription = semanticParts.joinToString(", ")
             }
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick,
+                onLongClickLabel = onLongClickLabel,
+            )
             // Slightly looser than the original 16pt so home Recent + History
             // breathe between rows without going sparse.
             .padding(horizontal = CashuTheme.spacing.comfortable, vertical = 18.dp),

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -56,6 +56,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -70,6 +72,7 @@ import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.displayText
+import com.cashu.me.Core.isPendingReceiveToken
 import com.cashu.me.Models.CashuRequest
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.WalletTransaction
@@ -111,6 +114,7 @@ fun HistoryScreen(
     var query by remember { mutableStateOf("") }
     var refreshing by remember { mutableStateOf(false) }
     var requestPendingDelete by remember { mutableStateOf<CashuRequest?>(null) }
+    var receiveTokenPendingDelete by remember { mutableStateOf<WalletTransaction?>(null) }
     val searchFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -172,12 +176,19 @@ fun HistoryScreen(
                         )
                     }
                     Box {
-                        IconButton(onClick = { filterMenuOpen = true }) {
+                        IconButton(
+                            onClick = { filterMenuOpen = true },
+                            // TalkBack reports the active filter on the control
+                            // (iOS .accessibilityValue(filter.label) parity).
+                            modifier = Modifier.semantics {
+                                stateDescription = filter.accessibilityValue
+                            },
+                        ) {
                             // Outlined ↔ filled glyph swap animates (symbol-replace parity).
                             IconSwap(
                                 icon = if (filter == HistoryFilter.All)
                                     Icons.Outlined.FilterList else Icons.Filled.FilterList,
-                                contentDescription = "Filter",
+                                contentDescription = "Filter transactions",
                                 iconSize = CashuTheme.iconSizes.toolbar,
                             )
                         }
@@ -319,6 +330,19 @@ fun HistoryScreen(
                                             modifier = Modifier.testTag(
                                                 UiTestTags.transactionRow(tx.id),
                                             ),
+                                            // Parked incoming ecash can be
+                                            // discarded from the list (iOS
+                                            // swipe-action parity).
+                                            onLongClick = if (tx.isPendingReceiveToken) {
+                                                { receiveTokenPendingDelete = tx }
+                                            } else {
+                                                null
+                                            },
+                                            onLongClickLabel = if (tx.isPendingReceiveToken) {
+                                                "Remove"
+                                            } else {
+                                                null
+                                            },
                                         )
                                     }
                                     is HistoryItem.Req -> {
@@ -356,7 +380,9 @@ fun HistoryScreen(
             title = { Text("Remove from history?") },
             text = {
                 Text(
-                    "Payments already received stay in your wallet; only the request entry is removed.",
+                    "Payments already received stay in your wallet, and the QR and any " +
+                        "pending payment routing stay valid. Only the entry is removed " +
+                        "from your history.",
                     style = MaterialTheme.typography.bodyMedium,
                 )
             },
@@ -373,6 +399,47 @@ fun HistoryScreen(
             },
         )
     }
+
+    receiveTokenPendingDelete?.let { tx ->
+        ParkedTokenRemovalDialog(
+            onConfirm = {
+                // The synthetic row id is the pending token id; discarding it
+                // drops the unclaimed ecash for good (iOS parity — only the
+                // sender can re-issue it).
+                walletManager.removePendingReceiveToken(tx.id)
+                receiveTokenPendingDelete = null
+                scope.launch { walletManager.loadTransactions() }
+            },
+            onDismiss = { receiveTokenPendingDelete = null },
+        )
+    }
+}
+
+/** Confirmation for discarding an unclaimed incoming token (iOS HistoryView parity). */
+@Composable
+internal fun ParkedTokenRemovalDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Remove this unclaimed ecash?") },
+        text = {
+            Text(
+                "This ecash hasn't been claimed. Removing it discards the token — " +
+                    "only the sender can re-issue it.",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text("Remove", color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        },
+    )
 }
 
 @Composable
@@ -465,8 +532,14 @@ internal fun unifiedFiltered(
                     tx.memo?.contains(query, ignoreCase = true) == true
             }
             is HistoryItem.Req -> {
+                // Matches the requested total and, once payments landed, the
+                // aggregate received total the row actually shows (iOS
+                // matchesSearch parity) — same raw-digit normalization as the
+                // transaction amount match.
                 item.request.displayTitle.contains(query, ignoreCase = true) ||
                     (item.request.amount?.toString()?.contains(query) == true) ||
+                    (item.request.totalReceived > 0 &&
+                        item.request.totalReceived.toString().contains(query)) ||
                     item.request.memo?.contains(query, ignoreCase = true) == true
             }
         }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -48,11 +48,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.DetailAmountPresentation
 import com.cashu.me.Core.PendingTokenClaimCheckResult
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.pendingSentTokenFor
 import com.cashu.me.Core.resolveTransactionForDetail
@@ -61,13 +64,15 @@ import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.shouldOfferManualClaimCheck
 import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.isPendingReceiveToken
 import com.cashu.me.Models.TransactionKind
 import com.cashu.me.Models.TransactionStatus
-import com.cashu.me.Models.TransactionType
 import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.DetailActionFooter
+import com.cashu.me.ui.components.DestructiveTextButton
 import com.cashu.me.ui.components.EmptyState
 import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.InspectorRow
@@ -88,6 +93,7 @@ import com.cashu.me.ui.testing.UiTestTags
 fun TransactionDetailScreen(
     walletManager: WalletManager,
     settingsManager: SettingsManager,
+    priceService: PriceService,
     transactionId: String,
     onClose: () -> Unit,
     onClaimReceiveToken: ((String) -> Unit)? = null,
@@ -95,6 +101,7 @@ fun TransactionDetailScreen(
 ) {
     val walletState by walletManager.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val formatter = remember { AmountFormatter() }
@@ -195,11 +202,8 @@ fun TransactionDetailScreen(
         }
 
         val explorerUrl = remember(transaction) { transaction.explorerUrl() }
-        val pendingReceiveToken = transaction.token?.takeIf {
-            transaction.isPendingToken &&
-                transaction.type == TransactionType.Incoming &&
-                transaction.status == TransactionStatus.Pending
-        }
+        val pendingReceiveToken = transaction.token?.takeIf { transaction.isPendingReceiveToken }
+        var removeParkedToken by remember { mutableStateOf(false) }
         val pendingSentToken = pendingSentTokenFor(transaction, walletState.pendingTokens)
         val offersManualClaimCheck = shouldOfferManualClaimCheck(
             automaticChecksEnabled = settings.checkSentTokens,
@@ -254,6 +258,14 @@ fun TransactionDetailScreen(
                 HeroAmount(
                     transaction = transaction,
                     formatter = formatter,
+                    amountPrimary = AmountDisplayPrimary.fromRaw(settings.amountDisplayPrimary),
+                    onFlipPrimary = { settingsManager.setAmountDisplayPrimary(it.rawValue) },
+                    btcPrice = if (settings.showFiatBalance) {
+                        priceState.btcPrice.takeIf { it > 0 }
+                    } else {
+                        null
+                    },
+                    currencyCode = settings.bitcoinPriceCurrency,
                     useBitcoinSymbol = settings.useBitcoinSymbol,
                     compact = showsQr,
                 )
@@ -319,6 +331,14 @@ fun TransactionDetailScreen(
                             text = "Receive",
                             onClick = { onClaimReceiveToken(pendingReceiveToken) },
                         )
+                        Spacer(Modifier.height(CashuTheme.spacing.snug))
+                        // Discard is the ordinary parked-token counterpart of
+                        // declining a held Cashu Request payment (iOS History
+                        // swipe-action parity, surfaced on the detail too).
+                        DestructiveTextButton(
+                            text = "Remove",
+                            onClick = { removeParkedToken = true },
+                        )
                     } else {
                         if (copyableContent != null) {
                             // Copy is a secondary convenience, not a primary action —
@@ -369,6 +389,20 @@ fun TransactionDetailScreen(
                 }
             }
         }
+
+        if (removeParkedToken) {
+            ParkedTokenRemovalDialog(
+                onConfirm = {
+                    // The synthetic row id is the pending token id; the reload
+                    // drops the row from History before the user lands back.
+                    removeParkedToken = false
+                    walletManager.removePendingReceiveToken(transaction.id)
+                    scope.launch { walletManager.loadTransactions() }
+                    onClose()
+                },
+                onDismiss = { removeParkedToken = false },
+            )
+        }
     }
 }
 
@@ -380,29 +414,53 @@ private val MonospacedLabels = setOf("Request", "Address", "Payment Proof", "Tra
 
 // Crisp primary amount hero — direction already lives in the screen title, so
 // the historical detail keeps the amount itself quiet and unsigned like iOS.
+// Sat-denominated Lightning/ecash records lead with the saved primary unit and
+// keep the alternate on the flip pill (iOS CurrencyAmountDisplay parity);
+// on-chain stays in sats and non-sat mint units stay native.
 @Composable
 private fun HeroAmount(
     transaction: WalletTransaction,
     formatter: AmountFormatter,
+    amountPrimary: AmountDisplayPrimary,
+    onFlipPrimary: (AmountDisplayPrimary) -> Unit,
+    btcPrice: Double?,
+    currencyCode: String,
     useBitcoinSymbol: Boolean,
     compact: Boolean,
 ) {
-    val formatted = if (transaction.unit.equals("sat", ignoreCase = true)) {
-        formatter.formatWalletSats(transaction.amount, useBitcoinSymbol)
+    val heroStyle = (if (compact) {
+        MaterialTheme.typography.headlineLarge
     } else {
-        CurrencyAmount(
-            transaction.amount,
-            CurrencyRegistry.currencyForMintUnit(transaction.unit),
-        ).formatted()
+        MaterialTheme.typography.displayMedium
+    }).copy(fontWeight = FontWeight.Bold)
+    when (TransactionDisplay.amountPresentation(transaction)) {
+        DetailAmountPresentation.PreferredUnit -> AmountFlipDisplay(
+            amountSats = transaction.amount,
+            primary = amountPrimary,
+            onFlip = onFlipPrimary,
+            btcPrice = btcPrice,
+            currencyCode = currencyCode,
+            useBitcoinSymbol = useBitcoinSymbol,
+            modifier = Modifier.padding(vertical = 5.dp),
+            primaryTextStyle = heroStyle,
+            primaryAccessibilityPrefix = "Amount",
+        )
+        DetailAmountPresentation.SatsOnly -> AmountText(
+            text = formatter.formatWalletSats(transaction.amount, useBitcoinSymbol),
+            style = heroStyle.withMonoDigits(),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(vertical = 5.dp),
+        )
+        DetailAmountPresentation.NativeUnit -> AmountText(
+            text = CurrencyAmount(
+                transaction.amount,
+                CurrencyRegistry.currencyForMintUnit(transaction.unit),
+            ).formatted(),
+            style = heroStyle.withMonoDigits(),
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(vertical = 5.dp),
+        )
     }
-    AmountText(
-        text = formatted,
-        style = (if (compact) MaterialTheme.typography.headlineLarge else MaterialTheme.typography.displayMedium)
-            .copy(fontWeight = FontWeight.Bold)
-            .withMonoDigits(),
-        color = MaterialTheme.colorScheme.onSurface,
-        modifier = Modifier.padding(vertical = 5.dp),
-    )
 }
 
 private fun WalletTransaction.explorerUrl(): String? {

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -335,9 +335,12 @@ fun TransactionDetailScreen(
                         // Discard is the ordinary parked-token counterpart of
                         // declining a held Cashu Request payment (iOS History
                         // swipe-action parity, surfaced on the detail too).
+                        // Full width keeps the label centered under the Receive
+                        // capsule (Remove mint on MintDetailScreen precedent).
                         DestructiveTextButton(
                             text = "Remove",
                             onClick = { removeParkedToken = true },
+                            modifier = Modifier.fillMaxWidth(),
                         )
                     } else {
                         if (copyableContent != null) {

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -109,6 +109,7 @@ fun CashuNavHost(
             TransactionDetailScreen(
                 walletManager = container.walletManager,
                 settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 transactionId = txId,
                 onClose = { navController.popBackStack() },
                 onClaimReceiveToken = onClaimReceiveToken,

--- a/android/app/src/test/java/com/cashu/me/Core/HistoryFiltersTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/HistoryFiltersTest.kt
@@ -76,6 +76,15 @@ class HistoryFiltersTest {
         assertEquals(listOf("earlier"), groups[4].transactions.map { it.id })
     }
 
+    @Test
+    fun filterAnnouncesTheActiveSelection() {
+        // TalkBack reports the selected filter on the History filter control
+        // (iOS .accessibilityValue(filter.label) parity).
+        assertEquals("All", HistoryFilter.All.accessibilityValue)
+        assertEquals("Pending only", HistoryFilter.Pending.accessibilityValue)
+        assertEquals("Completed only", HistoryFilter.Completed.accessibilityValue)
+    }
+
     private fun transaction(
         id: String,
         status: TransactionStatus,

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -151,8 +151,44 @@ class TransactionDisplayTest {
     }
 
     @Test
-    fun memoAppearsInHistoryDetailsOnlyWhenPresent() {
-        val withMemo = transaction(
+    fun parkedIncomingTokenIsFlaggedForRemoval() {
+        val parked = transaction(
+            kind = TransactionKind.Ecash,
+            type = TransactionType.Incoming,
+            token = "cashu-token",
+        ).copy(status = TransactionStatus.Pending, isPendingToken = true)
+        assertTrue(parked.isPendingReceiveToken)
+
+        // An unclaimed outgoing send is reclaimable, not discardable here.
+        val outgoingPending = parked.copy(type = TransactionType.Outgoing)
+        assertTrue(!outgoingPending.isPendingReceiveToken)
+
+        // Claimed rows and tokenless rows are never removable parked tokens.
+        assertTrue(!parked.copy(status = TransactionStatus.Completed).isPendingReceiveToken)
+        assertTrue(!parked.copy(token = null).isPendingReceiveToken)
+    }
+
+    @Test
+    fun detailAmountPresentationHonorsUnitAndRailExceptions() {
+        // Sat-denominated Lightning/ecash records follow the saved primary unit.
+        val lightning = transaction(kind = TransactionKind.Lightning, type = TransactionType.Incoming)
+        assertEquals(DetailAmountPresentation.PreferredUnit, TransactionDisplay.amountPresentation(lightning))
+        val ecash = transaction(kind = TransactionKind.Ecash, type = TransactionType.Outgoing)
+        assertEquals(DetailAmountPresentation.PreferredUnit, TransactionDisplay.amountPresentation(ecash))
+
+        // On-chain records always stay in sats (iOS TransactionDetailView parity).
+        val onchain = transaction(kind = TransactionKind.Onchain, type = TransactionType.Incoming)
+        assertEquals(DetailAmountPresentation.SatsOnly, TransactionDisplay.amountPresentation(onchain))
+
+        // Non-sat mint units render natively — never fiat-converted.
+        val usd = lightning.copy(unit = "usd")
+        assertEquals(DetailAmountPresentation.NativeUnit, TransactionDisplay.amountPresentation(usd))
+        val usdOnchain = onchain.copy(unit = "usd")
+        assertEquals(DetailAmountPresentation.NativeUnit, TransactionDisplay.amountPresentation(usdOnchain))
+    }
+
+    @Test
+    fun memoAppearsInHistoryDetailsOnlyWhenPresent() {        val withMemo = transaction(
             kind = TransactionKind.Ecash,
             type = TransactionType.Incoming,
             memo = "Coffee from Alice",

--- a/android/app/src/test/java/com/cashu/me/ui/history/HistorySearchTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/history/HistorySearchTest.kt
@@ -1,0 +1,113 @@
+package com.cashu.me.ui.history
+
+import com.cashu.me.Core.HistoryFilter
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.CashuRequestPayment
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HistorySearchTest {
+    @Test
+    fun `request search matches the requested amount`() {
+        val request = request(amount = 100, received = emptyList())
+
+        assertEquals(listOf(request), matchingRequests("100", request))
+        assertTrue(matchingRequests("95", request).isEmpty())
+    }
+
+    @Test
+    fun `request search matches the total received amount`() {
+        // iOS HistoryView.matchesSearch parity: once payments land, the
+        // aggregate received total is searchable with the same raw-digit
+        // normalization as every other History amount.
+        val request = request(
+            amount = 100,
+            received = listOf(
+                CashuRequestPayment("tx-1", amount = 60, receivedAtEpochMillis = 2),
+                CashuRequestPayment("tx-2", amount = 36, receivedAtEpochMillis = 3),
+            ),
+        )
+
+        assertEquals(listOf(request), matchingRequests("96", request))
+        // The configured amount stays searchable too.
+        assertEquals(listOf(request), matchingRequests("100", request))
+        assertTrue(matchingRequests("95", request).isEmpty())
+    }
+
+    @Test
+    fun `request search ignores a zero total received`() {
+        // Legacy rows carry payments with unknown (zero) amounts — a "0" query
+        // must not match a request that shows no received total.
+        val request = request(
+            amount = 5,
+            received = listOf(
+                CashuRequestPayment("tx-1", amount = 0, receivedAtEpochMillis = 2),
+            ),
+        )
+
+        assertTrue(matchingRequests("0", request).isEmpty())
+    }
+
+    @Test
+    fun `request search matches title and memo case-insensitively`() {
+        val request = request(amount = null, received = emptyList(), memo = "Coffee money")
+
+        assertEquals(listOf(request), matchingRequests("cashu request", request))
+        assertEquals(listOf(request), matchingRequests("COFFEE", request))
+    }
+
+    @Test
+    fun `transaction search matches title amount and memo`() {
+        val transaction = WalletTransaction(
+            id = "tx",
+            amount = 250,
+            type = TransactionType.Outgoing,
+            kind = TransactionKind.Lightning,
+            dateEpochMillis = 1,
+            status = TransactionStatus.Completed,
+            memo = "dinner split",
+        )
+
+        assertEquals(1, matchingTransactions("lightning paid", transaction).size)
+        assertEquals(1, matchingTransactions("250", transaction).size)
+        assertEquals(1, matchingTransactions("DINNER", transaction).size)
+        assertTrue(matchingTransactions("251", transaction).isEmpty())
+    }
+
+    private fun matchingRequests(query: String, vararg requests: CashuRequest): List<CashuRequest> =
+        unifiedFiltered(
+            transactions = emptyList(),
+            requests = requests.toList(),
+            filter = HistoryFilter.All,
+            query = query,
+        ).mapNotNull { (it as? HistoryItem.Req)?.request }
+
+    private fun matchingTransactions(
+        query: String,
+        vararg transactions: WalletTransaction,
+    ): List<WalletTransaction> =
+        unifiedFiltered(
+            transactions = transactions.toList(),
+            requests = emptyList(),
+            filter = HistoryFilter.All,
+            query = query,
+        ).mapNotNull { (it as? HistoryItem.Tx)?.transaction }
+
+    private fun request(
+        amount: Long?,
+        received: List<CashuRequestPayment>,
+        memo: String? = null,
+    ) = CashuRequest(
+        id = "request",
+        encoded = "creqA",
+        amount = amount,
+        memo = memo,
+        createdAtEpochMillis = 1,
+        receivedPayments = received,
+    )
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -104,15 +104,15 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P1 · Android → iOS] Search transaction and request memos.** Android includes memos in History search; iOS searches titles and numeric amounts only. **Done when:** iOS matches memo text case-insensitively for both item types.
 
-- [ ] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
+- [x] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
 
-- [ ] **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** iOS says the QR and pending payment routing remain valid; Android only says received payments stay in the wallet. **Done when:** Android states before deletion that previously received funds remain, the QR and payment routing remain valid, and only the History row is removed.
+- [x] **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** iOS says the QR and pending payment routing remain valid; Android only says received payments stay in the wallet. **Done when:** Android states before deletion that previously received funds remain, the QR and payment routing remain valid, and only the History row is removed.
 
-- [ ] **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** Android already supports declining a held Cashu Request payment, but it has no equivalent removal for a normal unclaimed token. **Done when:** Android provides a discoverable removal action for ordinary parked tokens and warns that the ecash will be discarded and only the sender can reissue it.
+- [x] **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** Android already supports declining a held Cashu Request payment, but it has no equivalent removal for a normal unclaimed token. **Done when:** Android provides a discoverable removal action for ordinary parked tokens and warns that the ecash will be discarded and only the sender can reissue it.
 
-- [ ] **[P2 · iOS → Android] Honor the preferred amount unit in transaction details.** iOS makes sats and fiat available for sat-denominated Lightning/ecash records; Android always displays sats. **Done when:** Android leads with the saved primary setting, exposes the alternate value accessibly, and preserves on-chain and non-sat-unit exceptions.
+- [x] **[P2 · iOS → Android] Honor the preferred amount unit in transaction details.** iOS makes sats and fiat available for sat-denominated Lightning/ecash records; Android always displays sats. **Done when:** Android leads with the saved primary setting, exposes the alternate value accessibly, and preserves on-chain and non-sat-unit exceptions.
 
-- [ ] **[P2 · iOS → Android] Announce the active History filter.** iOS exposes the selected filter as an accessibility value; Android’s filter control is announced only as “Filter.” **Done when:** TalkBack reports All, Pending only, or Completed only on the control.
+- [x] **[P2 · iOS → Android] Announce the active History filter.** iOS exposes the selected filter as an accessibility value; Android’s filter control is announced only as “Filter.” **Done when:** TalkBack reports All, Pending only, or Completed only on the control.
 
 ### Mints list, add, and discovery
 


### PR DESCRIPTION
Brings five verified iOS History / transaction-detail behaviors to Android. Checks off five items in `docs/product/ios-android-parity-checklist.md` (History and transaction details section).

- **[P2 · iOS → Android] Search a Cashu Request's Total received amount.** `unifiedFiltered` now also matches `request.totalReceived` (raw-digit `contains`, the same normalization as the transaction/request amount matches), guarded by `> 0` so legacy zero-amount payments never match. Verified by `HistorySearchTest` (`request search matches the total received amount`, `request search ignores a zero total received`).
- **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** The removal dialog now states all three facts: payments already received stay in the wallet, the QR and any pending payment routing stay valid, and only the History entry is removed (iOS copy: "The QR and any pending payment routing stay valid; this only removes the row from your history.").
- **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** iOS removes these via a History swipe action; Android now offers it (a) as a long-press on the History row — the same pattern the Cashu Request row already uses, with a TalkBack long-click label — and (b) as a destructive "Remove" action on the transaction detail screen next to the Receive CTA. Both route to one shared confirmation dialog using the iOS copy: the ecash hasn't been claimed, removing discards the token, only the sender can re-issue it. Removal goes through the existing `WalletManager.removePendingReceiveToken` + `loadTransactions` (same sequence as iOS). The parked-token predicate is the new tested `WalletTransaction.isPendingReceiveToken` extension.
- **[P2 · iOS → Android] Honor the preferred amount unit in transaction details.** The detail hero now follows `TransactionDisplay.amountPresentation` (iOS `TransactionDetailView` parity): sat-denominated Lightning/ecash records render through `AmountFlipDisplay` — leading with the saved primary unit, flip pill persists the setting via `setAmountDisplayPrimary`, alternate value announced as "Alternate amount: …" — while on-chain records stay in sats and non-sat mint units stay native with no fiat conversion. Unit-selection rule covered by `TransactionDisplayTest.detailAmountPresentationHonorsUnitAndRailExceptions`.
- **[P2 · iOS → Android] Announce the active History filter.** The filter control's content description is now "Filter transactions" (iOS label parity) and the active selection rides as a Compose `stateDescription` ("All" / "Pending only" / "Completed only", from `HistoryFilter.accessibilityValue`), so TalkBack reports the active filter on the control. Values pinned by `HistoryFiltersTest.filterAnnouncesTheActiveSelection`.

## Verification

- `./gradlew :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` — build successful, 454 unit tests pass (5 new in `HistorySearchTest`, 2 new in `TransactionDisplayTest`, 1 new in `HistoryFiltersTest`), lint clean.
- Manual TalkBack/visual verification not run in this automated pass; semantics follow the existing `DestructiveTextButton` stateDescription pattern and the `AmountFlipDisplay` accessibility contract already used on Receive/Send.