### PR TITLE
Serialize iOS wallet operations and recover interrupted payments

### DIFF
--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		D200000000000109 /* WalletErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000109 /* WalletErrors.swift */; };
 		D20000000000010A /* WalletManager+PendingMelts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010A /* WalletManager+PendingMelts.swift */; };
 		D20000000000010C /* PendingTokenClaim.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010C /* PendingTokenClaim.swift */; };
+		D20000000000010D /* WalletOperationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000010D /* WalletOperationCoordinator.swift */; };
 		D200000000000201 /* PaymentMethodKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000201 /* PaymentMethodKind.swift */; };
 		D200000000000202 /* PaymentRequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000202 /* PaymentRequestParser.swift */; };
 		D200000000000203 /* OnchainExplorer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D100000000000203 /* OnchainExplorer.swift */; };
@@ -250,6 +251,7 @@
 		D100000000000109 /* WalletErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletErrors.swift; sourceTree = "<group>"; };
 		D10000000000010A /* WalletManager+PendingMelts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalletManager+PendingMelts.swift"; sourceTree = "<group>"; };
 		D10000000000010C /* PendingTokenClaim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTokenClaim.swift; sourceTree = "<group>"; };
+		D10000000000010D /* WalletOperationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletOperationCoordinator.swift; sourceTree = "<group>"; };
 		D100000000000201 /* PaymentMethodKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodKind.swift; sourceTree = "<group>"; };
 		D100000000000202 /* PaymentRequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentRequestParser.swift; sourceTree = "<group>"; };
 		D100000000000203 /* OnchainExplorer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnchainExplorer.swift; sourceTree = "<group>"; };
@@ -649,6 +651,7 @@
 				D100000000000108 /* WalletManager+Backup.swift */,
 				D100000000000109 /* WalletErrors.swift */,
 				D10000000000010C /* PendingTokenClaim.swift */,
+				D10000000000010D /* WalletOperationCoordinator.swift */,
 			);
 			path = Wallet;
 			sourceTree = "<group>";
@@ -938,6 +941,7 @@
 				D200000000000108 /* WalletManager+Backup.swift in Sources */,
 				D200000000000109 /* WalletErrors.swift in Sources */,
 				D20000000000010C /* PendingTokenClaim.swift in Sources */,
+				D20000000000010D /* WalletOperationCoordinator.swift in Sources */,
 				D200000000000201 /* PaymentMethodKind.swift in Sources */,
 				D200000000000202 /* PaymentRequestParser.swift in Sources */,
 				D200000000000203 /* OnchainExplorer.swift in Sources */,

