### PR TITLE
docs: add SECURITY.md policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Reporting a Vulnerability
+
+To report security issues send an email to **cashu-security@pm.me**


### PR DESCRIPTION
Adds a simple security policy pointing security vulnerability reports to cashu-security@pm.me, consistent with the Cashu nutshell repository.