### PR TITLE
Skip clipboard auto-receive for spent tokens on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/TokenParser.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TokenParser.kt
@@ -46,6 +46,17 @@ object TokenParser {
         return runCatching { decoded.p2pkPubkeys() }.getOrDefault(emptyList())
     }
 
+    /**
+     * Decode only the token's mint URL — enough to scope a NUT-07 spent check
+     * without expanding proofs (`proofsSimple()` can fail for IDv2 keysets even
+     * though the token itself is valid).
+     */
+    fun mintUrl(from: String): String? {
+        val token = extractToken(from) ?: return null
+        val decoded = runCatching { CdkToken.decode(token) }.getOrNull() ?: return null
+        return runCatching { decoded.mintUrl().url }.getOrNull()
+    }
+
     private fun stripCashuScheme(token: String): String = when {
         token.startsWith("cashu://", ignoreCase = true) -> token.drop("cashu://".length)
         token.startsWith("cashu:", ignoreCase = true) -> token.drop("cashu:".length)

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveEcashScreen.kt
@@ -76,6 +76,15 @@ internal fun automaticReceiveClipboardToken(
 }
 
 /**
+ * Whether an auto-pasted clipboard token should fill the input (and thereby
+ * auto-route to the claim page). Only a *confirmed-spent* token is
+ * suppressed — when the spent check can't run (offline, unreachable mint,
+ * undecodable token) we paste anyway and let the claim page surface its own
+ * error. Mirrors iOS `UnifiedReceiveView.shouldAutoPasteClipboardToken`.
+ */
+internal fun shouldAutoPasteClipboardToken(spent: Boolean?): Boolean = spent != true
+
+/**
  * The Receive surface — the mirror of [com.cashu.me.ui.send.UnifiedSendScreen]'s
  * input face so Send and Receive read as one system: a paste field ("Paste a
  * Cashu token") over a Scan · Ecash · Bitcoin ways-to-receive row.
@@ -167,12 +176,29 @@ fun ReceiveEcashScreen(
     }
 
     LaunchedEffect(Unit) {
-        automaticReceiveClipboardToken(
+        val clipboardToken = automaticReceiveClipboardToken(
             enabled = allowAutomaticClipboardRead && settings.autoPasteEcashReceive,
             currentInput = input,
             prefilledPayload = prefilledPayload,
             clipboardText = { clipboard.getText()?.text },
-        )?.let { input = it }
+        ) ?: return@LaunchedEffect
+        // Auto-pasting skips this sheet via the typed-input auto-route, so gate
+        // it on a NUT-07 spent check: a spent token would otherwise hijack
+        // every Receive tap just to fail on the claim page. Show a hint instead
+        // and leave the field empty so something else can be received.
+        val mintUrl = TokenParser.mintUrl(clipboardToken)
+        val spent: Boolean? = if (mintUrl != null) {
+            runCatching { walletManager.checkTokenSpent(clipboardToken, mintUrl) }.getOrNull()
+        } else {
+            null
+        }
+        // Don't clobber input the user typed while the check was in flight.
+        if (input.isNotBlank()) return@LaunchedEffect
+        if (shouldAutoPasteClipboardToken(spent)) {
+            input = clipboardToken
+        } else {
+            inputHint = "The token in your clipboard was already redeemed."
+        }
     }
 
     // Typing settles for a beat before routing; paste/scan advance immediately.

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveAutoPasteTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReceiveAutoPasteTest.kt
@@ -58,4 +58,17 @@ class ReceiveAutoPasteTest {
         )
         assertEquals(false, clipboardRead)
     }
+
+    /**
+     * Only a confirmed-spent clipboard token suppresses the auto-paste (and
+     * thereby the auto-route to the claim page). When the NUT-07 check can't
+     * run — offline, unreachable mint, undecodable token — the token is pasted
+     * anyway and the claim page surfaces its own error.
+     */
+    @Test
+    fun onlyConfirmedSpentClipboardTokenSkipsAutoPaste() {
+        assertEquals(false, shouldAutoPasteClipboardToken(spent = true))
+        assertEquals(true, shouldAutoPasteClipboardToken(spent = false))
+        assertEquals(true, shouldAutoPasteClipboardToken(spent = null))
+    }
 }

--- a/ios/CashuWallet/Core/TokenParser.swift
+++ b/ios/CashuWallet/Core/TokenParser.swift
@@ -39,6 +39,18 @@ enum TokenParser {
         )
     }
 
+    /// Decode only the token's mint URL — enough to scope a NUT-07 spent
+    /// check without expanding proofs (`proofsSimple()` can fail for IDv2
+    /// keysets even though the token itself is valid).
+    static func mintUrl(from tokenString: String) -> String? {
+        guard let normalized = normalizedToken(from: tokenString),
+              let token = try? Token.decode(encodedToken: normalized),
+              let mint = try? token.mintUrl().url else {
+            return nil
+        }
+        return mint
+    }
+
     /// Decode only the token's mint account unit. Unlike `tokenInfo(from:)`,
     /// this deliberately does not expand proofs: `proofsSimple()` can fail for
     /// IDv2 keysets even though the token itself and its unit are valid.

