### PR TITLE
iOS QR codes: VoiceOver Copy/Share actions matching the context menu (Android parity)

### DIFF
--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000D /* CashuRequestRouteExplanationTests.swift */; };
 		C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */; };
 		T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000E /* CrashReportSanitizerTests.swift */; };
+		T2B000000000000F /* QRContextAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B000000000000F /* QRContextAccessibilityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -299,6 +300,7 @@
 		T1B000000000000D /* CashuRequestRouteExplanationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestRouteExplanationTests.swift; path = CashuWalletTests/CashuRequestRouteExplanationTests.swift; sourceTree = "<group>"; };
 		C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestPaymentObservationTests.swift; path = CashuWalletTests/CashuRequestPaymentObservationTests.swift; sourceTree = "<group>"; };
 		T1B000000000000E /* CrashReportSanitizerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CrashReportSanitizerTests.swift; path = CashuWalletTests/CrashReportSanitizerTests.swift; sourceTree = "<group>"; };
+		T1B000000000000F /* QRContextAccessibilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QRContextAccessibilityTests.swift; path = CashuWalletTests/QRContextAccessibilityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -353,6 +355,7 @@
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
 				T1B000000000000E /* CrashReportSanitizerTests.swift */,
+				T1B000000000000F /* QRContextAccessibilityTests.swift */,
 			);
 			name = CashuWalletTests;
 			sourceTree = "<group>";
@@ -899,6 +902,7 @@
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
 				T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */,
