### PR TITLE
Speed up Android tab transitions 2x

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/theme/Motion.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/theme/Motion.kt
@@ -36,8 +36,8 @@ object CashuMotion {
      * Outgoing empties in [TabFadeOutMs]; incoming settles over [TabFadeInMs]
      * after that delay, scaling from [TabFadeInitialScale].
      */
-    const val TabFadeOutMs = 80
-    const val TabFadeInMs = 500
+    const val TabFadeOutMs = 40
+    const val TabFadeInMs = 250
     const val TabFadeInitialScale = 0.992f
 
     /**


### PR DESCRIPTION
## Summary
- Halve Wallet / History / Mints tab fade-through durations (out 80→40ms, in 500→250ms) so switching tabs feels twice as fast.

## Test plan
- [ ] On Android, switch between Wallet, History, and Mints tabs
- [ ] Confirm the cross-fade is snappier without feeling abrupt
- [ ] Confirm push/pop navigation animations are unchanged