### PR TITLE
fix: narrow wallet database corruption recovery

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDatabaseRecovery.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDatabaseRecovery.kt
@@ -6,6 +6,7 @@ private val walletDatabaseCorruptionIndicators = listOf(
     "sqlite_corrupt",
     "sqlite_notadb",
     "database disk image is malformed",
+    "malformed database schema",
     "database disk image is corrupt",
     "file is not a database",
     "database corruption",

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDatabaseRecovery.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDatabaseRecovery.kt
@@ -1,10 +1,20 @@
 package com.cashu.me.Core
 
+// Moving the live database aside is safe only for definitive corruption signals.
+// Busy, I/O, permission, and generic open failures must preserve it for retry.
+private val walletDatabaseCorruptionIndicators = listOf(
+    "sqlite_corrupt",
+    "sqlite_notadb",
+    "database disk image is malformed",
+    "database disk image is corrupt",
+    "file is not a database",
+    "database corruption",
+    "database is corrupt",
+    "database is corrupted",
+    "corrupt database",
+)
+
 internal fun shouldAttemptWalletDatabaseRecovery(error: Throwable): Boolean {
     val normalized = (error.message ?: error.toString()).lowercase()
-    return normalized.contains("sqlite") ||
-        normalized.contains("database") ||
-        normalized.contains("corrupt") ||
-        normalized.contains("malformed") ||
-        normalized.contains("walletdb")
+    return walletDatabaseCorruptionIndicators.any { normalized.contains(it) }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
@@ -19,6 +19,7 @@ class WalletDatabaseRecoveryTest {
         listOf(
             "SQLite error SQLITE_CORRUPT: database disk image is malformed",
             "SQLite error SQLITE_NOTADB: file is not a database",
+            "malformed database schema (wallets)",
             "database disk image is corrupt",
         ).forEach { message ->
             assertTrue(message, shouldAttemptWalletDatabaseRecovery(IllegalStateException(message)))

--- a/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
@@ -15,16 +15,31 @@ class WalletDatabaseRecoveryTest {
     val temporaryFolder = TemporaryFolder()
 
     @Test
-    fun recoveryIsAttemptedForDatabaseOpenErrors() {
-        assertTrue(shouldAttemptWalletDatabaseRecovery(IllegalStateException("SQLite database is malformed")))
-        assertTrue(shouldAttemptWalletDatabaseRecovery(IllegalStateException("WalletDB open failed")))
-        assertTrue(shouldAttemptWalletDatabaseRecovery(IllegalStateException("database disk image is corrupt")))
+    fun recoveryIsAttemptedOnlyForExplicitCorruptionErrors() {
+        listOf(
+            "SQLite error SQLITE_CORRUPT: database disk image is malformed",
+            "SQLite error SQLITE_NOTADB: file is not a database",
+            "database disk image is corrupt",
+        ).forEach { message ->
+            assertTrue(message, shouldAttemptWalletDatabaseRecovery(IllegalStateException(message)))
+        }
     }
 
     @Test
-    fun recoveryIsNotAttemptedForNonDatabaseErrors() {
-        assertFalse(shouldAttemptWalletDatabaseRecovery(IllegalArgumentException("Invalid seed phrase.")))
-        assertFalse(shouldAttemptWalletDatabaseRecovery(IllegalStateException("Couldn't reach the mint.")))
+    fun recoveryIsNotAttemptedForTransientPermissionOrIoErrors() {
+        listOf(
+            "SQLite database is locked",
+            "SQLite database is busy",
+            "unable to open database file",
+            "attempt to write a readonly database",
+            "permission denied while opening WalletDB",
+            "SQLite disk I/O error",
+            "WalletDB open failed",
+            "Invalid seed phrase.",
+            "Couldn't reach the mint.",
+        ).forEach { message ->
+            assertFalse(message, shouldAttemptWalletDatabaseRecovery(IllegalStateException(message)))
+        }
     }
 
     @Test

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -43,6 +43,7 @@ enum WalletDatabaseRecoveryPolicy {
         "sqlite_corrupt",
         "sqlite_notadb",
         "database disk image is malformed",
+        "malformed database schema",
         "database disk image is corrupt",
         "file is not a database",
         "database corruption",

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -36,6 +36,27 @@ enum WalletStartupPolicy {
     }
 }
 
+enum WalletDatabaseRecoveryPolicy {
+    // Moving the live database aside is safe only for definitive corruption signals.
+    // Busy, I/O, permission, and generic open failures must preserve it for retry.
+    private static let corruptionIndicators = [
+        "sqlite_corrupt",
+        "sqlite_notadb",
+        "database disk image is malformed",
+        "database disk image is corrupt",
+        "file is not a database",
+        "database corruption",
+        "database is corrupt",
+        "database is corrupted",
+        "corrupt database",
+    ]
+
+    static func shouldRecover(errorDescription: String) -> Bool {
+        let normalized = errorDescription.lowercased()
+        return corruptionIndicators.contains(where: normalized.contains)
+    }
+}
+
 extension WalletManager {
     // MARK: - Public Initialization
 
@@ -776,12 +797,9 @@ extension WalletManager {
         fileManager: FileManager
     ) -> Bool {
         guard fileManager.fileExists(atPath: databaseURL.path) else { return false }
-        let description = String(describing: error).lowercased()
-        return description.contains("sqlite")
-            || description.contains("database")
-            || description.contains("corrupt")
-            || description.contains("malformed")
-            || description.contains("walletdb")
+        return WalletDatabaseRecoveryPolicy.shouldRecover(
+            errorDescription: String(describing: error)
+        )
     }
 
     nonisolated private static func backupLaunchDatabase(
@@ -814,12 +832,9 @@ extension WalletManager {
             return false
         }
         
-        let errorDescription = String(describing: error).lowercased()
-        return errorDescription.contains("sqlite")
-            || errorDescription.contains("database")
-            || errorDescription.contains("corrupt")
-            || errorDescription.contains("malformed")
-            || errorDescription.contains("walletdb")
+        return WalletDatabaseRecoveryPolicy.shouldRecover(
+            errorDescription: String(describing: error)
+        )
     }
 
     private func backupCorruptedDatabase(at databaseURL: URL) throws -> URL {

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -173,6 +173,7 @@ final class WalletStoreTests: XCTestCase {
         let corruptionErrors = [
             "SQLite error SQLITE_CORRUPT: database disk image is malformed",
             "SQLite error SQLITE_NOTADB: file is not a database",
+            "malformed database schema (wallets)",
             "database disk image is corrupt",
         ]
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -169,6 +169,42 @@ final class WalletStoreTests: XCTestCase {
         ))
     }
 
+    func testDatabaseRecoveryPolicyAcceptsOnlyExplicitCorruptionErrors() {
+        let corruptionErrors = [
+            "SQLite error SQLITE_CORRUPT: database disk image is malformed",
+            "SQLite error SQLITE_NOTADB: file is not a database",
+            "database disk image is corrupt",
+        ]
+
+        for message in corruptionErrors {
+            XCTAssertTrue(
+                WalletDatabaseRecoveryPolicy.shouldRecover(errorDescription: message),
+                message
+            )
+        }
+    }
+
+    func testDatabaseRecoveryPolicyRejectsTransientPermissionAndIOErrors() {
+        let nonCorruptionErrors = [
+            "SQLite database is locked",
+            "SQLite database is busy",
+            "unable to open database file",
+            "attempt to write a readonly database",
+            "permission denied while opening WalletDB",
+            "SQLite disk I/O error",
+            "WalletDB open failed",
+            "Invalid seed phrase.",
+            "Couldn't reach the mint.",
+        ]
+
+        for message in nonCorruptionErrors {
+            XCTAssertFalse(
+                WalletDatabaseRecoveryPolicy.shouldRecover(errorDescription: message),
+                message
+            )
+        }
+    }
+
     func testIncompleteICloudRestoreSuppressesBackupWrites() {
         XCTAssertFalse(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: true))
         XCTAssertTrue(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: false))


### PR DESCRIPTION
## Summary

- Restrict automatic database quarantine and recovery to explicit corruption signatures on Android and iOS.
- Preserve the existing wallet database for transient lock, permission, and general I/O failures.
- Add focused recovery-classification coverage on both platforms.

## Why

Broad error matching could mistake a temporary access failure for corruption and move a healthy wallet database out of the way.

## Testing

- Android focused database recovery tests passed.
- iOS focused database recovery tests passed.