--- a/ios/CashuWallet/Core/CashuRequestListener.swift
+++ b/ios/CashuWallet/Core/CashuRequestListener.swift
@@ -75,7 +75,9 @@ final class CashuRequestListener: ObservableObject {
         self.client = client
         await client.start()
         isRunning = true
-        AppLogger.wallet.notice("CashuRequestListener: started on \(relays.count) relays, pubkey=\(String(pubkeyHex.prefix(8)), privacy: .public), since=\(since)")
+        AppLogger.wallet.notice(
+            "CashuRequestListener: started relays=\(relays.count, privacy: .public) pubkey=\(WalletOperationCoordinator.privacySafeIdentifier(pubkeyHex), privacy: .public) since=\(since, privacy: .public)"
+        )
     }
 
     func stop() async {
@@ -104,7 +106,9 @@ final class CashuRequestListener: ObservableObject {
     private func handle(event: NostrIncomingEvent, recipientPrivateKey: Data) async {
         guard event.kind == 1059 else { return }
         guard !processedIds.contains(event.id) else { return }
-        AppLogger.wallet.notice("CashuRequestListener: gift wrap received id=\(String(event.id.prefix(8)), privacy: .public) createdAt=\(event.createdAt)")
+        AppLogger.wallet.notice(
+            "CashuRequestListener: gift wrap received event=\(WalletOperationCoordinator.privacySafeIdentifier(event.id), privacy: .public) created_at=\(event.createdAt, privacy: .public)"
+        )
 
         let rumor: NostrRumor
         do {
@@ -112,7 +116,9 @@ final class CashuRequestListener: ObservableObject {
         } catch {
             // Not encrypted for us (or an unrelated DM) — it can never succeed,
             // so mark it handled and stop reconsidering it.
-            AppLogger.wallet.notice("CashuRequestListener: NIP-17 unwrap failed for \(String(event.id.prefix(8)), privacy: .public): \(String(describing: error), privacy: .public)")
+            AppLogger.wallet.notice(
+                "CashuRequestListener: NIP-17 unwrap failed event=\(WalletOperationCoordinator.privacySafeIdentifier(event.id), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             markProcessed(event.id)
             return
         }
@@ -190,16 +196,21 @@ final class CashuRequestListener: ObservableObject {
         do {
             // A gift wrap can arrive exactly as the app backgrounds; hold a background-task
             // assertion so this SQLite-writing redeem finishes before suspension.
-            let amount = try await withBackgroundWriteAssertion("cashu-request-claim") {
+            _ = try await withBackgroundWriteAssertion("cashu-request-claim") {
                 try await walletManager.receiveCashuRequestPayment(
                     tokenString: tokenString,
                     requestId: requestId
                 )
             }
-            AppLogger.wallet.notice("CashuRequestListener: claimed \(amount) sat for request \(requestId ?? "—", privacy: .public)")
+            let requestHash = requestId.map(WalletOperationCoordinator.privacySafeIdentifier) ?? "none"
+            AppLogger.wallet.notice(
+                "CashuRequestListener: claimed payment request=\(requestHash, privacy: .public)"
+            )
             return .claimed
         } catch {
-            AppLogger.wallet.error("CashuRequestListener: redeem failed (will retry): \(String(describing: error), privacy: .public)")
+            AppLogger.wallet.error(
+                "CashuRequestListener: redeem failed (will retry) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return .transientFailure
         }
     }
@@ -254,7 +265,9 @@ final class CashuRequestListener: ObservableObject {
         )
         walletManager.savePendingReceiveToken(pending)
         heldForApproval = pending
-        AppLogger.wallet.notice("CashuRequestListener: payment from \(mintUrl, privacy: .public) held for approval (\(reason, privacy: .public))")
+        AppLogger.wallet.notice(
+            "CashuRequestListener: payment held for approval resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public) reason=\(reason, privacy: .public)"
+        )
         Task { await walletManager.loadTransactions() }
         return .held
     }
@@ -268,7 +281,9 @@ final class CashuRequestListener: ObservableObject {
             try await walletManager.claimPendingReceiveToken(pending)
         }
         if heldForApproval?.tokenId == pending.tokenId { heldForApproval = nil }
-        AppLogger.wallet.notice("CashuRequestListener: user approved claim of \(amount) sat from \(pending.mintUrl, privacy: .public)")
+        AppLogger.wallet.notice(
+            "CashuRequestListener: user approved claim resource=\(WalletOperationCoordinator.privacySafeIdentifier(pending.mintUrl), privacy: .public)"
+        )
         await claimEligibleHeldPayments()
         return amount
     }
@@ -277,7 +292,9 @@ final class CashuRequestListener: ObservableObject {
     func declineHeldPayment(_ pending: PendingReceiveToken) {
         walletManager?.removePendingReceiveToken(tokenId: pending.tokenId)
         if heldForApproval?.tokenId == pending.tokenId { heldForApproval = nil }
-        AppLogger.wallet.notice("CashuRequestListener: user declined payment from \(pending.mintUrl, privacy: .public)")
+        AppLogger.wallet.notice(
+            "CashuRequestListener: user declined payment resource=\(WalletOperationCoordinator.privacySafeIdentifier(pending.mintUrl), privacy: .public)"
+        )
         Task { await walletManager?.loadTransactions() }
     }
 
@@ -300,13 +317,17 @@ final class CashuRequestListener: ObservableObject {
         }
         for pending in eligible {
             do {
-                let amount = try await withBackgroundWriteAssertion("cashu-request-claim") {
+                _ = try await withBackgroundWriteAssertion("cashu-request-claim") {
                     try await walletManager.claimPendingReceiveToken(pending)
                 }
                 if heldForApproval?.tokenId == pending.tokenId { heldForApproval = nil }
-                AppLogger.wallet.notice("CashuRequestListener: claimed held payment of \(amount) sat from \(pending.mintUrl, privacy: .public)")
+                AppLogger.wallet.notice(
+                    "CashuRequestListener: claimed held payment resource=\(WalletOperationCoordinator.privacySafeIdentifier(pending.mintUrl), privacy: .public)"
+                )
             } catch {
-                AppLogger.wallet.error("CashuRequestListener: held-payment claim failed (stays claimable in History): \(String(describing: error), privacy: .public)")
+                AppLogger.wallet.error(
+                    "CashuRequestListener: held-payment claim failed (stays claimable in History) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
     }

--- a/ios/CashuWallet/Core/NWCManager.swift
+++ b/ios/CashuWallet/Core/NWCManager.swift
@@ -171,7 +171,9 @@ final class NWCManager: ObservableObject {
             isRunning = false
             service = nil
             errorMessage = error.userFacingWalletMessage
-            AppLogger.wallet.error("Failed to start NWC service: \(String(describing: error))")
+            AppLogger.wallet.error(
+                "NWC service start failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
         }
     }
 
@@ -225,7 +227,9 @@ final class NWCManager: ObservableObject {
             do {
                 try await service.stop()
             } catch {
-                AppLogger.wallet.error("Failed to stop NWC service: \(String(describing: error))")
+                AppLogger.wallet.error(
+                    "NWC service stop failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
         service = nil

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -259,7 +259,7 @@ class LightningService: ObservableObject {
                     }
                 } catch {
                     AppLogger.wallet.error(
-                        "Failed to release stored mint quote reservation \(operationId, privacy: .public): \(String(describing: error), privacy: .public)"
+                        "stored mint quote release failed operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
                     )
                 }
             }
@@ -327,6 +327,9 @@ class LightningService: ObservableObject {
             do {
                 let mintUrl = MintUrl(url: mint.url)
                 let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+                AppLogger.wallet.info(
+                    "wallet-op native-call kind=meltQuote resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) method=\(paymentMethod.rawValue, privacy: .public)"
+                )
                 let quote = try await wallet.meltQuote(
                     method: paymentMethod.cdkMethod,
                     request: normalizedRequest,
@@ -343,7 +346,9 @@ class LightningService: ObservableObject {
                 return meltQuoteInfo(from: quote, paymentMethod: paymentMethod, fallbackMintUrl: mint.url)
             } catch {
                 lastError = error
-                AppLogger.wallet.error("Failed to create \(paymentMethod.rawValue) melt quote with mint \(mint.url): \(error)")
+                AppLogger.wallet.error(
+                    "melt quote failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) method=\(paymentMethod.rawValue, privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
 
@@ -407,7 +412,9 @@ class LightningService: ObservableObject {
                     repo: repo
                 )
             } catch {
-                AppLogger.wallet.error("BIP-353 fallback failed for \(address): \(error)")
+                AppLogger.wallet.error(
+                    "BIP-353 fallback failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
                 throw resolverError
             }
         }
@@ -434,6 +441,9 @@ class LightningService: ObservableObject {
             do {
                 let mintUrl = MintUrl(url: mint.url)
                 let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+                AppLogger.wallet.info(
+                    "wallet-op native-call kind=meltQuote resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) method=bolt11"
+                )
                 let quote = try await wallet.meltQuote(
                     method: PaymentMethodKind.bolt11.cdkMethod,
                     request: invoice,
@@ -450,7 +460,9 @@ class LightningService: ObservableObject {
                 return meltQuoteInfo(from: quote, paymentMethod: .bolt11, fallbackMintUrl: mint.url)
             } catch {
                 lastError = error
-                AppLogger.wallet.error("Failed to create Lightning address melt quote with mint \(mint.url): \(error)")
+                AppLogger.wallet.error(
+                    "Lightning address melt quote failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
 
@@ -483,6 +495,9 @@ class LightningService: ObservableObject {
             do {
                 let mintUrl = MintUrl(url: mint.url)
                 let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+                AppLogger.wallet.info(
+                    "wallet-op native-call kind=meltQuote resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) method=bolt12"
+                )
                 let quote = try await wallet.meltHumanReadable(
                     address: address,
                     amountMsat: Amount(value: amount * 1000),
@@ -499,7 +514,9 @@ class LightningService: ObservableObject {
                 return meltQuoteInfo(from: quote, paymentMethod: paymentMethod, fallbackMintUrl: mint.url)
             } catch {
                 lastError = error
-                AppLogger.wallet.error("Failed to create BIP-353 melt quote with mint \(mint.url): \(error)")
+                AppLogger.wallet.error(
+                    "BIP-353 melt quote failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
 
@@ -537,6 +554,9 @@ class LightningService: ObservableObject {
             do {
                 let mintUrl = MintUrl(url: mint.url)
                 let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
+                AppLogger.wallet.info(
+                    "wallet-op native-call kind=meltQuote resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) method=onchain"
+                )
                 let quoteOptions = try await wallet.quoteOnchainMeltOptions(
                     address: normalizedAddress,
                     amount: Amount(value: amount),
@@ -558,7 +578,9 @@ class LightningService: ObservableObject {
                 return meltQuoteInfo(from: quote, paymentMethod: .onchain, fallbackMintUrl: mint.url)
             } catch {
                 lastError = error
-                AppLogger.wallet.error("Failed to create on-chain melt quote with mint \(mint.url): \(error)")
+                AppLogger.wallet.error(
+                    "on-chain melt quote failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
 
@@ -679,19 +701,15 @@ class LightningService: ObservableObject {
         return normalized
     }
     
-    /// Outcome of a melt confirmation. `pendingMelt` is non-nil when the mint
-    /// accepted the payment for asynchronous NUT-05 processing; the caller owns
-    /// waiting on it and finishing the bookkeeping once it settles.
+    /// Outcome of a melt confirmation. Pending results are persisted and
+    /// reconciled by the manager's serialized foreground poll.
     struct MeltConfirmation {
         let result: MeltPaymentResult
-        let pendingMelt: PendingMelt?
     }
 
     /// Pay a Lightning invoice or on-chain address (melt tokens)
     /// - Parameter quoteId: The quote ID to melt
-    /// - Returns: Melt confirmation. Settled immediately for synchronous mints;
-    ///   carries a `PendingMelt` handle when the mint processes asynchronously
-    ///   (NUT-05 `Prefer: respond-async`), which on-chain melts typically do.
+    /// - Returns: Melt confirmation, including whether settlement is pending.
     func meltTokens(quoteId: String, mintUrl preferredMintUrl: String? = nil) async throws -> MeltConfirmation {
         guard let repo = walletRepository() else {
             throw WalletError.notInitialized
@@ -707,33 +725,238 @@ class LightningService: ObservableObject {
         let mintUrl = MintUrl(url: mintURLString)
         let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: .sat)
 
-        let preparedMelt = try await wallet.prepareMelt(quoteId: quoteId)
-        switch try await preparedMelt.confirmPreferAsync() {
-        case .paid(let finalized):
+        let preparedMelt: PreparedMelt
+        do {
+            preparedMelt = try await wallet.prepareMelt(quoteId: quoteId)
+        } catch {
+            // Preparation can reserve proofs before its native future reports an
+            // error. If CDK persisted an operation, resolve it exactly like an
+            // interrupted confirmation instead of treating the quote as reusable.
+            guard let database = walletDatabase() else {
+                throw MeltPaymentRecoveryError.unresolved(
+                    quoteID: quoteId,
+                    mintURL: mintURLString,
+                    operationID: "unknown"
+                )
+            }
+            var reservedOperationID: String?
+            do {
+                let reservedQuote = try await database.getMeltQuote(quoteId: quoteId)
+                reservedOperationID = reservedQuote?.usedByOperation
+            } catch {
+                // A failed read cannot establish that prepareMelt left no
+                // reservation. Keep the outcome ambiguous and block a
+                // potentially duplicate retry until status can be checked.
+                throw MeltPaymentRecoveryError.unresolved(
+                    quoteID: quoteId,
+                    mintURL: mintURLString,
+                    operationID: "unknown"
+                )
+            }
+            guard let operationID = reservedOperationID else {
+                throw error
+            }
+            return try await resolveMeltAfterAmbiguousFailure(
+                wallet: wallet,
+                quoteId: quoteId,
+                mintURLString: mintURLString,
+                operationID: operationID,
+                fallbackQuote: storedMeltQuote
+            )
+        }
+
+        let operationID = preparedMelt.operationId()
+        AppLogger.wallet.info(
+            "wallet-op melt prepared operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationID), privacy: .public) quote=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public)"
+        )
+
+        do {
+            AppLogger.wallet.info(
+                "wallet-op native-call kind=melt phase=confirm operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationID), privacy: .public) quote=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public)"
+            )
+            switch try await preparedMelt.confirmPreferAsync() {
+            case .paid(let finalized):
+                return MeltConfirmation(
+                    result: MeltPaymentResult(
+                        preimage: finalized.preimage,
+                        amount: finalized.amount.value,
+                        feePaid: finalized.feePaid.value,
+                        mintUrl: mintURLString,
+                        settlement: .settled
+                    )
+                )
+            case .pending:
+                // Do not run `pendingMelt.wait()` after leaving the repository
+                // lane. That native future can live for minutes and may update
+                // the same store beside an interactive operation. Dropping the
+                // handle is intentional: the manager persists the quote and its
+                // coordinated foreground poll drives terminal reconciliation.
+                // Amount and fee aren't final until the payment settles; report the
+                // quote's numbers (fee = reserve upper bound) so the UI has facts to show.
+                return MeltConfirmation(
+                    result: MeltPaymentResult(
+                        preimage: nil,
+                        amount: storedMeltQuote?.amount.value ?? 0,
+                        feePaid: storedMeltQuote?.feeReserve.value ?? 0,
+                        mintUrl: mintURLString,
+                        settlement: .pending
+                    )
+                )
+            }
+        } catch {
+            AppLogger.wallet.warning(
+                "wallet-op melt confirmation returned error operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationID), privacy: .public) quote=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            return try await resolveMeltAfterAmbiguousFailure(
+                wallet: wallet,
+                quoteId: quoteId,
+                mintURLString: mintURLString,
+                operationID: operationID,
+                fallbackQuote: storedMeltQuote
+            )
+        }
+    }
+
+    /// Resolve a post-reservation error through the mint/CDK recovery path. A
+    /// paid or pending response becomes a normal result; a compensated response
+    /// explicitly requires a fresh quote; an unknowable result is persisted by
+    /// the manager and blocks immediate retry.
+    private func resolveMeltAfterAmbiguousFailure(
+        wallet: Wallet,
+        quoteId: String,
+        mintURLString: String,
+        operationID: String,
+        fallbackQuote: MeltQuote?
+    ) async throws -> MeltConfirmation {
+        let database = walletDatabase()
+        await logMeltReservationState(
+            wallet: wallet,
+            database: database,
+            quoteId: quoteId,
+            operationID: operationID,
+            stage: "before-resolution"
+        )
+
+        var checkedQuote: MeltQuote?
+        do {
+            checkedQuote = try await wallet.checkMeltQuoteStatus(quoteId: quoteId)
+        } catch {
+            // This is CDK's status-aware saga recovery, not an unconditional
+            // reservation release. It may safely leave a still-pending saga in
+            // place when the mint cannot establish a terminal outcome.
+            let report = try? await wallet.recoverIncompleteSagas()
+            AppLogger.wallet.info(
+                "wallet-op melt recovery operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationID), privacy: .public) recovered=\(report?.recovered ?? 0, privacy: .public) compensated=\(report?.compensated ?? 0, privacy: .public) skipped=\(report?.skipped ?? 0, privacy: .public) failed=\(report?.failed ?? 0, privacy: .public)"
+            )
+            checkedQuote = try? await wallet.checkMeltQuoteStatus(quoteId: quoteId)
+        }
+
+        await logMeltReservationState(
+            wallet: wallet,
+            database: database,
+            quoteId: quoteId,
+            operationID: operationID,
+            stage: "after-resolution"
+        )
+
+        guard let checkedQuote else {
+            throw MeltPaymentRecoveryError.unresolved(
+                quoteID: quoteId,
+                mintURL: mintURLString,
+                operationID: operationID
+            )
+        }
+
+        switch checkedQuote.state {
+        case .paid, .issued:
+            let transaction = try? await wallet.listTransactions(direction: .outgoing)
+                .last(where: { $0.quoteId == quoteId })
             return MeltConfirmation(
                 result: MeltPaymentResult(
-                    preimage: finalized.preimage,
-                    amount: finalized.amount.value,
-                    feePaid: finalized.feePaid.value,
+                    preimage: transaction?.paymentProof ?? checkedQuote.paymentProof,
+                    amount: transaction?.amount.value
+                        ?? (checkedQuote.amount.value > 0 ? checkedQuote.amount.value : fallbackQuote?.amount.value ?? 0),
+                    feePaid: transaction?.fee.value
+                        ?? (checkedQuote.feeReserve.value > 0 ? checkedQuote.feeReserve.value : fallbackQuote?.feeReserve.value ?? 0),
                     mintUrl: mintURLString,
                     settlement: .settled
-                ),
-                pendingMelt: nil
+                )
             )
-        case .pending(let pendingMelt):
-            // Amount and fee aren't final until the payment settles; report the
-            // quote's numbers (fee = reserve upper bound) so the UI has facts to show.
+        case .pending:
             return MeltConfirmation(
                 result: MeltPaymentResult(
                     preimage: nil,
-                    amount: storedMeltQuote?.amount.value ?? 0,
-                    feePaid: storedMeltQuote?.feeReserve.value ?? 0,
+                    amount: checkedQuote.amount.value > 0
+                        ? checkedQuote.amount.value
+                        : fallbackQuote?.amount.value ?? 0,
+                    feePaid: checkedQuote.feeReserve.value > 0
+                        ? checkedQuote.feeReserve.value
+                        : fallbackQuote?.feeReserve.value ?? 0,
                     mintUrl: mintURLString,
                     settlement: .pending
-                ),
-                pendingMelt: pendingMelt
+                )
             )
+        case .unpaid:
+            guard let database else {
+                throw MeltPaymentRecoveryError.unresolved(
+                    quoteID: quoteId,
+                    mintURL: mintURLString,
+                    operationID: operationID
+                )
+            }
+
+            do {
+                let storedQuote = try await database.getMeltQuote(quoteId: quoteId)
+                let saga = try await database.getSaga(id: operationID)
+                let reservedProofs = try await database.getReservedProofs(operationId: operationID)
+                guard saga == nil,
+                      storedQuote?.usedByOperation == nil,
+                      reservedProofs.isEmpty else {
+                    throw MeltPaymentRecoveryError.unresolved(
+                        quoteID: quoteId,
+                        mintURL: mintURLString,
+                        operationID: operationID
+                    )
+                }
+            } catch let recoveryError as MeltPaymentRecoveryError {
+                throw recoveryError
+            } catch {
+                // "Unpaid" only becomes definitely retryable after local
+                // saga and quote-reservation reads both succeed and show that
+                // compensation completed. An I/O error is not that evidence.
+                throw MeltPaymentRecoveryError.unresolved(
+                    quoteID: quoteId,
+                    mintURL: mintURLString,
+                    operationID: operationID
+                )
+            }
+            throw MeltPaymentRecoveryError.compensated(operationID: operationID)
         }
+    }
+
+    private func logMeltReservationState(
+        wallet: Wallet,
+        database: WalletSqliteDatabase?,
+        quoteId: String,
+        operationID: String,
+        stage: String
+    ) async {
+        var incompleteSagaCount = -1
+        var sagaExists = false
+        var reservedProofCount = -1
+        var quoteReserved = false
+        if let database {
+            incompleteSagaCount = (try? await database.getIncompleteSagas().count) ?? -1
+            sagaExists = ((try? await database.getSaga(id: operationID)) ?? nil) != nil
+            reservedProofCount = (try? await database.getReservedProofs(operationId: operationID).count) ?? -1
+            quoteReserved = (try? await database.getMeltQuote(quoteId: quoteId))?.usedByOperation != nil
+        }
+        let reservedBalance = (try? await wallet.totalReservedBalance().value) ?? UInt64.max
+        let pendingSendCount = (try? await wallet.getPendingSends().count) ?? -1
+
+        AppLogger.wallet.info(
+            "wallet-op melt state stage=\(stage, privacy: .public) operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationID), privacy: .public) incomplete_sagas=\(incompleteSagaCount, privacy: .public) saga_exists=\(sagaExists, privacy: .public) quote_reserved=\(quoteReserved, privacy: .public) reserved_proofs=\(reservedProofCount, privacy: .public) reserved_balance=\(reservedBalance, privacy: .public) pending_sends=\(pendingSendCount, privacy: .public)"
+        )
     }
 
     private func mintQuoteInfo(
@@ -844,7 +1067,7 @@ class LightningService: ObservableObject {
             try await replaceStoredMintQuote(quoteToPersist, in: walletDatabase)
         } catch {
             AppLogger.wallet.error(
-                "Failed to persist mint quote \(quote.id, privacy: .public): \(String(describing: error), privacy: .public)"
+                "mint quote persistence failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quote.id), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
         }
     }
@@ -926,7 +1149,7 @@ class LightningService: ObservableObject {
             return mintQuoteClearingReservation(quote)
         } catch {
             AppLogger.wallet.error(
-                "Failed to inspect mint quote reservation \(operationId, privacy: .public) for quote \(quote.id, privacy: .public): \(String(describing: error), privacy: .public)"
+                "mint quote reservation inspection failed operation=\(WalletOperationCoordinator.privacySafeIdentifier(operationId), privacy: .public) quote=\(WalletOperationCoordinator.privacySafeIdentifier(quote.id), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
             return quote
         }

--- a/ios/CashuWallet/Core/Services/MintService.swift
+++ b/ios/CashuWallet/Core/Services/MintService.swift
@@ -140,7 +140,9 @@ class MintService: ObservableObject {
                 let mintUrl = MintUrl(url: mint.url)
                 try await repo.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
             } catch {
-                AppLogger.wallet.error("Failed to add mint \(mint.url): \(error)")
+                AppLogger.wallet.error(
+                    "add mint failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mint.url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
     }
@@ -162,7 +164,9 @@ class MintService: ObservableObject {
                     updated = true
                 }
             } catch {
-                AppLogger.wallet.error("Failed to refresh mint info for \(self.mints[i].url): \(error)")
+                AppLogger.wallet.error(
+                    "mint info refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(self.mints[i].url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
 
@@ -264,7 +268,9 @@ class MintService: ObservableObject {
                 activeMint = enriched
             }
         } catch {
-            AppLogger.wallet.error("Failed to enrich token-discovered mint \(normalizedUrl): \(error)")
+            AppLogger.wallet.error(
+                "Failed to enrich token-discovered mint resource=\(WalletOperationCoordinator.privacySafeIdentifier(normalizedUrl), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             if existingIndex == nil {
                 appendPlaceholderMint(url: normalizedUrl, name: name)
             }

--- a/ios/CashuWallet/Core/Services/TokenService.swift
+++ b/ios/CashuWallet/Core/Services/TokenService.swift
@@ -191,6 +191,9 @@ class TokenService: ObservableObject {
         for attempt in 0..<maxAttempts {
             let wallet = try await repo.getWallet(mintUrl: tokenMintUrl, unit: tokenUnit)
             do {
+                AppLogger.wallet.info(
+                    "wallet-op native-call kind=receive resource=\(WalletOperationCoordinator.privacySafeIdentifier(tokenMintUrl.url), privacy: .public) attempt=\(attempt + 1, privacy: .public)"
+                )
                 let amount = try await wallet.receive(token: token, options: receiveOptions)
                 if let matchingLocalP2PKKey {
                     SettingsManager.shared.markP2PKKeyUsed(publicKey: matchingLocalP2PKKey.publicKey)
@@ -288,7 +291,9 @@ class TokenService: ObservableObject {
             }
             return (totalPpk + 999) / 1000
         } catch {
-            print("Failed to get keyset fee for calculation: \(error)")
+            AppLogger.wallet.debug(
+                "receive fee lookup failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return 0
         }
     }
@@ -327,7 +332,9 @@ class TokenService: ObservableObject {
         do {
             return try await checkTokenSpent(token: token, mintUrl: mintUrl)
         } catch {
-            AppLogger.wallet.error("Error checking token spent status: \(error)")
+            AppLogger.wallet.error(
+                "token spent status failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return false
         }
     }

--- a/ios/CashuWallet/Core/Wallet/WalletErrors.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletErrors.swift
@@ -31,6 +31,15 @@ struct WalletMessage {
 enum WalletErrorMessage {
     /// Resolve an error to its user-facing message **and** severity.
     static func classified(for error: Error) -> WalletMessage {
+        if let meltRecoveryError = error as? MeltPaymentRecoveryError {
+            switch meltRecoveryError {
+            case .compensated:
+                return .error("The payment did not complete. Create a fresh quote and try again.")
+            case .unresolved:
+                return .caution("The payment outcome is still being checked. Do not retry it yet.").terminal()
+            }
+        }
+
         if let walletError = error as? WalletError {
             return classified(for: walletError)
         }
@@ -361,6 +370,42 @@ enum WalletErrorMessage {
     }
 }
 
+/// A melt failed after CDK may have reserved proofs or contacted the mint.
+/// Keeping this separate from transport errors prevents the UI from treating
+/// an unknown payment outcome as a safe retry.
+enum MeltPaymentRecoveryError: LocalizedError, WalletOperationOutcomeError {
+    case compensated(operationID: String)
+    case unresolved(quoteID: String, mintURL: String, operationID: String)
+
+    var operationID: String {
+        switch self {
+        case .compensated(let operationID): operationID
+        case .unresolved(_, _, let operationID): operationID
+        }
+    }
+
+    var retryRequiresFreshQuote: Bool {
+        if case .compensated = self { return true }
+        return false
+    }
+
+    var unresolvedQuote: (id: String, mintURL: String)? {
+        guard case .unresolved(let quoteID, let mintURL, _) = self else { return nil }
+        return (quoteID, mintURL)
+    }
+
+    var walletOperationFailureOutcome: WalletOperationCoordinator.FailureOutcome {
+        switch self {
+        case .compensated: .definiteFailure
+        case .unresolved: .ambiguousFailure
+        }
+    }
+
+    var errorDescription: String? {
+        WalletErrorMessage.message(for: self)
+    }
+}
+
 extension Error {
     /// Text-only user-facing message (defaults the UI to the `.error` tier).
     var userFacingWalletMessage: String {
@@ -379,6 +424,10 @@ extension Error {
             return true
         }
         return WalletErrorMessage.classified(for: self).text == "Not enough balance."
+    }
+
+    var meltRetryRequiresFreshQuote: Bool {
+        (self as? MeltPaymentRecoveryError)?.retryRequiresFreshQuote == true
     }
 }
 

--- a/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
@@ -182,12 +182,32 @@ extension WalletManager {
             amount: amount,
             preferredMintURL: preferredMintURL
         )
-        let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: selectedMint.url), unit: .sat)
-        let customAmount = request.amount() == nil ? Amount(value: amount) : nil
+        try await operationCoordinator.perform(
+            kind: .send,
+            resourceID: selectedMint.url,
+            protectsBackgroundExecution: true,
+            defaultFailureOutcome: .ambiguousFailure
+        ) {
+            do {
+                let wallet = try await walletRepository.getWallet(
+                    mintUrl: MintUrl(url: selectedMint.url),
+                    unit: .sat
+                )
+                let customAmount = request.amount() == nil ? Amount(value: amount) : nil
 
-        try await wallet.payRequest(paymentRequest: request, customAmount: customAmount)
-        await refreshBalance()
-        await loadTransactions()
+                try await wallet.payRequest(paymentRequest: request, customAmount: customAmount)
+                await self.refreshBalanceAssumingWalletOperationLease()
+                await self.loadTransactionsAssumingWalletOperationLease()
+            } catch {
+                await self.captureWalletFailureDiagnostics(kind: .send)
+                await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                    kind: .send,
+                    preferredMintURL: selectedMint.url
+                )
+                await self.captureWalletFailureDiagnostics(kind: .send)
+                throw error
+            }
+        }
     }
 
     // MARK: - Fee estimation (for the pay-request screen)
@@ -199,10 +219,16 @@ extension WalletManager {
     func mintInputFeePpk(mintURL: String) async -> UInt64? {
         guard let walletRepository else { return nil }
         do {
-            let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: mintURL), unit: .sat)
-            let keysets = try await wallet.refreshKeysets()
-            let active = keysets.first(where: { $0.active }) ?? keysets.first
-            return active?.inputFeePpk
+            return try await operationCoordinator.perform(
+                kind: .feeEstimate,
+                resourceID: mintURL,
+                defaultFailureOutcome: .ambiguousFailure
+            ) {
+                let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: mintURL), unit: .sat)
+                let keysets = try await wallet.refreshKeysets()
+                let active = keysets.first(where: { $0.active }) ?? keysets.first
+                return active?.inputFeePpk
+            }
         } catch {
             return nil
         }
@@ -220,23 +246,38 @@ extension WalletManager {
     func estimateCashuPaymentFee(amountSats: UInt64, mintURL: String) async -> UInt64? {
         guard let walletRepository, amountSats > 0 else { return nil }
         do {
-            let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: mintURL), unit: .sat)
-            let options = SendOptions(
-                memo: nil,
-                conditions: nil,
-                amountSplitTarget: SplitTarget.none,
-                sendKind: SendKind.onlineExact,
-                includeFee: true,
-                useP2bk: false,
-                maxProofs: nil,
-                metadata: [:],
-                p2pkSigningKeys: [],
-                p2pkLockedProofSendMode: .swap
-            )
-            let prepared = try await wallet.prepareSend(amount: Amount(value: amountSats), options: options)
-            let fee = prepared.fee().value
-            try? await prepared.cancel()
-            return fee
+            return try await operationCoordinator.perform(
+                kind: .feeEstimate,
+                resourceID: mintURL
+            ) {
+                do {
+                    let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: mintURL), unit: .sat)
+                    let options = SendOptions(
+                        memo: nil,
+                        conditions: nil,
+                        amountSplitTarget: SplitTarget.none,
+                        sendKind: SendKind.onlineExact,
+                        includeFee: true,
+                        useP2bk: false,
+                        maxProofs: nil,
+                        metadata: [:],
+                        p2pkSigningKeys: [],
+                        p2pkLockedProofSendMode: .swap
+                    )
+                    let prepared = try await wallet.prepareSend(amount: Amount(value: amountSats), options: options)
+                    let fee = prepared.fee().value
+                    try await prepared.cancel()
+                    return fee
+                } catch {
+                    await self.captureWalletFailureDiagnostics(kind: .feeEstimate)
+                    await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                        kind: .feeEstimate,
+                        preferredMintURL: mintURL
+                    )
+                    await self.captureWalletFailureDiagnostics(kind: .feeEstimate)
+                    throw error
+                }
+            }
         } catch {
             return nil
         }
@@ -337,7 +378,12 @@ extension WalletManager {
     ) async throws {
         // 1. Commit the mint to the wallet so the final pay can select it.
         onStage(.addingMint)
-        await mintService.ensureMintTracked(url: targetMintURL)
+        try await operationCoordinator.perform(
+            kind: .addMint,
+            resourceID: targetMintURL
+        ) {
+            await self.mintService.ensureMintTracked(url: targetMintURL)
+        }
 
         // 2. Cover the target's input fee (if any) so the minted proofs can still
         //    send exactly `amount`. Virtually all mints charge 0 → no buffer.

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -206,36 +206,43 @@ extension WalletManager {
         let normalizedUrl = url.trimmingCharacters(in: .whitespacesAndNewlines)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
 
-        let mintUrl = MintUrl(url: normalizedUrl)
+        return try await operationCoordinator.perform(
+            kind: .restore,
+            priority: .recovery,
+            resourceID: normalizedUrl,
+            protectsBackgroundExecution: true
+        ) {
+            let mintUrl = MintUrl(url: normalizedUrl)
 
-        // Create wallet for this mint
-        try await walletRepository.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
+            // Create wallet for this mint
+            try await walletRepository.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
 
-        // Get the wallet instance
-        let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
+            // Get the wallet instance
+            let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
 
-        // Fetch mint info for display name
-        let info = try? await wallet.fetchMintInfo()
-        let mintName = info?.name ?? "Unknown Mint"
+            // Fetch mint info for display name
+            let info = try? await wallet.fetchMintInfo()
+            let mintName = info?.name ?? "Unknown Mint"
 
-        // Perform NUT-09 restore - this derives proofs from the seed and checks their state with the mint
-        let restored = try await wallet.restore()
+            // Perform NUT-09 restore - this derives proofs from the seed and checks their state with the mint
+            let restored = try await wallet.restore()
 
-        // Ensure mint is in our saved list
-        await mintService.ensureMintTracked(url: normalizedUrl, name: mintName)
+            // Ensure mint is in our saved list
+            await self.mintService.ensureMintTracked(url: normalizedUrl, name: mintName)
 
-        // Refresh balance after restore
-        await refreshBalance()
+            // Refresh balance while this restore still owns the repository.
+            await self.refreshBalanceAssumingWalletOperationLease()
 
-        SentryService.breadcrumb("Wallet restore from mint completed", category: "wallet.lifecycle")
-        return RestoreMintResult(
-            mintUrl: normalizedUrl,
-            mintName: mintName,
-            iconUrl: info?.iconUrl,
-            spent: restored.spent.value,
-            unspent: restored.unspent.value,
-            pending: restored.pending.value
-        )
+            SentryService.breadcrumb("Wallet restore from mint completed", category: "wallet.lifecycle")
+            return RestoreMintResult(
+                mintUrl: normalizedUrl,
+                mintName: mintName,
+                iconUrl: info?.iconUrl,
+                spent: restored.spent.value,
+                unspent: restored.unspent.value,
+                pending: restored.pending.value
+            )
+        }
     }
 
     /// Restore wallet from mnemonic - Phase 3: Complete restore and dismiss onboarding
@@ -863,6 +870,12 @@ extension WalletManager {
             }
             guard !Task.isCancelled else { return }
 
+            // These passive passes acquire only if the recovery lane is now
+            // idle; they never queue stale polling behind a user payment.
+            await self.syncPendingMeltQuotes()
+            await self.syncPendingMintQuotes()
+            guard !Task.isCancelled else { return }
+
             await NWCManager.shared.startIfEnabled()
             self.startupMaintenanceTask = nil
         }
@@ -871,6 +884,20 @@ extension WalletManager {
     /// Returns true when saga recovery changed local wallet state and balances
     /// should be read again.
     private func performBestEffortWalletStartupMaintenance() async -> Bool {
+        do {
+            return try await operationCoordinator.perform(
+                kind: .recovery,
+                priority: .recovery,
+                protectsBackgroundExecution: true
+            ) {
+                await self.performBestEffortWalletStartupMaintenanceAssumingLease()
+            }
+        } catch {
+            return false
+        }
+    }
+
+    private func performBestEffortWalletStartupMaintenanceAssumingLease() async -> Bool {
         guard let walletRepository else { return false }
         let mintUrls = trackedMintUrlsForWalletAccess()
         guard !mintUrls.isEmpty else { return false }
@@ -903,7 +930,7 @@ extension WalletManager {
                 }
             } catch {
                 AppLogger.wallet.error(
-                    "Wallet startup maintenance failed for mint \(mintUrlString, privacy: .public): \(String(describing: error), privacy: .public)"
+                    "wallet startup maintenance failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrlString), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
                 )
             }
         }
@@ -912,29 +939,25 @@ extension WalletManager {
             walletStore.saveMintKeysetRefreshTimestamps(keysetRefreshTimestamps)
         }
 
-        // Saga recovery above only single-polls async-accepted (NUT-05) melts and
-        // skips them while still pending; re-arm their completion tracking here.
-        // The mint-quote pass settles anything paid while the app was gone
-        // (Android startup parity) instead of waiting for the first poll tick.
-        if !Task.isCancelled {
-            await syncPendingMeltQuotes()
-            await syncPendingMintQuotes()
-        }
         return recoveredWalletState
     }
 
     private func recoverIncompleteSagasIfNeeded(wallet: Wallet, mintUrl: String) async -> Bool {
         do {
+            let beforeSagaCount = (try? await db?.getIncompleteSagas().count) ?? -1
+            let beforeReservedBalance = (try? await wallet.totalReservedBalance().value) ?? UInt64.max
             let report = try await wallet.recoverIncompleteSagas()
+            let afterSagaCount = (try? await db?.getIncompleteSagas().count) ?? -1
+            let afterReservedBalance = (try? await wallet.totalReservedBalance().value) ?? UInt64.max
             if report.recovered > 0 || report.compensated > 0 || report.skipped > 0 || report.failed > 0 {
                 AppLogger.wallet.info(
-                    "Recovered wallet sagas for mint \(mintUrl, privacy: .public): recovered=\(report.recovered, privacy: .public) compensated=\(report.compensated, privacy: .public) skipped=\(report.skipped, privacy: .public) failed=\(report.failed, privacy: .public)"
+                    "wallet recovery resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public) recovered=\(report.recovered, privacy: .public) compensated=\(report.compensated, privacy: .public) skipped=\(report.skipped, privacy: .public) failed=\(report.failed, privacy: .public) sagas_before=\(beforeSagaCount, privacy: .public) sagas_after=\(afterSagaCount, privacy: .public) reserved_before=\(beforeReservedBalance, privacy: .public) reserved_after=\(afterReservedBalance, privacy: .public)"
                 )
             }
             return report.recovered > 0 || report.compensated > 0
         } catch {
             AppLogger.wallet.error(
-                "Failed to recover wallet sagas for mint \(mintUrl, privacy: .public): \(String(describing: error), privacy: .public)"
+                "wallet recovery failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
             return false
         }
@@ -953,12 +976,12 @@ extension WalletManager {
         do {
             let keysets = try await wallet.refreshKeysets()
             AppLogger.wallet.info(
-                "Refreshed \(keysets.count, privacy: .public) keysets for mint \(mintUrl, privacy: .public)"
+                "refreshed keysets count=\(keysets.count, privacy: .public) resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public)"
             )
             return true
         } catch {
             AppLogger.wallet.error(
-                "Failed to refresh keysets for mint \(mintUrl, privacy: .public): \(String(describing: error), privacy: .public)"
+                "keyset refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
             return false
         }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
@@ -10,32 +10,64 @@ extension WalletManager {
         targetMintURL: String? = nil,
         unit: String = "sat"
     ) async throws -> MintQuoteInfo {
-        let quote = try await lightningService.createMintQuote(
-            amount: amount,
-            method: method,
-            targetMintURL: targetMintURL,
-            unit: PaymentRequestDecoder.currencyUnit(from: unit)
-        )
-        await loadTransactions()
-        return quote
+        try await operationCoordinator.perform(
+            kind: .mintQuote,
+            resourceID: targetMintURL
+        ) {
+            let quote = try await self.lightningService.createMintQuote(
+                amount: amount,
+                method: method,
+                targetMintURL: targetMintURL,
+                unit: PaymentRequestDecoder.currencyUnit(from: unit)
+            )
+            await self.loadTransactionsAssumingWalletOperationLease()
+            return quote
+        }
     }
 
     func existingAmountlessOffer() async throws -> MintQuoteInfo? {
-        try await lightningService.existingAmountlessOffer()
+        try await operationCoordinator.perform(kind: .mintQuote) {
+            try await self.lightningService.existingAmountlessOffer()
+        }
     }
 
     func existingOnchainMintQuote() async throws -> MintQuoteInfo? {
-        try await lightningService.existingOnchainMintQuote()
+        try await operationCoordinator.perform(kind: .mintQuote) {
+            try await self.lightningService.existingOnchainMintQuote()
+        }
     }
 
     func checkMintQuote(quoteId: String) async throws -> MintQuoteInfo {
-        return try await lightningService.checkMintQuote(quoteId: quoteId)
+        return try await operationCoordinator.perform(
+            kind: .mintQuote,
+            resourceID: quoteId
+        ) {
+            try await self.lightningService.checkMintQuote(quoteId: quoteId)
+        }
     }
 
     func mintTokens(quoteId: String) async throws -> UInt64 {
-        let amount = try await lightningService.mintTokens(quoteId: quoteId)
-        await refreshBalance()
-        await loadTransactions()
+        let amount = try await operationCoordinator.perform(
+            kind: .mint,
+            resourceID: quoteId,
+            protectsBackgroundExecution: true,
+            defaultFailureOutcome: .ambiguousFailure
+        ) {
+            do {
+                let amount = try await self.lightningService.mintTokens(quoteId: quoteId)
+                await self.refreshBalanceAssumingWalletOperationLease()
+                await self.loadTransactionsAssumingWalletOperationLease()
+                return amount
+            } catch {
+                await self.captureWalletFailureDiagnostics(kind: .mint, quoteID: quoteId)
+                await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                    kind: .mint,
+                    preferredMintURL: nil
+                )
+                await self.captureWalletFailureDiagnostics(kind: .mint, quoteID: quoteId)
+                throw error
+            }
+        }
         SentryService.breadcrumb("Lightning invoice minted", category: "wallet.lightning")
         return amount
     }
@@ -54,7 +86,9 @@ extension WalletManager {
                 try? await Task.sleep(nanoseconds: 2_500_000_000)
             }
         }
-        AppLogger.wallet.error("claimPaidMintQuote: gave up minting \(quoteId, privacy: .public)")
+        AppLogger.wallet.error(
+            "claimPaidMintQuote: gave up minting resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public)"
+        )
         SentryService.breadcrumb("Lightning mint claim gave up after retries", category: "wallet.lightning")
     }
 
@@ -62,10 +96,15 @@ extension WalletManager {
         request: String,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
-        try await lightningService.createMeltQuote(
-            request: request,
-            preferredMintURL: preferredMintURL
-        )
+        try await operationCoordinator.perform(
+            kind: .meltQuote,
+            resourceID: preferredMintURL
+        ) {
+            try await self.lightningService.createMeltQuote(
+                request: request,
+                preferredMintURL: preferredMintURL
+            )
+        }
     }
 
     func createMeltQuote(
@@ -80,11 +119,16 @@ extension WalletManager {
         amount: UInt64,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
-        try await lightningService.createHumanReadableMeltQuote(
-            address: address,
-            amount: amount,
-            preferredMintURL: preferredMintURL
-        )
+        try await operationCoordinator.perform(
+            kind: .meltQuote,
+            resourceID: preferredMintURL
+        ) {
+            try await self.lightningService.createHumanReadableMeltQuote(
+                address: address,
+                amount: amount,
+                preferredMintURL: preferredMintURL
+            )
+        }
     }
 
     func createOnchainMeltQuote(
@@ -92,32 +136,68 @@ extension WalletManager {
         amount: UInt64,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
-        try await lightningService.createOnchainMeltQuote(
-            address: address,
-            amount: amount,
-            preferredMintURL: preferredMintURL
-        )
+        try await operationCoordinator.perform(
+            kind: .meltQuote,
+            resourceID: preferredMintURL
+        ) {
+            try await self.lightningService.createOnchainMeltQuote(
+                address: address,
+                amount: amount,
+                preferredMintURL: preferredMintURL
+            )
+        }
     }
 
     func subscribeToMintQuote(
         quoteId: String,
         paymentMethod: PaymentMethodKind
     ) async throws -> ActiveSubscription? {
-        return try await lightningService.subscribeToMintQuote(
-            quoteId: quoteId,
-            paymentMethod: paymentMethod
-        )
+        // Creating the subscription touches the wallet and is serialized. The
+        // caller's long-lived `recv()` only waits for notifications; any quote
+        // status or mint work it triggers re-enters through coordinated methods.
+        return try await operationCoordinator.perform(
+            kind: .mintQuote,
+            resourceID: quoteId
+        ) {
+            try await self.lightningService.subscribeToMintQuote(
+                quoteId: quoteId,
+                paymentMethod: paymentMethod
+            )
+        }
     }
 
     func meltTokens(quoteId: String, mintUrl: String? = nil) async throws -> MeltPaymentResult {
-        let confirmation = try await lightningService.meltTokens(quoteId: quoteId, mintUrl: mintUrl)
+        let confirmation: LightningService.MeltConfirmation
+        do {
+            confirmation = try await operationCoordinator.perform(
+                kind: .melt,
+                resourceID: quoteId,
+                protectsBackgroundExecution: true,
+                defaultFailureOutcome: .ambiguousFailure
+            ) {
+                do {
+                    return try await self.lightningService.meltTokens(quoteId: quoteId, mintUrl: mintUrl)
+                } catch {
+                    await self.captureWalletFailureDiagnostics(
+                        kind: .melt,
+                        operationID: (error as? MeltPaymentRecoveryError)?.operationID,
+                        quoteID: quoteId
+                    )
+                    throw error
+                }
+            }
+        } catch let recoveryError as MeltPaymentRecoveryError {
+            if let unresolved = recoveryError.unresolvedQuote {
+                rememberPendingMeltQuote(quoteId: unresolved.id, mintUrl: unresolved.mintURL)
+            }
+            throw recoveryError
+        }
         let result = confirmation.result
-        if let pendingMelt = confirmation.pendingMelt {
+        if result.settlement == .pending {
             // Mint accepted the payment for asynchronous NUT-05 settlement (the
-            // usual case for on-chain melts). Remember the quote so a relaunch can
-            // pick it back up, then wait for it in the background.
+            // usual case for on-chain melts). Remember the quote so serialized
+            // foreground/startup polling can reconcile it, including after relaunch.
             rememberPendingMeltQuote(quoteId: quoteId, mintUrl: result.mintUrl)
-            watchPendingMelt(pendingMelt, quoteId: quoteId)
             SentryService.breadcrumb("Melt accepted for async settlement", category: "wallet.lightning")
         } else {
             recordFinalizedMelt(quoteId: quoteId, preimage: result.preimage, feePaid: result.feePaid)

--- a/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
@@ -22,16 +22,25 @@ extension WalletManager {
     /// debounce only). Does not touch the global loading flag.
     @discardableResult
     func refreshPendingMintQuote(quoteId: String) async -> Bool {
-        let minted = await syncPendingMintQuote(
-            quoteId: quoteId,
-            allowPendingOnchainMintAttempt: true,
-            force: true
-        )
-        if minted {
-            await refreshBalance()
+        do {
+            return try await operationCoordinator.perform(
+                kind: .mintQuote,
+                resourceID: quoteId
+            ) {
+                let minted = await self.syncPendingMintQuote(
+                    quoteId: quoteId,
+                    allowPendingOnchainMintAttempt: true,
+                    force: true
+                )
+                if minted {
+                    await self.refreshBalanceAssumingWalletOperationLease()
+                }
+                await self.loadTransactionsAssumingWalletOperationLease()
+                return minted
+            }
+        } catch {
+            return false
         }
-        await loadTransactions()
-        return minted
     }
 
     // MARK: - Foreground polling
@@ -69,6 +78,27 @@ extension WalletManager {
     ///   pass. When `true` (pull-to-refresh), every quote is eligible subject
     ///   only to a short per-quote debounce.
     func syncPendingMintQuotes(force: Bool = false) async {
+        if force {
+            do {
+                try await operationCoordinator.perform(kind: .quotePoll) {
+                    await self.syncPendingMintQuotesAssumingWalletOperationLease(force: true)
+                }
+            } catch {
+                // Explicit refresh cancellation is expected when its view exits.
+            }
+            return
+        }
+
+        do {
+            try await operationCoordinator.performIfIdle(kind: .quotePoll) {
+                await self.syncPendingMintQuotesAssumingWalletOperationLease(force: false)
+            }
+        } catch {
+            // Passive maintenance is best effort and will run again next tick.
+        }
+    }
+
+    private func syncPendingMintQuotesAssumingWalletOperationLease(force: Bool) async {
         // Coarse in-flight guard: collapse overlapping triggers into one pass.
         guard !isSyncingMintQuotes else { return }
         isSyncingMintQuotes = true
@@ -76,7 +106,7 @@ extension WalletManager {
         defer { isSyncingMintQuotes = false }
 
         guard let db else {
-            await loadTransactions()
+            await loadTransactionsAssumingWalletOperationLease()
             return
         }
 
@@ -109,16 +139,24 @@ extension WalletManager {
                     force: force
                 )
                 mintedAny = mintedAny || minted
+
+                // A poll that was already running when the user acted yields
+                // after the current quote instead of scanning the whole queue.
+                if !force, await operationCoordinator.hasWaitingUserOperation() {
+                    break
+                }
             }
         } catch {
-            AppLogger.wallet.error("Failed to sync pending mint quotes: \(error)")
+            AppLogger.wallet.error(
+                "pending mint quote sync failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
         }
 
         if mintedAny {
-            await refreshBalance()
+            await refreshBalanceAssumingWalletOperationLease()
         }
 
-        await loadTransactions()
+        await loadTransactionsAssumingWalletOperationLease()
     }
 
     func reclaimPendingToken(pendingToken: PendingToken) async throws -> UInt64 {
@@ -131,6 +169,21 @@ extension WalletManager {
     // MARK: - Transaction History
 
     func loadTransactions(includeRemoteObservations: Bool = true) async {
+        do {
+            try await operationCoordinator.perform(kind: .history) {
+                await self.loadTransactionsAssumingWalletOperationLease(
+                    includeRemoteObservations: includeRemoteObservations
+                )
+            }
+        } catch {
+            // History refresh is best effort and may be cancelled with its view.
+        }
+    }
+
+    /// Internal form for workflows that already own the repository lease.
+    func loadTransactionsAssumingWalletOperationLease(
+        includeRemoteObservations: Bool = true
+    ) async {
         await transactionService.loadTransactions(includeRemoteObservations: includeRemoteObservations)
         reconcileQuoteIntents()
         objectWillChange.send()
@@ -224,7 +277,15 @@ extension WalletManager {
                     return false
                 }
 
-                AppLogger.wallet.error("Failed to mint pending quote \(quoteId): \(error)")
+                await captureWalletFailureDiagnostics(kind: .mint, quoteID: quoteId)
+                await recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                    kind: .mint,
+                    preferredMintURL: nil
+                )
+                await captureWalletFailureDiagnostics(kind: .mint, quoteID: quoteId)
+                AppLogger.wallet.error(
+                    "pending quote mint failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
                 mintQuoteCheckThrottle[quoteId] = MintQuoteCheckBackoff.afterUnpaidOrError(
                     entry: prior,
                     now: now
@@ -239,7 +300,9 @@ extension WalletManager {
             if isMissingQuoteError(error) {
                 return false
             }
-            AppLogger.wallet.error("Failed to refresh pending quote \(quoteId): \(error)")
+            AppLogger.wallet.error(
+                "pending quote refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return false
         }
     }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -5,7 +5,12 @@ extension WalletManager {
     // MARK: - Mint Operations (Delegate to MintService)
 
     func addMint(url: String) async throws {
-        let mint = try await mintService.addMint(url: url)
+        let mint = try await operationCoordinator.perform(
+            kind: .addMint,
+            resourceID: url
+        ) {
+            try await self.mintService.addMint(url: url)
+        }
         performICloudBackup()
         Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         restoreAddedMintInBackground(url: mint.url)
@@ -25,11 +30,18 @@ extension WalletManager {
             }
 
             do {
-                let wallet = try await walletRepository.getWallet(
-                    mintUrl: MintUrl(url: url),
-                    unit: .sat
-                )
-                _ = try await wallet.restore()
+                try await self.operationCoordinator.perform(
+                    kind: .restore,
+                    priority: .maintenance,
+                    resourceID: url,
+                    protectsBackgroundExecution: true
+                ) {
+                    let wallet = try await walletRepository.getWallet(
+                        mintUrl: MintUrl(url: url),
+                        unit: .sat
+                    )
+                    _ = try await wallet.restore()
+                }
 
                 guard self.mintService.isMintTracked(url: url) else { return }
 
@@ -37,13 +49,25 @@ extension WalletManager {
                 await self.loadTransactions()
                 SentryService.breadcrumb("Mint restore completed", category: "wallet.mint")
             } catch {
-                AppLogger.wallet.error("Background restore failed for mint \(url): \(error)")
+                AppLogger.wallet.error(
+                    "background restore failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(url), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
         }
     }
 
     func removeMint(at offsets: IndexSet) async {
-        await mintService.removeMint(at: offsets)
+        do {
+            try await operationCoordinator.perform(kind: .addMint) {
+                await self.mintService.removeMint(at: offsets)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            AppLogger.wallet.error(
+                "remove mint failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+        }
         await refreshBalance()
         performICloudBackup()
         Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
@@ -51,7 +75,12 @@ extension WalletManager {
     }
 
     func setActiveMint(_ mint: MintInfo) async throws {
-        try await mintService.setActiveMint(mint)
+        try await operationCoordinator.perform(
+            kind: .mintInfo,
+            resourceID: mint.url
+        ) {
+            try await self.mintService.setActiveMint(mint)
+        }
         await refreshBalance()
     }
 
@@ -62,7 +91,13 @@ extension WalletManager {
 
 
     func refreshMintInfo() async {
-        await mintService.refreshMintInfo()
+        do {
+            try await operationCoordinator.perform(kind: .mintInfo) {
+                await self.mintService.refreshMintInfo()
+            }
+        } catch {
+            // Cancellation is expected when the owning view disappears.
+        }
     }
 
     /// Fetch full mint info from the mint's API via CashuDevKit
@@ -70,9 +105,11 @@ extension WalletManager {
         guard let walletRepository = walletRepository else {
             throw WalletError.notInitialized
         }
-        let mintUrlObj = MintUrl(url: mintUrl)
-        let wallet = try await walletRepository.getWallet(mintUrl: mintUrlObj, unit: .sat)
-        return try await wallet.fetchMintInfo()
+        return try await operationCoordinator.perform(kind: .mintInfo, resourceID: mintUrl) {
+            let mintUrlObj = MintUrl(url: mintUrl)
+            let wallet = try await walletRepository.getWallet(mintUrl: mintUrlObj, unit: .sat)
+            return try await wallet.fetchMintInfo()
+        }
     }
 
     /// Best-effort preview of a mint's identity (name, icon, payment methods),
@@ -87,21 +124,28 @@ extension WalletManager {
         let normalized = normalizePreviewMintUrl(url)
         let mintUrl = MintUrl(url: normalized)
         do {
-            if await !walletRepository.hasMint(mintUrl: mintUrl) {
-                try await walletRepository.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
+            return try await operationCoordinator.perform(
+                kind: .mintInfo,
+                resourceID: normalized
+            ) {
+                if await !walletRepository.hasMint(mintUrl: mintUrl) {
+                    try await walletRepository.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)
+                }
+                let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
+                guard let info = try await wallet.fetchMintInfo() else {
+                    return nil
+                }
+                let mintMethods = info.nuts.nut04.methods.compactMap { PaymentMethodKind.from($0.method) }
+                let meltMethods = info.nuts.nut05.methods.compactMap { PaymentMethodKind.from($0.method) }
+                let methods = PaymentMethodKind.allCases.filter {
+                    mintMethods.contains($0) || meltMethods.contains($0)
+                }
+                return MintPreviewInfo(name: info.name, iconUrl: info.iconUrl, methods: methods)
             }
-            let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
-            guard let info = try await wallet.fetchMintInfo() else {
-                return nil
-            }
-            let mintMethods = info.nuts.nut04.methods.compactMap { PaymentMethodKind.from($0.method) }
-            let meltMethods = info.nuts.nut05.methods.compactMap { PaymentMethodKind.from($0.method) }
-            let methods = PaymentMethodKind.allCases.filter {
-                mintMethods.contains($0) || meltMethods.contains($0)
-            }
-            return MintPreviewInfo(name: info.name, iconUrl: info.iconUrl, methods: methods)
         } catch {
-            AppLogger.wallet.error("Failed to fetch CDK mint preview for \(normalized): \(error)")
+            AppLogger.wallet.error(
+                "mint preview failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(normalized), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return nil
         }
     }
@@ -116,6 +160,19 @@ extension WalletManager {
 
     // MARK: - Balance Operations
     func refreshBalance() async {
+        do {
+            try await operationCoordinator.perform(kind: .balance) {
+                await self.refreshBalanceAssumingWalletOperationLease()
+            }
+        } catch {
+            // Balance refresh is best effort. The coordinator already records
+            // cancellation and timing without exposing wallet identifiers.
+        }
+    }
+
+    /// Internal form for a higher-level workflow that already owns the shared
+    /// repository lease. Never call this from an uncoordinated task.
+    func refreshBalanceAssumingWalletOperationLease() async {
         guard let walletRepository = walletRepository else { return }
         let mintUrls = trackedMintUrlsForWalletAccess()
         
@@ -142,7 +199,9 @@ extension WalletManager {
                 unitTotals["sat", default: 0] += walletBalance.value
             } catch {
                 balancesByMintURL[mintUrlString] = 0
-                AppLogger.wallet.error("Failed to refresh balance for mint \(mintUrlString): \(error)")
+                AppLogger.wallet.error(
+                    "balance refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrlString), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
 
             // Add this mint's non-sat unit balances. Only the units it advertises

--- a/ios/CashuWallet/Core/Wallet/WalletManager+NPC.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+NPC.swift
@@ -86,39 +86,56 @@ extension WalletManager {
             // The NPC poller can fire as the app backgrounds; hold a background-task
             // assertion so this SQLite-writing mint finishes before suspension.
             try await withBackgroundWriteAssertion("npc-mint-claim") {
-                guard let walletRepository = walletRepository else {
-                    throw WalletError.notInitialized
+                try await self.operationCoordinator.perform(
+                    kind: .mint,
+                    priority: .maintenance,
+                    resourceID: mintQuote.id,
+                    defaultFailureOutcome: .ambiguousFailure
+                ) {
+                    do {
+                        guard let walletRepository = self.walletRepository else {
+                            throw WalletError.notInitialized
+                        }
+
+                        let mintUrl = mintQuote.mintUrl
+                        await self.mintService.ensureMintTracked(url: mintUrl.url)
+
+                        if let db = self.db {
+                            try await self.replaceStoredNPCMintQuote(mintQuote, in: db)
+                        }
+
+                        let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
+
+                        let proofs = try await wallet.mintUnified(
+                            quoteId: mintQuote.id,
+                            amountSplitTarget: SplitTarget.none,
+                            spendingConditions: spendingConditions
+                        )
+                        let totalAmount = proofs.reduce(UInt64(0)) { $0 + $1.amount.value }
+
+                        self.markNPCQuoteProcessed(mintQuote.id)
+
+                        await self.refreshBalanceAssumingWalletOperationLease()
+                        await self.loadTransactionsAssumingWalletOperationLease()
+                        SentryService.breadcrumb("NPC quote minted", category: "wallet.npc")
+
+                        NotificationCenter.default.post(
+                            name: .cashuTokenReceived,
+                            object: nil,
+                            // Background receive: no receive sheet is up to confirm it, so
+                            // ask the home beat to fire the "sats landed" haptic.
+                            userInfo: ["amount": totalAmount, "source": "npub.cash", "homeHaptic": true]
+                        )
+                    } catch {
+                        await self.captureWalletFailureDiagnostics(kind: .mint, quoteID: mintQuote.id)
+                        await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                            kind: .mint,
+                            preferredMintURL: mintQuote.mintUrl.url
+                        )
+                        await self.captureWalletFailureDiagnostics(kind: .mint, quoteID: mintQuote.id)
+                        throw error
+                    }
                 }
-
-                let mintUrl = mintQuote.mintUrl
-                await mintService.ensureMintTracked(url: mintUrl.url)
-
-                if let db {
-                    try await replaceStoredNPCMintQuote(mintQuote, in: db)
-                }
-
-                let wallet = try await walletRepository.getWallet(mintUrl: mintUrl, unit: .sat)
-
-                let proofs = try await wallet.mintUnified(
-                    quoteId: mintQuote.id,
-                    amountSplitTarget: SplitTarget.none,
-                    spendingConditions: spendingConditions
-                )
-                let totalAmount = proofs.reduce(UInt64(0)) { $0 + $1.amount.value }
-
-                markNPCQuoteProcessed(mintQuote.id)
-
-                await refreshBalance()
-                await loadTransactions()
-                SentryService.breadcrumb("NPC quote minted", category: "wallet.npc")
-
-                NotificationCenter.default.post(
-                    name: .cashuTokenReceived,
-                    object: nil,
-                    // Background receive: no receive sheet is up to confirm it, so
-                    // ask the home beat to fire the "sats landed" haptic.
-                    userInfo: ["amount": totalAmount, "source": "npub.cash", "homeHaptic": true]
-                )
             }
         } catch {
             if isAlreadyIssuedMintError(error) {
@@ -126,7 +143,9 @@ extension WalletManager {
             } else {
                 SentryService.capture(error)
             }
-            AppLogger.wallet.error("Failed to mint NPC quote: \(error)")
+            AppLogger.wallet.error(
+                "NPC quote mint failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintQuote.id), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
         }
     }
 

--- a/ios/CashuWallet/Core/Wallet/WalletManager+PendingMelts.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+PendingMelts.swift
@@ -5,79 +5,115 @@ import Cdk
 ///
 /// When a mint accepts a melt with `Prefer: respond-async` — on-chain payments
 /// especially can take minutes to settle — `confirmPreferAsync()` hands back a
-/// `PendingMelt` instead of a final result. While the app lives, a waiter task
-/// subscribes to the quote until it settles. Because iOS can suspend or kill
-/// the process mid-wait, every accepted-pending quote is also persisted in
-/// `walletStore` and re-checked via `syncPendingMeltQuotes()` on launch and
-/// foreground; `checkMeltQuoteStatus` completes the underlying wallet saga
-/// (releasing change / compensating proofs) when the mint reports a terminal
-/// state. CDK's own `recoverIncompleteSagas()` at startup only single-polls a
-/// pending melt and skips it if still pending, so this app-side record is what
-/// guarantees the payment's bookkeeping eventually lands.
+/// `PendingMelt` instead of a final result. We intentionally do not run its
+/// long-lived `wait()` future beside normal wallet work: it can update the same
+/// native store after the app-level lease has ended. Instead, every pending
+/// quote is persisted and re-checked through the coordinator on launch and in
+/// the foreground. `checkMeltQuoteStatus` completes the underlying wallet saga
+/// when the mint reports a terminal state.
 extension WalletManager {
-    /// Wait in the background for an async-accepted melt and finish the
-    /// bookkeeping when it settles. One waiter per quote; the waiter dies with
-    /// the process and `syncPendingMeltQuotes()` takes over after relaunch.
-    func watchPendingMelt(_ pendingMelt: PendingMelt, quoteId: String) {
-        guard pendingMeltWaiters[quoteId] == nil else { return }
-        pendingMeltWaiters[quoteId] = Task { [weak self] in
-            defer { self?.pendingMeltWaiters[quoteId] = nil }
-            do {
-                let finalized = try await pendingMelt.wait()
-                await self?.finishPendingMelt(
-                    quoteId: quoteId,
-                    state: finalized.state,
-                    preimage: finalized.preimage,
-                    feePaid: finalized.feePaid.value
-                )
-            } catch {
-                // Leave the quote tracked — syncPendingMeltQuotes retries later.
-                AppLogger.wallet.error(
-                    "Pending melt wait failed for quote \(quoteId, privacy: .public): \(String(describing: error), privacy: .public)"
-                )
-            }
-        }
-    }
-
     /// Poll mints for melts still recorded as pending — e.g. after a relaunch
     /// killed the in-process waiter. Cheap no-op when nothing is tracked.
     func syncPendingMeltQuotes() async {
         let tracked = walletStore.loadPendingMeltQuotes()
         guard !tracked.isEmpty, let repo = walletRepository else { return }
 
+        do {
+            try await operationCoordinator.performIfIdle(kind: .pendingMeltPoll) {
+                await self.syncPendingMeltQuotesAssumingWalletOperationLease(
+                    tracked: tracked,
+                    repository: repo
+                )
+            }
+        } catch {
+            // Passive settlement polling will retry on the next foreground tick.
+        }
+    }
+
+    private func syncPendingMeltQuotesAssumingWalletOperationLease(
+        tracked: [String: String],
+        repository repo: WalletRepository
+    ) async {
         var settledAny = false
         for (quoteId, mintUrlString) in tracked {
-            // An in-process waiter owns this quote's completion.
-            guard pendingMeltWaiters[quoteId] == nil else { continue }
             do {
                 let wallet = try await repo.getWallet(mintUrl: MintUrl(url: mintUrlString), unit: .sat)
+                let operationID = try await db?.getMeltQuote(quoteId: quoteId)?.usedByOperation
                 let quote = try await wallet.checkMeltQuoteStatus(quoteId: quoteId)
                 switch quote.state {
-                case .paid:
+                case .paid, .issued:
+                    guard await meltReservationIsReleased(
+                        wallet: wallet,
+                        quoteID: quoteId,
+                        operationID: operationID
+                    ) else { continue }
                     recordFinalizedMelt(quoteId: quoteId, preimage: quote.paymentProof, feePaid: nil)
                     forgetPendingMeltQuote(quoteId: quoteId)
                     SentryService.breadcrumb("Async melt settled after resync", category: "wallet.lightning")
                     settledAny = true
                 case .unpaid:
-                    // Once a mint has accepted async processing, a fall back to
-                    // unpaid is terminal: the payment failed and the saga
-                    // compensated (proofs returned).
+                    // Treat unpaid as terminal only after local reads prove the
+                    // saga, quote reservation, and reserved proofs are gone.
+                    // Otherwise recovery/polling remains armed and retry stays
+                    // blocked by the unresolved pending record.
+                    guard await meltReservationIsReleased(
+                        wallet: wallet,
+                        quoteID: quoteId,
+                        operationID: operationID
+                    ) else { continue }
                     forgetPendingMeltQuote(quoteId: quoteId)
                     SentryService.breadcrumb("Async melt failed after resync", category: "wallet.lightning")
                     settledAny = true
-                case .pending, .issued:
+                case .pending:
                     continue
                 }
             } catch {
                 AppLogger.wallet.error(
-                    "Pending melt status check failed for quote \(quoteId, privacy: .public): \(String(describing: error), privacy: .public)"
+                    "pending melt status check failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
                 )
+            }
+
+            if await operationCoordinator.hasWaitingUserOperation() {
+                break
             }
         }
 
         if settledAny {
-            await refreshBalance()
-            await loadTransactions()
+            await refreshBalanceAssumingWalletOperationLease()
+            await loadTransactionsAssumingWalletOperationLease()
+        }
+    }
+
+    private func meltReservationIsReleased(
+        wallet: Wallet,
+        quoteID: String,
+        operationID: String?
+    ) async -> Bool {
+        guard let db else { return false }
+
+        func stateIsReleased() async throws -> Bool {
+            let quote = try await db.getMeltQuote(quoteId: quoteID)
+            let resolvedOperationID = operationID ?? quote?.usedByOperation
+            guard quote?.usedByOperation == nil else { return false }
+            guard let resolvedOperationID else { return true }
+            let saga = try await db.getSaga(id: resolvedOperationID)
+            let reservedProofs = try await db.getReservedProofs(operationId: resolvedOperationID)
+            return saga == nil && reservedProofs.isEmpty
+        }
+
+        do {
+            if try await stateIsReleased() { return true }
+
+            let report = try await wallet.recoverIncompleteSagas()
+            AppLogger.wallet.info(
+                "wallet-op pending melt recovery resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteID), privacy: .public) recovered=\(report.recovered, privacy: .public) compensated=\(report.compensated, privacy: .public) skipped=\(report.skipped, privacy: .public) failed=\(report.failed, privacy: .public)"
+            )
+            return try await stateIsReleased()
+        } catch {
+            AppLogger.wallet.warning(
+                "wallet-op pending melt release unresolved resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteID), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            return false
         }
     }
 
@@ -103,21 +139,4 @@ extension WalletManager {
         walletStore.savePendingMeltQuotes(tracked)
     }
 
-    private func finishPendingMelt(
-        quoteId: String,
-        state: QuoteState,
-        preimage: String?,
-        feePaid: UInt64
-    ) async {
-        if state == .paid {
-            recordFinalizedMelt(quoteId: quoteId, preimage: preimage, feePaid: feePaid)
-            SentryService.breadcrumb("Async melt settled", category: "wallet.lightning")
-        } else {
-            // Failed payment: the saga already compensated and returned the proofs.
-            SentryService.breadcrumb("Async melt failed", category: "wallet.lightning")
-        }
-        forgetPendingMeltQuote(quoteId: quoteId)
-        await refreshBalance()
-        await loadTransactions()
-    }
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -11,14 +11,34 @@ extension WalletManager {
         mintUrl preferredMintURL: String? = nil,
         unit: String = "sat"
     ) async throws -> SendTokenResult {
-        let result = try await tokenService.sendTokens(
-            amount: amount,
-            memo: memo,
-            p2pkPubkey: p2pkPubkey,
-            mintUrl: preferredMintURL,
-            unit: PaymentRequestDecoder.currencyUnit(from: unit)
-        )
-        let tokenMintURL = preferredMintURL ?? activeMint?.url ?? ""
+        let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
+        let recoveryMintURL = preferredMintURL ?? activeMint?.url
+        let result = try await operationCoordinator.perform(
+            kind: .send,
+            resourceID: recoveryMintURL,
+            protectsBackgroundExecution: true,
+            defaultFailureOutcome: .ambiguousFailure
+        ) {
+            do {
+                return try await self.tokenService.sendTokens(
+                    amount: amount,
+                    memo: memo,
+                    p2pkPubkey: p2pkPubkey,
+                    mintUrl: preferredMintURL,
+                    unit: currencyUnit
+                )
+            } catch {
+                await self.captureWalletFailureDiagnostics(kind: .send)
+                await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                    kind: .send,
+                    preferredMintURL: recoveryMintURL,
+                    unit: currencyUnit
+                )
+                await self.captureWalletFailureDiagnostics(kind: .send)
+                throw error
+            }
+        }
+        let tokenMintURL = recoveryMintURL ?? ""
         
         // Save pending token for tracking
         let tokenId = UUID().uuidString
@@ -50,41 +70,80 @@ extension WalletManager {
         }
         guard let repo = walletRepository else { return nil }
         do {
-            let mintUrl = MintUrl(url: mintURL)
-            let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
-            try await repo.createWallet(mintUrl: mintUrl, unit: currencyUnit, targetProofCount: nil)
-            let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: currencyUnit)
-            return try await wallet.totalBalance().value
+            return try await operationCoordinator.perform(
+                kind: .balance,
+                resourceID: mintURL
+            ) {
+                let mintUrl = MintUrl(url: mintURL)
+                let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
+                try await repo.createWallet(mintUrl: mintUrl, unit: currencyUnit, targetProofCount: nil)
+                let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: currencyUnit)
+                return try await wallet.totalBalance().value
+            }
         } catch {
-            AppLogger.wallet.debug("unitBalance(\(unit)) failed: \(String(describing: error))")
+            AppLogger.wallet.debug(
+                "unit balance failed unit=\(unit, privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return nil
         }
     }
 
     func receiveTokens(tokenString: String) async throws -> UInt64 {
-        // Receive first: tokenService creates the CDK wallet and consumes the
-        // keyset counter. Enriching the mint (createWallet/fetchMintInfo) before
-        // this desyncs the counter and makes the mint reject "duplicate outputs"
-        // on the first attempt. Track/enrich the mint only after a successful
-        // receive, so an unredeemed token never adds the mint either.
-        let beforeIds = await incomingTxIds(forTokenString: tokenString)
-        let amount = try await tokenService.receiveTokens(tokenString: tokenString)
+        let outcome = try await performTokenReceive(tokenString: tokenString)
 
-        // Persist the redeemed token, keyed to the CDK tx id this receive just
-        // created (found by the same before/after diff receiveCashuRequestPayment
-        // uses), so History can offer Copy-as-receipt on the settled row. The
-        // token's proofs are now spent — this is a record, not a reofferable
-        // payment code. Save before loadTransactions() so the new row picks it up.
-        if let newTxId = (await incomingTxIds(forTokenString: tokenString))
-            .subtracting(beforeIds).first {
-            transactionService.saveToken(txId: newTxId, token: tokenString)
+        if let transactionID = outcome.transactionID {
+            transactionService.saveToken(txId: transactionID, token: tokenString)
         }
 
-        try? await ensureMintTrackedForToken(tokenString)
         await refreshBalance()
         await loadTransactions()
         SentryService.breadcrumb("Token received", category: "wallet.token")
-        return amount
+        return outcome.amount
+    }
+
+    /// Holds one repository lease across transaction attribution, redemption,
+    /// and post-receive mint setup. This is the critical receive workflow used
+    /// both by the review screen and automatic Cashu Request claims.
+    private func performTokenReceive(
+        tokenString: String
+    ) async throws -> (amount: UInt64, transactionID: String?) {
+        let recoveryContext: (mintURL: String, unit: Cdk.CurrencyUnit)? = {
+            guard let token = try? tokenService.decodeToken(tokenString: tokenString),
+                  let mintURL = try? token.mintUrl().url else { return nil }
+            return (mintURL, token.unit() ?? .sat)
+        }()
+
+        return try await operationCoordinator.perform(
+            kind: .receive,
+            resourceID: recoveryContext?.mintURL,
+            protectsBackgroundExecution: true,
+            defaultFailureOutcome: .ambiguousFailure
+        ) {
+            do {
+                // Receive first: tokenService creates the CDK wallet and consumes the
+                // keyset counter. Enriching the mint (createWallet/fetchMintInfo) before
+                // this desyncs the counter and makes the mint reject "duplicate outputs"
+                // on the first attempt. Track/enrich the mint only after a successful
+                // receive, so an unredeemed token never adds the mint either.
+                let beforeIds = await self.incomingTxIds(forTokenString: tokenString)
+                let amount = try await self.tokenService.receiveTokens(tokenString: tokenString)
+                let newTransactionID = (await self.incomingTxIds(forTokenString: tokenString))
+                    .subtracting(beforeIds)
+                    .first
+
+                try? await self.ensureMintTrackedForToken(tokenString)
+                return (amount, newTransactionID)
+            } catch {
+                await self.captureWalletFailureDiagnostics(kind: .receive)
+                await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
+                    kind: .receive,
+                    preferredMintURL: recoveryContext?.mintURL,
+                    unit: recoveryContext?.unit ?? .sat
+                )
+                await self.captureWalletFailureDiagnostics(kind: .receive)
+                throw error
+            }
+        }
     }
 
     /// Auto-claim a token that arrived via a NUT-18 Cashu Request, optionally attributing
@@ -94,27 +153,31 @@ extension WalletManager {
     /// the duplicate "Received ecash" row.
     @discardableResult
     func receiveCashuRequestPayment(tokenString: String, requestId: String?) async throws -> UInt64 {
-        let beforeIds = await incomingTxIds(forTokenString: tokenString)
-        let amount = try await receiveTokens(tokenString: tokenString)
-        let afterIds = await incomingTxIds(forTokenString: tokenString)
-        let newTxId = afterIds.subtracting(beforeIds).first
+        let outcome = try await performTokenReceive(tokenString: tokenString)
+        if let transactionID = outcome.transactionID {
+            transactionService.saveToken(txId: transactionID, token: tokenString)
+        }
 
-        if let requestId, let txId = newTxId {
+        if let requestId, let txId = outcome.transactionID {
             CashuRequestStore.shared.attachPayment(
                 requestId: requestId,
                 transactionId: txId,
-                amount: amount
+                amount: outcome.amount
             )
         }
 
-        var userInfo: [String: Any] = ["amount": amount, "source": "cashu-request"]
+        await refreshBalance()
+        await loadTransactions()
+        SentryService.breadcrumb("Token received", category: "wallet.token")
+
+        var userInfo: [String: Any] = ["amount": outcome.amount, "source": "cashu-request"]
         if let requestId { userInfo["requestId"] = requestId }
         NotificationCenter.default.post(
             name: .cashuTokenReceived,
             object: nil,
             userInfo: userInfo
         )
-        return amount
+        return outcome.amount
     }
 
     /// Lists incoming transaction ids for the mint encoded in a token string.
@@ -132,7 +195,9 @@ extension WalletManager {
             let txs = try await wallet.listTransactions(direction: .incoming)
             return Set(txs.map { $0.id.hex })
         } catch {
-            AppLogger.wallet.debug("incomingTxIds lookup failed: \(String(describing: error))")
+            AppLogger.wallet.debug(
+                "incoming transaction attribution failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
             return []
         }
     }
@@ -146,7 +211,12 @@ extension WalletManager {
         // visible mint list (hiding the "new mint" badge on a later scan) and
         // disturbs the keyset counter before the receive. tokenService creates
         // the throwaway CDK wallet entry it needs for the calculation itself.
-        return try await tokenService.calculateReceiveFee(tokenString: tokenString)
+        return try await operationCoordinator.perform(
+            kind: .receiveFee,
+            priority: .maintenance
+        ) {
+            try await self.tokenService.calculateReceiveFee(tokenString: tokenString)
+        }
     }
 
     // MARK: - Pending Token Operations (Delegate to TransactionService)
@@ -209,11 +279,22 @@ extension WalletManager {
     func checkTokenSpendable(token: String, mintUrl: String? = nil) async -> Bool {
         let resolvedMintUrl = mintUrl ?? activeMint?.url ?? ""
         guard !resolvedMintUrl.isEmpty else { return false }
-        return await tokenService.checkTokenSpendable(token: token, mintUrl: resolvedMintUrl)
+        do {
+            return try await operationCoordinator.perform(
+                kind: .tokenStatus,
+                resourceID: resolvedMintUrl
+            ) {
+                await self.tokenService.checkTokenSpendable(token: token, mintUrl: resolvedMintUrl)
+            }
+        } catch {
+            return false
+        }
     }
 
     func checkTokenSpent(token: String, mintUrl: String) async throws -> Bool {
-        try await tokenService.checkTokenSpent(token: token, mintUrl: mintUrl)
+        try await operationCoordinator.perform(kind: .tokenStatus, resourceID: mintUrl) {
+            try await self.tokenService.checkTokenSpent(token: token, mintUrl: mintUrl)
+        }
     }
 
     @discardableResult
@@ -234,21 +315,37 @@ extension WalletManager {
         // Avoid a second all-mint transaction pass on the common empty queue.
         guard !pendingTokens.isEmpty else { return }
 
-        for token in pendingTokens {
-            do {
-                let isSpent = try await tokenService.checkTokenSpent(
-                    token: token.token,
-                    mintUrl: token.mintUrl
-                )
-                if isSpent {
-                    transactionService.markTokenAsClaimed(token: token.token)
+        do {
+            try await operationCoordinator.performIfIdle(kind: .pendingTokenCheck) {
+                for token in self.pendingTokens {
+                    do {
+                        let isSpent = try await self.tokenService.checkTokenSpent(
+                            token: token.token,
+                            mintUrl: token.mintUrl
+                        )
+                        if isSpent {
+                            self.transactionService.markTokenAsClaimed(token: token.token)
+                        }
+                    } catch is CancellationError {
+                        return
+                    } catch {
+                        AppLogger.wallet.error(
+                            "pending token status check failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                        )
+                    }
+
+                    if await self.operationCoordinator.hasWaitingUserOperation() {
+                        break
+                    }
                 }
-            } catch is CancellationError {
-                return
-            } catch {
-                AppLogger.wallet.error("Pending token status check failed: \(error)")
+                await self.loadTransactionsAssumingWalletOperationLease()
             }
+        } catch is CancellationError {
+            return
+        } catch {
+            AppLogger.wallet.error(
+                "pending token maintenance failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
         }
-        await loadTransactions()
     }
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager.swift
@@ -66,12 +66,6 @@ class WalletManager: ObservableObject {
     /// Per-quote passive-check backoff (Android `MintQuoteCheckBackoff` parity).
     var mintQuoteCheckThrottle: [String: MintQuoteCheckBackoff.Entry] = [:]
 
-    /// In-process waiters for melts a mint accepted asynchronously (NUT-05),
-    /// keyed by quote ID. These die with the process; `walletStore`'s
-    /// pending-melt-quote record plus `syncPendingMeltQuotes()` are the
-    /// relaunch backstop.
-    var pendingMeltWaiters: [String: Task<Void, Never>] = [:]
-
     /// Foreground quote poll (started/stopped on scenePhase changes). Re-checks
     /// pending mint + melt quotes while the app is active so a payment lands
     /// without pull-to-refresh (Android parity).
@@ -79,6 +73,10 @@ class WalletManager: ObservableObject {
     let pendingQuotePollInterval: TimeInterval = 5
 
     // MARK: - Services
+
+    /// One exclusive CDK/database lane for this repository. Main-actor
+    /// isolation alone is reentrant across `await` and cannot provide this.
+    let operationCoordinator = WalletOperationCoordinator()
 
     let walletStore = WalletStore()
     var processedQuotes: Set<String>
@@ -173,19 +171,27 @@ class WalletManager: ObservableObject {
     /// Connect the NWC service to the live CDK wallet and this wallet's
     /// deterministic seed material. The providers deliberately capture the
     /// manager weakly so the singleton never retains a discarded wallet.
+    /// Wallet acquisition is coordinated here. CDK's long-lived `NwcService`
+    /// performs later wallet work internally and exposes no per-request hook,
+    /// so that activity cannot yet participate in this app-side execution lane.
     private func configureNWCManager() {
         NWCManager.shared.configure(
             walletProvider: { [weak self] mintURL in
                 guard let self, let walletRepository = self.walletRepository else {
                     throw WalletError.notInitialized
                 }
-                let mintURL = MintUrl(url: mintURL)
-                try? await walletRepository.createWallet(
-                    mintUrl: mintURL,
-                    unit: .sat,
-                    targetProofCount: nil
-                )
-                return try await walletRepository.getWallet(mintUrl: mintURL, unit: .sat)
+                return try await self.operationCoordinator.perform(
+                    kind: .mintInfo,
+                    resourceID: mintURL
+                ) {
+                    let parsedMintURL = MintUrl(url: mintURL)
+                    try? await walletRepository.createWallet(
+                        mintUrl: parsedMintURL,
+                        unit: .sat,
+                        targetProofCount: nil
+                    )
+                    return try await walletRepository.getWallet(mintUrl: parsedMintURL, unit: .sat)
+                }
             },
             seedProvider: { [weak self] in
                 guard let mnemonic = self?.mnemonic else { return nil }

--- a/ios/CashuWallet/Core/Wallet/WalletOperationCoordinator.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletOperationCoordinator.swift
@@ -1,0 +1,497 @@
+import CryptoKit
+import Cdk
+import Foundation
+import UIKit
+
+/// The shared execution lane for CDK calls that use the wallet repository and
+/// SQLite database. `@MainActor` is not sufficient here: an actor can accept a
+/// second operation whenever the first one suspends at an `await`.
+///
+/// This coordinator records ownership explicitly, so actor reentrancy cannot
+/// admit a second operation until the first native future has actually
+/// returned. Cancellation never force-releases an executing lease.
+actor WalletOperationCoordinator {
+    enum Kind: String, Sendable {
+        case addMint
+        case balance
+        case feeEstimate
+        case history
+        case melt
+        case meltQuote
+        case mint
+        case mintInfo
+        case mintQuote
+        case pendingMeltPoll
+        case pendingTokenCheck
+        case quotePoll
+        case receive
+        case receiveFee
+        case recovery
+        case restore
+        case send
+        case tokenStatus
+    }
+
+    enum Priority: Int, Sendable {
+        case maintenance = 0
+        case userInitiated = 10
+        case recovery = 20
+    }
+
+    enum FailureOutcome: String, Sendable {
+        case definiteFailure = "definite-failure"
+        case ambiguousFailure = "ambiguous-failure"
+    }
+
+    struct Snapshot: Sendable {
+        let activeKind: Kind?
+        let waitingCount: Int
+        let waitingUserOperationCount: Int
+    }
+
+    private struct Request: Sendable {
+        let id: UUID
+        let kind: Kind
+        let priority: Priority
+        let sequence: UInt64
+    }
+
+    private struct Lease: Sendable {
+        let request: Request
+        let acquiredAt: UInt64
+    }
+
+    private struct Waiter {
+        let request: Request
+        let continuation: CheckedContinuation<Lease, Error>
+    }
+
+    private var activeLease: Lease?
+    private var waiters: [Waiter] = []
+    private var nextSequence: UInt64 = 0
+    private let watchdogThresholdNanoseconds: UInt64
+
+    init(watchdogThreshold: TimeInterval = 30) {
+        watchdogThresholdNanoseconds = UInt64(max(0, watchdogThreshold) * 1_000_000_000)
+    }
+
+    /// Queue an operation until the repository is exclusively available.
+    /// Higher-priority work is selected first; ordering is FIFO within a tier.
+    nonisolated func perform<T>(
+        kind: Kind,
+        priority: Priority = .userInitiated,
+        resourceID: String? = nil,
+        protectsBackgroundExecution: Bool = false,
+        defaultFailureOutcome: FailureOutcome = .definiteFailure,
+        operation: () async throws -> T
+    ) async throws -> T {
+        let requestedAt = DispatchTime.now().uptimeNanoseconds
+        let lease = try await acquire(kind: kind, priority: priority)
+
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await release(lease)
+            throw error
+        }
+
+        return try await execute(
+            lease: lease,
+            requestedAt: requestedAt,
+            resourceID: resourceID,
+            protectsBackgroundExecution: protectsBackgroundExecution,
+            defaultFailureOutcome: defaultFailureOutcome,
+            operation: operation
+        )
+    }
+
+    /// Run passive maintenance only when the lane is completely idle. Polling
+    /// never queues behind a payment and cannot become stale work that delays a
+    /// later user action.
+    @discardableResult
+    nonisolated func performIfIdle(
+        kind: Kind,
+        resourceID: String? = nil,
+        operation: () async throws -> Void
+    ) async throws -> Bool {
+        let requestedAt = DispatchTime.now().uptimeNanoseconds
+        guard let lease = await tryAcquire(kind: kind, priority: .maintenance) else {
+            Self.logSkipped(kind: kind)
+            return false
+        }
+
+        do {
+            try Task.checkCancellation()
+        } catch {
+            await release(lease)
+            throw error
+        }
+
+        _ = try await execute(
+            lease: lease,
+            requestedAt: requestedAt,
+            resourceID: resourceID,
+            protectsBackgroundExecution: false,
+            defaultFailureOutcome: .definiteFailure,
+            operation: operation
+        )
+        return true
+    }
+
+    func snapshot() -> Snapshot {
+        Snapshot(
+            activeKind: activeLease?.request.kind,
+            waitingCount: waiters.count,
+            waitingUserOperationCount: waiters.filter { $0.request.priority != .maintenance }.count
+        )
+    }
+
+    func hasWaitingUserOperation() -> Bool {
+        waiters.contains { $0.request.priority != .maintenance }
+    }
+
+    private func acquire(kind: Kind, priority: Priority) async throws -> Lease {
+        let request = makeRequest(kind: kind, priority: priority)
+        if activeLease == nil {
+            let lease = Lease(request: request, acquiredAt: DispatchTime.now().uptimeNanoseconds)
+            activeLease = lease
+            return lease
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                waiters.append(Waiter(request: request, continuation: continuation))
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task { await self.cancelWaiter(id: request.id) }
+        }
+    }
+
+    private func tryAcquire(kind: Kind, priority: Priority) -> Lease? {
+        guard activeLease == nil, waiters.isEmpty else { return nil }
+        let request = makeRequest(kind: kind, priority: priority)
+        let lease = Lease(request: request, acquiredAt: DispatchTime.now().uptimeNanoseconds)
+        activeLease = lease
+        return lease
+    }
+
+    private func makeRequest(kind: Kind, priority: Priority) -> Request {
+        defer { nextSequence &+= 1 }
+        return Request(
+            id: UUID(),
+            kind: kind,
+            priority: priority,
+            sequence: nextSequence
+        )
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.request.id == id }) else {
+            // The lease may already have been granted. The resumed task checks
+            // cancellation before entering the native operation and releases it.
+            return
+        }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func release(_ lease: Lease) {
+        guard activeLease?.request.id == lease.request.id else {
+            AppLogger.wallet.fault(
+                "wallet-op invalid release correlation=\(Self.correlationID(for: lease.request.id), privacy: .public) kind=\(lease.request.kind.rawValue, privacy: .public)"
+            )
+            return
+        }
+
+        activeLease = nil
+        guard let index = nextWaiterIndex() else { return }
+        let waiter = waiters.remove(at: index)
+        let nextLease = Lease(
+            request: waiter.request,
+            acquiredAt: DispatchTime.now().uptimeNanoseconds
+        )
+        activeLease = nextLease
+        waiter.continuation.resume(returning: nextLease)
+    }
+
+    private func nextWaiterIndex() -> Int? {
+        waiters.indices.max { left, right in
+            let lhs = waiters[left].request
+            let rhs = waiters[right].request
+            if lhs.priority.rawValue == rhs.priority.rawValue {
+                // `max` should choose the older (smaller sequence) request.
+                return lhs.sequence > rhs.sequence
+            }
+            return lhs.priority.rawValue < rhs.priority.rawValue
+        }
+    }
+
+    private nonisolated func execute<T>(
+        lease: Lease,
+        requestedAt: UInt64,
+        resourceID: String?,
+        protectsBackgroundExecution: Bool,
+        defaultFailureOutcome: FailureOutcome,
+        operation: () async throws -> T
+    ) async throws -> T {
+        let correlationID = Self.correlationID(for: lease.request.id)
+        let resourceHash = resourceID.map(Self.privacySafeIdentifier) ?? "none"
+        let waitMilliseconds = Self.milliseconds(from: requestedAt, to: lease.acquiredAt)
+        let appState = await MainActor.run { WalletApplicationState.current }
+        let executionStartedAt = DispatchTime.now().uptimeNanoseconds
+        let backgroundLease = await MainActor.run {
+            protectsBackgroundExecution
+                ? WalletBackgroundExecutionLease(kind: lease.request.kind, correlationID: correlationID)
+                : nil
+        }
+
+        AppLogger.wallet.info(
+            "wallet-op begin correlation=\(correlationID, privacy: .public) kind=\(lease.request.kind.rawValue, privacy: .public) resource=\(resourceHash, privacy: .public) wait_ms=\(waitMilliseconds, privacy: .public) app_state=\(appState, privacy: .public) cancelled=\(Task.isCancelled, privacy: .public)"
+        )
+
+        let watchdog = makeWatchdog(
+            kind: lease.request.kind,
+            correlationID: correlationID,
+            executionStartedAt: executionStartedAt
+        )
+
+        do {
+            let value = try await operation()
+            watchdog?.cancel()
+            await backgroundLease?.end()
+            let duration = Self.milliseconds(
+                from: executionStartedAt,
+                to: DispatchTime.now().uptimeNanoseconds
+            )
+            AppLogger.wallet.info(
+                "wallet-op end correlation=\(correlationID, privacy: .public) kind=\(lease.request.kind.rawValue, privacy: .public) outcome=success execution_ms=\(duration, privacy: .public) cancelled=\(Task.isCancelled, privacy: .public)"
+            )
+            await release(lease)
+            return value
+        } catch {
+            watchdog?.cancel()
+            await backgroundLease?.end()
+            let duration = Self.milliseconds(
+                from: executionStartedAt,
+                to: DispatchTime.now().uptimeNanoseconds
+            )
+            let outcome: String
+            if error is CancellationError {
+                outcome = "cancellation"
+            } else if let classified = error as? WalletOperationOutcomeError {
+                outcome = classified.walletOperationFailureOutcome.rawValue
+            } else {
+                outcome = defaultFailureOutcome.rawValue
+            }
+            AppLogger.wallet.error(
+                "wallet-op end correlation=\(correlationID, privacy: .public) kind=\(lease.request.kind.rawValue, privacy: .public) outcome=\(outcome, privacy: .public) execution_ms=\(duration, privacy: .public) cancelled=\(Task.isCancelled, privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            await release(lease)
+            throw error
+        }
+    }
+
+    private nonisolated func makeWatchdog(
+        kind: Kind,
+        correlationID: String,
+        executionStartedAt: UInt64
+    ) -> Task<Void, Never>? {
+        guard watchdogThresholdNanoseconds > 0 else { return nil }
+        let delay = watchdogThresholdNanoseconds
+        return Task.detached(priority: .utility) {
+            do {
+                try await Task.sleep(nanoseconds: delay)
+            } catch {
+                return
+            }
+            let elapsed = Self.milliseconds(
+                from: executionStartedAt,
+                to: DispatchTime.now().uptimeNanoseconds
+            )
+            AppLogger.wallet.warning(
+                "wallet-op watchdog correlation=\(correlationID, privacy: .public) kind=\(kind.rawValue, privacy: .public) execution_ms=\(elapsed, privacy: .public); lease remains held"
+            )
+        }
+    }
+
+    private nonisolated static func logSkipped(kind: Kind) {
+        AppLogger.wallet.debug(
+            "wallet-op skipped kind=\(kind.rawValue, privacy: .public) reason=busy"
+        )
+    }
+
+    private nonisolated static func correlationID(for id: UUID) -> String {
+        String(id.uuidString.prefix(8)).lowercased()
+    }
+
+    nonisolated static func privacySafeIdentifier(_ value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.prefix(6).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private nonisolated static func milliseconds(from start: UInt64, to end: UInt64) -> UInt64 {
+        guard end >= start else { return 0 }
+        return (end - start) / 1_000_000
+    }
+}
+
+extension WalletManager {
+    /// Read-only state capture at a failed-operation boundary. This method is
+    /// called while the coordinator lease is still held so the snapshot cannot
+    /// race a second CDK writer. It logs counts and hashes only—never tokens,
+    /// invoices, preimages, URLs, or saga JSON.
+    func captureWalletFailureDiagnostics(
+        kind: WalletOperationCoordinator.Kind,
+        operationID: String? = nil,
+        quoteID: String? = nil
+    ) async {
+        var incompleteSagaCount = -1
+        var knownSagaExists = false
+        var reservedProofCount = -1
+        var quoteReserved = false
+        var quoteOperationHash = "none"
+
+        if let db {
+            incompleteSagaCount = (try? await db.getIncompleteSagas().count) ?? -1
+            if let operationID {
+                knownSagaExists = ((try? await db.getSaga(id: operationID)) ?? nil) != nil
+                reservedProofCount = (try? await db.getReservedProofs(operationId: operationID).count) ?? -1
+            }
+            if let quoteID,
+               let quote = try? await db.getMeltQuote(quoteId: quoteID) {
+                quoteReserved = quote.usedByOperation != nil
+                if let usedByOperation = quote.usedByOperation {
+                    quoteOperationHash = WalletOperationCoordinator.privacySafeIdentifier(usedByOperation)
+                }
+            }
+        }
+
+        var inspectedWalletCount = 0
+        var totalReservedBalance: UInt64 = 0
+        var pendingSendCount = 0
+        if let walletRepository {
+            for mintURL in trackedMintUrlsForWalletAccess() {
+                guard let wallet = try? await walletRepository.getWallet(
+                    mintUrl: MintUrl(url: mintURL),
+                    unit: .sat
+                ) else { continue }
+                inspectedWalletCount += 1
+                if let reserved = try? await wallet.totalReservedBalance().value {
+                    totalReservedBalance &+= reserved
+                }
+                pendingSendCount += (try? await wallet.getPendingSends().count) ?? 0
+            }
+        }
+
+        let operationHash = operationID.map(WalletOperationCoordinator.privacySafeIdentifier) ?? "none"
+        let quoteHash = quoteID.map(WalletOperationCoordinator.privacySafeIdentifier) ?? "none"
+        AppLogger.wallet.info(
+            "wallet-op failure-state kind=\(kind.rawValue, privacy: .public) operation=\(operationHash, privacy: .public) quote=\(quoteHash, privacy: .public) incomplete_sagas=\(incompleteSagaCount, privacy: .public) known_saga=\(knownSagaExists, privacy: .public) quote_reserved=\(quoteReserved, privacy: .public) quote_operation=\(quoteOperationHash, privacy: .public) reserved_proofs=\(reservedProofCount, privacy: .public) reserved_balance=\(totalReservedBalance, privacy: .public) pending_sends=\(pendingSendCount, privacy: .public) wallets=\(inspectedWalletCount, privacy: .public)"
+        )
+    }
+
+    /// Ask CDK to reconcile any saga left by a failed interactive operation.
+    /// Call only while the shared operation lease is held. Recovery is
+    /// status-aware and may deliberately leave an externally ambiguous saga in
+    /// place; this method never releases proofs, quotes, or saga rows directly.
+    func recoverWalletStateAfterFailureAssumingWalletOperationLease(
+        kind: WalletOperationCoordinator.Kind,
+        preferredMintURL: String?,
+        unit: Cdk.CurrencyUnit = .sat
+    ) async {
+        guard let walletRepository else { return }
+
+        let mintURLs: [String]
+        if let preferredMintURL, !preferredMintURL.isEmpty {
+            mintURLs = [preferredMintURL]
+        } else {
+            mintURLs = trackedMintUrlsForWalletAccess()
+        }
+
+        for mintURL in mintURLs {
+            do {
+                let wallet = try await walletRepository.getWallet(
+                    mintUrl: MintUrl(url: mintURL),
+                    unit: unit
+                )
+                let sagasBefore = (try? await db?.getIncompleteSagas().count) ?? -1
+                let reservedBefore = (try? await wallet.totalReservedBalance().value) ?? UInt64.max
+                let pendingBefore = (try? await wallet.getPendingSends().count) ?? -1
+
+                // A successful zero count is positive evidence that this
+                // operation did not leave a recoverable saga. A failed read
+                // (-1) still warrants a best-effort CDK recovery attempt.
+                guard sagasBefore != 0 else {
+                    AppLogger.wallet.info(
+                        "wallet-op foreground recovery kind=\(kind.rawValue, privacy: .public) resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintURL), privacy: .public) skipped=no-incomplete-sagas reserved_before=\(reservedBefore, privacy: .public) pending_before=\(pendingBefore, privacy: .public)"
+                    )
+                    continue
+                }
+
+                let report = try await wallet.recoverIncompleteSagas()
+                let sagasAfter = (try? await db?.getIncompleteSagas().count) ?? -1
+                let reservedAfter = (try? await wallet.totalReservedBalance().value) ?? UInt64.max
+                let pendingAfter = (try? await wallet.getPendingSends().count) ?? -1
+                AppLogger.wallet.info(
+                    "wallet-op foreground recovery kind=\(kind.rawValue, privacy: .public) resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintURL), privacy: .public) recovered=\(report.recovered, privacy: .public) compensated=\(report.compensated, privacy: .public) skipped=\(report.skipped, privacy: .public) failed=\(report.failed, privacy: .public) sagas_before=\(sagasBefore, privacy: .public) sagas_after=\(sagasAfter, privacy: .public) reserved_before=\(reservedBefore, privacy: .public) reserved_after=\(reservedAfter, privacy: .public) pending_before=\(pendingBefore, privacy: .public) pending_after=\(pendingAfter, privacy: .public)"
+                )
+            } catch {
+                AppLogger.wallet.warning(
+                    "wallet-op foreground recovery failed kind=\(kind.rawValue, privacy: .public) resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintURL), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+            }
+        }
+    }
+}
+
+/// Errors can override the coordinator's conservative default when recovery
+/// has established whether a failed money movement is terminal or ambiguous.
+protocol WalletOperationOutcomeError: Error {
+    var walletOperationFailureOutcome: WalletOperationCoordinator.FailureOutcome { get }
+}
+
+@MainActor
+private enum WalletApplicationState {
+    static var current: String {
+        switch UIApplication.shared.applicationState {
+        case .active: "active"
+        case .inactive: "inactive"
+        case .background: "background"
+        @unknown default: "unknown"
+        }
+    }
+}
+
+/// Extends the time iOS gives a money-moving native future after the app moves
+/// to the background. Expiration ends only the OS assertion; it never unlocks
+/// the coordinator or pretends the CDK operation was cancelled.
+@MainActor
+private final class WalletBackgroundExecutionLease {
+    private var identifier: UIBackgroundTaskIdentifier = .invalid
+    private let kind: WalletOperationCoordinator.Kind
+    private let correlationID: String
+
+    init(kind: WalletOperationCoordinator.Kind, correlationID: String) {
+        self.kind = kind
+        self.correlationID = correlationID
+        identifier = UIApplication.shared.beginBackgroundTask(
+            withName: "wallet.\(kind.rawValue)"
+        ) { [weak self] in
+            self?.expire()
+        }
+    }
+
+    func end() {
+        guard identifier != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(identifier)
+        identifier = .invalid
+    }
+
+    private func expire() {
+        AppLogger.wallet.warning(
+            "wallet-op background time expired correlation=\(self.correlationID, privacy: .public) kind=\(self.kind.rawValue, privacy: .public); native operation remains serialized"
+        )
+        end()
+    }
+}

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1246,6 +1246,7 @@ struct UnifiedSendView: View {
     @State private var errorSeverity: ErrorSeverity = .error
     @State private var errorShowsMintAction = false
     @State private var errorIsTerminal = false
+    @State private var meltRetryNeedsFreshQuote = false
     /// Persisted across confirmation → processing/success/failure so a
     /// rail-changing or recovery route cannot disappear as wallet state updates.
     @State private var activeRouteExplanation: CashuRequestRouteExplanation?
@@ -2077,9 +2078,13 @@ struct UnifiedSendView: View {
             failureCTA: meltSwitchMintCTA,
             onDone: onClose,
             onRetry: {
-                // Only a failed payment reaches this status screen. Return to its
-                // already-created quote so retry still requires an explicit Pay tap.
                 withAnimation(.smooth(duration: 0.3)) { step = .confirm }
+                if meltRetryNeedsFreshQuote {
+                    // CDK confirmed compensation, so the prior quote is no
+                    // longer reused. Fetching a new quote is part of retry.
+                    meltQuote = nil
+                    fetchMeltQuote()
+                }
             }
         )
     }
@@ -2133,6 +2138,7 @@ struct UnifiedSendView: View {
         guard let quote = meltQuote else { return }
         HapticFeedback.impact(.medium)
         errorMessage = nil
+        meltRetryNeedsFreshQuote = false
         withAnimation(.smooth(duration: 0.3)) { step = .sending }
         Task { @MainActor in
             do {
@@ -2143,6 +2149,7 @@ struct UnifiedSendView: View {
                 // Keep errorMessage set so the confirm screen's notice + switch-mint
                 // CTA reappear when the user taps Try Again.
                 presentError(from: error)
+                meltRetryNeedsFreshQuote = error.meltRetryRequiresFreshQuote
                 withAnimation(.smooth(duration: 0.3)) { step = .failed }
             }
         }
@@ -2929,6 +2936,7 @@ struct MeltView: View {
     /// Drives the full-screen processing → success → failure status screen.
     /// nil while the user is still on input/confirm.
     @State private var paymentPhase: PaymentStatusView.Phase?
+    @State private var meltRetryNeedsFreshQuote = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private func presentError(_ message: String, severity: ErrorSeverity = .error) {
@@ -3539,7 +3547,13 @@ struct MeltView: View {
             // yet: the mint took the payment and pays out in the background.
             successTitle: meltSettlementPending ? "Payment Processing" : "Payment Sent!",
             onDone: close,
-            onRetry: { withAnimation(.smooth(duration: 0.3)) { paymentPhase = nil } }
+            onRetry: {
+                withAnimation(.smooth(duration: 0.3)) { paymentPhase = nil }
+                if meltRetryNeedsFreshQuote {
+                    meltQuote = nil
+                    getQuote()
+                }
+            }
         )
     }
 
@@ -3769,6 +3783,7 @@ struct MeltView: View {
 
         isPaying = true
         errorMessage = nil
+        meltRetryNeedsFreshQuote = false
         HapticFeedback.impact(.medium)
         withAnimation(.smooth(duration: 0.3)) { paymentPhase = .processing }
 
@@ -3782,6 +3797,7 @@ struct MeltView: View {
                 // Keep errorMessage populated so the confirm screen's notice reappears
                 // if the user taps Try Again.
                 presentError(walletMessage.text, severity: walletMessage.severity)
+                meltRetryNeedsFreshQuote = error.meltRetryRequiresFreshQuote
                 withAnimation(.smooth(duration: 0.3)) {
                     paymentPhase = .failure(
                         message: walletMessage.text,

--- a/ios/CashuWalletTests/TokenServiceTests.swift
+++ b/ios/CashuWalletTests/TokenServiceTests.swift
@@ -219,3 +219,322 @@ final class TokenServiceTests: XCTestCase {
             StubError(description: "Could not connect to the server.")))
     }
 }
+
+@MainActor
+final class WalletOperationCoordinatorTests: XCTestCase {
+    private enum TestFailure: Error { case expected }
+
+    func testReceiveFeeAndRedemptionNeverOverlap() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let probe = ConcurrencyProbe()
+
+        let tasks = (0..<12).map { index in
+            Task {
+                try await coordinator.perform(kind: index.isMultiple(of: 2) ? .receiveFee : .receive) {
+                    await probe.enter()
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                    await probe.leave()
+                }
+            }
+        }
+
+        for task in tasks {
+            try await task.value
+        }
+
+        let maximumConcurrentCount = await probe.maximumConcurrentCount()
+        XCTAssertEqual(maximumConcurrentCount, 1)
+    }
+
+    func testCriticalOperationKindsShareOneExecutionLane() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let probe = ConcurrencyProbe()
+        let kinds: [WalletOperationCoordinator.Kind] = [
+            .send, .receive, .melt, .mint, .restore, .balance, .history, .recovery,
+        ]
+
+        let tasks = kinds.map { kind in
+            Task {
+                try await coordinator.perform(kind: kind) {
+                    await probe.enter()
+                    try await Task.sleep(nanoseconds: 5_000_000)
+                    await probe.leave()
+                }
+            }
+        }
+
+        for task in tasks {
+            try await task.value
+        }
+
+        let maximumConcurrentCount = await probe.maximumConcurrentCount()
+        XCTAssertEqual(maximumConcurrentCount, 1)
+    }
+
+    func testThrownOperationReleasesPermit() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+
+        do {
+            _ = try await coordinator.perform(kind: .receive) {
+                throw TestFailure.expected
+            }
+            XCTFail("Expected the first operation to throw")
+        } catch TestFailure.expected {
+            // Expected.
+        }
+
+        let value = try await coordinator.perform(kind: .send) { 42 }
+        XCTAssertEqual(value, 42)
+    }
+
+    func testCancellationWhileWaitingRemovesWaiter() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let gate = AsyncTestGate()
+
+        let active = Task {
+            try await coordinator.perform(kind: .receive) {
+                await gate.wait()
+            }
+        }
+        let receiveBecameActive = await eventually { await coordinator.snapshot().activeKind == .receive }
+        XCTAssertTrue(receiveBecameActive)
+
+        let waiting = Task {
+            try await coordinator.perform(kind: .send) { 1 }
+        }
+        let waiterWasQueued = await eventually { await coordinator.snapshot().waitingCount == 1 }
+        XCTAssertTrue(waiterWasQueued)
+
+        waiting.cancel()
+        do {
+            _ = try await waiting.value
+            XCTFail("Expected the waiting operation to be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+        let waiterWasRemoved = await eventually { await coordinator.snapshot().waitingCount == 0 }
+        XCTAssertTrue(waiterWasRemoved)
+
+        await gate.open()
+        try await active.value
+    }
+
+    func testCancellationDoesNotUnlockExecutingNativeWork() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let nativeGate = AsyncTestGate()
+        let secondStarted = BooleanProbe()
+
+        let first = Task {
+            try await coordinator.perform(kind: .melt) {
+                // CheckedContinuation intentionally ignores Swift cancellation,
+                // matching the iOS UniFFI bridge described by the regression.
+                await nativeGate.wait()
+                return 1
+            }
+        }
+        let meltBecameActive = await eventually { await coordinator.snapshot().activeKind == .melt }
+        XCTAssertTrue(meltBecameActive)
+        first.cancel()
+
+        let second = Task {
+            try await coordinator.perform(kind: .receive) {
+                await secondStarted.setTrue()
+                return 2
+            }
+        }
+
+        let secondWasQueued = await eventually { await coordinator.snapshot().waitingCount == 1 }
+        XCTAssertTrue(secondWasQueued)
+        let didStartBeforeNativeReturn = await secondStarted.value()
+        XCTAssertFalse(didStartBeforeNativeReturn)
+
+        await nativeGate.open()
+        let firstValue = try await first.value
+        let secondValue = try await second.value
+        XCTAssertEqual(firstValue, 1)
+        XCTAssertEqual(secondValue, 2)
+        let didStartAfterNativeReturn = await secondStarted.value()
+        XCTAssertTrue(didStartAfterNativeReturn)
+    }
+
+    func testPassiveMaintenanceSkipsWhileUserOperationIsActive() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let gate = AsyncTestGate()
+
+        let active = Task {
+            try await coordinator.perform(kind: .send) {
+                await gate.wait()
+            }
+        }
+        let sendBecameActive = await eventually { await coordinator.snapshot().activeKind == .send }
+        XCTAssertTrue(sendBecameActive)
+
+        let performed = try await coordinator.performIfIdle(kind: .quotePoll) {
+            XCTFail("Passive operation should have been skipped")
+        }
+        XCTAssertFalse(performed)
+
+        await gate.open()
+        try await active.value
+    }
+
+    func testUserOperationRunsBeforeQueuedMaintenance() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let gate = AsyncTestGate()
+        let order = StringRecorder()
+
+        let active = Task {
+            try await coordinator.perform(kind: .restore) {
+                await gate.wait()
+            }
+        }
+        let restoreBecameActive = await eventually { await coordinator.snapshot().activeKind == .restore }
+        XCTAssertTrue(restoreBecameActive)
+
+        let maintenance = Task {
+            try await coordinator.perform(kind: .history, priority: .maintenance) {
+                await order.append("maintenance")
+            }
+        }
+        let user = Task {
+            try await coordinator.perform(kind: .receive) {
+                await order.append("user")
+            }
+        }
+        let bothWereQueued = await eventually { await coordinator.snapshot().waitingCount == 2 }
+        XCTAssertTrue(bothWereQueued)
+
+        await gate.open()
+        try await active.value
+        try await user.value
+        try await maintenance.value
+
+        let recordedOrder = await order.values()
+        XCTAssertEqual(recordedOrder, ["user", "maintenance"])
+    }
+
+    func testMeltWorkflowCannotBeInterleavedByPollingOrHistory() async throws {
+        let coordinator = WalletOperationCoordinator(watchdogThreshold: 0)
+        let nativeGate = AsyncTestGate()
+        let order = StringRecorder()
+
+        let melt = Task {
+            try await coordinator.perform(kind: .melt) {
+                await order.append("prepare")
+                await nativeGate.wait()
+                await order.append("confirm")
+            }
+        }
+        let meltBecameActive = await eventually { await coordinator.snapshot().activeKind == .melt }
+        XCTAssertTrue(meltBecameActive)
+
+        let pollRan = try await coordinator.performIfIdle(kind: .quotePoll) {
+            await order.append("poll")
+        }
+        XCTAssertFalse(pollRan)
+
+        let history = Task {
+            try await coordinator.perform(kind: .history) {
+                await order.append("history")
+            }
+        }
+        let historyWasQueued = await eventually { await coordinator.snapshot().waitingCount == 1 }
+        XCTAssertTrue(historyWasQueued)
+
+        await nativeGate.open()
+        try await melt.value
+        try await history.value
+
+        let recordedOrder = await order.values()
+        XCTAssertEqual(recordedOrder, ["prepare", "confirm", "history"])
+    }
+
+    func testCompensatedMeltRequiresFreshQuoteAndAllowsRetry() {
+        let error = MeltPaymentRecoveryError.compensated(operationID: "operation")
+        let message = error.walletMessage
+
+        XCTAssertTrue(error.retryRequiresFreshQuote)
+        if case .retryable = message.recoverability {
+            // Expected.
+        } else {
+            XCTFail("A compensated payment should permit a fresh-quote retry")
+        }
+    }
+
+    func testUnresolvedMeltBlocksRetryAndKeepsQuoteForReconciliation() {
+        let error = MeltPaymentRecoveryError.unresolved(
+            quoteID: "quote",
+            mintURL: "https://mint.invalid",
+            operationID: "operation"
+        )
+        let message = error.walletMessage
+
+        XCTAssertFalse(error.retryRequiresFreshQuote)
+        XCTAssertEqual(error.unresolvedQuote?.id, "quote")
+        if case .terminal = message.recoverability {
+            // Expected: terminal means no immediate retry CTA, not that the
+            // payment is known to have failed.
+        } else {
+            XCTFail("An unknown payment outcome must block immediate retry")
+        }
+        XCTAssertEqual(error.walletOperationFailureOutcome, .ambiguousFailure)
+    }
+
+    private func eventually(
+        attempts: Int = 200,
+        condition: () async -> Bool
+    ) async -> Bool {
+        for _ in 0..<attempts {
+            if await condition() { return true }
+            try? await Task.sleep(nanoseconds: 2_000_000)
+        }
+        return false
+    }
+}
+
+private actor AsyncTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor ConcurrencyProbe {
+    private var activeCount = 0
+    private var maximumCount = 0
+
+    func enter() {
+        activeCount += 1
+        maximumCount = max(maximumCount, activeCount)
+    }
+
+    func leave() {
+        activeCount -= 1
+    }
+
+    func maximumConcurrentCount() -> Int { maximumCount }
+}
+
+private actor BooleanProbe {
+    private var storedValue = false
+    func setTrue() { storedValue = true }
+    func value() -> Bool { storedValue }
+}
+
+private actor StringRecorder {
+    private var storedValues: [String] = []
+    func append(_ value: String) { storedValues.append(value) }
+    func values() -> [String] { storedValues }
+}


### PR DESCRIPTION
## Summary

This change adds a single serialized execution lane for iOS CDK wallet operations and hardens recovery after interrupted or ambiguous payments.

- Route send, receive, mint, melt, quote, balance, history, restore, and recovery work through a shared `WalletOperationCoordinator`.
- Prioritize interactive and recovery work ahead of passive maintenance while preserving FIFO ordering within each priority.
- Keep the coordinator lease until a native CDK call actually returns, even if the calling Swift task is cancelled.
- Use background execution assertions for money-moving workflows.
- Recover incomplete CDK sagas after ambiguous failures without manually deleting sagas or releasing reservations.
- Distinguish confirmed melt compensation from unresolved outcomes so retries either use a fresh quote or remain blocked.
- Replace unmanaged pending-melt waiters with serialized foreground/startup reconciliation.
- Add privacy-safe correlation, timing, reservation, saga, and lifecycle diagnostics.

## Why

The reported failure is intermittent: after an outgoing Lightning or token operation fails, a subsequent receive can appear to fail immediately and wallet state may remain unavailable until later recovery.

Static analysis found that the previous iOS implementation allowed multiple CDK/SQLite-backed wallet operations to overlap and did not consistently run foreground saga recovery after ambiguous failures. This can plausibly leave a saga, melt-quote reservation, or proof reservation unresolved.

The original failing physical-device run was not captured, so this PR is a defensive fix for a demonstrated architectural hazard rather than a claim that runtime causality has already been proven.

Approximate causal confidence:

- Overlapping CDK/SQLite operations stranding a saga or reservation: 55%.
- An interrupted sequential operation without foreground recovery: 30%.
- Lifecycle suspension during a money-moving operation: 10%.
- A serialized CDK or binding defect: 5%.

## Behavior changes

- User-triggered wallet work no longer interleaves with passive quote, pending-token, pending-melt, balance, or history refreshes.
- Passive maintenance skips execution when the coordinator is already occupied.
- A failed or cancelled native operation does not unlock the lane until the native future completes.
- Pending melts are reconciled from persisted quote state instead of retaining unmanaged native wait handles.
- A confirmed compensated melt discards its quote and requires a newly quoted retry.
- An unresolved melt remains non-retryable until recovery or polling establishes a terminal state.
- Failure diagnostics record hashed resource identifiers and state counts only; raw tokens, quotes, URLs, invoices, and wallet identifiers are not logged.

## Validation

- Generic iOS Simulator Debug build passed on the rebased commit.
- Full iOS test run passed: 356 tests, 0 failures, including 10 new coordinator/concurrency tests and the local CDK integration suite.
- `git diff --check` passed.
- Xcode project-file validation passed.

The build still emits existing warnings in unrelated scanner, Liquid Glass, and activity-orb code.

## Remaining validation and risks

A controlled physical-device run is still needed to capture the failing timeline, verify relaunch recovery, exercise background interruption, and confirm whether the second attempt reaches the network.

The native UniFFI call itself cannot be preempted safely; the watchdog reports a long-running call but intentionally does not release the coordinator. Long-lived internal NWC service activity also has no per-request hook in the current binding and therefore cannot fully participate in the coordinator.
