### PR TITLE
chore: bump Android versionCode to 5

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -27,7 +27,7 @@ android {
         applicationId = "com.cashu.me"
         minSdk = 26
         targetSdk = 36
-        versionCode = 4
+        versionCode = 5
         versionName = "0.3"
         testInstrumentationRunner = "com.cashu.me.test.CashuUiTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"


### PR DESCRIPTION
Bumps the Android `versionCode` from 4 to 5 in `android/app/build.gradle.kts` in preparation for the next release. `versionName` remains `0.3`.