### PR TITLE
Smooth every payment success/error state transition

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Views/Send/ContactlessPayView.kt
+++ b/android/app/src/main/java/com/cashu/me/Views/Send/ContactlessPayView.kt
@@ -9,6 +9,15 @@ import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.Ndef
 import android.provider.Settings
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -50,6 +59,7 @@ import com.cashu.me.Core.Services.NFCPaymentService
 import com.cashu.me.Core.Services.NFCReaderDelegate
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.ui.components.InlineNotice
+import com.cashu.me.ui.components.InlineNoticeHost
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
 
@@ -221,25 +231,54 @@ internal fun ContactlessPayContent(
                     horizontalArrangement = Arrangement.Center,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (isProcessing) {
+                    // The working indicator and the status line fade/swap
+                    // instead of popping per read-stage.
+                    AnimatedVisibility(
+                        visible = isProcessing,
+                        enter = fadeIn(tween(200)),
+                        exit = fadeOut(tween(150)),
+                    ) {
                         LoadingIndicator(modifier = Modifier.size(24.dp))
                     }
-                    Text(
-                        text = status,
-                        modifier = Modifier.padding(start = if (isProcessing) 8.dp else 0.dp),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
-                    )
+                    AnimatedContent(
+                        targetState = status,
+                        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+                        label = "contactless-status",
+                    ) { currentStatus ->
+                        Text(
+                            text = currentStatus,
+                            modifier = Modifier.padding(start = if (isProcessing) 8.dp else 0.dp),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
                 }
         }
 
-        if (paymentComplete) {
-            Text("Payment sent!", style = MaterialTheme.typography.titleMedium)
-            lastPaymentAmount?.let {
-                Text("$it sat", style = MaterialTheme.typography.headlineSmall)
+        // The success beat arrives with the same fade + scale-in the shared
+        // terminal glyph uses — a payment landing never pops in.
+        AnimatedVisibility(
+            visible = paymentComplete,
+            enter = fadeIn(tween(200)) + scaleIn(
+                animationSpec = spring(
+                    dampingRatio = 0.7f,
+                    stiffness = Spring.StiffnessMediumLow,
+                ),
+                initialScale = 0.9f,
+            ),
+            exit = fadeOut(tween(150)),
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text("Payment sent!", style = MaterialTheme.typography.titleMedium)
+                lastPaymentAmount?.let {
+                    Text("$it sat", style = MaterialTheme.typography.headlineSmall)
+                }
             }
         }
-        error?.let { InlineNotice(text = it, severity = NoticeSeverity.Error) }
+        InlineNoticeHost(text = error, severity = NoticeSeverity.Error)
 
         when (availability) {
             ContactlessAvailability.Disabled ->

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -1,5 +1,13 @@
 package com.cashu.me.ui.receive
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -205,308 +213,324 @@ fun CashuRequestDetailScreen(
     // Existing payments form the baseline, so revisiting history stays inline.
     val successPayment = request?.receivedPayments
         ?.firstOrNull { it.transactionId == successPaymentId }
-    if (request != null && successPayment != null && nfcState.phase != NfcReceivePhase.Success) {
-        val isSatRequest = request.unit.equals("sat", ignoreCase = true)
-        val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
-        val amountLabel = successPayment.amount.takeIf { it > 0L }?.let {
-            if (isSatRequest) formatter.formatWalletSats(it, settings.useBitcoinSymbol)
-            else CurrencyAmount(it, requestCurrency).formatted()
-        }
-        val transactionMintUrl = walletState.transactions
-            .firstOrNull { it.id == successPayment.transactionId }
-            ?.mintUrl
-        val creditedMintUrl = transactionMintUrl
-            ?: nfcState.settlementMint.takeIf { nfcState.phase == NfcReceivePhase.Success }
-            ?: request.mints.singleOrNull()
-        val mintName = creditedMintUrl?.let { url ->
-            walletState.mints.firstOrNull { it.url == url }?.name ?: url
-        }
-        CashuRequestSuccessTerminal(
-            amountLabel = amountLabel,
-            mintName = mintName,
-            onDone = {
-                nfcReceiveCoordinator.deactivate()
-                onClose()
-            },
-        )
-        return
-    }
+    val showSuccessTerminal = request != null && successPayment != null &&
+        nfcState.phase != NfcReceivePhase.Success
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = {
+    // One gate keeps the detail and the receipt in the same composition so
+    // the swap fades through instead of hard-cutting (iOS:
+    // .animation(.smooth(duration: 0.3)) on the same beat).
+    AnimatedContent(
+        targetState = showSuccessTerminal,
+        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+        label = "creq-detail-terminal",
+    ) { terminal ->
+        if (terminal && request != null && successPayment != null) {
+            val isSatRequest = request.unit.equals("sat", ignoreCase = true)
+            val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
+            val amountLabel = successPayment.amount.takeIf { it > 0L }?.let {
+                if (isSatRequest) formatter.formatWalletSats(it, settings.useBitcoinSymbol)
+                else CurrencyAmount(it, requestCurrency).formatted()
+            }
+            val transactionMintUrl = walletState.transactions
+                .firstOrNull { it.id == successPayment.transactionId }
+                ?.mintUrl
+            val creditedMintUrl = transactionMintUrl
+                ?: nfcState.settlementMint.takeIf { nfcState.phase == NfcReceivePhase.Success }
+                ?: request.mints.singleOrNull()
+            val mintName = creditedMintUrl?.let { url ->
+                walletState.mints.firstOrNull { it.url == url }?.name ?: url
+            }
+            CashuRequestSuccessTerminal(
+                amountLabel = amountLabel,
+                mintName = mintName,
+                onDone = {
+                    nfcReceiveCoordinator.deactivate()
+                    onClose()
+                },
+            )
+        } else {
+
+        Scaffold(
+            topBar = {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            request?.displayTitle ?: "Cashu Request",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onClose) {
+                            ToolbarIcon(
+                                imageVector = Icons.Outlined.Close,
+                                contentDescription = "Close",
+                            )
+                        }
+                    },
+                    actions = {
+                        if (request != null) {
+                            IconButton(onClick = {
+                                context.shareText(request.encoded, subject = request.displayTitle)
+                            }) {
+                                ToolbarIcon(Icons.Outlined.IosShare, contentDescription = "Share")
+                            }
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.background,
+                    ),
+                )
+            },
+        ) { padding ->
+            if (request == null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
                     Text(
-                        request?.displayTitle ?: "Cashu Request",
+                        text = "Request not found",
                         style = MaterialTheme.typography.titleMedium,
                     )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onClose) {
-                        ToolbarIcon(
-                            imageVector = Icons.Outlined.Close,
-                            contentDescription = "Close",
-                        )
-                    }
-                },
-                actions = {
-                    if (request != null) {
-                        IconButton(onClick = {
-                            context.shareText(request.encoded, subject = request.displayTitle)
-                        }) {
-                            ToolbarIcon(Icons.Outlined.IosShare, contentDescription = "Share")
-                        }
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                ),
-            )
-        },
-    ) { padding ->
-        if (request == null) {
+                    Spacer(Modifier.height(CashuTheme.spacing.comfortable))
+                    GhostButton(text = "Back", onClick = onClose)
+                }
+                return@Scaffold
+            }
+
+            if (keepNfcSessionMounted) {
+                NfcReceiveLifecycle(
+                    coordinator = nfcReceiveCoordinator,
+                    request = request,
+                    settlementMintUrl = walletState.activeMint?.url,
+                )
+            }
+
             Column(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
             ) {
-                Text(
-                    text = "Request not found",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Spacer(Modifier.height(CashuTheme.spacing.comfortable))
-                GhostButton(text = "Back", onClick = onClose)
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = CashuTheme.spacing.comfortable),
+                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Spacer(Modifier.height(CashuTheme.spacing.snug))
+                    QrCard(
+                        content = request.encoded,
+                        shareSubject = request.displayTitle,
+                        staticOnly = true,
+                        snackbarHostState = snackbarHostState,
+                    )
+
+                    // Request amounts render in the request's own unit.
+                    val isSatRequest = request.unit.equals("sat", ignoreCase = true)
+                    val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
+                    fun formatRequestAmount(amount: Long): String = if (isSatRequest) {
+                        formatter.formatWalletSats(amount, settings.useBitcoinSymbol)
+                    } else {
+                        CurrencyAmount(amount, requestCurrency).formatted()
+                    }
+
+                    if (request.amount != null && request.amount > 0L) {
+                        AmountText(
+                            text = formatRequestAmount(request.amount),
+                            style = MaterialTheme.typography.headlineMedium
+                                .copy(fontWeight = FontWeight.Bold)
+                                .withMonoDigits(),
+                            modifier = Modifier.padding(vertical = 5.dp),
+                        )
+                    }
+
+                    if (offerNfcReceive) {
+                        NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
+                    }
+
+                    val deliveryNotice = requestReadiness.deliveryNoticeOrNull()
+                    if (request.isEcashRequest && request.receivedPayments.isEmpty() && deliveryNotice != null) {
+                        InlineNotice(
+                            text = deliveryNotice.title,
+                            detail = deliveryNotice.message,
+                            severity = NoticeSeverity.Caution,
+                        )
+                    } else {
+                        StatusBlock(
+                            received = request.receivedPayments.isNotEmpty(),
+                            paymentCount = paymentCount,
+                        )
+                    }
+
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        val activeMintUrl = request.mints.firstOrNull()
+                        val requestMint = activeMintUrl?.let { url ->
+                            walletState.mints.firstOrNull { it.url == url }
+                        }
+                        val mintLabel = activeMintUrl?.let { url ->
+                            requestMint?.name ?: url
+                        } ?: "Any mint"
+                        val requestEditable = request.isEcashRequest && !nfcTransferActive
+                        InspectorRow(
+                            label = "Mint",
+                            value = mintLabel,
+                            leadingIcon = Icons.Outlined.AccountBalance,
+                            editable = requestEditable,
+                            onClick = { mintPickerOpen = true },
+                        )
+                        InspectorRow(
+                            label = "Amount",
+                            value = request.amount?.let {
+                                if (isSatRequest) "$it sat" else formatRequestAmount(it)
+                            } ?: "Any",
+                            leadingIcon = Icons.Outlined.AccountBalanceWallet,
+                            valueMonospaced = true,
+                            editable = requestEditable,
+                            onClick = { amountPickerOpen = true },
+                        )
+                        InspectorRow(
+                            label = "Unit",
+                            value = request.unit.uppercase(),
+                            leadingIcon = Icons.Outlined.CurrencyExchange,
+                            editable = requestEditable && requestMint?.supportsMultipleMintUnits == true,
+                            onClick = { unitPickerOpen = true },
+                        )
+                        InspectorRow(
+                            label = "Created",
+                            value = formatDate(request.createdAtEpochMillis),
+                            leadingIcon = Icons.Outlined.CalendarToday,
+                        )
+                        if (request.totalReceived > 0L) {
+                            InspectorRow(
+                                label = "Total received",
+                                value = formatRequestAmount(request.totalReceived),
+                                leadingIcon = Icons.Outlined.CheckCircle,
+                                valueMonospaced = true,
+                            )
+                        }
+                    }
+
+                    InlineNoticeHost(
+                        text = regenerateError,
+                        modifier = Modifier.fillMaxWidth(),
+                        severity = NoticeSeverity.Error,
+                    )
+
+                    Spacer(Modifier.height(CashuTheme.spacing.snug))
+                }
+
+                DetailActionFooter {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+                    ) {
+                        SecondaryButton(
+                            text = if (copied) "Copied" else "Copy",
+                            onClick = {
+                                clipboard.setText(AnnotatedString(request.encoded))
+                                copied = true
+                            },
+                            modifier = Modifier.weight(1f),
+                        )
+                        // Quote-backed invoices/addresses cannot be regenerated in
+                        // place; only a NUT-18 ecash request owns this action.
+                        if (request.isEcashRequest) {
+                            SecondaryButton(
+                                text = "New Request",
+                                onClick = { regenerate() },
+                                modifier = Modifier.weight(1f),
+                                enabled = !nfcTransferActive,
+                            )
+                        }
+                    }
+                }
             }
-            return@Scaffold
+        }
+
+        if (mintPickerOpen && request?.isEcashRequest == true) {
+            val activeMintUrl = request.mints.firstOrNull()
+            MintPickerSheet(
+                mints = walletState.mints,
+                activeMintUrl = activeMintUrl,
+                allowAnyMint = true,
+                onSelect = { mint ->
+                    regenerate(nextMints = listOfNotNull(mint?.url))
+                    mintPickerOpen = false
+                },
+                onDismiss = { mintPickerOpen = false },
+            )
+        }
+
+        if (amountPickerOpen && request?.isEcashRequest == true) {
+            val isSatRequest = request.unit.equals("sat", ignoreCase = true)
+            val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
+            CashuRequestAmountEditSheet(
+                initialAmount = request.amount,
+                isSat = isSatRequest,
+                unit = request.unit,
+                decimals = requestCurrency.decimals,
+                useBitcoinSymbol = settings.useBitcoinSymbol,
+                formatter = formatter,
+                onDone = { value ->
+                    regenerate(nextAmount = value)
+                    amountPickerOpen = false
+                },
+                onDismiss = { amountPickerOpen = false },
+            )
+        }
+
+        if (unitPickerOpen && request?.isEcashRequest == true) {
+            val requestMint = request.mints.firstOrNull()?.let { url ->
+                walletState.mints.firstOrNull { it.url == url }
+            }
+            if (requestMint != null && requestMint.supportsMultipleMintUnits) {
+                UnitPickerSheet(
+                    units = requestMint.effectiveMintUnits,
+                    selectedUnit = request.unit,
+                    title = "Choose request unit",
+                    onSelect = { unit ->
+                        regenerate(nextUnit = unit)
+                        unitPickerOpen = false
+                    },
+                    onDismiss = { unitPickerOpen = false },
+                )
+            } else {
+                LaunchedEffect(Unit) { unitPickerOpen = false }
+            }
         }
 
         if (keepNfcSessionMounted) {
-            NfcReceiveLifecycle(
+            val nfcSuccessAmountLabel = request?.let { currentRequest ->
+                nfcState.amount?.takeIf { it > 0L }?.let { amount ->
+                    if (currentRequest.unit.equals("sat", ignoreCase = true)) {
+                        formatter.formatWalletSats(amount, settings.useBitcoinSymbol)
+                    } else {
+                        CurrencyAmount(
+                            amount,
+                            CurrencyRegistry.currencyForMintUnit(currentRequest.unit),
+                        ).formatted()
+                    }
+                }
+            }
+            val nfcSuccessMintName = nfcState.settlementMint?.let { url ->
+                walletState.mints.firstOrNull { it.url == url }?.name ?: url
+            }
+            NfcReceiveOverlay(
                 coordinator = nfcReceiveCoordinator,
-                request = request,
-                settlementMintUrl = walletState.activeMint?.url,
-            )
-        }
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-        ) {
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = CashuTheme.spacing.comfortable),
-                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Spacer(Modifier.height(CashuTheme.spacing.snug))
-                QrCard(
-                    content = request.encoded,
-                    shareSubject = request.displayTitle,
-                    staticOnly = true,
-                    snackbarHostState = snackbarHostState,
-                )
-
-                // Request amounts render in the request's own unit.
-                val isSatRequest = request.unit.equals("sat", ignoreCase = true)
-                val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
-                fun formatRequestAmount(amount: Long): String = if (isSatRequest) {
-                    formatter.formatWalletSats(amount, settings.useBitcoinSymbol)
-                } else {
-                    CurrencyAmount(amount, requestCurrency).formatted()
-                }
-
-                if (request.amount != null && request.amount > 0L) {
-                    AmountText(
-                        text = formatRequestAmount(request.amount),
-                        style = MaterialTheme.typography.headlineMedium
-                            .copy(fontWeight = FontWeight.Bold)
-                            .withMonoDigits(),
-                        modifier = Modifier.padding(vertical = 5.dp),
-                    )
-                }
-
-                if (offerNfcReceive) {
-                    NfcReceiveIndicator(coordinator = nfcReceiveCoordinator)
-                }
-
-                val deliveryNotice = requestReadiness.deliveryNoticeOrNull()
-                if (request.isEcashRequest && request.receivedPayments.isEmpty() && deliveryNotice != null) {
-                    InlineNotice(
-                        text = deliveryNotice.title,
-                        detail = deliveryNotice.message,
-                        severity = NoticeSeverity.Caution,
-                    )
-                } else {
-                    StatusBlock(
-                        received = request.receivedPayments.isNotEmpty(),
-                        paymentCount = paymentCount,
-                    )
-                }
-
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    val activeMintUrl = request.mints.firstOrNull()
-                    val requestMint = activeMintUrl?.let { url ->
-                        walletState.mints.firstOrNull { it.url == url }
-                    }
-                    val mintLabel = activeMintUrl?.let { url ->
-                        requestMint?.name ?: url
-                    } ?: "Any mint"
-                    val requestEditable = request.isEcashRequest && !nfcTransferActive
-                    InspectorRow(
-                        label = "Mint",
-                        value = mintLabel,
-                        leadingIcon = Icons.Outlined.AccountBalance,
-                        editable = requestEditable,
-                        onClick = { mintPickerOpen = true },
-                    )
-                    InspectorRow(
-                        label = "Amount",
-                        value = request.amount?.let {
-                            if (isSatRequest) "$it sat" else formatRequestAmount(it)
-                        } ?: "Any",
-                        leadingIcon = Icons.Outlined.AccountBalanceWallet,
-                        valueMonospaced = true,
-                        editable = requestEditable,
-                        onClick = { amountPickerOpen = true },
-                    )
-                    InspectorRow(
-                        label = "Unit",
-                        value = request.unit.uppercase(),
-                        leadingIcon = Icons.Outlined.CurrencyExchange,
-                        editable = requestEditable && requestMint?.supportsMultipleMintUnits == true,
-                        onClick = { unitPickerOpen = true },
-                    )
-                    InspectorRow(
-                        label = "Created",
-                        value = formatDate(request.createdAtEpochMillis),
-                        leadingIcon = Icons.Outlined.CalendarToday,
-                    )
-                    if (request.totalReceived > 0L) {
-                        InspectorRow(
-                            label = "Total received",
-                            value = formatRequestAmount(request.totalReceived),
-                            leadingIcon = Icons.Outlined.CheckCircle,
-                            valueMonospaced = true,
-                        )
-                    }
-                }
-
-                InlineNoticeHost(text = regenerateError, modifier = Modifier.fillMaxWidth(), severity = NoticeSeverity.Error)
-
-                Spacer(Modifier.height(CashuTheme.spacing.snug))
-            }
-
-            DetailActionFooter {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-                ) {
-                    SecondaryButton(
-                        text = if (copied) "Copied" else "Copy",
-                        onClick = {
-                            clipboard.setText(AnnotatedString(request.encoded))
-                            copied = true
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                    // Quote-backed invoices/addresses cannot be regenerated in
-                    // place; only a NUT-18 ecash request owns this action.
-                    if (request.isEcashRequest) {
-                        SecondaryButton(
-                            text = "New Request",
-                            onClick = { regenerate() },
-                            modifier = Modifier.weight(1f),
-                            enabled = !nfcTransferActive,
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    if (mintPickerOpen && request?.isEcashRequest == true) {
-        val activeMintUrl = request.mints.firstOrNull()
-        MintPickerSheet(
-            mints = walletState.mints,
-            activeMintUrl = activeMintUrl,
-            allowAnyMint = true,
-            onSelect = { mint ->
-                regenerate(nextMints = listOfNotNull(mint?.url))
-                mintPickerOpen = false
-            },
-            onDismiss = { mintPickerOpen = false },
-        )
-    }
-
-    if (amountPickerOpen && request?.isEcashRequest == true) {
-        val isSatRequest = request.unit.equals("sat", ignoreCase = true)
-        val requestCurrency = CurrencyRegistry.currencyForMintUnit(request.unit)
-        CashuRequestAmountEditSheet(
-            initialAmount = request.amount,
-            isSat = isSatRequest,
-            unit = request.unit,
-            decimals = requestCurrency.decimals,
-            useBitcoinSymbol = settings.useBitcoinSymbol,
-            formatter = formatter,
-            onDone = { value ->
-                regenerate(nextAmount = value)
-                amountPickerOpen = false
-            },
-            onDismiss = { amountPickerOpen = false },
-        )
-    }
-
-    if (unitPickerOpen && request?.isEcashRequest == true) {
-        val requestMint = request.mints.firstOrNull()?.let { url ->
-            walletState.mints.firstOrNull { it.url == url }
-        }
-        if (requestMint != null && requestMint.supportsMultipleMintUnits) {
-            UnitPickerSheet(
-                units = requestMint.effectiveMintUnits,
-                selectedUnit = request.unit,
-                title = "Choose request unit",
-                onSelect = { unit ->
-                    regenerate(nextUnit = unit)
-                    unitPickerOpen = false
+                successAmountLabel = nfcSuccessAmountLabel,
+                successMintName = nfcSuccessMintName,
+                onSuccessDone = {
+                    nfcReceiveCoordinator.deactivate()
+                    onClose()
                 },
-                onDismiss = { unitPickerOpen = false },
             )
-        } else {
-            LaunchedEffect(Unit) { unitPickerOpen = false }
         }
-    }
-
-    if (keepNfcSessionMounted) {
-        val nfcSuccessAmountLabel = request?.let { currentRequest ->
-            nfcState.amount?.takeIf { it > 0L }?.let { amount ->
-                if (currentRequest.unit.equals("sat", ignoreCase = true)) {
-                    formatter.formatWalletSats(amount, settings.useBitcoinSymbol)
-                } else {
-                    CurrencyAmount(
-                        amount,
-                        CurrencyRegistry.currencyForMintUnit(currentRequest.unit),
-                    ).formatted()
-                }
-            }
         }
-        val nfcSuccessMintName = nfcState.settlementMint?.let { url ->
-            walletState.mints.firstOrNull { it.url == url }?.name ?: url
-        }
-        NfcReceiveOverlay(
-            coordinator = nfcReceiveCoordinator,
-            successAmountLabel = nfcSuccessAmountLabel,
-            successMintName = nfcSuccessMintName,
-            onSuccessDone = {
-                nfcReceiveCoordinator.deactivate()
-                onClose()
-            },
-        )
     }
 }
 
@@ -533,25 +557,43 @@ private fun NfcReceivePhase.isNfcTransferActive(): Boolean = this in setOf(
 
 @Composable
 private fun StatusBlock(received: Boolean, paymentCount: Int) {
-    if (received) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.CheckCircle,
-                contentDescription = null,
-                tint = CashuTheme.colors.received,
-                modifier = Modifier.size(CashuTheme.spacing.loose),
-            )
-            Text(
-                text = if (paymentCount == 1) "1 payment received" else "$paymentCount payments received",
-                style = MaterialTheme.typography.titleMedium,
-                color = CashuTheme.colors.received,
-            )
+    // Waiting → received swaps with the same fade + scale-in the terminal
+    // glyph uses, so an arriving payment reads as a morph, not a pop.
+    AnimatedContent(
+        targetState = received,
+        transitionSpec = {
+            (
+                fadeIn(tween(200)) + scaleIn(
+                    animationSpec = spring(
+                        dampingRatio = 0.7f,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+                    initialScale = 0.9f,
+                )
+                ) togetherWith fadeOut(tween(150))
+        },
+        label = "creq-status-block",
+    ) { isReceived ->
+        if (isReceived) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.CheckCircle,
+                    contentDescription = null,
+                    tint = CashuTheme.colors.received,
+                    modifier = Modifier.size(CashuTheme.spacing.loose),
+                )
+                Text(
+                    text = if (paymentCount == 1) "1 payment received" else "$paymentCount payments received",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = CashuTheme.colors.received,
+                )
+            }
+        } else {
+            WaitingForPaymentRow()
         }
-    } else {
-        WaitingForPaymentRow()
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashDetailScreen.kt
@@ -1,6 +1,11 @@
 package com.cashu.me.ui.receive
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -139,18 +144,26 @@ fun ReceiveEcashDetailScreen(
             .testTag(UiTestTags.ReceiveEcashDetail),
         color = MaterialTheme.colorScheme.background,
     ) {
-        when (val current = status) {
-            // Claiming / success / failure own the whole screen (iOS: the
-            // full-screen page morphs to PaymentStatusView).
-            is TokenClaimStatus -> TokenClaimTerminal(
-                status = current,
-                formatter = formatter,
-                useBitcoinSymbol = settings.useBitcoinSymbol,
-                onDone = onDone,
-                onRetry = { status = null },
-            )
-
-            null -> when (parsed) {
+        // One content key for every claim status keeps a single terminal
+        // mounted across Claiming → Claimed/Failed (TokenClaimTerminal morphs
+        // the spinner into the check/X in place); confirm ↔ terminal fades
+        // through instead of hard-cutting (iOS: the full-screen page morphs
+        // to PaymentStatusView).
+        AnimatedContent(
+            targetState = status,
+            transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+            label = "receive-ecash-terminal",
+            contentKey = { it != null },
+        ) { current ->
+            if (current != null) {
+                TokenClaimTerminal(
+                    status = current,
+                    formatter = formatter,
+                    useBitcoinSymbol = settings.useBitcoinSymbol,
+                    onDone = onDone,
+                    onRetry = { status = null },
+                )
+            } else when (parsed) {
                 is TokenParseOutcome.Invalid -> PaymentStatusScreen(
                     phase = PaymentStatusPhase.Failure,
                     title = "Couldn't read token",

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -1,6 +1,14 @@
 package com.cashu.me.ui.receive
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -1245,25 +1253,43 @@ internal fun GeneratedInvoiceAmount(
  */
 @Composable
 private fun ReusableOfferStatus(received: Boolean, receivedAmountLabel: String?) {
-    if (received) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.CheckCircle,
-                contentDescription = null,
-                tint = CashuTheme.colors.received,
-                modifier = Modifier.size(CashuTheme.spacing.loose),
-            )
-            Text(
-                text = receivedAmountLabel?.let { "Received $it" } ?: "Payment received!",
-                style = MaterialTheme.typography.titleMedium,
-                color = CashuTheme.colors.received,
-            )
+    // Waiting → received swaps with the same fade + scale-in the terminal
+    // glyph uses, so an arriving payment reads as a morph, not a pop.
+    AnimatedContent(
+        targetState = received,
+        transitionSpec = {
+            (
+                fadeIn(tween(200)) + scaleIn(
+                    animationSpec = spring(
+                        dampingRatio = 0.7f,
+                        stiffness = Spring.StiffnessMediumLow,
+                    ),
+                    initialScale = 0.9f,
+                )
+                ) togetherWith fadeOut(tween(150))
+        },
+        label = "reusable-offer-status",
+    ) { isReceived ->
+        if (isReceived) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.CheckCircle,
+                    contentDescription = null,
+                    tint = CashuTheme.colors.received,
+                    modifier = Modifier.size(CashuTheme.spacing.loose),
+                )
+                Text(
+                    text = receivedAmountLabel?.let { "Received $it" } ?: "Payment received!",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = CashuTheme.colors.received,
+                )
+            }
+        } else {
+            WaitingForPaymentRow()
         }
-    } else {
-        WaitingForPaymentRow()
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/nfc/NfcReceiveUi.kt
@@ -279,34 +279,43 @@ internal fun NfcReceiveOverlayContent(
     onSuccessDone: () -> Unit,
     onRetry: () -> Unit,
 ) {
-    when (state.phase) {
-        NfcReceivePhase.Failure -> PaymentStatusScreen(
-            phase = PaymentStatusPhase.Failure,
-            title = "Payment failed",
-            detail = state.message ?: "The payment could not be received.",
-            doneLabel = "Try again",
-            onDone = onRetry,
-        )
-        NfcReceivePhase.Validating,
-        NfcReceivePhase.Redeeming,
-        NfcReceivePhase.Converting,
-        NfcReceivePhase.Success,
-        -> {
-            val succeeded = state.phase == NfcReceivePhase.Success
+    // One content key for every status phase keeps a single
+    // PaymentStatusScreen mounted across Validating → … → Success/Failure, so
+    // the spinner morphs into the check/X and the title crossfades in place;
+    // keep-phones-together ↔ status fades through instead of hard-cutting.
+    AnimatedContent(
+        targetState = state.phase,
+        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+        label = "nfc-receive-terminal",
+        contentKey = { it in NfcStatusPhases },
+    ) { phase ->
+        if (phase in NfcStatusPhases) {
             PaymentStatusScreen(
-                phase = if (succeeded) PaymentStatusPhase.Success else PaymentStatusPhase.Processing,
-                title = if (succeeded) {
-                    "Payment Received!"
-                } else {
-                    when (state.phase) {
-                        NfcReceivePhase.Validating -> "Checking payment"
-                        NfcReceivePhase.Redeeming -> "Securing ecash"
-                        else -> "Moving to your default mint"
-                    }
+                phase = when (phase) {
+                    NfcReceivePhase.Success -> PaymentStatusPhase.Success
+                    NfcReceivePhase.Failure -> PaymentStatusPhase.Failure
+                    else -> PaymentStatusPhase.Processing
                 },
-                detail = if (succeeded) null else "Transfer complete — you can move the phones apart.",
-                onDone = onSuccessDone.takeIf { succeeded },
-                rows = if (succeeded) {
+                title = when (phase) {
+                    NfcReceivePhase.Success -> "Payment Received!"
+                    NfcReceivePhase.Failure -> "Payment failed"
+                    NfcReceivePhase.Validating -> "Checking payment"
+                    NfcReceivePhase.Redeeming -> "Securing ecash"
+                    else -> "Moving to your default mint"
+                },
+                detail = when (phase) {
+                    NfcReceivePhase.Failure ->
+                        state.message ?: "The payment could not be received."
+                    NfcReceivePhase.Success -> null
+                    else -> "Transfer complete — you can move the phones apart."
+                },
+                doneLabel = if (phase == NfcReceivePhase.Failure) "Try again" else "Done",
+                onDone = when (phase) {
+                    NfcReceivePhase.Success -> onSuccessDone
+                    NfcReceivePhase.Failure -> onRetry
+                    else -> null
+                },
+                rows = if (phase == NfcReceivePhase.Success) {
                     {
                         CashuRequestReceiptRows(
                             amountLabel = successAmountLabel,
@@ -317,10 +326,20 @@ internal fun NfcReceiveOverlayContent(
                     null
                 },
             )
+        } else {
+            NfcTransferScreen()
         }
-        else -> NfcTransferScreen()
     }
 }
+
+/** Phases rendered on the shared status terminal (the rest is the transfer beat). */
+private val NfcStatusPhases = setOf(
+    NfcReceivePhase.Validating,
+    NfcReceivePhase.Redeeming,
+    NfcReceivePhase.Converting,
+    NfcReceivePhase.Success,
+    NfcReceivePhase.Failure,
+)
 
 @Composable
 private fun NfcTransferScreen() {

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -1034,41 +1034,46 @@ private fun GeneratedFace(
     }
 
     // Claimed resolves to the shared full-screen terminal (iOS parity), with
-    // the same Amount/Fee/Mint facts shown while the token is pending.
-    if (claimState == ClaimState.Claimed) {
-        val receipt = buildSendEcashReceiptDetails(
-            amountLabel = amountPresentation.primary,
-            fee = result.fee,
-            unit = unit,
-            mintUrl = mintUrl,
-        )
-        com.cashu.me.ui.components.PaymentStatusScreen(
-            phase = com.cashu.me.ui.components.PaymentStatusPhase.Success,
-            title = "Claimed",
-            onDone = onDone,
-            rows = {
-                com.cashu.me.ui.components.InspectorRow(
-                    label = "Amount",
-                    value = amountPresentation.primary,
-                    leadingIcon = Icons.Outlined.Payments,
-                )
-                receipt.fee?.let { feeLabel ->
+    // the same Amount/Fee/Mint facts shown while the token is pending. The QR
+    // face fades into it instead of hard-cutting.
+    AnimatedContent(
+        targetState = claimState == ClaimState.Claimed,
+        transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+        label = "send-ecash-claimed-terminal",
+    ) { claimed ->
+        if (claimed) {
+            val receipt = buildSendEcashReceiptDetails(
+                amountLabel = amountPresentation.primary,
+                fee = result.fee,
+                unit = unit,
+                mintUrl = mintUrl,
+            )
+            com.cashu.me.ui.components.PaymentStatusScreen(
+                phase = com.cashu.me.ui.components.PaymentStatusPhase.Success,
+                title = "Claimed",
+                onDone = onDone,
+                rows = {
                     com.cashu.me.ui.components.InspectorRow(
-                        label = "Fee",
-                        value = feeLabel,
-                        valueMonospaced = true,
-                        leadingIcon = Icons.Outlined.Receipt,
+                        label = "Amount",
+                        value = amountPresentation.primary,
+                        leadingIcon = Icons.Outlined.Payments,
                     )
-                }
-                com.cashu.me.ui.components.InspectorRow(
-                    label = "Mint",
-                    value = receipt.mint,
-                    leadingIcon = Icons.Outlined.AccountBalance,
-                )
-            },
-        )
-        return
-    }
+                    receipt.fee?.let { feeLabel ->
+                        com.cashu.me.ui.components.InspectorRow(
+                            label = "Fee",
+                            value = feeLabel,
+                            valueMonospaced = true,
+                            leadingIcon = Icons.Outlined.Receipt,
+                        )
+                    }
+                    com.cashu.me.ui.components.InspectorRow(
+                        label = "Mint",
+                        value = receipt.mint,
+                        leadingIcon = Icons.Outlined.AccountBalance,
+                    )
+                },
+            )
+        } else {
 
     // Scroll region + pinned footer, mirroring iOS (ScrollView with the Copy
     // button outside it) and TransactionDetailScreen's Copy action.
@@ -1185,6 +1190,8 @@ private fun GeneratedFace(
             }
         }
         Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+    }
+        }
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -4,12 +4,12 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -477,43 +477,32 @@ fun UnifiedSendScreen(
             ).testTag(UiTestTags.SendSheet),
     ) {
         // Status terminal replaces the whole body (iOS PaymentStatusView slot).
-        when (val current = status) {
-            is SendStatus.Sending -> Box(Modifier.weight(1f).fillMaxWidth()) {
-                PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Processing,
-                    title = "Sending payment…",
-                    rows = { SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol) },
+        // One content key for every status value keeps a single
+        // PaymentStatusScreen mounted across Sending → Sent/Failed, so the
+        // spinner morphs into the check/X in place; the form ↔ terminal swap
+        // itself fades through instead of hard-cutting.
+        AnimatedContent(
+            targetState = status,
+            modifier = if (status == null && step == SendStep.Input) {
+                Modifier.fillMaxWidth()
+            } else {
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            },
+            transitionSpec = { fadeIn(tween(200)) togetherWith fadeOut(tween(150)) },
+            label = "unified-send-terminal",
+            contentKey = { it != null },
+        ) { current ->
+            if (current != null) {
+                SendStatusTerminal(
+                    status = current,
+                    formatter = formatter,
+                    useBitcoinSymbol = settings.useBitcoinSymbol,
+                    onClose = onClose,
+                    onRetry = { status = null },
                 )
-            }
-            is SendStatus.Sent -> Box(Modifier.weight(1f).fillMaxWidth()) {
-                // An async-accepted (NUT-05) melt — typical for on-chain — isn't
-                // settled yet: the mint took the payment and pays out in the
-                // background, so say "processing", not "sent" (iOS parity).
-                val settlementPending = current.result?.settlement == MeltSettlement.Pending
-                PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Success,
-                    title = if (settlementPending) "Payment processing" else "Payment sent",
-                    onDone = onClose,
-                    rows = {
-                        SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol)
-                    },
-                )
-            }
-            is SendStatus.Failed -> Box(Modifier.weight(1f).fillMaxWidth()) {
-                PaymentStatusScreen(
-                    phase = PaymentStatusPhase.Failure,
-                    title = "Payment failed",
-                    detail = current.message.text,
-                    // A terminal outcome (already paid) can't be retried — offer
-                    // Done; anything else returns to the confirm step.
-                    doneLabel = if (current.message.isTerminal) "Done" else "Try again",
-                    onDone = {
-                        if (current.message.isTerminal) onClose() else status = null
-                    },
-                    rows = { SendPaymentDetailRows(current.details, formatter, settings.useBitcoinSymbol) },
-                )
-            }
-            null -> if (step == SendStep.Input && walletState.mints.isEmpty()) {
+            } else if (step == SendStep.Input && walletState.mints.isEmpty()) {
                 // Same surface the wallet-home "Add mint" CTA opens. It draws its
                 // own header so it can swap the title and reveal a back chevron
                 // when its URL / discovery steps are pushed — don't add one here.
@@ -545,12 +534,12 @@ fun UnifiedSendScreen(
                 }
                 TwoFaceScreen(
                     targetState = step,
+                    // The AnimatedContent above carries the Column weight; the
+                    // faces just fill it (Input stays wrap-height).
                     modifier = if (step == SendStep.Input) {
                         Modifier.fillMaxWidth()
                     } else {
-                        Modifier
-                            .weight(1f)
-                            .fillMaxWidth()
+                        Modifier.fillMaxSize()
                     },
                     forward = { initial, target -> target.ordinal >= initial.ordinal },
                     label = "unified-send-step",
@@ -688,6 +677,52 @@ fun UnifiedSendScreen(
             onDismiss = { topUpQuote = null },
         )
     }
+}
+
+/**
+ * One [PaymentStatusScreen] for every send status: staying mounted across
+ * Sending → Sent/Failed lets the spinner morph into the check/X in place and
+ * the title crossfade (iOS PaymentStatusView), instead of remounting a fresh
+ * terminal per outcome.
+ */
+@Composable
+private fun SendStatusTerminal(
+    status: SendStatus,
+    formatter: AmountFormatter,
+    useBitcoinSymbol: Boolean,
+    onClose: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    // An async-accepted (NUT-05) melt — typical for on-chain — isn't settled
+    // yet: the mint took the payment and pays out in the background, so say
+    // "processing", not "sent" (iOS parity).
+    val settlementPending = (status as? SendStatus.Sent)
+        ?.result?.settlement == MeltSettlement.Pending
+    // A terminal outcome (already paid) can't be retried — offer Done;
+    // anything else returns to the confirm step.
+    val failure = (status as? SendStatus.Failed)?.message
+    PaymentStatusScreen(
+        phase = when (status) {
+            is SendStatus.Sending -> PaymentStatusPhase.Processing
+            is SendStatus.Sent -> PaymentStatusPhase.Success
+            is SendStatus.Failed -> PaymentStatusPhase.Failure
+        },
+        title = when (status) {
+            is SendStatus.Sending -> "Sending payment…"
+            is SendStatus.Sent -> if (settlementPending) "Payment processing" else "Payment sent"
+            is SendStatus.Failed -> "Payment failed"
+        },
+        detail = failure?.text,
+        doneLabel = if (failure != null && !failure.isTerminal) "Try again" else "Done",
+        onDone = when (status) {
+            is SendStatus.Sending -> null
+            is SendStatus.Sent -> onClose
+            is SendStatus.Failed -> {
+                { if (status.message.isTerminal) onClose() else onRetry() }
+            }
+        },
+        rows = { SendPaymentDetailRows(status.details, formatter, useBitcoinSymbol) },
+    )
 }
 
 @Composable

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -1466,10 +1466,12 @@ struct CashuTopUpInvoiceSheet: View {
                         }
 
                         statusRow
+                            .animation(.smooth(duration: 0.3), value: phase)
 
                         if let errorMessage {
                             InlineNotice(message: errorMessage, severity: errorSeverity)
                                 .padding(.horizontal)
+                                .transition(.opacity)
                         }
                     }
                     .padding(.top, 12)
@@ -1510,11 +1512,14 @@ struct CashuTopUpInvoiceSheet: View {
 
     @ViewBuilder
     private var statusRow: some View {
+        // Phase swaps fade through (the app-wide .smooth(0.3) payment
+        // choreography) instead of popping per poll beat.
         switch phase {
         case .awaitingPayment:
             Label("Waiting for payment…", systemImage: "clock")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+                .transition(.opacity)
         case .paying:
             HStack(spacing: 8) {
                 ProgressView().controlSize(.small)
@@ -1522,12 +1527,14 @@ struct CashuTopUpInvoiceSheet: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
+            .transition(.opacity)
         case .done:
             // Monochrome, not green — green is reserved for the 64pt hero success
             // checks (DESIGN.md retired the small worded green ✓ badge).
             Label("Sent", systemImage: "checkmark.circle.fill")
                 .font(.subheadline)
                 .foregroundStyle(.primary)
+                .transition(.opacity)
         }
     }
 
@@ -1556,7 +1563,7 @@ struct CashuTopUpInvoiceSheet: View {
                 }
                 guard state == .paid || state == .issued else { continue }
 
-                phase = .paying
+                withAnimation(.smooth(duration: 0.3)) { phase = .paying }
                 do {
                     try await walletManager.finishTopUpAndPayCashuRequest(
                         context.summary,
@@ -1564,15 +1571,17 @@ struct CashuTopUpInvoiceSheet: View {
                         targetMintURL: context.targetMintURL,
                         targetQuoteId: context.quote.id
                     )
-                    phase = .done
+                    withAnimation(.smooth(duration: 0.3)) { phase = .done }
                     HapticFeedback.notification(.success)
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
                     onComplete()
                 } catch {
                     let walletMessage = error.walletMessage
-                    errorMessage = walletMessage.text
-                    errorSeverity = walletMessage.severity
-                    phase = .awaitingPayment   // let the retries/History backstop settle it
+                    withAnimation(.smooth(duration: 0.3)) {
+                        errorMessage = walletMessage.text
+                        errorSeverity = walletMessage.severity
+                        phase = .awaitingPayment   // let the retries/History backstop settle it
+                    }
                 }
                 return
             }


### PR DESCRIPTION
## What

A full review of success/error state transitions across **all payment scenarios** on both platforms, fixing every remaining hard cut so state changes always animate.

### The review

Both platforms share the same terminal design (`PaymentStatusView` / `PaymentStatusScreen`): one mounted instance morphs spinner → check/X in place, titles crossfade, rows and the CTA arrive on a delayed fade. Most flows honor it. These didn't:

| Flow | Before | After |
| --- | --- | --- |
| Android send (Lightning/on-chain/Cashu Request) | form → terminal hard cut; three separate `PaymentStatusScreen` call sites, so Sending → Sent/Failed **remounted** instead of morphing | single `SendStatusTerminal` across all statuses + content-keyed `AnimatedContent` fade (`UnifiedSendScreen.kt`) |
| Android send ecash | QR face → "Claimed" terminal hard cut (early return) | `AnimatedContent` fade (`SendEcashScreen.kt`) |
| Android receive ecash (token claim) | confirm → claiming hard cut | content-keyed `AnimatedContent`; terminal still morphs Claiming → Claimed/Failed in place (`ReceiveEcashDetailScreen.kt`) |
| Android Cashu Request detail | payment lands → success receipt hard cut (early return) | detail fades into the receipt; `StatusBlock` waiting → received now uses the glyph's fade + scale-in (`CashuRequestDetailScreen.kt`) |
| Android NFC receive | keep-phones-together → status hard cut; Failure was a **separate call site** (remount, no morph) | one hoisted `PaymentStatusScreen` across Validating → … → Success/Failure + fade between transfer beat and terminal (`NfcReceiveUi.kt`) |
| Android contactless pay | status text, "Payment sent!" beat, and error notice all popped instantly | status line crossfades per read-stage, success beat fades + scales in, errors use `InlineNoticeHost`'s animated entrance (`ContactlessPayView.kt`) |
| Android BOLT12 reusable offer | waiting row → "Payment received!" instant if/else | same fade + scale-in as the terminal glyph (`ReceiveLightningScreen.kt`) |
| iOS top-up sheet (Cashu Request recovery) | `awaitingPayment` → `paying` → `done` and the error notice swapped with no animation | app-wide `.smooth(0.3)` choreography + opacity transitions (`ScannerWrapperView.swift`) |

Already smooth (verified, untouched): iOS send/receive/claim/Cashu-Request/NUT-18 flows (all wrapped in `.animation(.smooth(0.3))`), Android Lightning-receive terminal (`Crossfade`), Android token-claim terminal, home received-payment beats on both platforms.

### Motion values

No new vocabulary: every added transition reuses the shared terminal's existing timing — fade 200ms in / 150ms out, scale-in from 0.9 with a damping-0.7 spring, opacity/scale only. Reduced-motion safe (opacity-led, matching the existing terminal entrance).

## Test plan

- [x] `:app:compileDebugKotlin`, `:app:compileDebugAndroidTestKotlin`, `:app:testDebugUnitTest` — green
- [x] `xcodebuild -scheme CashuWallet build` — green
- [x] Existing `NfcReceiveSuccessTransitionComposeTest` (processing morphs into receipt) preserved by construction — same content key across phases
- [ ] Manual: send Lightning payment, send ecash (watch claim), claim a token, open Cashu Request and pay it from another wallet, NFC tap-to-pay — every success/error should fade/morph, never pop