### PR TITLE
Android Wallet Connect reset warning: mention recovery requires sharing new code

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/settings/NwcSettingsScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/NwcSettingsScreen.kt
@@ -250,7 +250,7 @@ fun NwcSettingsScreen(
             title = { Text("Reset connection") },
             text = {
                 Text(
-                    "This creates a new connection code. Apps paired with the current code will stop working.",
+                    "This creates a new connection code. Apps paired with the current code will stop working until you share the new code with them.",
                 )
             },
             confirmButton = {


### PR DESCRIPTION
## Summary

Parity gap from `docs/product/ios-android-parity-checklist.md`:

> [P2 · iOS → Android] Complete the reset-connection recovery warning. Android already says paired apps will stop working; iOS also explains that access remains broken until the new code is shared. **Done when:** Android states both the disruption and the recovery required before reset.

iOS's reset-connection alert states both the disruption and the recovery:

> "This creates a new connection code. Any app paired with the current one will stop working **until you share the new code**." — `ios/CashuWallet/Views/Settings/NWCSettingsSection.swift:120`

Android's dialog only stated the disruption:

> "This creates a new connection code. Apps paired with the current code will stop working." — `android/app/src/main/java/com/cashu/me/ui/settings/NwcSettingsScreen.kt:253`

## Change

Extended the Android reset-confirmation copy in `NwcSettingsScreen.kt` to:

> "This creates a new connection code. Apps paired with the current code will stop working until you share the new code with them."

Follows the existing pattern in this file (inline dialog strings, as used by the surrounding Wallet Connect settings UI).

## Verification

- `ANDROID_HOME=/Users/asm/Library/Android/sdk ./gradlew :app:compileDebugKotlin` — builds successfully.
- No unit/UI tests cover this dialog copy (searched `android/app/src/test` for the dialog text).