### PR TITLE
Android mint detail: iOS parity for metadata, payment rails, and actions

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -60,7 +60,7 @@ class NativeWalletLocalMintInstrumentedTest {
             payer.gateway.ensureWallet(nutshellMintUrl)
             val nutshellInfo = payer.gateway.fetchMintInfo(nutshellMintUrl)
             assertNotNull(nutshellInfo)
-            assertTrue(nutshellInfo!!.supportedMintMethods.contains(PaymentMethodKind.Bolt11))
+            assertTrue(nutshellInfo!!.supportedMintMethods.orEmpty().contains(PaymentMethodKind.Bolt11))
 
             step = "Nutshell BOLT11 mint"
             val paidQuote = payer.gateway.createMintQuote(
@@ -108,8 +108,8 @@ class NativeWalletLocalMintInstrumentedTest {
             payer.gateway.ensureWallet(cdkMintUrl)
             val cdkInfo = payer.gateway.fetchMintInfo(cdkMintUrl)
             assertNotNull(cdkInfo)
-            assertTrue(cdkInfo!!.supportedMintMethods.contains(PaymentMethodKind.Bolt12))
-            assertTrue(cdkInfo.supportedMintMethods.contains(PaymentMethodKind.Onchain))
+            assertTrue(cdkInfo!!.supportedMintMethods.orEmpty().contains(PaymentMethodKind.Bolt12))
+            assertTrue(cdkInfo.supportedMintMethods.orEmpty().contains(PaymentMethodKind.Onchain))
             assertTrue(cdkInfo.effectiveMintUnits.contains("usd"))
 
             step = "CDK BOLT11 sat mint"

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkMintMethodMapping.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkMintMethodMapping.kt
@@ -1,0 +1,36 @@
+package com.cashu.me.Core.CDK
+
+import com.cashu.me.Models.PaymentMethodKind
+import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
+import org.cashudevkit.Nuts as CdkNuts
+import org.cashudevkit.PaymentMethod as CdkPaymentMethod
+
+/**
+ * NUT-04 mint rails exactly as reported by the mint: an empty list stays empty
+ * (reported-absent — the detail screen hides the direction). The unknown /
+ * never-fetched compatibility default lives on `MintInfo.effectiveMintMethods`,
+ * not here. Unknown custom rails are dropped, never remapped (iOS `compactMap`).
+ */
+internal fun CdkNuts.reportedMintMethods(): List<PaymentMethodKind> =
+    nut04.methods
+        .mapNotNull { it.method.toKnownPaymentMethodKind() }
+        .distinct()
+        .sortedBy { it.sortOrder }
+
+/**
+ * NUT-05 melt rails exactly as reported, sat-only (pay-side non-sat is
+ * deferred). Same reported-empty semantics as [reportedMintMethods].
+ */
+internal fun CdkNuts.reportedMeltMethods(): List<PaymentMethodKind> =
+    nut05.methods
+        .filter { it.unit == CdkCurrencyUnit.Sat }
+        .mapNotNull { it.method.toKnownPaymentMethodKind() }
+        .distinct()
+        .sortedBy { it.sortOrder }
+
+private fun CdkPaymentMethod.toKnownPaymentMethodKind(): PaymentMethodKind? = when (this) {
+    CdkPaymentMethod.Bolt11 -> PaymentMethodKind.Bolt11
+    CdkPaymentMethod.Bolt12 -> PaymentMethodKind.Bolt12
+    CdkPaymentMethod.Onchain -> PaymentMethodKind.Onchain
+    is CdkPaymentMethod.Custom -> PaymentMethodKind.fromRaw(method)
+}

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -20,10 +20,12 @@ import com.cashu.me.Models.MeltPaymentResult
 import com.cashu.me.Models.MeltQuoteInfo
 import com.cashu.me.Models.MeltQuoteState
 import com.cashu.me.Models.MeltSettlement
+import com.cashu.me.Models.MintContact
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
-import com.cashu.me.Models.NutSupport
 import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.MintSoftware
+import com.cashu.me.Models.NutSupport
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.Models.RestoreMintResult
 import com.cashu.me.Models.SendTokenResult
@@ -747,6 +749,9 @@ class CdkWalletGatewayImpl : WalletGateway {
             mintUnits = mintUnits,
             supportedMintMethods = mintMethods,
             supportedMeltMethods = meltMethods,
+            contacts = contact.orEmpty().map { MintContact(method = it.method, info = it.info) },
+            tosUrl = tosUrl,
+            software = version?.let { MintSoftware(name = it.name, version = it.version) },
             descriptionLong = descriptionLong,
             motd = motd,
             nutSupport = NutSupport(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -724,19 +724,10 @@ class CdkWalletGatewayImpl : WalletGateway {
     }
 
     private fun CdkMintInfo.toDomain(mintUrl: String): MintInfo {
-        // NUT-04 methods are no longer filtered to sat — minting into usd/eur is
-        // supported. NUT-05 melt stays sat-only (pay-side non-sat is deferred).
-        val mintMethods = nuts.nut04.methods
-            .map { it.method.toDomain() }
-            .distinct()
-            .sortedBy { it.sortOrder }
-            .ifEmpty { listOf(PaymentMethodKind.Bolt11) }
-        val meltMethods = nuts.nut05.methods
-            .filter { it.unit == CdkCurrencyUnit.Sat }
-            .map { it.method.toDomain() }
-            .distinct()
-            .sortedBy { it.sortOrder }
-            .ifEmpty { listOf(PaymentMethodKind.Bolt11) }
+        // NUT-04/05 rails keep their reported-empty state (an absent direction is
+        // hidden, not replaced with BOLT11); see CdkMintMethodMapping.kt.
+        val mintMethods = nuts.reportedMintMethods()
+        val meltMethods = nuts.reportedMeltMethods()
         val units = (nuts.mintUnits + nuts.meltUnits)
             .map { it.toDomainUnit() }
             .distinct()

--- a/android/app/src/main/java/com/cashu/me/Core/MintSelection.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintSelection.kt
@@ -28,7 +28,7 @@ internal fun compatibleMintsForMeltPayment(
     mints: List<MintInfo>,
     paymentMethod: PaymentMethodKind,
 ): List<MintInfo> =
-    mints.filter { paymentMethod in it.supportedMeltMethods }
+    mints.filter { paymentMethod in it.effectiveMeltMethods }
 
 internal fun selectMintForMeltPayment(
     mints: List<MintInfo>,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -455,8 +455,11 @@ class WalletManager(
                 iconUrl = fetched.iconUrl ?: mint.iconUrl,
                 units = fetched.units.ifEmpty { mint.units },
                 mintUnits = fetched.mintUnits.ifEmpty { mint.mintUnits },
-                supportedMintMethods = fetched.supportedMintMethods.ifEmpty { mint.supportedMintMethods },
-                supportedMeltMethods = fetched.supportedMeltMethods.ifEmpty { mint.supportedMeltMethods },
+                // A live report is authoritative — including a reported-empty
+                // list (the mint dropped a rail); only an unknown (unfetched)
+                // value keeps the previously stored one.
+                supportedMintMethods = fetched.supportedMintMethods ?: mint.supportedMintMethods,
+                supportedMeltMethods = fetched.supportedMeltMethods ?: mint.supportedMeltMethods,
                 lastUpdatedEpochMillis = System.currentTimeMillis(),
                 balance = mint.balance,
                 isActive = mint.isActive,

--- a/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
@@ -20,6 +20,11 @@ data class MintInfo(
     val supportedMintMethods: List<PaymentMethodKind>? = null,
     val supportedMeltMethods: List<PaymentMethodKind>? = null,
     val onchainMintConfirmations: Int? = null,
+    // NUT-06 self-reported metadata (contact / terms / software). Empty or null
+    // when the mint did not report it — the UI never invents placeholders.
+    val contacts: List<MintContact> = emptyList(),
+    val tosUrl: String? = null,
+    val software: MintSoftware? = null,
     val descriptionLong: String? = null,
     val motd: String? = null,
     val nutSupport: NutSupport = NutSupport(),
@@ -58,6 +63,23 @@ data class MintInfo(
         else -> candidates.sorted().firstOrNull() ?: "sat"
     }
 }
+
+/**
+ * One contact channel the mint self-reports via NUT-06 (`method` is e.g.
+ * "email", "nostr", "twitter"; `info` the address/handle/URL).
+ */
+@Serializable
+data class MintContact(
+    val method: String,
+    val info: String,
+)
+
+/** Mint implementation name + version self-reported via NUT-06. */
+@Serializable
+data class MintSoftware(
+    val name: String,
+    val version: String,
+)
 
 /**
  * Per-NUT capability flags reported by the mint (NUT-06 info). All default false so

--- a/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Mints/MintInfo.kt
@@ -14,8 +14,11 @@ data class MintInfo(
     // NUT-04 mintable units. Empty for records stored before multi-unit landed;
     // effectiveMintUnits falls back to the full unit set until the next refresh.
     val mintUnits: List<String> = emptyList(),
-    val supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
-    val supportedMeltMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
+    // NUT-04/NUT-05 rails, tri-state: null = never fetched (unknown — the
+    // compatibility default applies), empty = the live mint reported none
+    // (absent — hide the direction), non-empty = the reported methods.
+    val supportedMintMethods: List<PaymentMethodKind>? = null,
+    val supportedMeltMethods: List<PaymentMethodKind>? = null,
     val onchainMintConfirmations: Int? = null,
     val descriptionLong: String? = null,
     val motd: String? = null,
@@ -23,6 +26,18 @@ data class MintInfo(
     val lastUpdatedEpochMillis: Long = System.currentTimeMillis(),
 ) {
     val id: String get() = url
+
+    /**
+     * Mint (receive) rails with the pre-fetch compatibility default: a mint whose
+     * NUT-06 metadata was never fetched is assumed BOLT11; a mint that reported
+     * an empty list stays empty.
+     */
+    val effectiveMintMethods: List<PaymentMethodKind>
+        get() = supportedMintMethods ?: listOf(PaymentMethodKind.Bolt11)
+
+    /** Melt (send) rails with the pre-fetch compatibility default (see [effectiveMintMethods]). */
+    val effectiveMeltMethods: List<PaymentMethodKind>
+        get() = supportedMeltMethods ?: listOf(PaymentMethodKind.Bolt11)
 
     val effectiveMintUnits: List<String> get() = mintUnits.ifEmpty { units }
 

--- a/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/InspectorRow.kt
@@ -38,6 +38,8 @@ private val InspectorEditHintSize = 16.dp
  * @param loading skeleton fill-in (iOS `.redacted(.placeholder)` on confirm fee
  *   rows): while true a quiet placeholder bar holds the value slot, then the
  *   real value crossfades in place when it lands.
+ * @param secondaryValue optional caption beneath the value (iOS mint detail's
+ *   fiat conversion under the sat balance), always quiet onSurfaceVariant.
  */
 @Composable
 fun InspectorRow(
@@ -51,6 +53,7 @@ fun InspectorRow(
     trailingIconTint: Color? = null,
     valueMonospaced: Boolean = false,
     valueColor: Color? = null,
+    secondaryValue: String? = null,
     loading: Boolean = false,
 ) {
     val rowMod = if (onClick != null) {
@@ -83,16 +86,30 @@ fun InspectorRow(
         // flush against the trailing edge, matching iOS (HStack + Spacer).
         Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.CenterEnd) {
             SkeletonValue(loading = loading) {
-                Text(
-                    text = value,
-                    style = if (valueMonospaced) {
-                        MaterialTheme.typography.bodyMedium.withMonoDigits()
-                    } else MaterialTheme.typography.bodyMedium,
-                    color = valueColor ?: MaterialTheme.colorScheme.onSurface,
-                    maxLines = 1,
-                    overflow = TextOverflow.MiddleEllipsis,
-                    textAlign = TextAlign.End,
-                )
+                Column(horizontalAlignment = Alignment.End) {
+                    Text(
+                        text = value,
+                        style = if (valueMonospaced) {
+                            MaterialTheme.typography.bodyMedium.withMonoDigits()
+                        } else MaterialTheme.typography.bodyMedium,
+                        color = valueColor ?: MaterialTheme.colorScheme.onSurface,
+                        maxLines = 1,
+                        overflow = TextOverflow.MiddleEllipsis,
+                        textAlign = TextAlign.End,
+                    )
+                    if (secondaryValue != null) {
+                        Text(
+                            text = secondaryValue,
+                            style = if (valueMonospaced) {
+                                MaterialTheme.typography.bodySmall.withMonoDigits()
+                            } else MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            maxLines = 1,
+                            overflow = TextOverflow.MiddleEllipsis,
+                            textAlign = TextAlign.End,
+                        )
+                    }
+                }
             }
         }
         if (editable) {

--- a/android/app/src/main/java/com/cashu/me/ui/components/MintMethodChips.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/MintMethodChips.kt
@@ -36,7 +36,7 @@ fun MintMethodChips(
     modifier: Modifier = Modifier,
 ) {
     val methods = remember(mint.supportedMintMethods, mint.supportedMeltMethods) {
-        (mint.supportedMintMethods + mint.supportedMeltMethods).distinct().sortedBy { it.sortOrder }
+        (mint.effectiveMintMethods + mint.effectiveMeltMethods).distinct().sortedBy { it.sortOrder }
     }
     MintMethodChips(methods = methods, modifier = modifier)
 }

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintContactLinks.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintContactLinks.kt
@@ -1,0 +1,62 @@
+package com.cashu.me.ui.mints
+
+import java.net.URI
+
+/**
+ * Build a tappable target for a mint-reported contact (iOS `contactURL`).
+ * The scheme allowlist is mailto:/http(s) with a parseable host — everything
+ * else (javascript:, intent:, garbage) returns null and the row renders as
+ * plain text instead of a dead or unsafe link.
+ */
+internal fun mintContactLink(method: String, info: String): String? {
+    val trimmed = info.trim()
+    if (trimmed.isEmpty()) return null
+    val candidate = when (method.trim().lowercase()) {
+        "email" -> if (isPlausibleEmail(trimmed)) "mailto:$trimmed" else null
+        "website", "url", "web" -> withHttpScheme(trimmed)        "twitter", "x" ->
+            if (trimmed.startsWith("http")) trimmed
+            else "https://twitter.com/${trimmed.removePrefix("@")}"
+        "telegram" ->
+            if (trimmed.startsWith("http")) trimmed
+            else "https://t.me/${trimmed.removePrefix("@")}"
+        else -> if (trimmed.startsWith("http")) trimmed else null
+    } ?: return null
+    return candidate.takeIf(::isSafeExternalLink)
+}
+
+/**
+ * A mint-reported external URL (e.g. Terms of Service) that is safe to open:
+ * trimmed, http(s) only, with a non-blank host. Null when invalid or absent,
+ * so callers render no row rather than a dead one.
+ */
+internal fun safeExternalHttpUrl(raw: String?): String? {
+    val trimmed = raw?.trim().orEmpty()
+    if (trimmed.isEmpty()) return null
+    return trimmed.takeIf(::isSafeExternalLink)
+}
+
+/** Host portion of a safe external URL, for labeling the link's destination. */
+internal fun externalUrlHost(url: String): String? =
+    runCatching { URI(url).host }.getOrNull()
+
+// Bare hosts gain https://; anything already carrying a non-http scheme
+// (intent:, ftp:, javascript:, …) is rejected rather than disguised.
+private val explicitScheme = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+private fun withHttpScheme(raw: String): String? = when {
+    raw.startsWith("http") -> raw
+    explicitScheme.containsMatchIn(raw) -> null
+    else -> "https://$raw"
+}
+
+private fun isPlausibleEmail(value: String): Boolean =
+    value.length <= 254 && value.none { it.isWhitespace() } && value.count { it == '@' } == 1
+
+private fun isSafeExternalLink(url: String): Boolean {
+    val uri = runCatching { URI(url) }.getOrNull() ?: return false
+    return when (uri.scheme?.lowercase()) {
+        "mailto" -> true
+        "http", "https" -> !uri.host.isNullOrBlank()
+        else -> false
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -73,8 +73,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
+import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.shortenMintUrl
@@ -101,10 +104,14 @@ import com.cashu.me.ui.testing.UiTestTags
 @Composable
 fun MintDetailScreen(
     walletManager: WalletManager,
+    settingsManager: SettingsManager,
+    priceService: PriceService,
     mintUrl: String,
     onClose: () -> Unit,
 ) {
     val walletState by walletManager.state.collectAsState()
+    val settings by settingsManager.state.collectAsState()
+    val priceState by priceService.state.collectAsState()
     val mint = walletState.mints.firstOrNull { it.url == mintUrl }
     val isActive = walletState.activeMint?.url == mintUrl
     var confirmingRemove by remember { mutableStateOf(false) }
@@ -206,6 +213,15 @@ fun MintDetailScreen(
                 InspectorRow(
                     label = "Balance",
                     value = "${mint.balance} sat",
+                    // iOS parity: the fiat conversion rides beneath the sat
+                    // balance when the user enabled it — sats only, never the
+                    // non-sat unit rows below.
+                    secondaryValue = mintSatBalanceFiatSecondary(
+                        balanceSats = mint.balance,
+                        showFiat = settings.showFiatBalance,
+                        btcPrice = priceState.btcPrice,
+                        currencyCode = settings.bitcoinPriceCurrency,
+                    ),
                     leadingIcon = Icons.Outlined.CurrencyBitcoin,
                     valueMonospaced = true,
                 )
@@ -726,6 +742,23 @@ private fun mintContactIcon(method: String): ImageVector = when (method.trim().l
     "website", "url", "web" -> Icons.Outlined.Public
     "telegram" -> Icons.Outlined.Send
     else -> Icons.Outlined.Person
+}
+
+/**
+ * Fiat caption beneath a sat balance (iOS `showFiat`): only when the user's
+ * fiat-balance preference is on and a usable BTC price is loaded. Sub-cent
+ * conversions stay hidden (`AmountFormatter.formatFiat` returns null), and
+ * non-sat unit balances never reach here — they render native-only.
+ */
+internal fun mintSatBalanceFiatSecondary(
+    balanceSats: Long,
+    showFiat: Boolean,
+    btcPrice: Double,
+    currencyCode: String,
+    formatter: AmountFormatter = AmountFormatter(),
+): String? {
+    if (!showFiat || btcPrice <= 0) return null
+    return formatter.formatFiat(balanceSats, btcPrice, currencyCode)
 }
 
 // Inline copy-row glyph (smaller than the body 20dp).

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -433,6 +433,15 @@ fun MintDetailScreen(
                 }
             }
 
+            // Provenance (iOS `footerNote`): descriptions, contacts, software,
+            // and terms above are the mint's own claims, not wallet-verified.
+            Text(
+                text = "Information reported by the mint.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
+            )
+
             Spacer(Modifier.height(CashuTheme.spacing.comfortable))
             Column(
                 modifier = Modifier

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -115,6 +115,8 @@ fun MintDetailScreen(
     val mint = walletState.mints.firstOrNull { it.url == mintUrl }
     val isActive = walletState.activeMint?.url == mintUrl
     var confirmingRemove by remember { mutableStateOf(false) }
+    var settingDefault by remember(mintUrl) { mutableStateOf(false) }
+    var setDefaultError by remember(mintUrl) { mutableStateOf<String?>(null) }
 
     Scaffold(
         modifier = Modifier.testTag(UiTestTags.MintDetailScreen),
@@ -467,10 +469,26 @@ fun MintDetailScreen(
             ) {
                 // When it's the default, the button disappears and the header
                 // shows a "Default mint" pill instead (iOS parity).
+                if (setDefaultError != null) {
+                    InlineNotice(text = setDefaultError.orEmpty())
+                }
                 if (!isActive) {
+                    // iOS parity: progress disables the action while in flight
+                    // and a failure renders inline without flipping the
+                    // apparent default (the pill/header only follow walletState).
                     PrimaryButton(
                         text = "Set as Default",
-                        onClick = { walletManager.launch { walletManager.setActiveMint(mint) } },
+                        loading = settingDefault,
+                        onClick = {
+                            if (settingDefault) return@PrimaryButton
+                            settingDefault = true
+                            setDefaultError = null
+                            walletManager.launch {
+                                runCatching { walletManager.setActiveMint(mint) }
+                                    .onFailure { setDefaultError = it.userFacingWalletMessage }
+                                settingDefault = false
+                            }
+                        },
                         colors = neutralActionButtonColors(),
                     )
                 }

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -281,19 +281,31 @@ fun MintDetailScreen(
                 TechnicalDetails(nut = live.nutSupport)
             }
 
-            SectionHeader("Payment methods")
-            Column(modifier = Modifier.fillMaxWidth()) {
-                InspectorRow(
-                    label = "Receive",
-                    value = mint.supportedMintMethods.distinct().joinToString(" · ") { it.displayName }.ifBlank { "None" },
-                    leadingIcon = Icons.Outlined.ArrowDownward,
-                )
-                CanvasDivider(leadingInset = 16.dp)
-                InspectorRow(
-                    label = "Send",
-                    value = mint.supportedMeltMethods.distinct().joinToString(" · ") { it.displayName }.ifBlank { "None" },
-                    leadingIcon = Icons.Outlined.ArrowUpward,
-                )
+            // Live NUT-06 is authoritative for the rails; the persisted report
+            // fills in until it lands, and the BOLT11 compatibility default only
+            // applies to a mint that was never fetched (tri-state — a direction
+            // the live mint reported as absent is hidden, matching iOS).
+            val receiveMethods = liveInfo?.supportedMintMethods ?: mint.effectiveMintMethods
+            val sendMethods = liveInfo?.supportedMeltMethods ?: mint.effectiveMeltMethods
+            if (receiveMethods.isNotEmpty() || sendMethods.isNotEmpty()) {
+                SectionHeader("Payment methods")
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    if (receiveMethods.isNotEmpty()) {
+                        InspectorRow(
+                            label = "Receive",
+                            value = receiveMethods.joinToString(" · ") { it.displayName },
+                            leadingIcon = Icons.Outlined.ArrowDownward,
+                        )
+                    }
+                    if (sendMethods.isNotEmpty()) {
+                        if (receiveMethods.isNotEmpty()) CanvasDivider(leadingInset = 16.dp)
+                        InspectorRow(
+                            label = "Send",
+                            value = sendMethods.joinToString(" · ") { it.displayName },
+                            leadingIcon = Icons.Outlined.ArrowUpward,
+                        )
+                    }
+                }
             }
 
             SectionHeader("Details")

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
+import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.shortenMintUrl
 import com.cashu.me.Models.MintInfo
@@ -73,10 +74,12 @@ import com.cashu.me.ui.components.CanvasDivider
 import com.cashu.me.ui.components.DestructiveTextButton
 import com.cashu.me.ui.components.GhostButton
 import com.cashu.me.ui.components.IconSwap
+import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.InspectorRow
 import com.cashu.me.ui.components.MintAvatar
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.SectionHeader
+import com.cashu.me.ui.components.SpinnerRing
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.components.neutralActionButtonColors
 import com.cashu.me.ui.theme.CapsuleShape
@@ -145,20 +148,48 @@ fun MintDetailScreen(
             // metadata (long description, MOTD, capabilities) — mirroring iOS's
             // `cdkInfo`. `info` prefers the fetched record, falling back to the
             // persisted mint until it lands (persisted supplies balance/icon/name).
+            // A failed fetch surfaces an inline explanation + Retry, and the rows
+            // below keep showing the saved record (stale), never a fake success.
             var liveInfo by remember(mint.url) { mutableStateOf<MintInfo?>(null) }
             var connection by remember(mint.url) { mutableStateOf(MintConnectionState.Checking) }
-            LaunchedEffect(mint.url) {
+            var infoError by remember(mint.url) { mutableStateOf<String?>(null) }
+            var refreshNonce by remember(mint.url) { mutableStateOf(0) }
+            LaunchedEffect(mint.url, refreshNonce) {
+                connection = MintConnectionState.Checking
+                infoError = null
                 runCatching { walletManager.fetchLiveMintInfo(mint.url) }
                     .fold(
                         { fetched ->
-                            liveInfo = fetched
-                            connection = if (fetched != null) MintConnectionState.Online
-                            else MintConnectionState.Offline
+                            if (fetched != null) {
+                                liveInfo = fetched
+                                connection = MintConnectionState.Online
+                            } else {
+                                connection = MintConnectionState.Offline
+                                infoError = "The mint did not respond."
+                            }
                         },
-                        { connection = MintConnectionState.Offline },
+                        { error ->
+                            connection = MintConnectionState.Offline
+                            infoError = error.userFacingWalletMessage
+                        },
                     )
             }
             val info = liveInfo ?: mint
+
+            if (infoError != null) {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    InlineNotice(
+                        text = infoError.orEmpty(),
+                        detail = "Showing saved information.",
+                    )
+                    GhostButton(
+                        text = "Retry",
+                        onClick = { refreshNonce += 1 },
+                        enabled = connection != MintConnectionState.Checking,
+                        modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
+                    )
+                }
+            }
 
             Column(modifier = Modifier.fillMaxWidth()) {
                 InspectorRow(
@@ -189,6 +220,33 @@ fun MintDetailScreen(
                         MintConnectionState.Online -> null
                     },
                 )
+            }
+
+            // iOS `loadingRow`: remote metadata is still in flight — hold the
+            // sections' place with a quiet spinner line instead of popping them
+            // in unannounced.
+            if (liveInfo == null && connection == MintConnectionState.Checking) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            horizontal = CashuTheme.spacing.comfortable,
+                            vertical = CashuTheme.spacing.loose,
+                        ),
+                ) {
+                    SpinnerRing(
+                        size = 18.dp,
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = "Loading mint info…",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
             }
 
             // About: short description reads primary/white; the long description

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -23,16 +23,24 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.OpenInNew
+import androidx.compose.material.icons.outlined.AlternateEmail
 import androidx.compose.material.icons.outlined.ArrowDownward
 import androidx.compose.material.icons.outlined.ArrowUpward
 import androidx.compose.material.icons.outlined.Check
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.CurrencyBitcoin
+import androidx.compose.material.icons.outlined.Description
+import androidx.compose.material.icons.outlined.Inventory2
+import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.Lock
+import androidx.compose.material.icons.outlined.MailOutline
 import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material.icons.outlined.Remove
+import androidx.compose.material.icons.outlined.Send
 import androidx.compose.material.icons.outlined.Straighten
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -55,7 +63,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -82,6 +92,7 @@ import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.SpinnerRing
 import com.cashu.me.ui.components.ToolbarIcon
 import com.cashu.me.ui.components.neutralActionButtonColors
+import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.theme.CapsuleShape
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.testing.UiTestTags
@@ -366,12 +377,61 @@ fun MintDetailScreen(
                 }
             }
 
+            // Contact: every channel the live mint reported (blank values are
+            // skipped — no dead rows). A row only becomes tappable when its
+            // target parses into the mailto:/http(s) allowlist; anything else
+            // stays plain text (iOS `contactSection` + `contactURL`).
+            val context = LocalContext.current
+            val contactRows = liveInfo?.contacts.orEmpty()
+                .filter { it.info.isNotBlank() }
+                .map { contact -> contact to mintContactLink(contact.method, contact.info) }
+            if (contactRows.isNotEmpty()) {
+                SectionHeader("Contact")
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    contactRows.forEachIndexed { index, (contact, link) ->
+                        InspectorRow(
+                            label = contact.method.replaceFirstChar { it.uppercase() },
+                            value = contact.info,
+                            leadingIcon = mintContactIcon(contact.method),
+                            onClick = link?.let { target -> { context.openInBrowser(target) } },
+                            valueColor = if (link != null) MaterialTheme.colorScheme.primary else null,
+                        )
+                        if (index < contactRows.lastIndex) CanvasDivider(leadingInset = 16.dp)
+                    }
+                }
+            }
+
+            // Details: software and terms come only from the live NUT-06 record
+            // (iOS gates on `cdkInfo`) — absent or unparseable values render no
+            // row rather than a placeholder or a dead link.
+            val tosUrl = safeExternalHttpUrl(liveInfo?.tosUrl)
+            val software = liveInfo?.software
             SectionHeader("Details")
-            InspectorRow(
-                label = "Units",
-                value = mint.units.joinToString(", ").ifBlank { "sat" },
-                leadingIcon = Icons.Outlined.Straighten,
-            )
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (software != null) {
+                    InspectorRow(
+                        label = "Software",
+                        value = "${software.name} ${software.version}",
+                        leadingIcon = Icons.Outlined.Inventory2,
+                    )
+                    CanvasDivider(leadingInset = 16.dp)
+                }
+                InspectorRow(
+                    label = "Units",
+                    value = mint.units.joinToString(", ").ifBlank { "sat" },
+                    leadingIcon = Icons.Outlined.Straighten,
+                )
+                if (tosUrl != null) {
+                    CanvasDivider(leadingInset = 16.dp)
+                    InspectorRow(
+                        label = "Terms of Service",
+                        value = externalUrlHost(tosUrl) ?: tosUrl,
+                        leadingIcon = Icons.Outlined.Description,
+                        onClick = { context.openInBrowser(tosUrl) },
+                        trailingIcon = Icons.AutoMirrored.Outlined.OpenInNew,
+                    )
+                }
+            }
 
             Spacer(Modifier.height(CashuTheme.spacing.comfortable))
             Column(
@@ -647,6 +707,16 @@ private enum class MintConnectionState(val label: String) {
     Checking("Checking…"),
     Online("Online"),
     Offline("Offline"),
+}
+
+/// Per-channel contact glyph (iOS `contactIcon`).
+private fun mintContactIcon(method: String): ImageVector = when (method.trim().lowercase()) {
+    "email" -> Icons.Outlined.MailOutline
+    "twitter", "x" -> Icons.Outlined.AlternateEmail
+    "nostr" -> Icons.Outlined.Key
+    "website", "url", "web" -> Icons.Outlined.Public
+    "telegram" -> Icons.Outlined.Send
+    else -> Icons.Outlined.Person
 }
 
 // Inline copy-row glyph (smaller than the body 20dp).

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDiscoveryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDiscoveryScreen.kt
@@ -231,7 +231,7 @@ private fun DiscoveryRow(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f, fill = false),
                 )
-                if (mint.supportedMintMethods.isNotEmpty() || mint.supportedMeltMethods.isNotEmpty()) {
+                if (!mint.supportedMintMethods.isNullOrEmpty() || !mint.supportedMeltMethods.isNullOrEmpty()) {
                     MintMethodChips(mint = mint)
                 }
             }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -96,6 +96,8 @@ fun CashuNavHost(
             val mintUrl = URLDecoder.decode(encoded, StandardCharsets.UTF_8.name())
             MintDetailScreen(
                 walletManager = container.walletManager,
+                settingsManager = container.settingsManager,
+                priceService = container.priceService,
                 mintUrl = mintUrl,
                 onClose = { navController.popBackStack() },
             )

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
@@ -1,0 +1,123 @@
+package com.cashu.me.Core.CDK
+
+import com.cashu.me.Models.PaymentMethodKind
+import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
+import org.cashudevkit.MeltMethodSettings as CdkMeltMethodSettings
+import org.cashudevkit.MintMethodSettings as CdkMintMethodSettings
+import org.cashudevkit.Nut04Settings as CdkNut04Settings
+import org.cashudevkit.Nut05Settings as CdkNut05Settings
+import org.cashudevkit.Nut29Settings as CdkNut29Settings
+import org.cashudevkit.Nuts as CdkNuts
+import org.cashudevkit.PaymentMethod as CdkPaymentMethod
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * NUT-04/05 rails keep their tri-state through the CDK → domain mapping:
+ * reported-empty stays empty (never substituted with BOLT11) and unknown custom
+ * rails are dropped, matching iOS `supportedMintPaymentMethods` / `…Melt…`.
+ */
+class CdkMintMethodMappingTest {
+
+    @Test
+    fun emptyNut04MethodListStaysReportedEmpty() {
+        val nuts = nuts(nut04Methods = emptyList())
+
+        assertTrue(nuts.reportedMintMethods().isEmpty())
+    }
+
+    @Test
+    fun emptyNut05MethodListStaysReportedEmpty() {
+        val nuts = nuts(nut05Methods = emptyList())
+
+        assertTrue(nuts.reportedMeltMethods().isEmpty())
+    }
+
+    @Test
+    fun mintMethodsAreDedupedAcrossUnitsAndSortedCanonically() {
+        val nuts = nuts(
+            nut04Methods = listOf(
+                mintMethod(CdkPaymentMethod.Onchain, CdkCurrencyUnit.Sat),
+                mintMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Sat),
+                mintMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Usd),
+                mintMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat),
+            ),
+        )
+
+        assertEquals(
+            listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Bolt12, PaymentMethodKind.Onchain),
+            nuts.reportedMintMethods(),
+        )
+    }
+
+    @Test
+    fun meltMethodsStaySatOnly() {
+        val nuts = nuts(
+            nut05Methods = listOf(
+                meltMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Usd),
+                meltMethod(CdkPaymentMethod.Bolt12, CdkCurrencyUnit.Sat),
+            ),
+        )
+
+        assertEquals(listOf(PaymentMethodKind.Bolt12), nuts.reportedMeltMethods())
+    }
+
+    @Test
+    fun unknownCustomMethodsAreDroppedNotRemapped() {
+        val nuts = nuts(
+            nut04Methods = listOf(
+                mintMethod(CdkPaymentMethod.Custom("unknown"), CdkCurrencyUnit.Sat),
+            ),
+            nut05Methods = listOf(
+                meltMethod(CdkPaymentMethod.Custom("unknown"), CdkCurrencyUnit.Sat),
+            ),
+        )
+
+        assertTrue(nuts.reportedMintMethods().isEmpty())
+        assertTrue(nuts.reportedMeltMethods().isEmpty())
+    }
+
+    private fun mintMethod(method: CdkPaymentMethod, unit: CdkCurrencyUnit) =
+        CdkMintMethodSettings(
+            method = method,
+            unit = unit,
+            minAmount = null,
+            maxAmount = null,
+            description = null,
+        )
+
+    private fun meltMethod(method: CdkPaymentMethod, unit: CdkCurrencyUnit) =
+        CdkMeltMethodSettings(
+            method = method,
+            unit = unit,
+            minAmount = null,
+            maxAmount = null,
+            amountless = null,
+        )
+
+    private fun nuts(
+        nut04Methods: List<CdkMintMethodSettings> = listOf(
+            mintMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Sat),
+        ),
+        nut05Methods: List<CdkMeltMethodSettings> = listOf(
+            meltMethod(CdkPaymentMethod.Bolt11, CdkCurrencyUnit.Sat),
+        ),
+    ) = CdkNuts(
+        nut04 = CdkNut04Settings(methods = nut04Methods, disabled = false),
+        nut05 = CdkNut05Settings(methods = nut05Methods, disabled = false),
+        nut07Supported = false,
+        nut08Supported = false,
+        nut09Supported = false,
+        nut10Supported = false,
+        nut11Supported = false,
+        nut12Supported = false,
+        nut14Supported = false,
+        nut20Supported = false,
+        nut21 = null,
+        nut22 = null,
+        nut29 = CdkNut29Settings(maxBatchSize = null, methods = null),
+        mintUnits = listOf(CdkCurrencyUnit.Sat),
+        meltUnits = listOf(CdkCurrencyUnit.Sat),
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/Core/MintInfoMethodsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintInfoMethodsTest.kt
@@ -1,0 +1,70 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.PaymentMethodKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tri-state NUT-04/05 rails on [MintInfo]: null = never fetched (compatibility
+ * default applies), empty = reported-absent (stays empty), non-empty = reported.
+ */
+class MintInfoMethodsTest {
+
+    @Test
+    fun unknownRailsFallBackToBolt11CompatibilityDefault() {
+        val mint = MintInfo(url = "https://mint.example")
+
+        assertEquals(listOf(PaymentMethodKind.Bolt11), mint.effectiveMintMethods)
+        assertEquals(listOf(PaymentMethodKind.Bolt11), mint.effectiveMeltMethods)
+    }
+
+    @Test
+    fun reportedEmptyRailsStayEmpty() {
+        val mint = MintInfo(
+            url = "https://mint.example",
+            supportedMintMethods = emptyList(),
+            supportedMeltMethods = emptyList(),
+        )
+
+        assertTrue(mint.effectiveMintMethods.isEmpty())
+        assertTrue(mint.effectiveMeltMethods.isEmpty())
+    }
+
+    @Test
+    fun reportedRailsPassThrough() {
+        val mint = MintInfo(
+            url = "https://mint.example",
+            supportedMintMethods = listOf(PaymentMethodKind.Bolt12),
+            supportedMeltMethods = listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Onchain),
+        )
+
+        assertEquals(listOf(PaymentMethodKind.Bolt12), mint.effectiveMintMethods)
+        assertEquals(listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Onchain), mint.effectiveMeltMethods)
+    }
+
+    @Test
+    fun meltSelectionAssumesBolt11OnlyForUnfetchedMints() {
+        val unfetched = MintInfo(url = "https://unfetched.example", balance = 100)
+        val reportedEmpty = MintInfo(
+            url = "https://empty.example",
+            balance = 100,
+            supportedMeltMethods = emptyList(),
+        )
+
+        val bolt11Compatible = compatibleMintsForMeltPayment(
+            mints = listOf(unfetched, reportedEmpty),
+            paymentMethod = PaymentMethodKind.Bolt11,
+        )
+        val onchainCompatible = compatibleMintsForMeltPayment(
+            mints = listOf(unfetched, reportedEmpty),
+            paymentMethod = PaymentMethodKind.Onchain,
+        )
+
+        // Unknown (never fetched) keeps the BOLT11 compatibility default…
+        assertEquals(listOf(unfetched), bolt11Compatible)
+        // …but only for BOLT11, and a mint that reported no melt rails is excluded.
+        assertTrue(onchainCompatible.isEmpty())
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/ui/mints/MintContactLinksTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/mints/MintContactLinksTest.kt
@@ -1,0 +1,70 @@
+package com.cashu.me.ui.mints
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Mint-reported contacts and external links only become tappable when they
+ * parse into the mailto:/http(s) allowlist (iOS `contactURL`, hardened).
+ */
+class MintContactLinksTest {
+
+    @Test
+    fun emailBuildsMailtoForPlausibleAddresses() {
+        assertEquals("mailto:support@mint.example", mintContactLink("email", "support@mint.example"))
+        assertEquals("mailto:support@mint.example", mintContactLink("Email", "  support@mint.example  "))
+    }
+
+    @Test
+    fun emailWithoutAddressShapeIsNotTappable() {
+        assertNull(mintContactLink("email", "not-an-address"))
+        assertNull(mintContactLink("email", "two @ addresses"))
+        assertNull(mintContactLink("email", ""))
+    }
+
+    @Test
+    fun websiteGainsHttpsSchemeWhenMissing() {
+        assertEquals("https://mint.example", mintContactLink("website", "mint.example"))
+        assertEquals("https://mint.example/about", mintContactLink("url", "https://mint.example/about"))
+        assertEquals("http://mint.example", mintContactLink("web", "http://mint.example"))
+    }
+
+    @Test
+    fun twitterAndTelegramHandlesBecomeProfileLinks() {
+        assertEquals("https://twitter.com/mint", mintContactLink("twitter", "@mint"))
+        assertEquals("https://twitter.com/mint", mintContactLink("x", "mint"))
+        assertEquals("https://t.me/mint", mintContactLink("telegram", "@mint"))
+        assertEquals("https://t.me/s/mint", mintContactLink("telegram", "https://t.me/s/mint"))
+    }
+
+    @Test
+    fun nostrAndUnknownMethodsStayTextUnlessTheyAreUrls() {
+        assertNull(mintContactLink("nostr", "npub1abc"))
+        assertEquals("https://mint.example", mintContactLink("nostr", "https://mint.example"))
+    }
+
+    @Test
+    fun unsafeSchemesAreRejected() {
+        assertNull(mintContactLink("website", "javascript:alert(1)"))
+        assertNull(mintContactLink("website", "intent://scan"))
+        assertNull(mintContactLink("website", "file:///etc/passwd"))
+        assertNull(mintContactLink("website", "https://"))
+    }
+
+    @Test
+    fun termsOfServiceUrlMustBeHttpWithAHost() {
+        assertEquals("https://mint.example/tos", safeExternalHttpUrl(" https://mint.example/tos "))
+        assertNull(safeExternalHttpUrl(null))
+        assertNull(safeExternalHttpUrl(""))
+        assertNull(safeExternalHttpUrl("not a url"))
+        assertNull(safeExternalHttpUrl("ftp://mint.example/tos"))
+        assertNull(safeExternalHttpUrl("https://"))
+    }
+
+    @Test
+    fun hostExtractionLabelsTheDestination() {
+        assertEquals("mint.example", externalUrlHost("https://mint.example/tos?x=1"))
+        assertNull(externalUrlHost("not a url"))
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/ui/mints/MintSatBalanceFiatSecondaryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/mints/MintSatBalanceFiatSecondaryTest.kt
@@ -1,0 +1,62 @@
+package com.cashu.me.ui.mints
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The fiat caption beneath the mint detail's sat balance mirrors the global
+ * fiat-balance preference and needs a usable BTC price; sub-cent conversions
+ * stay hidden (iOS `showFiat`).
+ */
+class MintSatBalanceFiatSecondaryTest {
+
+    @Test
+    fun preferenceOffHidesTheCaption() {
+        assertNull(
+            mintSatBalanceFiatSecondary(
+                balanceSats = 100_000,
+                showFiat = false,
+                btcPrice = 50_000.0,
+                currencyCode = "USD",
+            ),
+        )
+    }
+
+    @Test
+    fun missingPriceHidesTheCaption() {
+        assertNull(
+            mintSatBalanceFiatSecondary(
+                balanceSats = 100_000,
+                showFiat = true,
+                btcPrice = 0.0,
+                currencyCode = "USD",
+            ),
+        )
+    }
+
+    @Test
+    fun subCentConversionHidesTheCaption() {
+        assertNull(
+            mintSatBalanceFiatSecondary(
+                balanceSats = 1,
+                showFiat = true,
+                btcPrice = 50_000.0,
+                currencyCode = "USD",
+            ),
+        )
+    }
+
+    @Test
+    fun enabledWithPriceShowsTheConversion() {
+        assertEquals(
+            "$50.00",
+            mintSatBalanceFiatSecondary(
+                balanceSats = 100_000,
+                showFiat = true,
+                btcPrice = 50_000.0,
+                currencyCode = "USD",
+            ),
+        )
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -124,21 +124,21 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Mint details
 
-- [ ] **[P2 · iOS → Android] Show the fiat secondary balance when enabled.** iOS adds the fiat conversion beneath the sat balance; Android shows only sats plus native non-sat-unit balances. **Done when:** Android mirrors the user’s global fiat-balance preference without converting balances whose unit is not sat.
+- [x] **[P2 · iOS → Android] Show the fiat secondary balance when enabled.** iOS adds the fiat conversion beneath the sat balance; Android shows only sats plus native non-sat-unit balances. **Done when:** Android mirrors the user’s global fiat-balance preference without converting balances whose unit is not sat.
 
-- [ ] **[P1 · iOS → Android] Distinguish cached mint metadata from live refresh state.** Android already shows Checking, Online, and Offline connection states, but it can silently display cached NUT-06 data after a live fetch fails, with no failure message or retry. iOS surfaces the failure with a banner and Offline state, though it too falls back to cached description and payment methods without a stale label. **Done when:** Android identifies loading or refresh, distinguishes cached/stale content from a successful live response, presents a user-facing failure explanation, and offers Retry where useful.
+- [x] **[P1 · iOS → Android] Distinguish cached mint metadata from live refresh state.** Android already shows Checking, Online, and Offline connection states, but it can silently display cached NUT-06 data after a live fetch fails, with no failure message or retry. iOS surfaces the failure with a banner and Offline state, though it too falls back to cached description and payment methods without a stale label. **Done when:** Android identifies loading or refresh, distinguishes cached/stale content from a successful live response, presents a user-facing failure explanation, and offers Retry where useful.
 
-- [ ] **[P1 · iOS → Android] Add the Contact section.** iOS renders reported email, web, Nostr, Twitter/X, and Telegram contacts with appropriate actions; Android omits them. **Done when:** Android displays every reported contact, labels the remote source, and opens only safely parsed supported targets.
+- [x] **[P1 · iOS → Android] Add the Contact section.** iOS renders reported email, web, Nostr, Twitter/X, and Telegram contacts with appropriate actions; Android omits them. **Done when:** Android displays every reported contact, labels the remote source, and opens only safely parsed supported targets.
 
-- [ ] **[P1 · iOS → Android] Show reported Terms of Service.** iOS includes the mint’s live Terms link; Android omits it. **Done when:** Android shows a safely parsed external link when reported, clearly identifies the destination, and handles an invalid or absent value without a dead row.
+- [x] **[P1 · iOS → Android] Show reported Terms of Service.** iOS includes the mint’s live Terms link; Android omits it. **Done when:** Android shows a safely parsed external link when reported, clearly identifies the destination, and handles an invalid or absent value without a dead row.
 
-- [ ] **[P2 · iOS → Android] Show reported mint software and version.** iOS includes the live software name/version; Android omits it. **Done when:** Android displays the fields when reported and does not invent placeholders for absent values.
+- [x] **[P2 · iOS → Android] Show reported mint software and version.** iOS includes the live software name/version; Android omits it. **Done when:** Android displays the fields when reported and does not invent placeholders for absent values.
 
-- [ ] **[P2 · iOS → Android] Add the metadata provenance footer.** iOS says “Information reported by the mint”; Android does not identify the source of remote descriptions, contacts, software, or terms. **Done when:** Android includes an equivalent qualification near the metadata.
+- [x] **[P2 · iOS → Android] Add the metadata provenance footer.** iOS says “Information reported by the mint”; Android does not identify the source of remote descriptions, contacts, software, or terms. **Done when:** Android includes an equivalent qualification near the metadata.
 
-- [ ] **[P1 · iOS → Android] Preserve and hide absent payment methods.** Android’s domain mapping substitutes BOLT11 when a live NUT-04 or NUT-05 method list is empty, and details always render both directions. **Done when:** Android preserves whether each direction was actually reported, uses compatibility fallback only when metadata is genuinely unknown, and hides a direction the live mint reports as absent.
+- [x] **[P1 · iOS → Android] Preserve and hide absent payment methods.** Android’s domain mapping substitutes BOLT11 when a live NUT-04 or NUT-05 method list is empty, and details always render both directions. **Done when:** Android preserves whether each direction was actually reported, uses compatibility fallback only when metadata is genuinely unknown, and hides a direction the live mint reports as absent.
 
-- [ ] **[P1 · iOS → Android] Surface Set as Default progress and errors.** iOS disables the action, shows progress, and renders an inline failure; Android launches the operation with no visible progress or error. **Done when:** Android prevents duplicate submission and clearly reports success or failure without changing the apparent default on failure.
+- [x] **[P1 · iOS → Android] Surface Set as Default progress and errors.** iOS disables the action, shows progress, and renders an inline failure; Android launches the operation with no visible progress or error. **Done when:** Android prevents duplicate submission and clearly reports success or failure without changing the apparent default on failure.
 
 ### Settings — information architecture, display, and destructive actions
 


### PR DESCRIPTION
Closes eight Android items in `docs/product/ios-android-parity-checklist.md` (orchestrator ticks the boxes), all in the mint-details area. iOS reference: `ios/CashuWallet/Views/Mints/MintDetailView.swift`. Six logical commits, one per area.

## Items

- **[P2] Show the fiat secondary balance when enabled.** The sat balance row now carries the fiat conversion as a quiet caption beneath the sats when the user's global fiat-balance preference is on and a BTC price is loaded (new `InspectorRow.secondaryValue` slot; `mintSatBalanceFiatSecondary` helper). Non-sat unit balances render native-only — the conversion never touches them. Verified by `MintSatBalanceFiatSecondaryTest` (preference off / zero price / sub-cent / happy path).

- **[P1] Distinguish cached mint metadata from live refresh state.** A failed live NUT-06 fetch previously flipped Connection to Offline while cached metadata kept rendering silently. The screen now shows a "Loading mint info…" row while the first fetch is in flight, an `InlineNotice` naming the failure with a "Showing saved information." stale detail, and a Retry action that re-runs the fetch (disabled while Checking). The persisted record still backs description/payment rails until a live response lands, matching iOS's unlabeled fallback.

- **[P1] Add the Contact section.** Every mint-reported contact renders with per-channel icons (email / web / Nostr / Twitter-X / Telegram / generic), labeled by its reported method. Rows become tappable only when `mintContactLink` parses the target into a mailto:/http(s) allowlist (bare hosts gain `https://`; `intent:`/`javascript:`/`ftp:`/garbage are rejected); non-tappable rows stay plain text and blank values are skipped — no dead rows. Verified by `MintContactLinksTest`.

- **[P1] Show reported Terms of Service.** Details gains a Terms of Service row when the live mint reports a URL that parses as http(s) with a real host; the row value names the destination host and opens via `ACTION_VIEW`. Invalid or absent values render no row. Covered by `MintContactLinksTest.termsOfServiceUrlMustBeHttpWithAHost`.

- **[P2] Show reported mint software and version.** Details shows `name version` from the live NUT-06 record when reported; nothing is invented for absent values. Domain model carries `MintSoftware` from the CDK fetch.

- **[P2] Add the metadata provenance footer.** "Information reported by the mint." caption sits beneath the metadata, matching iOS `footerNote`, identifying descriptions/contacts/software/terms as the mint's own claims.

- **[P1] Preserve and hide absent payment methods.** Domain-model change to a tri-state: `supportedMintMethods`/`supportedMeltMethods` are now `List<PaymentMethodKind>?` — null = never fetched (BOLT11 compatibility default via `effectiveMintMethods`/`effectiveMeltMethods`), empty = reported-absent, non-empty = reported. The CDK mapping no longer substitutes BOLT11 for an empty live NUT-04/05 list and drops unknown custom rails instead of remapping them (iOS `compactMap`). The detail screen treats live NUT-06 as authoritative and hides a direction the live mint reports as absent; `refreshMintInfo` lets a live report (including empty) overwrite the stored value. Verified by `CdkMintMethodMappingTest` and `MintInfoMethodsTest` (fallbacks, reported-empty pass-through, melt-selection compat).

- **[P1] Surface Set as Default progress and errors.** The action now shows progress and blocks duplicate submission while in flight (`PrimaryButton.loading`), and failures render an inline notice via `userFacingWalletMessage`. The apparent default only follows `walletState`, so a failed attempt never flips it.

## Verification

`./gradlew --no-daemon :app:assembleDebug :app:testDebugUnitTest :app:lintDebug` — build successful, all unit tests pass (including the three new test classes), lint reports 0 errors / 0 warnings.