+				T2B000000000000F /* QRContextAccessibilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CashuWallet/Views/Components/QRCodeView.swift
+++ b/ios/CashuWallet/Views/Components/QRCodeView.swift
@@ -52,6 +52,14 @@ enum QRSize: String, CaseIterable {
 
 // MARK: - QR Code View with Controls
 
+/// VoiceOver action names exposed on actionable QR codes. They mirror the
+/// Copy / Share entries of the long-press context menu the call site attaches —
+/// the same options Android's shared QrCard announces to TalkBack.
+enum QRContextAccessibility {
+    static let copyActionName = "Copy"
+    static let shareActionName = "Share"
+}
+
 /// QR Code display view with animation support for large data
 /// Includes per-QR speed and size controls like cashu.me
 struct QRCodeView: View {
@@ -63,6 +71,12 @@ struct QRCodeView: View {
     /// expect to scan as a single static frame. UR-animated QRs only make
     /// sense for our own long Cashu tokens.
     var staticOnly: Bool = false
+    /// VoiceOver Copy action, mirroring the long-press context menu's Copy.
+    /// Leave nil on non-actionable QRs so assistive tech never promises an
+    /// unavailable action.
+    var onCopy: (() -> Void)? = nil
+    /// VoiceOver Share action, mirroring the long-press context menu's Share.
+    var onShare: (() -> Void)? = nil
 
     // Local settings per QR instance
     @State private var speed: QRSpeed = .fast
@@ -88,6 +102,14 @@ struct QRCodeView: View {
                         .scaledToFit()
                         .accessibilityLabel("QR code")
                         .accessibilityHint("Contains scannable payment data")
+                        .accessibilityActions {
+                            if let onCopy {
+                                Button(QRContextAccessibility.copyActionName, action: onCopy)
+                            }
+                            if let onShare {
+                                Button(QRContextAccessibility.shareActionName, action: onShare)
+                            }
+                        }
                 } else {
                     Rectangle()
                         .fill(.tertiary)

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -1583,6 +1583,9 @@ struct CashuTopUpInvoiceSheet: View {
     @State private var monitorTask: Task<Void, Never>?
     @State private var errorMessage: String?
     @State private var errorSeverity: ErrorSeverity = .error
+    /// VoiceOver Share action for the QR: ShareLink can't be invoked
+    /// imperatively, so the accessibility action presents the share sheet.
+    @State private var showShareSheet = false
 
     private enum Phase: Equatable {
         case awaitingPayment   // showing the QR, polling the quote
@@ -1599,7 +1602,13 @@ struct CashuTopUpInvoiceSheet: View {
                     VStack(spacing: 24) {
                         header
 
-                        QRCodeView(content: context.quote.request, showControls: false, staticOnly: true)
+                        QRCodeView(
+                            content: context.quote.request,
+                            showControls: false,
+                            staticOnly: true,
+                            onCopy: copyInvoice,
+                            onShare: { showShareSheet = true }
+                        )
                             .frame(width: 280, height: 280)
                             .padding(16)
                             .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
@@ -1611,6 +1620,9 @@ struct CashuTopUpInvoiceSheet: View {
                                 ShareLink(item: context.quote.request) {
                                     Label("Share", systemImage: "square.and.arrow.up")
                                 }
+                            }
+                            .sheet(isPresented: $showShareSheet) {
+                                ShareSheet(items: [context.quote.request])
                             }
 
                         CurrencyAmountDisplay(sats: context.amount, primary: $settings.amountDisplayPrimary)

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -277,7 +277,9 @@ struct TransactionDetailView: View {
                 showControls: false,
                 // Lightning invoices / Bitcoin addresses are standard QR formats;
                 // ecash tokens are long and benefit from UR-animated encoding.
-                staticOnly: transaction.kind != .ecash
+                staticOnly: transaction.kind != .ecash,
+                onCopy: { copyContent(content) },
+                onShare: { showShareSheet = true }
             )
             .frame(width: 280, height: 280)
             .padding(16)

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -22,6 +22,9 @@ struct CashuRequestDetailView: View {
     /// Amount of the payment that just landed, for the shared success screen.
     @State private var receivedAmount: UInt64?
     @State private var showPaymentSuccess = false
+    /// VoiceOver Share action for the QR: ShareLink can't be invoked
+    /// imperatively, so the accessibility action presents the share sheet.
+    @State private var showShareSheet = false
 
     init(request: CashuRequest, onClose: (() -> Void)? = nil) {
         self._requestId = State(initialValue: request.id)
@@ -163,7 +166,13 @@ struct CashuRequestDetailView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 24) {
-                    QRCodeView(content: request.encoded, showControls: false, staticOnly: true)
+                    QRCodeView(
+                        content: request.encoded,
+                        showControls: false,
+                        staticOnly: true,
+                        onCopy: { copy(request.encoded) },
+                        onShare: { showShareSheet = true }
+                    )
                         .frame(width: 280, height: 280)
                         .padding(16)
                         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
@@ -175,6 +184,9 @@ struct CashuRequestDetailView: View {
                             ShareLink(item: request.encoded) {
                                 Label("Share", systemImage: "square.and.arrow.up")
                             }
+                        }
+                        .sheet(isPresented: $showShareSheet) {
+                            ShareSheet(items: [request.encoded])
                         }
 
                     if let amount = request.amount, amount > 0 {

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -23,6 +23,10 @@ struct ReceiveLightningView: View {
     /// Reusable BOLT12 offer: drives the Amount-row pencil → amount picker sheet.
     @State private var showReusableAmountPicker = false
     @State private var copiedRequest = false
+    /// VoiceOver Share action for the QR cards: ShareLink can't be invoked
+    /// imperatively, so the accessibility action presents the share sheet.
+    @State private var showShareSheet = false
+    @State private var qrShareText = ""
     @State private var quoteStatusTask: Task<Void, Never>?
     @State private var expiryTimeRemaining: TimeInterval = 0
     @State private var expiryTimer: Timer?
@@ -512,7 +516,13 @@ struct ReceiveLightningView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 24) {
-                    QRCodeView(content: quote.request, showControls: false, staticOnly: true)
+                    QRCodeView(
+                        content: quote.request,
+                        showControls: false,
+                        staticOnly: true,
+                        onCopy: { copyRequest(quote.request) },
+                        onShare: { shareQuoteRequest(quote.request) }
+                    )
                         .frame(width: 280, height: 280)
                         .padding(16)
                         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
@@ -530,6 +540,9 @@ struct ReceiveLightningView: View {
                                 Label("New reusable invoice", systemImage: "arrow.2.squarepath")
                             }
                             .disabled(isCreatingRequest)
+                        }
+                        .sheet(isPresented: $showShareSheet) {
+                            ShareSheet(items: [qrShareText])
                         }
 
                     if let amount = quote.amount, amount > 0 {
@@ -643,7 +656,13 @@ struct ReceiveLightningView: View {
         VStack(spacing: 0) {
             ScrollView {
                 VStack(spacing: 24) {
-                    QRCodeView(content: quote.request, showControls: false, staticOnly: true)
+                    QRCodeView(
+                        content: quote.request,
+                        showControls: false,
+                        staticOnly: true,
+                        onCopy: { copyRequest(quote.request) },
+                        onShare: { shareQuoteRequest(quote.request) }
+                    )
                         .frame(width: 280, height: 280)
                         .padding(16)
                         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
@@ -655,6 +674,9 @@ struct ReceiveLightningView: View {
                             ShareLink(item: quote.request) {
                                 Label("Share", systemImage: "square.and.arrow.up")
                             }
+                        }
+                        .sheet(isPresented: $showShareSheet) {
+                            ShareSheet(items: [qrShareText])
                         }
 
                     amountSummary(for: quote)
@@ -1185,6 +1207,11 @@ struct ReceiveLightningView: View {
             }
             isCreatingRequest = false
         }
+    }
+
+    private func shareQuoteRequest(_ request: String) {
+        qrShareText = request
+        showShareSheet = true
     }
 
     private func copyRequest(_ request: String) {

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -609,7 +609,12 @@ struct SendView: View {
                     // Cashu tokens often exceed a single QR's capacity so
                     // UR encoding stays on, but the SPEED/SIZE dev HUD is
                     // suppressed from production.
-                    QRCodeView(content: token, showControls: false)
+                    QRCodeView(
+                        content: token,
+                        showControls: false,
+                        onCopy: { copyToken(token) },
+                        onShare: { showShareSheet = true }
+                    )
                         .frame(width: 280, height: 280)
                         .padding(16)
                         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))

--- a/ios/CashuWalletTests/QRContextAccessibilityTests.swift
+++ b/ios/CashuWalletTests/QRContextAccessibilityTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import CashuWallet
+
+final class QRContextAccessibilityTests: XCTestCase {
+    func testActionNamesMatchContextMenuEntries() {
+        XCTAssertEqual(QRContextAccessibility.copyActionName, "Copy")
+        XCTAssertEqual(QRContextAccessibility.shareActionName, "Share")
+    }
+
+    func testBaseQRViewPromisesNoActionsByDefault() {
+        let qr = QRCodeView(content: "cashuAeyJwcm9vZnMiOlt7InByb29mIjoiIn1d")
+        XCTAssertNil(qr.onCopy, "Non-actionable QR views must not promise a Copy action")
+        XCTAssertNil(qr.onShare, "Non-actionable QR views must not promise a Share action")
+    }
+
+    func testActionableQRViewExposesCopyAndShareClosures() {
+        var copied = false
+        var shared = false
+        let qr = QRCodeView(
+            content: "lnbc1…",
+            onCopy: { copied = true },
+            onShare: { shared = true }
+        )
+        qr.onCopy?()
+        qr.onShare?()
+        XCTAssertTrue(copied)
+        XCTAssertTrue(shared)
+    }
+}


### PR DESCRIPTION
## Parity gap

From `docs/product/ios-android-parity-checklist.md`:

> [P2 · Android → iOS] Advertise QR context actions to assistive technology. Android's shared QR card announces long-press Copy/Share options; iOS's base QR view can omit actionable context. **Done when:** every actionable iOS QR exposes native accessibility actions or an accurate hint; non-actionable QR views do not promise unavailable actions.

Android's shared `QrCard` announces "QR code. Long press for copy and share options." to TalkBack (`android/app/src/main/java/com/cashu/me/ui/components/QrCard.kt:73`). iOS's shared `QRCodeView` only announced "QR code / Contains scannable payment data" — the six call sites that attach a long-press `.contextMenu` with Copy/Share gave VoiceOver users no way to discover or trigger those actions.

## What changed (iOS only)

- `QRCodeView` gains optional `onCopy` / `onShare` closures; when provided, the QR image exposes matching `.accessibilityActions` ("Copy", "Share" via `QRContextAccessibility`). Default is nil, so non-actionable QRs (AmountEntryView token card, `QRCodeDetailSheet` — both already have visible Copy/Share buttons) promise nothing.
- Wired the six actionable call sites to pass closures mirroring their context menus:
  - SendView token QR, TransactionDetailView hero QR (existing `copyToken`/`copyContent` + `showShareSheet`)
  - ReceiveLightningView (standard + reusable-offer QR), CashuRequestDetailView, and the top-up invoice sheet in ScannerWrapperView — these used `ShareLink`, which can't be invoked imperatively, so the VoiceOver Share action presents the existing `ShareSheet` representable.
- Added `QRContextAccessibilityTests` (registered in project.pbxproj): action names match the context-menu entries, the base view promises no actions by default, and provided closures fire.

## Verification

- `xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination 'platform=iOS Simulator,name=iPhone 17' -skipPackagePluginValidation build` — **BUILD SUCCEEDED**
- `xcodebuild test ... -only-testing:CashuWalletTests/QRContextAccessibilityTests` — **TEST SUCCEEDED** (3/3)

After merge, tick the "Advertise QR context actions to assistive technology" item in `docs/product/ios-android-parity-checklist.md`.