### PR TITLE
Hug the content in every iOS content-fit sheet

### DIFF
--- a/ios/CashuWallet/Views/Components/LiquidGlassModifiers.swift
+++ b/ios/CashuWallet/Views/Components/LiquidGlassModifiers.swift
@@ -83,6 +83,59 @@ extension View {
         modifier(ScreenEntryFade())
     }
 
+    /// Measures a content-fit sheet's body for
+    /// ``contentFitDetent(_:enabled:estimate:navigationBar:)``. Apply to the body
+    /// itself — inside the `NavigationStack`, for the sheets that host one.
+    ///
+    /// The `ScrollView` is load-bearing, not decoration. A detent derived from a
+    /// measurement taken inside that same sheet is a feedback loop — measured
+    /// height → detent → sheet height → the height proposed back to the content.
+    /// Since the chrome allowance is close to the real chrome, the loop is
+    /// *neutrally stable*: it settles wherever the first layout pass left it,
+    /// which during the presentation transition is roughly full-screen, and then
+    /// never recovers. A `ScrollView` proposes `nil` height to its content, so
+    /// the measured view always reports its **ideal** size no matter how tall the
+    /// sheet currently is — which breaks the loop.
+    ///
+    /// Never hang `.onGeometryChange` off a bare view to drive a detent.
+    func contentFitMeasured(_ onHeight: @escaping (CGFloat) -> Void) -> some View {
+        ScrollView {
+            self.onGeometryChange(for: CGFloat.self) { proxy in
+                proxy.size.height
+            } action: { newHeight in
+                onHeight(newHeight)
+            }
+        }
+        .scrollBounceBehavior(.basedOnSize)
+    }
+
+    /// Sizes a sheet to the height reported by ``contentFitMeasured(_:)``.
+    /// Apply on the sheet root, *outside* any `NavigationStack` — detents can't
+    /// be set from within the navigation content, which is why this is a pair.
+    ///
+    /// - Parameters:
+    ///   - contentHeight: the measured body height; `0` until geometry lands.
+    ///   - enabled: `false` falls through to `.large`, for steps that need the
+    ///     full sheet (Send's keypad/confirm, mint discovery's scrolling list).
+    ///   - estimate: first-frame stand-in before the measurement arrives, so the
+    ///     sheet doesn't open tiny and then jump.
+    ///   - navigationBar: whether the sheet hosts a `NavigationStack` with an
+    ///     inline title. Pass `false` for a bare sheet, or its detent carries
+    ///     44pt of chrome for a navigation bar that isn't there.
+    func contentFitDetent(
+        _ contentHeight: CGFloat,
+        enabled: Bool = true,
+        estimate: CGFloat = ContentFitSheetMetrics.bodyEstimate,
+        navigationBar: Bool = true
+    ) -> some View {
+        modifier(ContentFitDetent(
+            contentHeight: contentHeight,
+            enabled: enabled,
+            estimate: estimate,
+            navigationBar: navigationBar
+        ))
+    }
+
 }
 
 // MARK: - Sheet Close Button
@@ -168,6 +221,102 @@ private struct CanvasSheetBackground: ViewModifier {
             ))
             .ignoresSafeArea()
         }
