### PR TITLE
Fix Android UI retry temp-file portability

### DIFF
--- a/CI/retry-android-ui-test.sh
+++ b/CI/retry-android-ui-test.sh
@@ -19,7 +19,10 @@ MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 LOG_FILE="${LOG_FILE:-android-ui-test.log}"
 TRANSIENT_PATTERN="device offline|Failed to retrieve additional test outputs|emulator: ERROR|INSTALL_FAILED_DEVICE|DEVICE_UNAVAILABLE|adb: device .* not found|Emulator.*crashed|Failed to (install|push).*device"
 RESULTS_GLOB="app/build/outputs/androidTest-results/managedDevice/debug/*/TEST-*.xml"
-PASSED_CLASSES_FILE="$(mktemp -t android-ui-passed-classes)"
+if ! PASSED_CLASSES_FILE="$(mktemp "${TMPDIR:-/tmp}/android-ui-passed-classes.XXXXXX")"; then
+  echo "Failed to create the passed-class ledger." >&2
+  exit 1
+fi
 trap 'rm -f "$PASSED_CLASSES_FILE"' EXIT
 
 reset_device_state() {


### PR DESCRIPTION
## Summary

- create the passed-class ledger with a portable `XXXXXX` template
- stop with a clear error if the ledger cannot be created
- restore resume-on-retry behavior on Ubuntu CI while retaining macOS compatibility

## Root cause

GNU `mktemp` rejects `mktemp -t android-ui-passed-classes` because its template has no `X` placeholders. Since the retry script intentionally does not use `set -e`, it continued with an empty ledger path. Passed test classes were therefore never recorded or excluded, so every retry restarted all 89 tests and reached the same managed-emulator `device offline` failure around test 55.

## Validation

- `bash -n CI/retry-android-ui-test.sh`
- verified temp-file creation and cleanup on macOS and Debian/GNU
- verified the explicit temp-file failure path
- simulated a transient `device offline` failure and confirmed attempt two excluded the already-passed class and succeeded