### PR TITLE
Standardize zero-fee wording by meaning across iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -265,7 +265,9 @@ internal fun TokenInspectorRows(
             label = "Fee",
             value = when {
                 fee == null -> ""
-                fee == 0L -> "Free"
+                // Prospective charge (docs/product/copy-guidance.md): a
+                // charge-absence phrase, never a bare "0 sat".
+                fee == 0L -> "No fee"
                 isSatToken -> "$fee sat"
                 else -> CurrencyAmount(fee, tokenCurrency).formatted()
             },

--- a/docs/product/copy-guidance.md
+++ b/docs/product/copy-guidance.md
@@ -1,0 +1,54 @@
+# Copy guidance
+
+Shared product copy contracts for the iOS and Android apps. Each section is
+self-contained; platform-native wording may differ where a section allows it,
+but equivalent contexts must communicate the same meaning.
+
+## Zero-fee wording by meaning
+
+"Free", "No fee", and "0 sat" are not interchangeable. Which one is correct
+depends on what the row means, not on which screen renders it. Three meanings
+exist; each has exactly one wording class per platform.
+
+### 1. Prospective user charge — "you will be charged nothing"
+
+Context: a fee estimate or preview shown *before* the user commits (send/pay
+confirmation, scanned-invoice preview, receive-token review). The row tells
+the user what they will be charged; zero means "no charge applies".
+
+Wording: a charge-absence phrase — **"No fee"** on both platforms. Never a
+bare numeric zero: "0 sat" reads as an accounting figure, not as a statement
+about the user's charge.
+
+- iOS: `SendView` and `ScannerWrapperView` fee rows (`FeeState.free` →
+  "No fee"); `ReceiveTokenDetailView` confirm fee row ("No fee" when the
+  previewed fee is zero).
+- Android: `CashuRequestFeeEstimate.NoFee` → "No fee";
+  `SendPaymentDetailRows` fee-detail rows with amount 0 → "No fee";
+  `TokenInspectorRows` fee preview → "No fee" when the previewed fee is zero.
+
+### 2. Accounting value — the fee actually paid was zero
+
+Context: a settled receipt, success screen, or history detail describing what
+happened. The row records a fact about the completed transaction.
+
+Wording: when the recorded fee is greater than zero, show the recorded amount
+("N sat" or the fiat-formatted equivalent). When the recorded fee is zero,
+**omit the fee row entirely** — a receipt records what happened, and a
+zero-fee line is noise. Never "0 sat", "Free", or "No fee" as a receipt
+value.
+
+- iOS: `TransactionDetailView` (fee row only when `fee > 0`), `SendView`
+  generated-token and claimed rows (only when `tokenFee > 0`),
+  `ReceiveTokenDetailView` success rows (fee row omitted when the paid/preview
+  fee is zero).
+- Android: `ReceiveTokenReview` claimed receipt (fee row only when
+  `claimed.fee > 0`), `formatSendEcashFee` (returns null for zero so the row
+  is omitted).
+
+### 3. Numeric reserve / upper bound — labeled estimate, not a zero-fee statement
+
+Context: a Lightning quote reserve ("Max fee", "Network fee" shown with an
+"Up to …" value). The label carries the estimate meaning, so the value stays
+numeric ("N sat" / "Up to N sat") even when the reserve is zero. This class
+is not a zero-fee statement and does not use the classes above.

--- a/ios/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
@@ -204,7 +204,14 @@ struct ReceiveTokenDetailView: View {
                         .padding(.horizontal, 4)
                         .padding(.vertical, 14)
                     } else {
-                        detailRow(icon: "arrow.up.arrow.down", label: "Fee", value: formatFee(receiveFee))
+                        // Prospective charge (docs/product/copy-guidance.md):
+                        // "No fee" states the user is charged nothing; a bare
+                        // "0 sat" reads as an accounting figure.
+                        detailRow(
+                            icon: "arrow.up.arrow.down",
+                            label: "Fee",
+                            value: receiveFee == 0 ? "No fee" : formatFee(receiveFee)
+                        )
                     }
                     canvasDivider
                     detailRow(icon: "bitcoinsign.bank.building", label: "Mint", value: shortMintUrl(mintUrl))
@@ -281,7 +288,9 @@ struct ReceiveTokenDetailView: View {
     /// Status rows for the processing/success screen. "Amount" is the net
     /// credited to the balance: the estimate (token value − previewed fee)
     /// while claiming, then the exact net CDK returned. The fee row likewise
-    /// firms up from the preview to the actually charged fee.
+    /// firms up from the preview to the actually charged fee; a zero fee
+    /// omits the row — receipts never render "0 sat" (accounting value,
+    /// docs/product/copy-guidance.md).
     private var successRows: [PaymentStatusView.DetailRow] {
         let paidFee = claimedAmount.map { tokenAmount - min($0, tokenAmount) }
         var rows: [PaymentStatusView.DetailRow] = [
@@ -290,8 +299,11 @@ struct ReceiveTokenDetailView: View {
                 label: "Amount",
                 value: formatAmount(claimedAmount ?? netReceiveAmount)
             ),
-            .init(icon: "arrow.up.arrow.down", label: "Fee", value: formatFee(paidFee ?? receiveFee)),
         ]
+        let settledFee = paidFee ?? receiveFee
+        if settledFee > 0 {
+            rows.append(.init(icon: "arrow.up.arrow.down", label: "Fee", value: formatFee(settledFee)))
+        }
         if !mintUrl.isEmpty {
             rows.append(.init(
                 icon: "bitcoinsign.bank.building",


### PR DESCRIPTION
## Parity gap

From `docs/product/ios-android-parity-checklist.md`:

> [P2 · Converge] Standardize zero-fee wording by meaning. The apps alternate among "Free," "No fee," and "0 sat" for different concepts. **Done when:** shared copy guidance distinguishes a prospective user charge from an accounting value, and equivalent contexts communicate the same meaning. Platform-native wording may differ.

Verified findings before the fix:

**Prospective user charge (pre-commit estimate, "you will be charged nothing"):**
- iOS send/scan fee rows: "No fee" (`ios/CashuWallet/Views/Send/SendView.swift:2714`, `ios/CashuWallet/Views/Components/ScannerWrapperView.swift:983`)
- Android send fee rows: "No fee" (`android/app/src/main/java/com/cashu/me/ui/send/CashuRequestFeeEstimate.kt:51`, `android/.../ui/send/UnifiedSendScreen.kt:690`)
- iOS receive-token confirm: **"0 sat"** (`ios/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift:207` via `formatFee`)
- Android receive-token review: **"Free"** (`android/.../ui/receive/ReceiveTokenReview.kt:268`)

→ Four different wordings for the same meaning; the receive-token context disagreed across platforms and each platform also mixed classes internally.

**Accounting value (settled receipt / history, fee actually paid):**
- iOS receive success rows showed **"0 sat"** when the fee was zero (`ReceiveTokenDetailView.swift:293`), while Android omits the row (`ReceiveTokenReview.kt:376` `if (claimed.fee > 0L)`) and iOS itself omits zero-fee rows in History (`TransactionDetailView.swift:354`) and send-ecash receipts (`SendView.swift:705,782`).

## Copy contract adopted

New `docs/product/copy-guidance.md`, section **"Zero-fee wording by meaning"**, defining three meanings and one wording class each:

1. **Prospective user charge** — a charge-absence phrase: **"No fee"** on both platforms; never a bare "0 sat".
2. **Accounting value** — show the recorded amount when the fee > 0; **omit the fee row** when the fee is zero; never "0 sat"/"Free"/"No fee" on a receipt.
3. **Numeric reserve / upper bound** ("Max fee", "Network fee" with "Up to…") — stays numeric; not a zero-fee statement. (Unchanged on both platforms.)

## Per-platform changes

- **Android** `ReceiveTokenReview.kt`: receive-token fee preview `"Free"` → `"No fee"` (prospective class). Android accounting behavior already matched the contract (rows omitted when zero).
- **iOS** `ReceiveTokenDetailView.swift`:
  - Confirm fee row: `"No fee"` when the previewed fee is zero (was `"0 sat"`).
  - Success/status rows: fee row omitted when the paid/preview fee is zero (was `"0 sat"`), matching Android and iOS History/send-ecash receipts.

## Verification

- `cd android && ./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL; `:app:testDebugUnitTest --tests com.cashu.me.ui.send.CashuRequestFeeEstimateTest` — passes.
- `xcodebuild build -scheme CashuWallet -destination generic/platform=iOS Simulator` — BUILD SUCCEEDED.