### PR TITLE
Fix iOS mint selector tap area on Receive and Send

### DIFF
--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -518,6 +518,11 @@ struct ReceiveLightningView: View {
             }
             .padding(12)
             .liquidGlass(in: RoundedRectangle(cornerRadius: 12), interactive: true)
+            // The glass pill is drawn across the whole padded frame, but neither
+            // the glass nor the fallback background expands the hit area — without
+            // an explicit content shape only the glyphs respond, leaving the
+            // pill's middle and edges dead.
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .combine)

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1100,13 +1100,16 @@ struct MintAmountSelectorRow: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
+                    // The spacer lives inside the button so it absorbs the row's
+                    // spare width and the content shape below stretches over it —
+                    // outside the button it was a dead zone that swallowed taps
+                    // (Android's MintSelectorRow opens the picker on the same area).
+                    Spacer(minLength: 8)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Paying mint: \(mint.name), \(balanceText)")
-
-            Spacer(minLength: 8)
 
             Button(action: onUseMax) {
                 Text("Send Max")


### PR DESCRIPTION
## Problem

On iOS, the mint selector pills on the **Receive** and **Send** screens only responded to taps on the mint name or the chevron glyph. Tapping anywhere else on the pill — its middle or edges — did nothing, so the mint picker felt broken.

## Root cause

SwiftUI `Button`s only hit-test where the label has actual content:

- **Receive** (`ReceiveLightningView.mintSelector`): the label had no `.contentShape` at all, so only the text/icon glyphs were hittable — the padded glass pill around them was dead.
- **Send** (`MintAmountSelectorRow`): the choose-mint button's `contentShape(Rectangle())` covered only the avatar + name/balance block. The `Spacer` filling the row's middle sat *outside* any button and swallowed taps.

## Fix

- Receive: added `.contentShape(Rectangle())` to the label after the padding/glass, so the entire visible pill opens the picker.
- Send: moved `Spacer(minLength: 8)` inside the choose-mint button's label so the button absorbs the row's spare width and its content shape covers it. The Send Max pill and chevron button are untouched.

This restores parity with Android's `MintSelectorRow`, which already opens the picker on a tap anywhere in the row except the Send Max pill. No Android changes needed.

## Testing

- `xcodebuild` build: succeeded
- Unit tests: pass (`NutshellIntegrationTests` excluded — requires the live localhost mints started by CI)

+10 / −2 lines across `ReceiveLightningView.swift` and `SendView.swift`.