### PR TITLE
chore: set app version to 1.0 on iOS and Android

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 5
-        versionName = "0.3"
+        versionName = "1.0"
         testInstrumentationRunner = "com.cashu.me.test.CashuUiTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         testInstrumentationRunnerArguments["useTestStorageService"] = "true"

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -1305,7 +1305,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3;
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -1344,7 +1344,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3;
+				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/ios/CashuWalletTests/AppVersionTests.swift
+++ b/ios/CashuWalletTests/AppVersionTests.swift
@@ -11,7 +11,7 @@ final class AppVersionTests: XCTestCase {
     func testDisplayStringMatchesMarketingVersionBuildSetting() {
         // The hosted test bundle's main bundle is CashuWallet.app, whose
         // CFBundleShortVersionString is generated from MARKETING_VERSION.
-        XCTAssertEqual(AppVersion.displayString(), "0.3")
+        XCTAssertEqual(AppVersion.displayString(), "1.0")
     }
 
     func testDisplayStringFallsBackToNilWhenVersionMissing() {


### PR DESCRIPTION
Reverts #300, which downgraded the app version from 1.0 to 0.3. Restores 1.0 on both platforms:

- Android `versionName`: `0.3` → `1.0`
- iOS `MARKETING_VERSION` (Debug + Release): `0.3` → `1.0`
- iOS `AppVersionTests` expectation: `0.3` → `1.0`

Android `versionCode` is intentionally left at 5 (from #304) — it must stay monotonically increasing for Play Store uploads, so it is not part of the revert.

No tag or GitHub release is created here; cutting a release tagged `v1.0` will trigger `.github/workflows/release.yml` (Android UI gate → signed APK attached to the release). iOS ships separately via Xcode/App Store Connect.