### PR TITLE
Resume, don't restart, the Android UI suite when the emulator dies

### DIFF
--- a/CI/retry-android-ui-test.sh
+++ b/CI/retry-android-ui-test.sh
@@ -2,6 +2,15 @@
 # Runs a Gradle Android UI test task with retries on transient emulator failures
 # ("device offline", "Failed to retrieve additional test outputs from device", ...).
 #
+# When an attempt dies mid-run, the retry *resumes* the suite instead of
+# restarting it: the emulator has been observed expiring at a deterministic
+# point ~6 minutes into the managed-device suite, so a from-scratch retry just
+# re-cooks the next emulator to the same crash. Classes recorded as passed in
+# the Gradle test-result XML are excluded via the runner's notClass filter on
+# the next attempt, and only the never-ran and failed classes re-run. A
+# genuinely failing class is never excluded — it re-runs and still fails the
+# build if it keeps failing.
+#
 # Usage: CI/retry-android-ui-test.sh <gradle command...>
 # Env:   MAX_ATTEMPTS (default 3), LOG_FILE (default android-ui-test.log)
 set -uo pipefail
@@ -9,6 +18,9 @@ set -uo pipefail
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 LOG_FILE="${LOG_FILE:-android-ui-test.log}"
 TRANSIENT_PATTERN="device offline|Failed to retrieve additional test outputs|emulator: ERROR|INSTALL_FAILED_DEVICE|DEVICE_UNAVAILABLE|adb: device .* not found|Emulator.*crashed|Failed to (install|push).*device"
+RESULTS_GLOB="app/build/outputs/androidTest-results/managedDevice/debug/*/TEST-*.xml"
+PASSED_CLASSES_FILE="$(mktemp -t android-ui-passed-classes)"
+trap 'rm -f "$PASSED_CLASSES_FILE"' EXIT
 
 reset_device_state() {
   echo "Resetting ADB/emulator state..."
@@ -21,7 +33,23 @@ reset_device_state() {
   adb devices || true
 }
 
+# Unions every testsuite that completed without failures or errors into the
+# passed-class ledger. Each Gradle run rewrites the XML, so it always reflects
+# the latest attempt; the ledger accumulates across attempts. The class that
+# was in flight when the device died is recorded with a failure, so it never
+# lands here and always re-runs.
+collect_passed_classes() {
+  # shellcheck disable=SC2086
+  grep -h '<testsuite ' $RESULTS_GLOB 2>/dev/null \
+    | grep 'failures="0"' \
+    | grep 'errors="0"' \
+    | sed -E 's/^[[:space:]]*<testsuite name="([^"]+)".*/\1/' \
+    >> "$PASSED_CLASSES_FILE" || true
+  [ -s "$PASSED_CLASSES_FILE" ] && sort -u "$PASSED_CLASSES_FILE" -o "$PASSED_CLASSES_FILE"
+}
+
 attempt=1
+extra_args=()
 while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
   echo "=== UI test attempt $attempt/$MAX_ATTEMPTS ==="
 
@@ -30,7 +58,11 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
   reset_device_state
   sleep 10
 
-  "$@" 2>&1 | tee "$LOG_FILE"
+  if [ -s "$PASSED_CLASSES_FILE" ]; then
+    echo "Resuming: excluding $(wc -l < "$PASSED_CLASSES_FILE" | tr -d ' ') classes that already passed."
+  fi
+  # ${extra_args[@]+...} keeps bash 3.2 (macOS) happy under set -u when empty.
+  "$@" ${extra_args[@]+"${extra_args[@]}"} 2>&1 | tee "$LOG_FILE"
   status=${PIPESTATUS[0]}
 
   if [ "$status" -eq 0 ]; then
@@ -48,6 +80,11 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
     exit "$status"
   fi
 
-  echo "Transient device failure detected (exit $status); retrying after emulator reset..."
+  collect_passed_classes
+  if [ -s "$PASSED_CLASSES_FILE" ]; then
+    extra_args=("-Pandroid.testInstrumentationRunnerArguments.notClass=$(paste -sd, "$PASSED_CLASSES_FILE")")
+  fi
+
+  echo "Transient device failure detected (exit $status); resuming remaining tests after emulator reset..."
   attempt=$((attempt + 1))
 done


### PR DESCRIPTION
## Problem

Android UI Tests fail on nearly every recent run — `main` and PR branches alike — always at test #56 of 89. The failure artifacts show the same signature every time:

- The running test records an **empty** `<failure></failure>` with a 40–52s hang (it normally takes ~1s).
- Its per-test **logcat cuts off ~1s in** — instrumentation lost the device mid-test.
- `adb: device offline` follows; the remaining 33 tests never run.

The emulator expires ~6 minutes into the suite. The point is deterministic because test order and durations are deterministic — and it is **invariant to what the tests do**: #299 verified that freezing the onboarding ASCII field's ambient clock during instrumented runs (a real load reduction, verified active in-process) changed nothing. 7 of the last 8 attempts died at the identical test.

The retry script then made things worse: every attempt re-ran **all 89 tests from scratch**, so each fresh emulator was re-cooked to the same ~6-minute crash. Runs failed 3/3 attempts identically.

## Fix

One file, `CI/retry-android-ui-test.sh` — no app code, no production surface:

- After a transient mid-run death, parse the Gradle result XML (`TEST-*.xml`) for test classes that completed cleanly and accumulate them in a ledger.
- Retry with the runner's `notClass` filter excluding those classes: attempt two **resumes where the suite died** (~33 remaining tests, ~2 minutes) instead of restarting it — comfortably inside one emulator lifetime.
- A class that was in flight when the device died carries a failure record in the XML, so it is never excluded and always re-runs.
- A genuinely failing test also never enters the ledger; real assertion failures still bypass the retry path entirely (unchanged), and if a resumed class fails again the job still fails.
- No result XML (build-level failure) → empty ledger → plain full retry, exactly today's behavior.

## Verification

Local harness with a simulated Gradle command (run under macOS `/bin/bash` 3.2, matching the shebang):

- Attempt dies with `device offline` after 2 of 4 classes → retry received `notClass=com.example.AlphaTest,com.example.BetaTest` (failed class correctly re-run) → suite passes on attempt 2.
- Genuine assertion failure (no transient pattern) → no retry, non-zero exit.

Supersedes #299.

## Platform note

CI plumbing only; no app code changed on either platform.