+    }
+}
+
+// MARK: - Content-Fit Sheet Detent
+
+/// Pins the sheet to the newest computed height.
+///
+/// Handing `presentationDetents` a fresh single-element set is not enough. The
+/// body's height can be reported more than once as layout settles — a transient
+/// value, then the real one, milliseconds apart. UIKit resolves the new set but
+/// keeps the sheet on whichever detent it had already selected, so a transient
+/// measurement wins and the final one is silently ignored. Measured on an
+/// iPhone 17 Pro: 0 → 469 → 241pt in 70ms, leaving the sheet stuck at the 547pt
+/// detent instead of settling on 319pt.
+///
+/// Binding the selection alongside the set removes the race — the sheet is told
+/// which detent to be on, not merely which are available.
+private struct ContentFitDetent: ViewModifier {
+    let contentHeight: CGFloat
+    let enabled: Bool
+    let estimate: CGFloat
+    let navigationBar: Bool
+
+    @State private var selection: PresentationDetent = .large
+
+    private var detent: PresentationDetent {
+        guard enabled else { return .large }
+        return .height(ContentFitSheetMetrics.detentHeight(
+            for: contentHeight,
+            estimate: estimate,
+            hasNavigationBar: navigationBar
+        ))
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .presentationDetents([detent], selection: $selection)
+            .onAppear { selection = detent }
+            .onChange(of: detent) { _, newDetent in selection = newDetent }
+    }
+}
+
+// MARK: - Content-Fit Sheet Metrics
+
+/// The one place the content-fit sheet arithmetic lives. Every partial-height
+/// sheet in the app — Send's compact input, Receive, Add Mint, connect-a-mint,
+/// onboarding's "What is ecash?" — hugs its content through
+/// ``View/contentFitMeasured(_:)`` +
+/// ``View/contentFitDetent(_:enabled:estimate:navigationBar:)``.
+@MainActor
+enum ContentFitSheetMetrics {
+    /// Inline navigation bar — the only chrome that actually consumes layout
+    /// height above the body.
+    ///
+    /// Notably absent: the drag indicator. `presentationDragIndicator` draws the
+    /// grabber as an *overlay* over the content's own top padding, so reserving
+    /// height for it doesn't move the content down — it just lands as dead space
+    /// at the bottom of the sheet. Same for any "breathing room" fudge: each
+    /// sheet's body already carries its own bottom padding, and the home
+    /// indicator gets the safe-area inset below that.
+    static let navigationBar: CGFloat = 44
+
+    /// Chrome above the measured body. The bottom safe area is *not* folded in
+    /// here — it's 34pt on Face ID devices and 0 on home-button ones, so it's
+    /// resolved per device in ``detentHeight(for:estimate:hasNavigationBar:)``.
+    static func chrome(hasNavigationBar: Bool) -> CGFloat {
+        hasNavigationBar ? navigationBar : 0
+    }
+
+    /// First-frame stand-in before the geometry measurement lands.
+    static let bodyEstimate: CGFloat = 220
+
+    /// Ceiling as a fraction of the screen. Past this the body scrolls inside
+    /// the sheet rather than the sheet growing — at accessibility text sizes an
+    /// unclamped detent would silently pin the sheet to full height.
+    static let maxScreenFraction: CGFloat = 0.9
+
+    static func detentHeight(
+        for contentHeight: CGFloat,
+        estimate: CGFloat = bodyEstimate,
+        hasNavigationBar: Bool = true
+    ) -> CGFloat {
+        let body = contentHeight > 0 ? contentHeight : estimate
+        let window = activeWindow
+        let wanted = body + chrome(hasNavigationBar: hasNavigationBar) + (window?.safeAreaInsets.bottom ?? 0)
+        // Read the ceiling from the *screen*, never from the sheet's own
+        // geometry — the latter would reintroduce the feedback loop this whole
+        // mechanism exists to avoid.
+        guard let screenHeight = window?.screen.bounds.height, screenHeight > 0 else { return wanted }
+        return min(wanted, screenHeight * maxScreenFraction)
+    }
+
+    private static var activeWindow: UIWindow? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        return scene?.keyWindow ?? scene?.windows.first
     }
 }
 

