### PR TITLE
Show only the spinner while a payment is sending

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -478,7 +478,6 @@ fun UnifiedSendScreen(
                     phase = PaymentStatusPhase.Processing,
                     title = "Sending payment…",
                     rows = { SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol) },
-                    showRowsDuringProcessing = true,
                 )
             }
             is SendStatus.Sent -> Box(Modifier.weight(1f).fillMaxWidth()) {

--- a/ios/CashuWallet/Views/Send/Components/AuthorizingOverlay.swift
+++ b/ios/CashuWallet/Views/Send/Components/AuthorizingOverlay.swift
@@ -97,7 +97,9 @@ struct PaymentStatusView: View {
                 }
             }
         } details: {
-            if !details.isEmpty {
+            // Payment facts are terminal-only: processing shows just the spinner
+            // and title, matching the claiming screen.
+            if !details.isEmpty, phase != .processing {
                 VStack(spacing: 0) {
                     ForEach(Array(details.enumerated()), id: \.element.id) { index, row in
                         detailRow(row)


### PR DESCRIPTION
## What

While a payment is in the **sending/processing** state, both apps now show only the loading spinner and title. Payment detail rows (Method / Amount / Network fee / Mint) appear only in the terminal **success** and **failure** states — matching how the claiming screen already behaves on Android.

This walks back the UI half of #217 ("Preserve payment facts through Send terminal states"). The data half stays: `SendStatus.Sending` still carries the details snapshot, so terminal states render the same stable row set.

## Changes

- **Android** — `UnifiedSendScreen.kt`: drop the `showRowsDuringProcessing = true` opt-in in the send sheet. `PaymentStatusScreen`'s existing phase gate now suppresses rows during processing. The flag, component, and all tests are untouched.
- **iOS** — `PaymentStatusView` (`AuthorizingOverlay.swift`): the details section renders only when `phase != .processing`. This covers all three send call sites (unified send, melt, scanner cashu-request pay).

⚠️ **Behavior change worth calling out:** because the iOS gate is in the shared `PaymentStatusView`, the iOS **claiming** screen ("Claiming…") also becomes spinner-only during claiming. Previously iOS claiming showed Amount/Fee/Mint rows while claiming; Android claiming was already spinner-only, so this also resolves that platform divergence.

## Screenshots (before / after)

Captured with the repo's `wallet-ui-visual-review` workflow from isolated builds of the merge-base (`8d44ba9`) and this branch (`2093e7e`), on matched runtimes (Android API 36 emulator, iOS 26.5 iPhone 17 Pro simulator; newest installed stable — official API 37 / iOS 26.6 images weren't installed).

### Android — sending

| Before | After |
|---|---|
| ![Android sending screen showing spinner plus Method, Amount, Network fee, and Mint rows](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/android-before-send-processing-api36-444dp-light.png?raw=true) | ![Android sending screen showing only the spinner and Sending payment title](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/android-after-send-processing-api36-444dp-light.png?raw=true) |

### Android — sent (unchanged control)

| Before | After |
|---|---|
| ![Android payment sent screen with detail rows and Done button](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/android-before-send-success-api36-444dp-light.png?raw=true) | ![Android payment sent screen with detail rows and Done button, unchanged](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/android-after-send-success-api36-444dp-light.png?raw=true) |

### iOS — sending

| Before | After |
|---|---|
| ![iOS processing screen showing spinner plus Method, Amount, Network fee, and Mint rows](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-before-send-processing-ios26.5-iphone17pro-light.png?raw=true) | ![iOS processing screen showing only the spinner and Processing title](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-after-send-processing-ios26.5-iphone17pro-light.png?raw=true) |

### iOS — sent (unchanged control)

| Before | After |
|---|---|
| ![iOS payment sent screen with detail rows and Done button](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-before-send-success-ios26.5-iphone17pro-light.png?raw=true) | ![iOS payment sent screen with detail rows and Done button, unchanged](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-after-send-success-ios26.5-iphone17pro-light.png?raw=true) |

### iOS — claiming (intentional change from the shared gate)

| Before | After |
|---|---|
| ![iOS claiming screen showing spinner plus Amount, Fee, and Mint rows](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-before-claim-processing-ios26.5-iphone17pro-light.png?raw=true) | ![iOS claiming screen showing only the spinner and Claiming title](https://github.com/swedishfrenchpress/wallet/blob/0c54c288a248ad0f3c076e403d535e18b4706cc6/ios-after-claim-processing-ios26.5-iphone17pro-light.png?raw=true) |

**Fixture disclosure:** Android drives the real send sheet with the repo's `FakeWalletGateway` (synthetic funded wallet, fixed invoice), held in the sending state by a temporary latch added only inside the isolated capture worktrees. iOS mounts the real `PaymentStatusView` via a temporary debug-only launch fixture (`UITEST_STATUS_VIEW_FIXTURE`) with representative rows, also only inside the capture worktrees; both patches were reversed and verified clean. All data is synthetic. Static screenshots prove rendering only, not payment completion.

## Testing

- Android: `:app:compileDebugKotlin`, `:app:testDebugUnitTest` pass
- iOS: `xcodebuild` Debug build for iOS Simulator succeeds