### PR TITLE
Align privacy-setting copy on concepts, timing, and consequences

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt
@@ -105,21 +105,21 @@ fun PrivacyScreen(
             CanvasDivider(leadingInset = 16.dp)
             ToggleRow(
                 title = "Check sent token claims",
-                subtitle = "Detect when recipients redeem tokens you sent",
+                subtitle = "Asks the mint whether tokens you sent were claimed, while the app is open. Off, the wallet stays quiet and you check manually instead.",
                 checked = settings.checkSentTokens,
                 onCheckedChange = settingsManager::setCheckSentTokens,
             )
             CanvasDivider(leadingInset = 16.dp)
             ToggleRow(
                 title = "Check incoming invoices",
-                subtitle = "Poll mint quotes while screens are open",
+                subtitle = "Checks for incoming payments while the app is open, contacting the mint each time. Off, the wallet doesn't check on its own.",
                 checked = settings.checkIncomingInvoices,
                 onCheckedChange = settingsManager::setCheckIncomingInvoices,
             )
             CanvasDivider(leadingInset = 16.dp)
             ToggleRow(
                 title = "Periodic invoice checks",
-                subtitle = "Refresh quote status on a timer",
+                subtitle = "Every couple of minutes while the app is open, each check contacting the mint. Off, the wallet checks only once when it opens.",
                 checked = settings.periodicallyCheckIncomingInvoices,
                 onCheckedChange = settingsManager::setPeriodicallyCheckIncomingInvoices,
             )
@@ -142,7 +142,7 @@ fun PrivacyScreen(
             CanvasDivider(leadingInset = 16.dp)
             ToggleRow(
                 title = "Receive automatically",
-                subtitle = "Automatically receive payments from mints you already trust",
+                subtitle = "Payments from mints you already trust arrive without asking. Off, you confirm each payment before it's received.",
                 checked = settings.receivePaymentRequestsAutomatically,
                 onCheckedChange = settingsManager::setReceivePaymentRequestsAutomatically,
                 enabled = settings.enablePaymentRequests,
@@ -162,6 +162,13 @@ fun PrivacyScreen(
                 subtitle = "Opt-in. Screenshots and view hierarchy are not attached. Reports can include technical error details and recent wallet actions.",
                 checked = settings.sentryEnabled,
                 onCheckedChange = settingsManager::setSentryEnabled,
+            )
+
+            Text(
+                text = "Checks contact the mint over the network — more checks mean faster updates, fewer give the mint less to see.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(16.dp),
             )
 
         }

--- a/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
@@ -6,19 +6,40 @@ struct PrivacySettingsSection: View {
     var body: some View {
         LazyVStack(spacing: 0) {
             SettingsSectionGroup(nil) {
-                Toggle("Check incoming invoice", isOn: $settings.checkIncomingInvoices)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 14)
+                Toggle(isOn: $settings.checkIncomingInvoices) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check incoming invoices")
+                        Text("Checks for incoming payments while the app is open, contacting the mint each time. Off, the wallet doesn't check on its own.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 14)
 
-                Toggle("Check all invoices", isOn: $settings.periodicallyCheckIncomingInvoices)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 14)
-                    .disabled(!settings.checkIncomingInvoices)
-                    .opacity(settings.checkIncomingInvoices ? 1.0 : 0.5)
+                Toggle(isOn: $settings.periodicallyCheckIncomingInvoices) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Repeat checks on a timer")
+                        Text("Every couple of minutes while the app is open, each check contacting the mint. Off, the wallet checks only once when it opens.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 14)
+                .disabled(!settings.checkIncomingInvoices)
+                .opacity(settings.checkIncomingInvoices ? 1.0 : 0.5)
 
-                Toggle("Check sent ecash", isOn: $settings.checkSentTokens)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 14)
+                Toggle(isOn: $settings.checkSentTokens) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Check sent ecash")
+                        Text("Asks the mint whether sent ecash was claimed, while the app is open. Off, the wallet stays quiet and you check manually instead.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 14)
 
                 Toggle("Use WebSockets", isOn: $settings.useWebsockets)
                     .padding(.horizontal, 4)
@@ -43,8 +64,8 @@ struct PrivacySettingsSection: View {
 
                 Toggle(isOn: $settings.receivePaymentRequestsAutomatically) {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Claim received ecash automatically")
-                        Text("Off asks you to confirm each incoming payment before it's claimed.")
+                        Text("Receive payments automatically")
+                        Text("Payments from mints you already trust are claimed without asking. Off, you confirm each payment before it's received.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -67,7 +88,7 @@ struct PrivacySettingsSection: View {
             }
 
             SettingsSectionFooter {
-                Text("These settings affect your privacy and wallet responsiveness.")
+                Text("Checks contact the mint over the network — more checks mean faster updates, fewer give the mint less to see.")
             }
         }
     }


### PR DESCRIPTION
## Summary

Parity gap from `docs/product/ios-android-parity-checklist.md`:

> **[P2 · Converge] Align privacy-setting concepts and consequences.** Labels differ for sent-ecash checks, periodic invoice checks, and automatic receive. **Done when:** both platforms use equivalent plain-language concepts and explain timing, network activity, and consequences. Native label length and sentence structure may differ.

Before this change, iOS showed bare labels ("Check sent ecash", "Check all invoices") with no explanation, while Android explained only fragments (timing *or* consequence, never network activity). Automatic-receive copy covered the trust limit on Android but only the off-behavior on iOS.

## Aligned concepts (both platforms now state)

- **Sent checks** — asks the mint whether sent ecash/tokens were claimed, while the app is open; off, the wallet stays quiet and you check manually.
- **Incoming invoice checks** — checks for incoming payments while the app is open, contacting the mint each time; off, the wallet does not check on its own.
- **Periodic invoice checks** — repeats every couple of minutes while the app is open, each check contacting the mint; off, the wallet checks only once when it opens.
- **Automatic receive** — payments from mints you already trust are received without asking; off, you confirm each payment first.
- **Footer** (now on both platforms) — checks contact the mint over the network; more checks mean faster updates, fewer give the mint less to see.

## Per-platform changes

**iOS** (`ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift`)
- "Check incoming invoice" → "Check incoming invoices" + caption
- "Check all invoices" → "Repeat checks on a timer" + caption
- "Check sent ecash" → kept label, added caption
- "Claim received ecash automatically" → "Receive payments automatically" + caption covering trust limit and off-behavior
- Footer now states the network/privacy trade-off

**Android** (`android/app/src/main/java/com/cashu/me/ui/settings/PrivacyScreen.kt`)
- "Check sent token claims", "Check incoming invoices", "Periodic invoice checks", "Receive automatically" → labels kept (platform-native "token" vocabulary), subtitles aligned to the shared concepts
- Added the same footer text below the sections

Copy-only: no toggle logic, enabled/disabled rules, or runtime behavior changed. Vocabulary stays platform-native ("ecash" on iOS, "token" on Android).

## Verification

- `cd android && ./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- `xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination generic/platform=iOS\ Simulator -skipPackagePluginValidation build` — BUILD SUCCEEDED
- `./gradlew :app:testDebugUnitTest --tests com.cashu.me.Core.SettingsManagerTest` — passed