### PR TITLE
fix: restart incomplete onboarding, keep original seed; stop seed-grid flicker (#172)

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -86,6 +86,13 @@ object StorageKeys {
     const val settingsSentryEnabled = "settings.sentryEnabled"
     const val settingsAppLockEnabled = "settings.appLockEnabled"
 
+    // Onboarding completion marker. Written `false` when a wallet is installed
+    // during first-launch onboarding and `true` only once onboarding is fully
+    // passed (past the first-mint screen via Continue or Skip, or a finished
+    // restore); absent on installs that predate the marker — those are
+    // grandfathered to completed at launch.
+    const val onboardingCompleted = "cashu.local.onboardingCompleted"
+
     const val npcEnabled = "npc.enabled"
     const val npcAutomaticClaim = "npc.automaticClaim"
     const val npcSelectedMint = "npc.selectedMint"

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
@@ -292,6 +292,15 @@ class SettingsManager(
         settingsStore.clearWalletScopedData()
     }
 
+    var onboardingCompleted: Boolean
+        get() = settingsStore.onboardingCompleted
+        set(value) {
+            settingsStore.onboardingCompleted = value
+        }
+
+    val hasOnboardingCompletionMarker: Boolean
+        get() = settingsStore.hasOnboardingCompletionMarker
+
     internal fun snapshotWalletScopedData(): SettingsWalletScopedSnapshot =
         SettingsWalletScopedSnapshot(
             preferences = settingsStore.snapshotWalletScopedData(),

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -90,6 +90,13 @@ class SettingsStore(
         get() = store.boolean(StorageKeys.settingsAppLockEnabled, false)
         set(value) = store.putBoolean(StorageKeys.settingsAppLockEnabled, value)
 
+    var onboardingCompleted: Boolean
+        get() = store.boolean(StorageKeys.onboardingCompleted, false)
+        set(value) = store.putBoolean(StorageKeys.onboardingCompleted, value)
+
+    val hasOnboardingCompletionMarker: Boolean
+        get() = StorageKeys.onboardingCompleted in store.keys()
+
     var checkIncomingInvoices: Boolean
         get() = store.boolean(StorageKeys.settingsCheckIncomingInvoices, true)
         set(value) = store.putBoolean(StorageKeys.settingsCheckIncomingInvoices, value)
@@ -228,6 +235,7 @@ class SettingsStore(
         StorageKeys.nwcEnabled,
         StorageKeys.nwcSelectedMint,
         StorageKeys.nwcBudgetSats,
+        StorageKeys.onboardingCompleted,
     )
 }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -126,7 +126,14 @@ class WalletManager(
                 // decrypting the seed, deriving keys, or starting background services.
                 // This is the same cache-first boundary used by iOS.
                 if (hasStoredWallet) {
-                    loadCachedState(needsOnboarding = false)
+                    // Wallets installed before the completion marker existed
+                    // are treated as fully onboarded; only installs from this
+                    // version on can be incomplete (e.g. process death before
+                    // the first-mint step was passed).
+                    if (!settingsManager.hasOnboardingCompletionMarker) {
+                        settingsManager.onboardingCompleted = true
+                    }
+                    loadCachedState(needsOnboarding = !settingsManager.onboardingCompleted)
                 } else {
                     update {
                         copy(
@@ -265,7 +272,28 @@ class WalletManager(
             "Seed phrase must be ${MnemonicInput.supportedWordCountLabel} words."
         }
         require(gateway.validateMnemonic(normalized)) { "Invalid seed phrase." }
+        // Onboarding resumed after process death: the same seed is already
+        // installed — reinstalling would wipe its partially added mints.
+        if (mutableState.value.isRuntimeReady &&
+            secureStorage.loadString(StorageKeys.secureWalletMnemonic) == normalized
+        ) {
+            return
+        }
         withLoading { installCleanWallet(normalized, needsOnboarding = true) }
+    }
+
+    /**
+     * Seed persisted by an onboarding run that never completed (process death
+     * before the first-mint step was passed). A resumed onboarding must re-show
+     * these same words — the user may have written them down already — instead
+     * of silently regenerating a new seed.
+     */
+    suspend fun persistedOnboardingMnemonic(): String? = withContext(Dispatchers.IO) {
+        if (settingsManager.onboardingCompleted) {
+            null
+        } else {
+            secureStorage.loadString(StorageKeys.secureWalletMnemonic)
+        }
     }
 
     /**
@@ -1207,6 +1235,7 @@ class WalletManager(
     }
 
     suspend fun completeOnboarding() {
+        settingsManager.onboardingCompleted = true
         loadCachedState(needsOnboarding = false)
         refreshBalance()
         loadTransactions()
@@ -1263,6 +1292,10 @@ class WalletManager(
             nostrMintBackupService.resetForWalletBoundary()
             databasePathManager.removeWalletFileBackups(backups)
             loadCachedState(needsOnboarding = needsOnboarding)
+            // A wallet installed during first-launch onboarding is incomplete
+            // until completeOnboarding(); installs from Settings skip
+            // onboarding entirely and are complete immediately.
+            settingsManager.onboardingCompleted = !needsOnboarding
         }.onFailure { error ->
             gateway.closeWalletRepository()
             walletStore.restoreWalletScopedData(walletSnapshot)

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingScreen.kt
@@ -285,7 +285,10 @@ fun OnboardingScreen(
                         creating = true
                         createError = null
                         try {
-                            val mnemonic = walletManager.generateMnemonicForOnboarding()
+                            // Resume an interrupted onboarding with its original
+                            // seed — the user may have written those words down.
+                            val mnemonic = walletManager.persistedOnboardingMnemonic()
+                                ?: walletManager.generateMnemonicForOnboarding()
                             step = OnboardingStep.ShowMnemonic(mnemonic)
                         } catch (t: Throwable) {
                             createError = t.message ?: "Couldn't create a wallet."
@@ -569,11 +572,14 @@ private fun ShowMnemonicFace(
                 )
             }
         }
+        // The seed grid deliberately gets NO riseIn entrance: any motion on
+        // this block reads as a flicker on first paint, and recomposition
+        // mid-entrance restarts it. The step crossfade owns its appearance;
+        // the tap-to-reveal swap is untouched.
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = CashuTheme.spacing.section)
-                .riseIn(appeared, 1),
+                .padding(top = CashuTheme.spacing.section),
             verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -102,6 +102,11 @@ enum StorageKeys {
     static let processedNPCQuotes = "wallet.processedNPCQuotes"
     static let nostrMintBackupLastBackupDate = "wallet.nostrMintBackup.lastBackupDate"
 
+    // Onboarding completion marker. Written `false` when a wallet is installed
+    // and `true` only when onboarding is fully passed; absent on installs that
+    // predate the marker (treated as completed at launch).
+    static let onboardingCompleted = "cashu.local.onboardingCompleted"
+
     // Cashu Requests (receive intents shown in History). Key names predate the
     // `wallet.` prefix convention and must stay stable for existing installs,
     // so they are wallet-scoped via `walletDataKeys` membership instead.
@@ -249,6 +254,7 @@ enum StorageKeys {
 
     static var walletBoundaryKeys: [String] {
         walletDataKeys + walletDataLegacyKeys + walletScopedSettingsKeys + walletScopedSettingsLegacyKeys
+            + [onboardingCompleted]
     }
     
     // Keychain (Secure Storage)

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
@@ -44,9 +44,34 @@ enum ICloudRestorePolicy {
 
     static func needsOnboarding(
         hasStoredMnemonic: Bool,
-        restoreIncomplete: Bool
+        restoreIncomplete: Bool,
+        onboardingCompleted: Bool
     ) -> Bool {
-        !hasStoredMnemonic || restoreIncomplete
+        !hasStoredMnemonic || restoreIncomplete || !onboardingCompleted
+    }
+}
+
+/// Tracks whether onboarding was fully passed (create path: past the first-mint
+/// screen via Continue or Skip; restore path: restore finished). The seed is
+/// persisted the moment a wallet is installed, so its presence alone cannot
+/// distinguish "wallet ready" from "killed mid-onboarding" — this marker can.
+/// Absent on installs that predate it; those are grandfathered to completed at
+/// launch, before any routing decision.
+enum OnboardingCompletionState {
+    static func isCompleted(defaults: UserDefaults = .standard) -> Bool {
+        defaults.bool(forKey: StorageKeys.onboardingCompleted)
+    }
+
+    static func hasMarker(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: StorageKeys.onboardingCompleted) != nil
+    }
+
+    static func setCompleted(_ completed: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(completed, forKey: StorageKeys.onboardingCompleted)
+    }
+
+    static func clear(defaults: UserDefaults = .standard) {
+        defaults.removeObject(forKey: StorageKeys.onboardingCompleted)
     }
 }
 

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -50,6 +50,7 @@ extension WalletManager {
             try? keychainService.deleteMnemonic()
             try? keychainService.deleteNostrPrivateKey()
             setICloudRestoreIncomplete(false)
+            OnboardingCompletionState.clear()
             SettingsManager.shared.resetWalletScopedData()
         }
 
@@ -89,9 +90,16 @@ extension WalletManager {
             if let storedMnemonic {
                 mnemonic = storedMnemonic
                 loadCachedWalletState()
+                // Wallets installed before the completion marker existed are
+                // treated as fully onboarded; only installs from this version
+                // on can be incomplete.
+                if !OnboardingCompletionState.hasMarker() {
+                    OnboardingCompletionState.setCompleted(true)
+                }
                 needsOnboarding = ICloudRestorePolicy.needsOnboarding(
                     hasStoredMnemonic: true,
-                    restoreIncomplete: hasIncompleteICloudRestore
+                    restoreIncomplete: hasIncompleteICloudRestore,
+                    onboardingCompleted: OnboardingCompletionState.isCompleted()
                 )
                 isInitialized = true
                 publishedCachedWallet = true
@@ -119,9 +127,11 @@ extension WalletManager {
                 startDeferredStartupMaintenance()
                 SentryService.breadcrumb("Wallet loaded", category: "wallet.lifecycle")
             } else {
+                OnboardingCompletionState.clear()
                 needsOnboarding = ICloudRestorePolicy.needsOnboarding(
                     hasStoredMnemonic: false,
-                    restoreIncomplete: hasIncompleteICloudRestore
+                    restoreIncomplete: hasIncompleteICloudRestore,
+                    onboardingCompleted: false
                 )
                 isRuntimeReady = true
                 isInitialized = true
@@ -249,6 +259,7 @@ extension WalletManager {
 
     func completeOnboarding() {
         transactionService.loadCachedState()
+        OnboardingCompletionState.setCompleted(true)
         if hasIncompleteICloudRestore {
             // Choosing a different onboarding path after an interrupted iCloud
             // restore is also a valid completion. Release the write barrier only
@@ -277,6 +288,7 @@ extension WalletManager {
         resetRuntimeState()
         try keychainService.deleteMnemonic()
         try? keychainService.deleteNostrPrivateKey()
+        OnboardingCompletionState.clear()
         try removeWalletDatabaseFiles()
         walletStore.removeAllWalletData()
         SettingsManager.shared.resetWalletScopedData()
@@ -323,6 +335,9 @@ extension WalletManager {
             try initializeWalletForCreation(mnemonic: newMnemonic)
             try keychainService.saveMnemonic(newMnemonic)
             mnemonic = newMnemonic
+            // A freshly installed wallet has not finished onboarding; only
+            // completeOnboarding()/completeRestore() may flip this to done.
+            OnboardingCompletionState.setCompleted(false)
             SettingsManager.shared.resetWalletScopedData(resetRuntimeServices: false)
             try removeWalletFileBackups(fileBackups)
             if !IntegrationTestConfig.shouldUseDeterministicUIRuntime {

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -31,6 +31,9 @@ struct OnboardingView: View {
     @State private var seedRevealed = false
     @State private var seedAcknowledged = false
     @State private var seedCopied = false
+    // Snapshot of the seed words taken when the seed step appears, so wallet
+    // manager publishes during the step can't rebuild (and re-animate) the grid.
+    @State private var mnemonicWords: [String] = []
 
     // First-mint state (create path)
     @State private var showConceptSheet = false
@@ -638,56 +641,58 @@ struct OnboardingView: View {
                 .padding(.horizontal, 28)
             }
 
-            stagger(appeared: mnemonicAppeared, index: 1) {
-                VStack(spacing: 12) {
-                    // Mnemonic words — plain on canvas, blurred until revealed
-                    ZStack {
-                        mnemonicWordsGrid(words: walletManager.getMnemonicWords())
-                            // Hide the seed at the CONTENT level, not just visually.
-                            // A bare `.blur` is animatable, and on this screen's
-                            // entrance transition SwiftUI ramps the radius up from its
-                            // identity (0 = fully legible), briefly exposing the phrase
-                            // before it settles at 9 — the "flicker" users reported.
-                            // Redaction can't be defeated by an animation: while
-                            // unrevealed the real characters are never drawn, so no
-                            // animation timing can leak them. The blur stays purely for
-                            // the reveal aesthetic and animates 9 → 0 on tap; the
-                            // simultaneous un-redact is masked under that blur.
-                            .redacted(reason: seedRevealed ? [] : .placeholder)
-                            .blur(radius: seedRevealed ? 0 : 9)
-                            .allowsHitTesting(seedRevealed)
-                            // Keep the secret words out of the accessibility tree
-                            // until revealed — otherwise VoiceOver reads all 12
-                            // aloud while they're still blurred on screen.
-                            .accessibilityHidden(!seedRevealed)
+            // The seed grid deliberately gets NO stagger entrance: any offset/
+            // blur ramp on this block reads as a flicker on first paint, and
+            // re-composition mid-entrance restarts it. The step crossfade owns
+            // its appearance; the tap-to-reveal animation is untouched.
+            VStack(spacing: 12) {
+                // Mnemonic words — plain on canvas, blurred until revealed
+                ZStack {
+                    mnemonicWordsGrid(words: mnemonicWords)
+                        // Hide the seed at the CONTENT level, not just visually.
+                        // A bare `.blur` is animatable, and on this screen's
+                        // entrance transition SwiftUI ramps the radius up from its
+                        // identity (0 = fully legible), briefly exposing the phrase
+                        // before it settles at 9 — the "flicker" users reported.
+                        // Redaction can't be defeated by an animation: while
+                        // unrevealed the real characters are never drawn, so no
+                        // animation timing can leak them. The blur stays purely for
+                        // the reveal aesthetic and animates 9 → 0 on tap; the
+                        // simultaneous un-redact is masked under that blur.
+                        .redacted(reason: seedRevealed ? [] : .placeholder)
+                        .blur(radius: seedRevealed ? 0 : 9)
+                        .allowsHitTesting(seedRevealed)
+                        // Keep the secret words out of the accessibility tree
+                        // until revealed — otherwise VoiceOver reads all 12
+                        // aloud while they're still blurred on screen.
+                        .accessibilityHidden(!seedRevealed)
 
-                        if !seedRevealed {
-                            VStack(spacing: 6) {
-                                Image(systemName: "eye")
-                                    .font(.title3)
-                                Text("Tap to reveal")
-                                    .font(.subheadline)
-                            }
-                            .foregroundStyle(.secondary)
-                            .accessibilityElement(children: .ignore)
-                            .accessibilityLabel("Reveal seed phrase")
-                            .accessibilityHint("Shows your 12-word recovery phrase")
-                            .accessibilityAddTraits(.isButton)
-                            .accessibilityAction(.default, revealSeed)
+                    if !seedRevealed {
+                        VStack(spacing: 6) {
+                            Image(systemName: "eye")
+                                .font(.title3)
+                            Text("Tap to reveal")
+                                .font(.subheadline)
                         }
+                        .foregroundStyle(.secondary)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("Reveal seed phrase")
+                        .accessibilityHint("Shows your 12-word recovery phrase")
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityAction(.default, revealSeed)
                     }
-                    .contentShape(Rectangle())
-                    .onTapGesture(perform: revealSeed)
-                    .padding(.horizontal, 28)
-
-                    Button(action: copyMnemonic) {
-                        Text(seedCopied ? "Copied" : "Copy")
-                            .contentTransition(.opacity)
-                    }
-                    .textLinkButton()
                 }
-                .padding(.top, 24)
+                .contentShape(Rectangle())
+                .onTapGesture(perform: revealSeed)
+                .padding(.horizontal, 28)
+
+                Button(action: copyMnemonic) {
+                    Text(seedCopied ? "Copied" : "Copy")
+                        .contentTransition(.opacity)
+                }
+                .textLinkButton()
             }
+            .padding(.top, 24)
 
             Spacer()
 
@@ -729,6 +734,7 @@ struct OnboardingView: View {
             }
         }
         .onAppear {
+            mnemonicWords = walletManager.getMnemonicWords()
             triggerEntrance { mnemonicAppeared = true }
         }
     }
@@ -742,7 +748,7 @@ struct OnboardingView: View {
     }
 
     private func copyMnemonic() {
-        UIPasteboard.general.string = walletManager.getMnemonicWords().joined(separator: " ")
+        UIPasteboard.general.string = mnemonicWords.joined(separator: " ")
         withAnimation(.snappy) { seedCopied = true }
         HapticFeedback.selection()
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
@@ -1502,6 +1508,14 @@ struct OnboardingView: View {
     // MARK: - Actions
 
     private func createWallet() {
+        // An interrupted onboarding may have already created and persisted a
+        // wallet. Never regenerate its seed — the user may have written those
+        // words down. Re-show the existing phrase instead.
+        if walletManager.mnemonic != nil {
+            advance(to: .showMnemonic)
+            return
+        }
+
         isCreating = true
         errorMessage = nil
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -286,16 +286,48 @@ final class WalletStoreTests: XCTestCase {
     func testIncompleteICloudRestoreRequiresOnboardingWithStoredSeed() {
         XCTAssertTrue(ICloudRestorePolicy.needsOnboarding(
             hasStoredMnemonic: true,
-            restoreIncomplete: true
+            restoreIncomplete: true,
+            onboardingCompleted: true
         ))
         XCTAssertFalse(ICloudRestorePolicy.needsOnboarding(
             hasStoredMnemonic: true,
-            restoreIncomplete: false
+            restoreIncomplete: false,
+            onboardingCompleted: true
         ))
         XCTAssertTrue(ICloudRestorePolicy.needsOnboarding(
             hasStoredMnemonic: false,
-            restoreIncomplete: false
+            restoreIncomplete: false,
+            onboardingCompleted: false
         ))
+    }
+
+    func testIncompleteOnboardingRequiresOnboardingWithStoredSeed() {
+        // Killed mid-onboarding: seed persisted, completion marker false.
+        XCTAssertTrue(ICloudRestorePolicy.needsOnboarding(
+            hasStoredMnemonic: true,
+            restoreIncomplete: false,
+            onboardingCompleted: false
+        ))
+    }
+
+    func testOnboardingCompletionMarkerRoundTrips() {
+        let suiteName = "OnboardingCompletionStateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(OnboardingCompletionState.hasMarker(defaults: defaults))
+        XCTAssertFalse(OnboardingCompletionState.isCompleted(defaults: defaults))
+
+        OnboardingCompletionState.setCompleted(false, defaults: defaults)
+        XCTAssertTrue(OnboardingCompletionState.hasMarker(defaults: defaults))
+        XCTAssertFalse(OnboardingCompletionState.isCompleted(defaults: defaults))
+
+        OnboardingCompletionState.setCompleted(true, defaults: defaults)
+        XCTAssertTrue(OnboardingCompletionState.hasMarker(defaults: defaults))
+        XCTAssertTrue(OnboardingCompletionState.isCompleted(defaults: defaults))
+
+        OnboardingCompletionState.clear(defaults: defaults)
+        XCTAssertFalse(OnboardingCompletionState.hasMarker(defaults: defaults))
     }
 
     func testIncompleteICloudRestoreOverridesPublishedCacheAfterRuntimeFailure() {


### PR DESCRIPTION
## Summary

Fixes three related onboarding issues on iOS and Android:

1. **Blank wallet after killing the app mid-onboarding (iOS + Android).** The seed is persisted the moment a wallet is installed (iOS: on the Create Wallet tap; Android: when the mint-selection step appears), and launch routing inferred "onboarding done" from the stored mnemonic alone. Killing the app anywhere before the first-mint step was passed relaunched straight into a blank wallet with no mints.
2. **Seed phrase flicker on the onboarding reveal screen (#172).** The seed grid ran a staggered rise+blur entrance on top of the step crossfade; re-composition mid-entrance restarted it.
3. **Seed regeneration risk on resume.** Re-running Create Wallet after an interrupted onboarding would silently generate a new seed, invalidating a phrase the user may have written down.

## Changes

- **Persisted onboarding-completion marker** (iOS UserDefaults / Android SettingsStore, wallet-boundary scoped on both): written `false` on wallet install during first-launch onboarding, `true` only by `completeOnboarding()`/`completeRestore()`, cleared by `deleteWallet()`. Launch routing now requires the marker; installs that predate it are grandfathered to completed so existing users are unaffected.
- **Resume reuses the original seed.** A relaunched onboarding re-shows the same words instead of regenerating; Android additionally no-ops `initializeNewWalletForOnboarding()` when the same seed is already installed, preserving partially added mints.
- **Seed-grid entrance de-animated** (both platforms): the grid no longer gets the staggered rise+blur (header/CTA keep theirs); iOS snapshots the words into `@State` on step entry so wallet-manager publishes can't rebuild the grid. Tap-to-reveal animation untouched.

## Test plan

- [x] iOS build + unit tests (incl. new completion-policy/marker tests)
- [x] Android compile + unit tests
- [x] iOS UI test failures verified pre-existing on unmodified main (environment issue)
- [ ] Device: kill app on seed screen → relaunch lands on Welcome → Create Wallet shows same words
- [ ] Device: kill app on mint selection → relaunch restarts onboarding
- [ ] Device: Continue and Skip both land on wallet home permanently
- [ ] Upgrade: complete onboarding on previous build → upgrade → lands on wallet home

Closes #172