### PR TITLE
chore: set app version to 0.3 on iOS and Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 4
-        versionName = "1.0"
+        versionName = "0.3"
         testInstrumentationRunner = "com.cashu.me.test.CashuUiTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         testInstrumentationRunnerArguments["useTestStorageService"] = "true"

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -1305,7 +1305,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -1344,7 +1344,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/ios/CashuWalletTests/AppVersionTests.swift
+++ b/ios/CashuWalletTests/AppVersionTests.swift
@@ -11,7 +11,7 @@ final class AppVersionTests: XCTestCase {
     func testDisplayStringMatchesMarketingVersionBuildSetting() {
         // The hosted test bundle's main bundle is CashuWallet.app, whose
         // CFBundleShortVersionString is generated from MARKETING_VERSION.
-        XCTAssertEqual(AppVersion.displayString(), "1.0")
+        XCTAssertEqual(AppVersion.displayString(), "0.3")
     }
 
     func testDisplayStringFallsBackToNilWhenVersionMissing() {


### PR DESCRIPTION
Sets the marketing version / versionName to 0.3 across iOS and Android settings and project configuration, and updates relevant unit tests.