### PR TITLE
Freeze the ASCII field's ambient clock under instrumentation

### DIFF
--- a/android/app/src/debug/java/com/cashu/me/App/UiTestApplication.kt
+++ b/android/app/src/debug/java/com/cashu/me/App/UiTestApplication.kt
@@ -10,6 +10,14 @@ package com.cashu.me.App
 class UiTestApplication : CashuWalletApplication() {
     override val createContainerAutomatically: Boolean = false
 
+    override fun onCreate() {
+        // Marks the process as an instrumented UI run so decorative ambient
+        // motion (the onboarding ASCII field's clock) freezes like it does
+        // for Reduce Motion — see UiTestRuntime.
+        UiTestRuntime.active = true
+        super.onCreate()
+    }
+
     fun installContainer(container: AppContainer) {
         check(this.container.value == null) {
             "A UI-test container is already installed in this process."

--- a/android/app/src/main/java/com/cashu/me/App/CashuWalletApplication.kt
+++ b/android/app/src/main/java/com/cashu/me/App/CashuWalletApplication.kt
@@ -55,3 +55,13 @@ open class CashuWalletApplication : Application() {
         mutableContainer.value = container
     }
 }
+
+/** True only in processes running the debug-only UiTestApplication the
+ * instrumentation runner installs — i.e. instrumented UI runs. Decorative
+ * ambient motion (the onboarding ASCII field's clock) freezes there the
+ * same way it does for Reduce Motion and battery saver, sparing the CI
+ * emulator's software GPU. The production manifest always installs
+ * [CashuWalletApplication], so this stays false outside tests. */
+internal object UiTestRuntime {
+    @Volatile var active = false
+}

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
@@ -1,5 +1,6 @@
 package com.cashu.me.ui.onboarding
 
+import android.app.ActivityManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -968,7 +969,14 @@ internal fun AsciiField(
     // still frame; leaving the step pair or opening the concept sheet stops
     // the clockwork. Backgrounding pauses for free — withFrameNanos simply
     // stops being serviced while the choreographer is idle.
-    val clockRuns = staticTime == null && !reducedMotion && !powerSave && active
+    //
+    // Instrumented runs freeze the ambient clock too, the same way Reduce
+    // Motion and battery saver do: the field is decoration, and a 30fps
+    // full-window software render held across a whole journey suite kept
+    // killing the CI emulator mid-run. One still frame keeps layout,
+    // goldens, and the handoff intact.
+    val testHarness = remember { !inspectionMode && isRunningInTestHarness() }
+    val clockRuns = staticTime == null && !reducedMotion && !powerSave && !testHarness && active
 
     // Wall-clock zero. Time is always derived from the monotonic clock —
     // never a frame counter — so a pause/resume never rewinds or replays;
@@ -1085,6 +1093,13 @@ internal val AsciiFieldVaultTargetKey = SemanticsPropertyKey<Float>("AsciiFieldV
 /** Wall-clock seconds for the warp envelope — monotonic, arbitrary epoch;
  * only differences are ever used. */
 private fun nowSeconds(): Double = System.nanoTime() / 1e9
+
+/** True while the process runs under instrumentation. The ambient field
+ * clock freezes there exactly like it does for Reduce Motion and battery
+ * saver — the motion is decoration, and holding a 30fps full-window
+ * software render across a whole journey suite kept killing the CI
+ * emulator mid-run. */
+internal fun isRunningInTestHarness(): Boolean = ActivityManager.isRunningInTestHarness()
 
 /**
  * Paints, glyph metrics, and reusable buckets — everything the frame loop

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/AsciiField.kt
@@ -1,6 +1,5 @@
 package com.cashu.me.ui.onboarding
 
-import android.app.ActivityManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -48,6 +47,7 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.testTag
+import com.cashu.me.App.UiTestRuntime
 import com.cashu.me.ui.testing.UiTestTags
 import com.cashu.me.ui.theme.rememberReducedMotion
 import kotlin.math.PI
@@ -973,10 +973,10 @@ internal fun AsciiField(
     // Instrumented runs freeze the ambient clock too, the same way Reduce
     // Motion and battery saver do: the field is decoration, and a 30fps
     // full-window software render held across a whole journey suite kept
-    // killing the CI emulator mid-run. One still frame keeps layout,
-    // goldens, and the handoff intact.
-    val testHarness = remember { !inspectionMode && isRunningInTestHarness() }
-    val clockRuns = staticTime == null && !reducedMotion && !powerSave && !testHarness && active
+    // killing the CI emulator mid-run. UiTestRuntime flips only under the
+    // instrumentation runner's application — never in production. One still
+    // frame keeps layout, goldens, and the handoff intact.
+    val clockRuns = staticTime == null && !reducedMotion && !powerSave && !UiTestRuntime.active && active
 
     // Wall-clock zero. Time is always derived from the monotonic clock —
     // never a frame counter — so a pause/resume never rewinds or replays;
@@ -1093,13 +1093,6 @@ internal val AsciiFieldVaultTargetKey = SemanticsPropertyKey<Float>("AsciiFieldV
 /** Wall-clock seconds for the warp envelope — monotonic, arbitrary epoch;
  * only differences are ever used. */
 private fun nowSeconds(): Double = System.nanoTime() / 1e9
-
-/** True while the process runs under instrumentation. The ambient field
- * clock freezes there exactly like it does for Reduce Motion and battery
- * saver — the motion is decoration, and holding a 30fps full-window
- * software render across a whole journey suite kept killing the CI
- * emulator mid-run. */
-internal fun isRunningInTestHarness(): Boolean = ActivityManager.isRunningInTestHarness()
 
 /**
  * Paints, glyph metrics, and reusable buckets — everything the frame loop

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingHandoff.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingHandoff.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.cashu.me.App.UiTestRuntime
 import com.cashu.me.ui.theme.rememberReducedMotion
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -266,7 +267,7 @@ internal fun OnboardingHandoffHost(controller: OnboardingHandoffController) {
             // see AsciiField) the press would sit invisible and release stale.
             val powerSave = (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)
                 ?.isPowerSaveMode == true
-            val canBloom = !powerSave && !isRunningInTestHarness()
+            val canBloom = !powerSave && !UiTestRuntime.active
             if (canBloom) session.touch.press(centerXDp, centerYDp, nowSeconds())
 
             delay(HoldMs.toLong())

--- a/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingHandoff.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/onboarding/OnboardingHandoff.kt
@@ -262,10 +262,12 @@ internal fun OnboardingHandoffHost(controller: OnboardingHandoffController) {
 
             delay(BloomDelayMs.toLong())
             // Bloom only when the field's frame clock can render it — under
-            // battery saver the press would sit invisible and release stale.
+            // battery saver or instrumentation (the clock freezes for both,
+            // see AsciiField) the press would sit invisible and release stale.
             val powerSave = (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)
                 ?.isPowerSaveMode == true
-            if (!powerSave) session.touch.press(centerXDp, centerYDp, nowSeconds())
+            val canBloom = !powerSave && !isRunningInTestHarness()
+            if (canBloom) session.touch.press(centerXDp, centerYDp, nowSeconds())
 
             delay(HoldMs.toLong())
             // Linear driver on purpose: every stage of the exit carries its
@@ -274,7 +276,7 @@ internal fun OnboardingHandoffHost(controller: OnboardingHandoffController) {
             launch { erosion.animateTo(1f, tween(ErosionMs, easing = LinearEasing)) }
 
             delay(ReleaseDelayMs.toLong())
-            if (!powerSave) session.touch.release(nowSeconds())
+            if (canBloom) session.touch.release(nowSeconds())
 
             delay((ErosionMs - ReleaseDelayMs).toLong())
             controller.end()


### PR DESCRIPTION
## Problem

Android UI Tests on CI have been failing on every recent run — `main` and PR branches alike — always at the same point: test #56 of 89, currently `OnboardingAsciiFieldLayoutComposeTest.suppressedLayoutKeepsTheFieldMountedButLaysOutTheFallbackBand`.

The failure artifact tells the real story:

- The test records an **empty** `<failure></failure>` and a 52s runtime (it normally takes ~1s).
- Its per-test **logcat cuts off one second in** — instrumentation lost the device mid-test.
- `adb: device offline` follows immediately and the remaining 33 tests never run.

The emulator dies mid-suite and whichever test is running takes the blame. It's always #56 because test order and durations are deterministic. The retry script then re-runs the whole suite from scratch, which re-cooks the emulator to the same point — attempts 2 and 3 died at the identical test.

## Root cause

Since the onboarding restyle, the welcome backdrop renders a decorative ASCII terrain at 30fps across a full-window, offscreen-composited Canvas with a DstIn gradient. Journey tests launch the real app and spend real time on onboarding, so the suite software-renders that field continuously for minutes on the emulator's software GPU (swiftshader). The death is load-driven and timing-deterministic; whichever test runs at the ~5-minute mark loses.

## Fix

Reduce Motion and battery saver already freeze this ambient clock for exactly this class of reason — the motion is decoration. This extends the same freeze to instrumented UI runs, signalled **explicitly**:

- `UiTestRuntime.active` (new, main sourceset) flips only in `UiTestApplication.onCreate` — the debug-only application `CashuUiTestRunner` already installs for instrumented runs. The production manifest installs `CashuWalletApplication`, so the flag can never be true in production.
- `AsciiField`: `clockRuns` now also requires `!UiTestRuntime.active`. One still frame still renders (same as Reduce Motion), so layout, goldens, and semantics are unchanged.
- `OnboardingHandoff`: the erosion dissolve is driven by its own `Animatable` and is untouched; the decorative bloom press/release is now gated on the same condition, mirroring the existing battery-saver gate (a frozen clock would leave the press invisible and stale).

Journey tests keep full behavioral coverage — the field never carries assistive content or state. Macrobenchmarks are unaffected: their runner doesn't install `UiTestApplication`, so the field renders live there.

(First commit used `ActivityManager.isRunningInTestHarness()`; it reads the deprecated device-wide `ro.test_harness` property — false on user builds and on the CI emulator — so it never engaged. The second commit replaces it with this explicit, verified signal.)

## Production safety

The flag's only writer lives in the `debug` sourceset and is only instantiated by the instrumentation runner; production code paths are untouched when the flag is false, which is always outside instrumentation. No reflection, no system properties, no deprecated APIs.

## Verification

- In-process assertion under instrumentation: `UiTestRuntime.active == true` (scratch test, since removed).
- Local instrumented run of the exact CI-failing class: `OnboardingAsciiFieldLayoutComposeTest` — OK (2 tests, 1.9s).
- All onboarding compose tests (`OnboardingAsciiFieldLayoutComposeTest`, `OnboardingChassisLayoutComposeTest`, `SeedPhraseAccessibilityComposeTest`, `WalletStartupFailureComposeTest`) — OK (9 tests), exercising the frozen-clock path.
- Control experiment: a journey-test idling issue seen on local API 36/37 AVDs reproduces identically with and without this change (pre-existing local image quirk, unrelated — CI journey tests pass on the CI image).

## Platform note

Android-only, test-infrastructure mitigation. iOS freezes the same ambient motion for Reduce Motion / low power already; its UI tests run on the simulator and don't exhibit this failure mode, so no iOS change is included.