--- a/ios/CashuWallet/Views/Receive/ReceiveView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveView.swift
@@ -32,6 +32,7 @@ struct UnifiedReceiveView: View {
     @State private var route: ReceiveRoute?
     @State private var showingScanner = false
     @State private var autoRouteTask: Task<Void, Never>?
+    @State private var clipboardCheckTask: Task<Void, Never>?
 
     /// Measured height of the input body (field + methods). Drives a content-fit
     /// detent so the buttons stay thumb-reachable — same technique as
@@ -70,9 +71,11 @@ struct UnifiedReceiveView: View {
                         currentInput: tokenInput,
                         clipboardText: { UIPasteboard.general.string }
                     ) else { return }
-                    tokenInput = token
+                    clipboardCheckTask = Task { @MainActor in
+                        await autoPasteClipboardToken(token)
+                    }
                 }
-                .onDisappear { autoRouteTask?.cancel() }
+                .onDisappear { autoRouteTask?.cancel(); clipboardCheckTask?.cancel() }
         }
         .contentFitDetent(compactContentHeight)
         .presentationDragIndicator(.visible)
@@ -90,6 +93,37 @@ struct UnifiedReceiveView: View {
               currentInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               let clipboardText = clipboardText() else { return nil }
         return TokenParser.normalizedToken(from: clipboardText)
+    }
+
+    /// Whether an auto-pasted clipboard token should fill the input (and
+    /// thereby auto-route to the claim page). Only a *confirmed-spent* token
+    /// is suppressed — when the spent check can't run (offline, unreachable
+    /// mint, undecodable token) we paste anyway and let the claim page
+    /// surface its own error. Mirrors Android `shouldAutoPasteClipboardToken`.
+    static func shouldAutoPasteClipboardToken(spent: Bool?) -> Bool {
+        spent != true
+    }
+
+    /// Auto-pasting skips this sheet via the typed-input auto-route, so gate
+    /// it on a NUT-07 spent check: a spent token would otherwise hijack every
+    /// Receive tap just to fail on the claim page. Show a hint instead and
+    /// leave the field empty so something else can be received.
+    @MainActor
+    private func autoPasteClipboardToken(_ token: String) async {
+        let spent: Bool?
+        if let mintUrl = TokenParser.mintUrl(from: token) {
+            spent = try? await walletManager.checkTokenSpent(token: token, mintUrl: mintUrl)
+        } else {
+            spent = nil
+        }
+        // Don't clobber input the user typed while the check was in flight.
+        guard !Task.isCancelled,
+              tokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        if Self.shouldAutoPasteClipboardToken(spent: spent) {
+            tokenInput = token
+        } else {
+            inputHint = "The token in your clipboard was already redeemed."
+        }
     }
 
     // MARK: Input step

--- a/ios/CashuWalletTests/ReceiveAutoPasteTests.swift
+++ b/ios/CashuWalletTests/ReceiveAutoPasteTests.swift
@@ -51,6 +51,16 @@ final class ReceiveAutoPasteTests: XCTestCase {
             )
         )
     }
+
+    /// Only a confirmed-spent clipboard token suppresses the auto-paste (and
+    /// thereby the auto-route to the claim page). When the NUT-07 check can't
+    /// run — offline, unreachable mint, undecodable token — the token is
+    /// pasted anyway and the claim page surfaces its own error.
+    func testOnlyConfirmedSpentClipboardTokenSkipsAutoPaste() {
+        XCTAssertFalse(UnifiedReceiveView.shouldAutoPasteClipboardToken(spent: true))
+        XCTAssertTrue(UnifiedReceiveView.shouldAutoPasteClipboardToken(spent: false))
+        XCTAssertTrue(UnifiedReceiveView.shouldAutoPasteClipboardToken(spent: nil))
+    }
 }
 
 final class ReceiveTokenMemoReviewTests: XCTestCase {


### PR DESCRIPTION
## Problem

When the clipboard holds a Cashu token, tapping **Receive** auto-pastes it and the typed-input auto-route skips the receive sheet straight to the claim page. That's nice exactly once: if the token is already spent, the claim only fails *after* tapping Receive there — and while the token sits on the clipboard, every Receive tap gets hijacked, so nothing else (Cashu Request, Lightning, scan) can be started from the sheet.

## Fix

Gate the clipboard auto-paste on the existing NUT-07 spent check (`checkTokenSpent`) on both platforms:

- **Confirmed-spent** clipboard token → the input stays empty and a caution hint is shown ("The token in your clipboard was already redeemed."), leaving Scan · Ecash · Bitcoin fully usable.
- **Check can't run** (offline, unreachable mint, undecodable token) → fall back to the previous behavior; the claim page already surfaces its own errors.
- **User types while the check is in flight** → the result never clobbers their input.
- Manual paste, scans, and deep links are untouched — explicit actions still route immediately without the extra round-trip, and the "Paste ecash automatically" privacy setting still gates the whole flow.

Also adds a `TokenParser.mintUrl` helper (iOS + Android) that decodes only the token's mint URL without expanding proofs (`proofsSimple()` can fail for IDv2 keysets), and unit tests for the paste/suppress decision (`shouldAutoPasteClipboardToken`: spent → skip, spendable/unknown → paste).

## Tests

- iOS: `ReceiveAutoPasteTests` (incl. new `testOnlyConfirmedSpentClipboardTokenSkipsAutoPaste`) — passing
- Android: `ReceiveAutoPasteTest`, `TokenParserTest`, `ModelsParityTest`, `ReceivedTokenMintTrackingTest` — passing