--- a/ios/CashuWallet/Views/Main/OnboardingView.swift
+++ b/ios/CashuWallet/Views/Main/OnboardingView.swift
@@ -38,9 +38,8 @@ struct OnboardingView: View {
     // First-mint state (create path)
     @State private var showConceptSheet = false
     /// Measured height of `conceptSheet`, so the sheet hugs its content instead
-    /// of sitting at a fixed `.medium` detent. Seeded with a plausible value so
-    /// the first layout pass is close; corrected on measure.
-    @State private var conceptSheetHeight: CGFloat = 360
+    /// of sitting at a fixed `.medium` detent.
+    @State private var conceptSheetHeight: CGFloat = 0
     @State private var selectedMintUrls: Set<String> = []
     @State private var customMintUrls: [String] = []
     @State private var showCustomMintInput = false
@@ -311,14 +310,11 @@ struct OnboardingView: View {
         // (~107pt on iPhone 17e, ~134pt on iPhone 11) rather than a designed
         // value. Measuring keeps the copy-to-button gap a constant 20pt and
         // matches Android, whose sheet already hugs its content.
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.height
-        } action: { height in
-            conceptSheetHeight = height
-        }
-        // `.large` stays available so very large accessibility text can still
-        // expand past the measured height rather than clip.
-        .presentationDetents([.height(conceptSheetHeight), .large])
+        .contentFitMeasured { conceptSheetHeight = $0 }
+        // No `NavigationStack` here, so the detent must not reserve nav-bar
+        // chrome. Very large accessibility text scrolls inside the clamped
+        // sheet — the same contract as every other content-fit sheet.
+        .contentFitDetent(conceptSheetHeight, estimate: 360, navigationBar: false)
         .presentationDragIndicator(.visible)
     }
 

--- a/ios/CashuWallet/Views/Mints/AddMintSheet.swift
+++ b/ios/CashuWallet/Views/Mints/AddMintSheet.swift
@@ -99,11 +99,7 @@ struct AddMintFormView: View {
         .padding(.horizontal, 20)
         .padding(.top, 8)
         .padding(.bottom, 16)
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.height
-        } action: { newHeight in
-            onHeightChange(newHeight)
-        }
+        .contentFitMeasured { onHeightChange($0) }
         .navigationTitle("Add Mint")
         .navigationBarTitleDisplayMode(.inline)
         // Sheet, not fullScreenCover — the one presentation kind every
