### PR TITLE
Re-arm the QR scanner whenever its camera surface reappears

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Views/Components/ScannerView.kt
+++ b/android/app/src/main/java/com/cashu/me/Views/Components/ScannerView.kt
@@ -104,6 +104,12 @@ fun ScannerView(
     useDeterministicPermission: Boolean = false,
     promptText: String = ScannerDefaultPrompt,
     quickActions: List<ScannerQuickAction> = emptyList(),
+    // Bumped by the host every time the scanner opens. The exit animation keeps
+    // this composable in composition, so a reopen that reverses that exit would
+    // otherwise resurrect `completedScan = true` — a live camera that silently
+    // drops every scan. Keying the scan state to the opening guarantees a
+    // visible scanner is always an armed scanner.
+    sessionId: Int = 0,
 ) {
     val context = LocalContext.current
     val activity = remember(context) { context.findActivity() }
@@ -119,10 +125,10 @@ fun ScannerView(
         )
     }
     var cameraError by remember { mutableStateOf<String?>(null) }
-    var completedScan by remember { mutableStateOf(false) }
-    var animatedProgress by remember { mutableStateOf(0f) }
-    var animatedError by remember { mutableStateOf<String?>(null) }
-    val animatedUrDecoder = remember { AnimatedUrDecoder() }
+    var completedScan by remember(sessionId) { mutableStateOf(false) }
+    var animatedProgress by remember(sessionId) { mutableStateOf(0f) }
+    var animatedError by remember(sessionId) { mutableStateOf<String?>(null) }
+    val animatedUrDecoder = remember(sessionId) { AnimatedUrDecoder() }
     val permissionLauncher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
         cameraPermissionState = cameraPermissionResultState(
             granted = granted,

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -397,6 +397,14 @@ private fun AuthenticatedShell(container: AppContainer) {
     }
 
     val activeScannerTarget = scannerTarget
+    // One id per scanner opening. The scanner overlay's exit animation keeps the
+    // composable alive briefly, so a fast reopen can reuse that composition —
+    // the id keys its one-shot scan state back to fresh (iOS viewWillAppear
+    // re-arm parity).
+    var scannerSessionId by remember { mutableStateOf(0) }
+    LaunchedEffect(activeScannerTarget) {
+        if (activeScannerTarget != null) scannerSessionId += 1
+    }
     // The shell stays mounted; camera surfaces animate over it (slide-up + fade)
     // instead of replacing it with a one-frame cut.
     var lastScannerTarget by remember { mutableStateOf(ScannerTarget.Auto) }
@@ -454,6 +462,7 @@ private fun AuthenticatedShell(container: AppContainer) {
                     container.runtimePolicy.useDeterministicCameraPermission,
                 promptText = if (scanningP2pkKey) LockEcashCopy.ScanPrompt else ScannerDefaultPrompt,
                 quickActions = if (scanningP2pkKey) p2pkQuickActions else emptyList(),
+                sessionId = scannerSessionId,
                 onScanned = { payload ->
                     scannerTarget = null
                     routeScannedPayload(

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -181,6 +181,16 @@ struct ScannerWrapperView: View {
                             },
                             onFailure: { error in
                                 cameraFailureMessage = error
+                            },
+                            onAppear: {
+                                // A visible scanner must be an armed scanner.
+                                // The camera surface can (re)appear without a
+                                // fresh model — a cancelled interactive sheet
+                                // dismissal, a stacked cover closing, or SwiftUI
+                                // reusing retained sheet state — and without this
+                                // reset the preview looks live while `isScanning`
+                                // stays false and every scan is silently dropped.
+                                scannerModel.reset()
                             }
                         )
                         .ignoresSafeArea()
@@ -1204,37 +1214,48 @@ struct CashuPaymentRequestPayView: View {
 struct LegacyQRScannerView: UIViewControllerRepresentable {
     var onResult: (String) -> Void
     var onFailure: (String) -> Void
-    
+    /// Fires every time the camera surface (re)appears — including the cases
+    /// SwiftUI can't see: cancelled interactive dismissals and stacked covers
+    /// closing. Callers use it to re-arm scan intake.
+    var onAppear: () -> Void
+
     func makeUIViewController(context: Context) -> QRScannerViewController {
         let controller = QRScannerViewController()
         controller.delegate = context.coordinator
         return controller
     }
-    
+
     func updateUIViewController(_ uiViewController: QRScannerViewController, context: Context) {
         context.coordinator.onResult = onResult
         context.coordinator.onFailure = onFailure
+        context.coordinator.onAppear = onAppear
     }
-    
+
     func makeCoordinator() -> Coordinator {
-        Coordinator(onResult: onResult, onFailure: onFailure)
+        Coordinator(onResult: onResult, onFailure: onFailure, onAppear: onAppear)
     }
-    
+
     class Coordinator: NSObject, QRScannerViewControllerDelegate {
         var onResult: (String) -> Void
         var onFailure: (String) -> Void
-        
-        init(onResult: @escaping (String) -> Void, onFailure: @escaping (String) -> Void) {
+        var onAppear: () -> Void
+
+        init(onResult: @escaping (String) -> Void, onFailure: @escaping (String) -> Void, onAppear: @escaping () -> Void) {
             self.onResult = onResult
             self.onFailure = onFailure
+            self.onAppear = onAppear
         }
-        
+
         func didFound(code: String) {
             onResult(code)
         }
-        
+
         func didFail(error: String) {
             onFailure(error)
+        }
+
+        func scannerDidAppear() {
+            onAppear()
         }
     }
 }
@@ -1242,6 +1263,7 @@ struct LegacyQRScannerView: UIViewControllerRepresentable {
 protocol QRScannerViewControllerDelegate: AnyObject {
     func didFound(code: String)
     func didFail(error: String)
+    func scannerDidAppear()
 }
 
 class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
@@ -1322,6 +1344,12 @@ class QRScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsD
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        // Re-arm intake on every (re)appearance: a consumed scan sets
+        // `isScanning = false`, and appearances that don't rebuild the view
+        // (cancelled interactive dismissal, a stacked cover closing, a reused
+        // sheet) would otherwise leave a live camera that silently drops scans.
+        delegate?.scannerDidAppear()
 
         // A cancelled interactive sheet dismissal fires viewWillDisappear (which
         // stops the session) and then viewWillAppear without reloading the view,


### PR DESCRIPTION
## Problem

The QR scanner only works once per session: after a successful scan, if the scanner surface is still (or again) visible, pointing it at another QR code does nothing. Closing and reopening the scanner is the only way to scan again.

## Root cause

A consumed scan latches the intake gate off (`isScanning = false` on iOS, `completedScan = true` on Android), and it was only restored on a single path (iOS's inline-reject timer). Any appearance path that doesn't rebuild the scanner state left a live camera preview that silently dropped every scan:

- a cancelled interactive sheet dismissal (iOS)
- a stacked confirm cover closing on top of the scanner (iOS — the residual symptom of #173)
- SwiftUI reusing retained sheet state on reopen (iOS)
- a Compose composition surviving an exit-animation reversal on a fast reopen (Android)

## Fix

Both platforms now enforce one invariant: **a visible scanner is always an armed scanner.**

- **iOS** (`ScannerWrapperView.swift`): `QRScannerViewController.viewWillAppear` reports through a new `scannerDidAppear()` delegate method, and the scanner resets its scan model on every (re)appearance. UIKit appearance callbacks fire for exactly the cases SwiftUI state can't see (cancelled interactive dismissals, stacked covers closing, reused sheets). No double-delivery risk: the latch stays closed during the accept/routing handoff because the view is disappearing, not appearing.
- **Android** (`ScannerView.kt`, `CashuApp.kt`): the shell bumps a `scannerSessionId` per scanner opening and the one-shot scan state (completed latch, animated-QR progress, UR decoder) is keyed to it, so a reused composition re-arms on reopen. Android's home scanner already closes on every scan, so this closes the remaining exit-reversal hole for parity.

Related: #173 (its stacked-cover symptom is one of the appearance paths this re-arms).

## Verification

- iOS: `xcodebuild` build succeeds; `ScanRouterTests` and `WalletSurfaceCoordinatorTests` pass.
- Android: `:app:compileDebugKotlin` succeeds; scanner + flow-handoff unit tests pass.
- Camera behavior itself needs a physical device sanity check (scan → route → cancel → scan again), as the simulator has no camera.