### PR TITLE
Save device key nickname on change, not just keyboard Submit

### DIFF
--- a/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
@@ -496,6 +496,7 @@ private struct DeviceKeyDetailView: View {
                             .font(.body)
                             .submitLabel(.done)
                             .onSubmit { saveName() }
+                            .onChange(of: nameText) { _, _ in saveName() }
                             .padding(.horizontal, 4)
                             .padding(.vertical, 14)
                     }
@@ -527,6 +528,7 @@ private struct DeviceKeyDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.hidden, for: .navigationBar)
         .onAppear { nameText = key?.nickname ?? "" }
+        .onDisappear { saveName() }
         .onChange(of: key == nil) { _, removed in if removed { dismiss() } }
         .sheet(item: $activeQR) { payload in
             QRCodeDetailSheet(title: payload.title, content: payload.content)
@@ -552,6 +554,8 @@ private struct DeviceKeyDetailView: View {
     }
 
     private func saveName() {
+        let trimmed = nameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed != (key?.nickname ?? "") else { return }
         settings.setP2PKKeyNickname(nameText, for: keyId)
     }
 


### PR DESCRIPTION
## Summary

Parity gap from `docs/product/ios-android-parity-checklist.md`:

> [P1 · Android → iOS] Save a device-key nickname without requiring keyboard Submit. Android persists each edit; iOS can lose the rename when the user navigates back. **Done when:** iOS saves on change, focus loss, or view disappearance and does not require a hidden keyboard-specific action.

Android persists every keystroke (`DeviceKeyDetailScreen.kt` → `onValueChange { settingsManager.setP2PKKeyNickname(key.id, it) }`), while iOS only committed the rename in `TextField.onSubmit`, so navigating back without pressing keyboard Done silently dropped the new name.

## What changed

`ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift` (`DeviceKeyDetailView`):

- Added `.onChange(of: nameText)` to persist the nickname on every edit, matching Android behavior (storage layer already persists via `p2pkKeys.didSet`).
- Added `.onDisappear { saveName() }` as a safety net so view disappearance never loses an edit.
- `saveName()` now skips no-op writes (trimmed text equal to the stored nickname) so seeding `nameText` in `.onAppear` does not trigger redundant Keychain rewrites.
- Keyboard Submit (`onSubmit`) still works as before.

## Verification

- `xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination "platform=iOS Simulator,name=iPhone 17" -skipPackagePluginValidation build` — **BUILD SUCCEEDED** (plugin-validation flag needed only because the build runs from a `/tmp` worktree).
- No automated test pattern exists for this SwiftUI settings view; `SettingsManager.setP2PKKeyNickname` logic itself is unchanged.