@@ -195,10 +191,7 @@ struct AddMintFormView: View {
 struct AddMintSheet: View {
     @Environment(\.dismiss) private var dismiss
 
-    @State private var contentHeight: CGFloat = 260
-
-    /// Matches the connect-a-mint sheet's chrome allowance.
-    private let sheetChrome: CGFloat = 108
+    @State private var contentHeight: CGFloat = 0
 
     var body: some View {
         NavigationStack {
@@ -208,7 +201,7 @@ struct AddMintSheet: View {
             )
         }
         // Hugs the form, like every other content-fit sheet in the app.
-        .presentationDetents([.height(contentHeight + sheetChrome)])
+        .contentFitDetent(contentHeight, estimate: 260)
         .presentationDragIndicator(.visible)
     }
 }

--- a/ios/CashuWallet/Views/Mints/ConnectMintView.swift
+++ b/ios/CashuWallet/Views/Mints/ConnectMintView.swift
@@ -66,60 +66,53 @@ struct ConnectMintPicker: View {
     var onHeightChange: (CGFloat) -> Void = { _ in }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                if context.showsHeadline {
-                    Text(ConnectMintContext.headline)
-                        .font(.title3.weight(.medium))
-                        .padding(.bottom, ConnectMintMetrics.headlineToSubtitle)
-                }
+        VStack(alignment: .leading, spacing: 0) {
+            if context.showsHeadline {
+                Text(ConnectMintContext.headline)
+                    .font(.title3.weight(.medium))
+                    .padding(.bottom, ConnectMintMetrics.headlineToSubtitle)
+            }
 
-                Text(ConnectMintContext.subtitle)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+            Text(ConnectMintContext.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
 
-                SuggestedMintsSection(existingURLs: existingURLs, onAdd: onAdd)
+            SuggestedMintsSection(existingURLs: existingURLs, onAdd: onAdd)
 
-                if let errorMessage {
-                    InlineNotice(message: errorMessage, severity: .error)
-                        .padding(.top, ConnectMintMetrics.footerSpacing)
-                }
+            if let errorMessage {
+                InlineNotice(message: errorMessage, severity: .error)
+                    .padding(.top, ConnectMintMetrics.footerSpacing)
+            }
 
-                // Spacing lives in each label's vertical padding so the links keep
-                // 44pt hit targets; stacking them with plain spacing would leave
-                // ~20pt-tall taps.
-                VStack(spacing: 0) {
+            // Spacing lives in each label's vertical padding so the links keep
+            // 44pt hit targets; stacking them with plain spacing would leave
+            // ~20pt-tall taps.
+            VStack(spacing: 0) {
+                footerLink(
+                    title: "Add custom mint URL",
+                    systemImage: "plus",
+                    route: .addCustom
+                )
+                // Discovery rides Nostr relays over WebSockets. With the
+                // setting off it can only show a "turn this on" dead end, so
+                // it isn't offered at all.
+                if discoveryAvailable {
                     footerLink(
-                        title: "Add custom mint URL",
-                        systemImage: "plus",
-                        route: .addCustom
+                        title: "Discover mints",
+                        systemImage: "magnifyingglass",
+                        route: .discover
                     )
-                    // Discovery rides Nostr relays over WebSockets. With the
-                    // setting off it can only show a "turn this on" dead end, so
-                    // it isn't offered at all.
-                    if discoveryAvailable {
-                        footerLink(
-                            title: "Discover mints",
-                            systemImage: "magnifyingglass",
-                            route: .discover
-                        )
-                    }
                 }
-                // The first link carries 12pt of its own padding; net gap is the
-                // designed 20pt.
-                .padding(.top, ConnectMintMetrics.rowsToFooter - ConnectMintMetrics.footerSpacing)
             }
-            .padding(.horizontal, ConnectMintMetrics.gutter)
-            .padding(.top, 8)
-            .padding(.bottom, 16)
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.height
-            } action: { newHeight in
-                onHeightChange(newHeight)
-            }
+            // The first link carries 12pt of its own padding; net gap is the
+            // designed 20pt.
+            .padding(.top, ConnectMintMetrics.rowsToFooter - ConnectMintMetrics.footerSpacing)
         }
-        .scrollBounceBehavior(.basedOnSize)
+        .padding(.horizontal, ConnectMintMetrics.gutter)
+        .padding(.top, 8)
+        .padding(.bottom, 16)
+        .contentFitMeasured { onHeightChange($0) }
     }
 
     @ViewBuilder
@@ -261,11 +254,8 @@ struct ConnectMintSheet: View {
     @ObservedObject private var settings = SettingsManager.shared
 
     @State private var route: ConnectMintRoute?
-    @State private var contentHeight: CGFloat = 220
+    @State private var contentHeight: CGFloat = 0
     @State private var addMintError: String?
-
-    /// Matches the Send sheet's compact-detent chrome allowance.
-    private let sheetChrome: CGFloat = 108
 
     var body: some View {
         NavigationStack {
@@ -296,9 +286,7 @@ struct ConnectMintSheet: View {
         // Both the shortlist and the pushed URL step hug their content, matching
         // Android. Only discovery fills the sheet — it hosts a scrolling list and
         // needs bounded height.
-        .presentationDetents(
-            route == .discover ? [.large] : [.height(contentHeight + sheetChrome)]
-        )
+        .contentFitDetent(contentHeight, enabled: route != .discover)
         .presentationDragIndicator(.visible)
         // Hugging the shortlist, this floats over the canvas and keeps the
         // system's elevated background; only the pushed full-height steps adopt

--- a/ios/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveView.swift
@@ -38,11 +38,6 @@ struct UnifiedReceiveView: View {
     /// `UnifiedSendView`'s compact input step.
     @State private var compactContentHeight: CGFloat = 0
 
-    /// Fixed sheet chrome around measured content: drag indicator + inline nav
-    /// bar + a little extra. Mirrors `UnifiedSendView`.
-    private static let compactSheetChrome: CGFloat = 108
-    private static let compactBodyEstimate: CGFloat = 220
-
     /// The freshly-minted Cashu Request detail — the one destination this
     /// sheet still presents itself; its close tears down to the wallet.
     private enum ReceiveRoute: Identifiable {
@@ -52,11 +47,6 @@ struct UnifiedReceiveView: View {
             case .request(let request): return "request-\(request.id)"
             }
         }
-    }
-
-    private var compactDetentHeight: CGFloat {
-        let body = compactContentHeight > 0 ? compactContentHeight : Self.compactBodyEstimate
-        return body + Self.compactSheetChrome
     }
 
     var body: some View {
@@ -82,7 +72,7 @@ struct UnifiedReceiveView: View {
                 }
                 .onDisappear { autoRouteTask?.cancel() }
         }
-        .presentationDetents([.height(compactDetentHeight)])
+        .contentFitDetent(compactContentHeight)
         .presentationDragIndicator(.visible)
     }
 
@@ -103,38 +93,33 @@ struct UnifiedReceiveView: View {
     // MARK: Input step
 
     private var inputForm: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                destinationField
-                    .padding(.horizontal)
-                    .padding(.top, 12)
+        VStack(alignment: .leading, spacing: 0) {
+            destinationField
+                .padding(.horizontal)
+                .padding(.top, 12)
 
-                if let inputHint {
-                    InlineNotice(message: inputHint, severity: .caution)
-                        .padding(.horizontal, 20)
-                        .padding(.top, 10)
-                        .transition(
-                            reduceMotion
-                                ? .opacity
-                                : .opacity.combined(with: .scale(scale: 0.95, anchor: .top))
-                        )
-                }
+            if let inputHint {
+                InlineNotice(message: inputHint, severity: .caution)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 10)
+                    .transition(
+                        reduceMotion
+                            ? .opacity
+                            : .opacity.combined(with: .scale(scale: 0.95, anchor: .top))
+                    )
+            }
 
-                // A centered row of round Liquid Glass icon buttons — the primary
-                // "ways to receive" (Scan · Ecash · Bitcoin), one-word label under each.
-                receiveMethodRow
-                    .padding(.horizontal)
-                    .padding(.top, 32)
-            }
-            .padding(.bottom, 24)
-            .animation(reduceMotion ? .easeInOut(duration: 0.2) : .snappy(duration: 0.25), value: inputHint != nil)
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.height
-            } action: { newHeight in
-                compactContentHeight = newHeight
-            }
+            // A centered row of round Liquid Glass icon buttons — the primary
+            // "ways to receive" (Scan · Ecash · Bitcoin), one-word label under each.
+            receiveMethodRow
+                .padding(.horizontal)
+                .padding(.top, 32)
         }
-        .scrollBounceBehavior(.basedOnSize)
+        .padding(.bottom, 24)
+        // Animate on the measured body, inside the content-fit ScrollView, so the
+        // hint's entrance and the detent's resize run as one motion.
+        .animation(reduceMotion ? .easeInOut(duration: 0.2) : .snappy(duration: 0.25), value: inputHint != nil)
+        .contentFitMeasured { compactContentHeight = $0 }
         .scrollDismissesKeyboard(.interactively)
     }
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1353,12 +1353,6 @@ struct UnifiedSendView: View {
     /// instead of sitting at the bottom of a `.large` sheet.
     @State private var compactContentHeight: CGFloat = 0
 
-    /// Fixed sheet chrome around measured content: drag indicator + inline nav
-    /// bar + a little extra so the sheet sits just above the elements.
-    private static let compactSheetChrome: CGFloat = 108
-    /// First-frame estimate before geometry lands so the sheet doesn't open tiny.
-    private static let compactBodyEstimate: CGFloat = 220
-
     enum Step: Equatable { case input, amount, confirm, sending, sent, failed }
 
     enum LockedDestination: Equatable {
@@ -1376,11 +1370,6 @@ struct UnifiedSendView: View {
     private var prefersCompactSheet: Bool {
         // The pushed URL step hugs too; only discovery needs the full sheet.
         statusPhase == nil && step == .input && connectMintRoute != .discover
-    }
-
-    private var compactDetentHeight: CGFloat {
-        let body = compactContentHeight > 0 ? compactContentHeight : Self.compactBodyEstimate
-        return body + Self.compactSheetChrome
     }
 
     var body: some View {
@@ -1464,7 +1453,7 @@ struct UnifiedSendView: View {
         }
         // Own the sheet chrome so the detent can follow the step: compact for
         // input, `.large` + flat canvas for amount/confirm/status.
-        .presentationDetents(prefersCompactSheet ? [.height(compactDetentHeight)] : [.large])
+        .contentFitDetent(compactContentHeight, enabled: prefersCompactSheet)
         .presentationDragIndicator(.visible)
         // A stray swipe must not tear down the flow while the melt is executing.
         .interactiveDismissDisabled(step == .sending)
@@ -1485,32 +1474,25 @@ struct UnifiedSendView: View {
     }
 
     private var inputForm: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                destinationField
-                    .padding(.horizontal)
-                    .padding(.top, 12)
+        VStack(alignment: .leading, spacing: 0) {
+            destinationField
+                .padding(.horizontal)
+                .padding(.top, 12)
 
-                if let inputHint {
-                    InlineNotice(message: inputHint, severity: .caution)
-                        .padding(.horizontal, 20)
-                        .padding(.top, 10)
-                }
+            if let inputHint {
+                InlineNotice(message: inputHint, severity: .caution)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 10)
+            }
 
-                // A centered row of round Liquid Glass icon buttons — the primary
-                // "ways to send" (Scan · Ecash · Tap), one-word label under each.
-                sendMethodRow
-                    .padding(.horizontal)
-                    .padding(.top, 32)
-            }
-            .padding(.bottom, 24)
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.height
-            } action: { newHeight in
-                compactContentHeight = newHeight
-            }
+            // A centered row of round Liquid Glass icon buttons — the primary
+            // "ways to send" (Scan · Ecash · Tap), one-word label under each.
+            sendMethodRow
+                .padding(.horizontal)
+                .padding(.top, 32)
         }
-        .scrollBounceBehavior(.basedOnSize)
+        .padding(.bottom, 24)
+        .contentFitMeasured { compactContentHeight = $0 }
         .scrollDismissesKeyboard(.interactively)
     }
 
@@ -2839,11 +2821,7 @@ struct UnifiedSendView: View {
             actionTitle: "Receive",
             action: onReceive
         )
-        .onGeometryChange(for: CGFloat.self) { proxy in
-            proxy.size.height
-        } action: { newHeight in
-            compactContentHeight = newHeight
-        }
+        .contentFitMeasured { compactContentHeight = $0 }
     }
 
     private func addMint(_ url: String) {


### PR DESCRIPTION
## The bug

The zero-balance **Send** sheet and the **Add Mint** sheet opened at ~70% of the screen with their content floating in a large void. Android's equivalents hug their content — `UnifiedSendScreen.kt` even says so: *"Compact (no fillMaxHeight) so the sheet hugs this empty state."*

| before (`556566f`) | after (`601e7e7`) |
|---|---|
| <img src="https://raw.githubusercontent.com/swedishfrenchpress/wallet/pr-281-assets/docs/pr-assets/281/send-before.png" width="300"> | <img src="https://raw.githubusercontent.com/swedishfrenchpress/wallet/pr-281-assets/docs/pr-assets/281/send-after.png" width="300"> |
| 592pt — cluster centered in a void | **347pt — hugs its content** |

## Root cause, part 1: a measurement loop

Every partial-height sheet derives its detent from a height measured **inside that same sheet**:

```
measured height → detent → sheet height → height proposed back to the content
```

Because the chrome allowance nearly matched the real chrome, the loop was *neutrally stable*: it settled wherever the first layout pass left it — roughly full-screen, during the presentation transition — and never recovered.

A `ScrollView` proposes `nil` height to its content, so a view measured inside one always reports its **ideal** size regardless of how tall the sheet currently is. That breaks the loop, and it predicted exactly which sheets were broken, 5/5:

| Site | Measured | Status |
|---|---|---|
| `SendView.inputForm` | inner VStack in a ScrollView | fine |
| `ReceiveView.inputForm` | inner VStack in a ScrollView | fine |
| `ConnectMintPicker` | inner VStack in a ScrollView | fine |
| `SendView.noBalanceState` | **bare `NativeEmptyState`** | **latched** |
| `AddMintFormView` | **bare VStack** | **latched** |

## Root cause, part 2: a detent race

Breaking the loop is necessary but not sufficient, and this one only showed up under the matched capture — manual testing won the race and looked fine.

The body's height is reported more than once as layout settles. Handing `presentationDetents` a fresh single-element set does **not** move the sheet: UIKit resolves the new set but keeps whichever detent it had already selected, so a transient measurement wins and the final one is silently ignored. Instrumented on an iPhone 17 Pro:

```
[CFS] measured=0    → detent 298   (first-frame estimate)
[CFS] measured=469  → detent 547   ← transient, and what the sheet stayed on
[CFS] measured=241  → detent 319   ← correct, silently ignored
```

All three within 70ms. Binding the selection alongside the set fixes it — the sheet is told *which* detent to be on, not merely which ones exist.

## The change

Four hand-rolled copies of the mechanism collapse into one pair of modifiers:

```swift
.contentFitMeasured { ... }   // inside the NavigationStack — owns the ScrollView + measurement
.contentFitDetent(height)     // on the sheet root — owns the arithmetic and the selection
```

`ContentFitSheetMetrics` is the single place the arithmetic lives:

```
detent = content + navigationBar (44, when present) + bottomSafeArea,  clamped to 0.9 × screen
```

Notably absent: any allowance for the drag indicator. `presentationDragIndicator` draws the grabber as an **overlay** over the content's own top padding, so reserving height for it never moved the content down — it landed as dead space at the *bottom*. The old flat `108` carried 20pt of that plus 10pt of slack; removing both tightens every sheet by 30pt.

The bottom safe area is resolved per device rather than assumed, so home-button iPhones no longer over-shoot by 34pt. The clamp means accessibility text sizes scroll inside the sheet rather than silently pinning it full-height.

## Onboarding's "What is ecash?" sheet

Joined to the same mechanism for consistency. It hosts no `NavigationStack`, hence the `navigationBar:` flag. It loses its second `.large` detent — the ScrollView and the clamp cover the large-text case that detent existed for, and every other content-fit sheet is single-detent.

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/swedishfrenchpress/wallet/pr-281-assets/docs/pr-assets/281/concept-before.png" width="300"> | <img src="https://raw.githubusercontent.com/swedishfrenchpress/wallet/pr-281-assets/docs/pr-assets/281/concept-after.png" width="300"> |
| ~391pt | ~397pt |

This one is **essentially unchanged in size, and slightly taller by design**: the old detent was the measured content with no chrome at all, so the sheet borrowed the home-indicator strip. It now accounts for it.

## Capture conditions

Both sides built from isolated worktrees with separate Derived Data, captured on one simulator instance.

- base `556566f` (upstream/main) · head `601e7e7`
- iOS 26.5 (23F77), iPhone 17 Pro, 1206×2622 @3x (402×874pt)
- Xcode 26.6 (17F113)
- light appearance, en_US, default Dynamic Type, status bar pinned to 9:41
- fixture: `RESET_WALLET` + `UITEST_SEED_WALLET` + `UITEST_SEED_MINT` with a synthetic mint URL (`https://mint.example.test`) — no network, no real wallet data

**Not captured in the matched run:** Add Mint, Receive, and the connect-a-mint picker. They go through the identical code path and were checked by hand, but they do not have before/after evidence here.

No Android changes. No `project.pbxproj` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
