### PR TITLE
Android privacy: disable periodic invoice checks when incoming checks are off

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
@@ -307,11 +307,13 @@ class NPCService(
     private fun applyPollingPreferences() {
         val settings = settingsManager.state.value
         val state = mutableState.value
-        if (!state.isEnabled || !state.isConnected || !settings.checkIncomingInvoices) {
-            stopBackgroundRefresh()
-            return
-        }
-        if (!settings.periodicallyCheckIncomingInvoices) {
+        val shouldRun = shouldRunPeriodicInvoiceChecks(
+            isEnabled = state.isEnabled,
+            isConnected = state.isConnected,
+            checkIncomingInvoices = settings.checkIncomingInvoices,
+            periodicallyCheckIncomingInvoices = settings.periodicallyCheckIncomingInvoices,
+        )
+        if (!shouldRun) {
             stopBackgroundRefresh()
             return
         }
@@ -377,6 +379,13 @@ class NPCService(
             quotes
                 .filter { it.isPaid && it.id !in processedQuoteIds }
                 .sortedBy { it.paidAtEpochSeconds ?: it.createdAtEpochSeconds ?: Long.MAX_VALUE }
+
+        internal fun shouldRunPeriodicInvoiceChecks(
+            isEnabled: Boolean,
+            isConnected: Boolean,
+            checkIncomingInvoices: Boolean,
+            periodicallyCheckIncomingInvoices: Boolean,
+        ): Boolean = isEnabled && isConnected && checkIncomingInvoices && periodicallyCheckIncomingInvoices
 
     }
 

--- a/android/app/src/main/java/com/cashu/me/ui/components/SettingsRows.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/SettingsRows.kt
@@ -99,19 +99,30 @@ fun ToggleRow(
     enabled: Boolean = true,
     leadingIcon: ImageVector? = null,
 ) {
+    val contentAlpha = if (enabled) 1f else 0.38f
     ListItem(
         modifier = modifier.clickable(enabled = enabled) { onCheckedChange(!checked) },
         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-        headlineContent = { Text(text = title) },
+        headlineContent = {
+            Text(
+                text = title,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+            )
+        },
         supportingContent = subtitle?.let {
-            { Text(text = it) }
+            {
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
+                )
+            }
         },
         leadingContent = leadingIcon?.let {
             {
                 Icon(
                     imageVector = it,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = contentAlpha),
                     modifier = Modifier.size(CashuTheme.spacing.section),
                 )
             }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
@@ -122,6 +122,7 @@ fun PrivacyScreen(
                 subtitle = "Refresh quote status on a timer",
                 checked = settings.periodicallyCheckIncomingInvoices,
                 onCheckedChange = settingsManager::setPeriodicallyCheckIncomingInvoices,
+                enabled = settings.checkIncomingInvoices,
             )
 
             SectionHeader("Network")

--- a/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Core
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.cashudevkit.NpubCashQuote
@@ -91,5 +92,49 @@ class NPCServiceTest {
         )
 
         assertEquals(listOf("oldest", "newest"), quotes.map { it.id })
+    }
+
+    @Test
+    fun periodicInvoiceChecksRequireBothPreferences() {
+        assertTrue(
+            NPCService.shouldRunPeriodicInvoiceChecks(
+                isEnabled = true,
+                isConnected = true,
+                checkIncomingInvoices = true,
+                periodicallyCheckIncomingInvoices = true,
+            ),
+        )
+        assertFalse(
+            NPCService.shouldRunPeriodicInvoiceChecks(
+                isEnabled = true,
+                isConnected = true,
+                checkIncomingInvoices = false,
+                periodicallyCheckIncomingInvoices = true,
+            ),
+        )
+        assertFalse(
+            NPCService.shouldRunPeriodicInvoiceChecks(
+                isEnabled = true,
+                isConnected = true,
+                checkIncomingInvoices = true,
+                periodicallyCheckIncomingInvoices = false,
+            ),
+        )
+        assertFalse(
+            NPCService.shouldRunPeriodicInvoiceChecks(
+                isEnabled = false,
+                isConnected = true,
+                checkIncomingInvoices = true,
+                periodicallyCheckIncomingInvoices = true,
+            ),
+        )
+        assertFalse(
+            NPCService.shouldRunPeriodicInvoiceChecks(
+                isEnabled = true,
+                isConnected = false,
+                checkIncomingInvoices = true,
+                periodicallyCheckIncomingInvoices = true,
+            ),
+        )
     }
 }


### PR DESCRIPTION
## Summary

Parity gap from `docs/product/ios-android-parity-checklist.md`:

> [P1 · iOS → Android] Disable periodic invoice checks when incoming checks are off. Android leaves the child control interactive even though the runtime requires incoming checks before periodic work runs. **Done when:** Android disables the child visually and semantically, preserves its saved preference for later re-enable, and keeps the effective runtime rule as the logical combination of both settings.

On iOS the "Check all invoices" toggle is disabled and dimmed while "Check incoming invoice" is off (`ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift:16-17`). On Android the "Periodic invoice checks" row stayed interactive (`PrivacyScreen.kt`), even though the runtime already required both settings — toggling the child while the parent was off was a silent no-op (`NPCService.applyPollingPreferences`).

## What changed

- `PrivacyScreen.kt`: "Periodic invoice checks" `ToggleRow` now passes `enabled = settings.checkIncomingInvoices`, matching the existing "Receive automatically" child-toggle pattern. The saved child preference is untouched — it takes effect again when the parent is re-enabled.
- `SettingsRows.kt` (`ToggleRow`): disabled rows now dim title/subtitle/leading icon with the M3 disabled content alpha (0.38f, per `RestoreWalletFlow.kt` convention). The `Switch` already rendered disabled colors; `clickable(enabled = false)` + `Switch(enabled = false)` report the disabled state to TalkBack.
- `NPCService.kt`: extracted the effective rule into pure `NPCService.shouldRunPeriodicInvoiceChecks(isEnabled, isConnected, checkIncomingInvoices, periodicallyCheckIncomingInvoices)` — periodic work runs only when the service is enabled/connected AND both preferences are on (unchanged semantics, now testable).
- `NPCServiceTest.kt`: unit coverage for the AND combination (parent off + child on → no periodic work, etc.).

## Verification

- `./gradlew :app:compileDebugKotlin` — success
- `./gradlew :app:testDebugUnitTest` — full suite success, including the new `periodicInvoiceChecksRequireBothPreferences` test

No iOS changes; no checklist edits; no copy string changes.