### PR TITLE
iOS Settings: read app version from bundle metadata

### DIFF
--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -114,6 +114,8 @@
 		EE00000000000003 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000013 /* SettingsStore.swift */; };
 		EE00000000000004 /* TokenParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000014 /* TokenParser.swift */; };
 		EE00000000000005 /* AmountFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000015 /* AmountFormatter.swift */; };
+		AV00000000000001 /* AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = AV00000000000011 /* AppVersion.swift */; };
+		AV00000000000002 /* AppVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AV00000000000012 /* AppVersionTests.swift */; };
 		EE00000000000006 /* LightningRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE00000000000016 /* LightningRequestParser.swift */; };
 		F100000000000001 /* NDEFTextRecordCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F200000000000001 /* NDEFTextRecordCoder.swift */; };
 		F100000000000002 /* NFCReaderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F200000000000002 /* NFCReaderDelegate.swift */; };
@@ -299,6 +301,8 @@
 		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
 		C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestPaymentObservationTests.swift; path = CashuWalletTests/CashuRequestPaymentObservationTests.swift; sourceTree = "<group>"; };
 		T1B000000000000E /* CrashReportSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrashReportSanitizerTests.swift; path = CashuWalletTests/CrashReportSanitizerTests.swift; sourceTree = "<group>"; };
+		AV00000000000011 /* AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersion.swift; sourceTree = "<group>"; };
+		AV00000000000012 /* AppVersionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AppVersionTests.swift; path = CashuWalletTests/AppVersionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,6 +357,7 @@
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
 				T1B000000000000E /* CrashReportSanitizerTests.swift */,
+				AV00000000000012 /* AppVersionTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -419,6 +424,7 @@
 				2100000000000005 /* KeychainService.swift */,
 				EE00000000000014 /* TokenParser.swift */,
 				EE00000000000015 /* AmountFormatter.swift */,
+				AV00000000000011 /* AppVersion.swift */,
 				EE00000000000016 /* LightningRequestParser.swift */,
 				EE00000000000013 /* SettingsStore.swift */,
 				EE00000000000012 /* WalletStore.swift */,
@@ -899,6 +905,7 @@
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
 				T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */,
+				AV00000000000002 /* AppVersionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -990,6 +997,7 @@
 				DD00000000000004 /* ErrorBannerView.swift in Sources */,
 				EE00000000000004 /* TokenParser.swift in Sources */,
 				EE00000000000005 /* AmountFormatter.swift in Sources */,
+				AV00000000000001 /* AppVersion.swift in Sources */,
 				EE00000000000006 /* LightningRequestParser.swift in Sources */,
 				EE00000000000003 /* SettingsStore.swift in Sources */,
 				EE00000000000002 /* WalletStore.swift in Sources */,

--- a/ios/CashuWallet/Core/AppVersion.swift
+++ b/ios/CashuWallet/Core/AppVersion.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Sources the displayed app version from bundle metadata (CFBundleShortVersionString,
+/// CFBundleVersion) instead of a hard-coded literal — the iOS counterpart of Android
+/// rendering BuildConfig.VERSION_NAME in Settings.
+enum AppVersion {
+    /// Version string for the Settings footer, e.g. "1.0". Nil when the bundle carries
+    /// no marketing version, so callers can omit the version rather than show a stale one.
+    static func displayString(bundle: Bundle = .main) -> String? {
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        return displayString(version: version)
+    }
+
+    static func displayString(version: String?) -> String? {
+        guard let version, !version.isEmpty else { return nil }
+        return version
+    }
+}

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -82,7 +82,7 @@ struct SettingsView: View {
                     .buttonStyle(.plain)
                 }
 
-                Text("Cashu Wallet · 1.0.0")
+                Text(versionFooter)
                     .font(.caption2)
                     .foregroundStyle(.tertiary)
                     .frame(maxWidth: .infinity)
@@ -127,6 +127,15 @@ struct SettingsView: View {
     }
 
     // MARK: - Section + Row Helpers
+
+    /// Footer mirrors Android's "Cashu Wallet · <VERSION_NAME>", sourced from bundle
+    /// metadata so a version bump never leaves Settings showing a stale literal.
+    private var versionFooter: String {
+        if let version = AppVersion.displayString() {
+            return "Cashu Wallet · \(version)"
+        }
+        return "Cashu Wallet"
+    }
 
     @ViewBuilder
     private func sectionGroup<Content: View>(

--- a/ios/CashuWalletTests/AppVersionTests.swift
+++ b/ios/CashuWalletTests/AppVersionTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import CashuWallet
+
+final class AppVersionTests: XCTestCase {
+    func testDisplayStringComesFromMainBundleMetadata() {
+        let expected = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        XCTAssertNotNil(expected)
+        XCTAssertEqual(AppVersion.displayString(), expected)
+    }
+
+    func testDisplayStringMatchesMarketingVersionBuildSetting() {
+        // The hosted test bundle's main bundle is CashuWallet.app, whose
+        // CFBundleShortVersionString is generated from MARKETING_VERSION.
+        XCTAssertEqual(AppVersion.displayString(), "1.0")
+    }
+
+    func testDisplayStringFallsBackToNilWhenVersionMissing() {
+        XCTAssertNil(AppVersion.displayString(version: nil))
+        XCTAssertNil(AppVersion.displayString(version: ""))
+    }
+}


### PR DESCRIPTION
## Parity gap

From `docs/product/ios-android-parity-checklist.md`:

> [P1 · Android → iOS] Read the app version from build metadata. Android uses BuildConfig.VERSION_NAME; iOS hard-codes 1.0.0. **Done when:** iOS displays the shipped bundle version and, if included, its build number from metadata.

Android renders `Cashu Wallet · ${BuildConfig.VERSION_NAME}` (`SettingsScreen.kt:211`), while iOS hard-coded `Text("Cashu Wallet · 1.0.0")` in `SettingsView.swift` — stale the moment MARKETING_VERSION (currently 1.0) moves.

## What changed

- New `AppVersion` helper (`ios/CashuWallet/Core/AppVersion.swift`) reads `CFBundleShortVersionString` from `Bundle.main` (auto-generated from MARKETING_VERSION via GENERATE_INFOPLIST_FILE), returning nil when absent.
- Settings footer (`SettingsView.swift`) now renders `Cashu Wallet · <version>` from that helper, falling back to plain `Cashu Wallet` if the bundle has no version — same format as Android (no build number, matching Android UI).
- New `AppVersionTests` covering: value sourced from `Bundle.main` metadata, equality with the MARKETING_VERSION-derived bundle value (1.0), and nil fallback for missing/empty versions.

## Verification

- `xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination "platform=iOS Simulator,name=iPhone 17" -skipPackagePluginValidation build` — **BUILD SUCCEEDED** (iPhone 16 simulator not installed on this machine; plugin validation flag works around a local swift-secp256k1 plugin trust prompt, unrelated to this change).
- `xcodebuild ... test -only-testing:CashuWalletTests/AppVersionTests` — **TEST SUCCEEDED**, all 3 tests pass, confirming the shipped bundle metadata carries CFBundleShortVersionString = 1.0.