### PR TITLE
Require iOS and Android feature parity in agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Repository agent guidance
+
+- Never leak any personally identifiable information (PII) about the user or their computer, such as usernames, local file paths, device names, or IP addresses, through GitHub or Git activity, including commit messages and pull requests.
+- Use `gh` for GitHub operations.
+- Never override the Git author or committer identity to Codex.
+
+## Cross-platform parity
+
+- Always aim for cross-platform compatibility and the same level of quality across the iOS and Android apps, including behavior, UX polish, accessibility, tests, and documentation.
+- When a feature or user-facing change is requested or implemented for only one platform, explicitly ask the user whether they want the equivalent work implemented for the other platform as well. Do not silently assume that a platform-specific divergence is intentional.
+- If the user chooses to keep a change platform-specific, clearly note the resulting parity gap and any follow-up work needed for the other platform.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,5 +7,6 @@
 ## Cross-platform parity
 
 - Always aim for cross-platform compatibility and the same level of quality across the iOS and Android apps, including behavior, UX polish, accessibility, tests, and documentation.
+- Use only platform-native UI components in both apps: native iOS components on iOS and native Android components on Android. Do not introduce cross-platform UI frameworks or web-based UI substitutes.
 - When a feature or user-facing change is requested or implemented for only one platform, explicitly ask the user whether they want the equivalent work implemented for the other platform as well. Do not silently assume that a platform-specific divergence is intentional.
 - If the user chooses to keep a change platform-specific, clearly note the resulting parity gap and any follow-up work needed for the other platform.


### PR DESCRIPTION
## Summary

- add root-level agent guidance while preserving the existing repository directives
- require cross-platform compatibility and equivalent quality across iOS and Android
- require agents to ask about matching work on the other platform and call out intentional parity gaps

## Validation

- git diff --check
- documentation-only change; app tests not applicable