### PR TITLE
Keep iOS WebSockets toggle independent of invoice/token polling

### DIFF
--- a/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift
@@ -20,11 +20,16 @@ struct PrivacySettingsSection: View {
                     .padding(.horizontal, 4)
                     .padding(.vertical, 14)
 
-                Toggle("Use WebSockets", isOn: $settings.useWebsockets)
-                    .padding(.horizontal, 4)
-                    .padding(.vertical, 14)
-                    .disabled(!settings.checkIncomingInvoices && !settings.checkSentTokens)
-                    .opacity((settings.checkIncomingInvoices || settings.checkSentTokens) ? 1 : 0.5)
+                Toggle(isOn: $settings.useWebsockets) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Use WebSockets")
+                        Text("Required for Nostr discovery and live invoice updates.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 4)
+                .padding(.vertical, 14)
 
                 Toggle("Paste ecash automatically", isOn: $settings.autoPasteEcashReceive)
                     .padding(.horizontal, 4)

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -34,4 +34,53 @@ final class SettingsUITests: UITestBase {
         XCTAssertTrue(app.buttons["wallet-settings-button"].waitForExistence(timeout: 5))
         waitForSelectedTab("Wallet")
     }
+
+    private func privacySwitch(_ labelPrefix: String) -> XCUIElement {
+        app.switches
+            .matching(NSPredicate(format: "label BEGINSWITH %@", labelPrefix))
+            .firstMatch
+    }
+
+    private func setSwitch(_ element: XCUIElement, toOn: Bool) {
+        let isOn = (element.value as? String) == "1"
+        if isOn != toOn {
+            tapSwitchControl(element)
+        }
+    }
+
+    /// SwiftUI Toggle outside a List only responds on the switch control at the
+    /// trailing edge; a center tap lands on the label and does nothing.
+    private func tapSwitchControl(_ element: XCUIElement) {
+        element.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+    }
+
+    func testWebSocketsToggleStaysEnabledWhenPollingDisabled() throws {
+        navigateToSettings()
+
+        let privacyRow = app.buttons["Privacy"].firstMatch
+        tapWhenReady(privacyRow, timeout: 10)
+
+        let incoming = privacySwitch("Check incoming invoice")
+        XCTAssertTrue(incoming.waitForExistence(timeout: 10), "Privacy settings should appear")
+        setSwitch(incoming, toOn: false)
+
+        let sent = privacySwitch("Check sent ecash")
+        XCTAssertTrue(sent.waitForExistence(timeout: 5))
+        setSwitch(sent, toOn: false)
+
+        let webSockets = privacySwitch("Use WebSockets")
+        XCTAssertTrue(webSockets.waitForExistence(timeout: 5))
+        XCTAssertTrue(
+            webSockets.isEnabled,
+            "WebSockets toggle must stay enabled when invoice/token polling is off"
+        )
+
+        let before = webSockets.value as? String
+        tapSwitchControl(webSockets)
+        XCTAssertNotEqual(
+            webSockets.value as? String,
+            before,
+            "WebSockets toggle must remain settable independently of polling settings"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the parity-checklist item:

> **[P1 · Android → iOS] Keep WebSockets independent of invoice/token polling.** Android correctly notes that WebSockets also power Nostr discovery; iOS disables the toggle when both incoming-invoice and sent-token checks are off. **Done when:** iOS users can enable discovery and live Nostr features independently.

### Finding

- iOS Settings → Privacy greyed out the "Use WebSockets" toggle whenever both "Check incoming invoice" and "Check sent ecash" were off (`PrivacySettingsSection.swift`, old lines 26–27).
- The runtime was already independent: Nostr mint discovery (`MintDiscoveryManager.swift:56`), live quote subscriptions (`ReceiveLightningView.swift:1323`), and Nostr backup (`NostrMintBackupService.swift:38`) all gate on `useWebsockets` only — nothing ties WebSocket teardown to the polling toggles. The dependency was UI-only.
- Android reference: `PrivacyScreen.kt:128–133` keeps the toggle always enabled with the subtitle "Required for Nostr discovery and live invoice updates".

### What changed (iOS only)

- `ios/CashuWallet/Views/Settings/PrivacySettingsSection.swift` — removed the `.disabled`/`.opacity` coupling to the polling toggles; the WebSockets toggle is now always settable. Added Android-mirroring subtitle "Required for Nostr discovery and live invoice updates." using the existing iOS subtitle-toggle pattern.
- `ios/CashuWalletUITests/SettingsUITests.swift` — new UI test `testWebSocketsToggleStaysEnabledWhenPollingDisabled`: disables both polling toggles, asserts the WebSockets switch stays enabled and can still be flipped.

## Verification

- `xcodebuild -project ios/CashuWallet.xcodeproj -scheme CashuWallet -destination 'platform=iOS Simulator,name=iPhone 17' -skipPackagePluginValidation build` → **BUILD SUCCEEDED** (iPhone 16 simulator not installed on this machine; used iPhone 17).
- `xcodebuild test ... -only-testing:CashuWalletUITests/SettingsUITests` → **TEST SUCCEEDED** — both `testSettingsRoundTrip` and the new `testWebSocketsToggleStaysEnabledWhenPollingDisabled` pass on iPhone 17 Pro simulator.