### PR TITLE
fix(mobile): make P2PK key storage transactional

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Core/P2PKStorageTransactionInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/P2PKStorageTransactionInstrumentedTest.kt
@@ -1,0 +1,199 @@
+package com.cashu.me.Core
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.util.UUID
+import com.cashu.me.Core.Protocols.SecureStorage
+import com.cashu.me.Models.P2PKKeyInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class P2PKStorageTransactionInstrumentedTest {
+    private val context: Context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val privateKeyHex = "0".repeat(63) + "1"
+    private val publicKeyHex =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+    @Test
+    fun importSecureFailureDoesNotPublishMetadata() {
+        val metadata = FakeP2PKMetadataStore()
+        val secureStorage = FakeP2PKSecureStorage().apply { failSaves = true }
+        val manager = manager(metadata, secureStorage)
+
+        assertThrows(IllegalStateException::class.java) {
+            manager.importP2PKNsec(nsecForPrivateKeyOne())
+        }
+
+        assertTrue(metadata.keys.isEmpty())
+        assertTrue(secureStorage.values.isEmpty())
+        assertTrue(manager.state.value.p2pkKeys.isEmpty())
+    }
+
+    @Test
+    fun importMetadataFailureRollsBackNewSecureSecretAndPublishedState() {
+        val metadata = FakeP2PKMetadataStore().apply { failKeySaves = true }
+        val secureStorage = FakeP2PKSecureStorage()
+        val manager = manager(metadata, secureStorage)
+
+        assertThrows(IllegalStateException::class.java) {
+            manager.importP2PKNsec(nsecForPrivateKeyOne())
+        }
+
+        assertTrue(metadata.keys.isEmpty())
+        assertTrue(secureStorage.values.isEmpty())
+        assertTrue(manager.state.value.p2pkKeys.isEmpty())
+    }
+
+    @Test
+    fun removalMetadataFailureRestoresEncryptedSecret() {
+        val key = storedKey()
+        val metadata = FakeP2PKMetadataStore(listOf(key))
+        val secureStorage = FakeP2PKSecureStorage(
+            mutableMapOf(primaryStorageKey(key.id) to privateKeyHex),
+        )
+        val manager = manager(metadata, secureStorage)
+        metadata.failKeySaves = true
+
+        assertThrows(IllegalStateException::class.java) {
+            manager.removeP2PKKey(key.id)
+        }
+
+        assertEquals(listOf(key), metadata.keys)
+        assertEquals(privateKeyHex, secureStorage.values[primaryStorageKey(key.id)])
+        assertFalse(secureStorage.values.containsKey(fallbackStorageKey(key.id)))
+        assertTrue(metadata.pendingDeletionIds.isEmpty())
+        assertEquals(listOf(key), manager.state.value.p2pkKeys)
+    }
+
+    @Test
+    fun interruptedRemovalRestoresEncryptedSecretWithoutMetadataSecret() {
+        val key = storedKey()
+        val metadata = FakeP2PKMetadataStore(listOf(key)).apply {
+            pendingDeletionIds = setOf(key.id)
+        }
+        val secureStorage = FakeP2PKSecureStorage(
+            mutableMapOf(fallbackStorageKey(key.id) to privateKeyHex),
+        )
+
+        val manager = manager(metadata, secureStorage)
+
+        assertEquals(privateKeyHex, secureStorage.values[primaryStorageKey(key.id)])
+        assertFalse(secureStorage.values.containsKey(fallbackStorageKey(key.id)))
+        assertTrue(metadata.pendingDeletionIds.isEmpty())
+        assertTrue(manager.state.value.p2pkUnavailableKeyIds.isEmpty())
+    }
+
+    @Test
+    fun metadataOnlyKeyIsUnavailableUntilMatchingNsecRepairsIt() {
+        val key = storedKey()
+        val metadata = FakeP2PKMetadataStore(listOf(key))
+        val secureStorage = FakeP2PKSecureStorage()
+        val manager = manager(metadata, secureStorage)
+
+        assertEquals(setOf(key.id), manager.state.value.p2pkUnavailableKeyIds)
+
+        manager.importP2PKNsec(nsecForPrivateKeyOne())
+
+        assertEquals(listOf(key), metadata.keys)
+        assertTrue(manager.state.value.p2pkUnavailableKeyIds.isEmpty())
+        assertEquals(privateKeyHex, secureStorage.values[primaryStorageKey(key.id)])
+    }
+
+    @Test
+    fun metadataOnlyKeyCanBeRemovedWithoutASecret() {
+        val key = storedKey()
+        val metadata = FakeP2PKMetadataStore(listOf(key))
+        val secureStorage = FakeP2PKSecureStorage()
+        val manager = manager(metadata, secureStorage)
+
+        manager.removeP2PKKey(key.id)
+
+        assertTrue(metadata.keys.isEmpty())
+        assertTrue(metadata.pendingDeletionIds.isEmpty())
+        assertTrue(secureStorage.values.isEmpty())
+        assertTrue(manager.state.value.p2pkKeys.isEmpty())
+    }
+
+    private fun manager(
+        metadata: FakeP2PKMetadataStore,
+        secureStorage: FakeP2PKSecureStorage,
+    ): SettingsManager = SettingsManager(
+        settingsStore = SettingsStore(context, "p2pk-test.${UUID.randomUUID()}"),
+        secureStorage = secureStorage,
+        p2pkStore = metadata,
+    )
+
+    private fun storedKey() = P2PKKeyInfo(
+        id = UUID.randomUUID().toString(),
+        publicKey = publicKeyHex,
+        label = "Stored key",
+    )
+
+    private fun nsecForPrivateKeyOne(): String = Bech32.encode(
+        "nsec",
+        ByteArray(32).also { it[31] = 1 },
+    )
+
+    private fun primaryStorageKey(id: String) = "settings.p2pk.$id.privateKey"
+
+    private fun fallbackStorageKey(id: String) = "${primaryStorageKey(id)}.removalFallback"
+}
+
+private class FakeP2PKMetadataStore(
+    initialKeys: List<P2PKKeyInfo> = emptyList(),
+) : P2PKMetadataStore {
+    private var storedKeys = initialKeys
+    private var storedPendingDeletionIds = emptySet<String>()
+    var failKeySaves = false
+    var failPendingSaves = false
+
+    override val keys: List<P2PKKeyInfo>
+        get() = storedKeys
+
+    override var pendingDeletionIds: Set<String>
+        get() = storedPendingDeletionIds
+        set(value) {
+            if (failPendingSaves) error("metadata unavailable")
+            storedPendingDeletionIds = value
+        }
+
+    override fun saveKeys(
+        keys: List<P2PKKeyInfo>,
+        preservingLegacySecrets: Map<String, String>,
+    ) {
+        if (failKeySaves) error("metadata unavailable")
+        check(preservingLegacySecrets.isEmpty()) {
+            "Tests must not persist private keys in metadata."
+        }
+        storedKeys = keys
+    }
+}
+
+private class FakeP2PKSecureStorage(
+    val values: MutableMap<String, String> = mutableMapOf(),
+) : SecureStorage {
+    var failSaves = false
+    var failDeletes = false
+
+    override fun loadString(key: String): String? = values[key]
+
+    override fun saveString(key: String, value: String) {
+        if (failSaves) error("secure storage unavailable")
+        values[key] = value
+    }
+
+    override fun delete(key: String) {
+        if (failDeletes) error("secure storage unavailable")
+        values.remove(key)
+    }
+
+    override fun contains(key: String): Boolean = key in values
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Platform/AndroidSecureStorage.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Platform/AndroidSecureStorage.kt
@@ -34,19 +34,24 @@ class AndroidSecureStorage(context: Context) : SecureStorage {
         val payload = Base64.encodeToString(cipher.iv, Base64.NO_WRAP) +
             ":" +
             Base64.encodeToString(encrypted, Base64.NO_WRAP)
-        prefs.edit().putString(key, payload).apply()
+        check(prefs.edit().putString(key, payload).commit()) {
+            "Failed to persist secure value."
+        }
     }
 
     override fun delete(key: String) {
-        prefs.edit().remove(key).apply()
+        check(prefs.edit().remove(key).commit()) {
+            "Failed to remove secure value."
+        }
     }
 
     override fun deletePrefix(prefix: String) {
         val matchingKeys = prefs.all.keys.filter { it.startsWith(prefix) }
         if (matchingKeys.isEmpty()) return
-        prefs.edit().apply {
+        val committed = prefs.edit().apply {
             matchingKeys.forEach(::remove)
-        }.apply()
+        }.commit()
+        check(committed) { "Failed to remove secure values." }
     }
 
     override fun contains(key: String): Boolean = prefs.contains(key)

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -80,6 +80,7 @@ object StorageKeys {
     const val settingsReceivePaymentRequestsAutomatically = "settings.receivePaymentRequestsAutomatically"
     const val settingsShowP2PKButtonInDrawer = "settings.showP2PKButtonInDrawer"
     const val settingsP2PKKeys = "settings.p2pkKeys"
+    const val settingsP2PKPendingDeletionIds = "settings.p2pkPendingDeletionIds"
     const val settingsCheckIncomingInvoices = "settings.checkIncomingInvoices"
     const val settingsPeriodicallyCheckIncomingInvoices = "settings.periodicallyCheckIncomingInvoices"
     const val settingsNostrRelays = "settings.nostrRelays"
@@ -149,6 +150,7 @@ object StorageKeys {
         cashuRequests,
         cashuRequestsCurrentId,
         settingsP2PKKeys,
+        settingsP2PKPendingDeletionIds,
         npcEnabled,
         npcAutomaticClaim,
         npcSelectedMint,

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
@@ -69,11 +69,38 @@ data class SettingsState(
     val nostrRelays: List<String> = emptyList(),
     val nostrMintBackupEnabled: Boolean = true,
     val p2pkKeys: List<P2PKKeyInfo> = emptyList(),
+    val p2pkUnavailableKeyIds: Set<String> = emptySet(),
 )
 
 internal data class LegacySettingsSecretMigration(
     val p2pkKeysToPersist: List<P2PKKeyInfo>?,
+    val pendingLegacySecrets: Map<String, String>,
 )
+
+internal interface P2PKMetadataStore {
+    val keys: List<P2PKKeyInfo>
+    var pendingDeletionIds: Set<String>
+    fun saveKeys(keys: List<P2PKKeyInfo>, preservingLegacySecrets: Map<String, String> = emptyMap())
+}
+
+private class SettingsP2PKMetadataStore(
+    private val settingsStore: SettingsStore,
+) : P2PKMetadataStore {
+    override val keys: List<P2PKKeyInfo> get() = settingsStore.p2pkKeys
+    override var pendingDeletionIds: Set<String>
+        get() = settingsStore.p2pkPendingDeletionIds
+        set(value) { settingsStore.p2pkPendingDeletionIds = value }
+
+    override fun saveKeys(
+        keys: List<P2PKKeyInfo>,
+        preservingLegacySecrets: Map<String, String>,
+    ) {
+        settingsStore.saveP2PKKeys(keys, preservingLegacySecrets)
+    }
+}
+
+private class P2PKStorageException(message: String, cause: Throwable? = null) :
+    IllegalStateException(message, cause)
 
 /** The wallet's seed-derived P2PK identity: compressed 02-prefixed pubkey + private hex. */
 data class PrimaryP2PKKey(
@@ -84,6 +111,7 @@ data class PrimaryP2PKKey(
 internal data class SettingsWalletScopedSnapshot(
     val preferences: PreferenceSnapshot,
     val p2pkKeys: List<P2PKKeyInfo>,
+    val pendingP2PKDeletionIds: Set<String> = emptySet(),
 )
 
 internal object LegacySettingsSecretMigrator {
@@ -91,42 +119,50 @@ internal object LegacySettingsSecretMigrator {
         p2pkRecords: List<LegacyP2PKKeyRecord>,
         loadSecret: (String) -> String?,
         saveSecret: (String, String) -> Unit,
+        isUsableSecret: (P2PKKeyInfo, String) -> Boolean,
     ): LegacySettingsSecretMigration {
         var shouldPersistP2PK = false
+        val pendingLegacySecrets = mutableMapOf<String, String>()
         val p2pkMetadata = p2pkRecords.map { record ->
-            migrateSecret(
-                key = secureP2PKPrivateKey(record.metadata.id),
-                legacyValue = record.privateKey,
-                loadSecret = loadSecret,
-                saveSecret = saveSecret,
-            )
+            val storageKey = secureP2PKPrivateKey(record.metadata.id)
+            val storedSecret = runCatching { loadSecret(storageKey) }.getOrNull()
+            val hasUsableStoredSecret = storedSecret != null &&
+                isUsableSecret(record.metadata, storedSecret)
+
+            if (!hasUsableStoredSecret && record.privateKey.isNotBlank()) {
+                if (isUsableSecret(record.metadata, record.privateKey)) {
+                    runCatching { saveSecret(storageKey, record.privateKey) }
+                        .onFailure {
+                            pendingLegacySecrets[record.metadata.id] = record.privateKey
+                        }
+                }
+            }
             shouldPersistP2PK = shouldPersistP2PK || record.shouldRewriteMetadata || record.hasLegacySecret
             record.metadata
         }
 
         return LegacySettingsSecretMigration(
             p2pkKeysToPersist = p2pkMetadata.takeIf { shouldPersistP2PK },
+            pendingLegacySecrets = pendingLegacySecrets,
         )
-    }
-
-    private fun migrateSecret(
-        key: String,
-        legacyValue: String,
-        loadSecret: (String) -> String?,
-        saveSecret: (String, String) -> Unit,
-    ) {
-        if (legacyValue.isBlank() || loadSecret(key) != null) return
-        saveSecret(key, legacyValue)
     }
 
     fun secureP2PKPrivateKey(id: String): String = "settings.p2pk.$id.privateKey"
 }
 
-class SettingsManager(
+class SettingsManager internal constructor(
     private val settingsStore: SettingsStore,
     private val secureStorage: SecureStorage,
+    private val p2pkStore: P2PKMetadataStore,
 ) : MintDiscoverySettings {
     private val secureRandom = SecureRandom()
+    private val pendingLegacyP2PKSecrets = mutableMapOf<String, String>()
+
+    constructor(settingsStore: SettingsStore, secureStorage: SecureStorage) : this(
+        settingsStore = settingsStore,
+        secureStorage = secureStorage,
+        p2pkStore = SettingsP2PKMetadataStore(settingsStore),
+    )
 
     companion object {
         /** The relay list a fresh install starts with, and what "reset" restores. */
@@ -168,6 +204,7 @@ class SettingsManager(
     }
 
     init {
+        recoverInterruptedP2PKRemovals()
         migrateLegacyStoredSecrets()
     }
 
@@ -191,14 +228,17 @@ class SettingsManager(
     fun primaryP2PKKeyInfo(): PrimaryP2PKKey? = primaryP2PKKey()
 
     /** Stored private key hex for a device key — used only for nsec backup/reveal. */
-    fun p2pkPrivateKeyHex(id: String): String? =
-        secureStorage.loadString(secureP2PKPrivateKey(id))
+    fun p2pkPrivateKeyHex(id: String): String? {
+        val key = p2pkStore.keys.firstOrNull { it.id == id } ?: return null
+        return availableP2PKPrivateKey(key)
+    }
 
     /** Rename a device key (iOS setP2PKKeyNickname). */
-    fun setP2PKKeyNickname(id: String, label: String) = update {
-        settingsStore.p2pkKeys = settingsStore.p2pkKeys.map {
+    fun setP2PKKeyNickname(id: String, label: String) {
+        val updated = p2pkStore.keys.map {
             if (it.id == id) it.copy(label = label.trim()) else it
         }
+        persistP2PKMetadata(updated)
     }
 
     fun setUseBitcoinSymbol(value: Boolean) = update { settingsStore.useBitcoinSymbol = value }
@@ -281,14 +321,10 @@ class SettingsManager(
             publicKey = normalized,
             label = label,
         )
-        update { settingsStore.p2pkKeys = settingsStore.p2pkKeys + key }
+        persistP2PKMetadata(p2pkStore.keys + key)
     }
 
-    fun generateP2PKKey(): Boolean =
-        runCatching {
-            val privateKey = generateRandomPrivateKey()
-            addP2PKPrivateKey(privateKey)
-        }.isSuccess
+    fun generateP2PKKey(): P2PKKeyInfo = addP2PKPrivateKey(generateRandomPrivateKey())
 
     fun importP2PKNsec(nsec: String) {
         val trimmed = nsec.trim()
@@ -298,9 +334,59 @@ class SettingsManager(
         addP2PKPrivateKey(privateKey)
     }
 
-    fun removeP2PKKey(id: String) = update {
-        secureStorage.delete(secureP2PKPrivateKey(id))
-        settingsStore.p2pkKeys = settingsStore.p2pkKeys.filterNot { it.id == id }
+    fun removeP2PKKey(id: String) {
+        val key = p2pkStore.keys.firstOrNull { it.id == id } ?: return
+        val privateKey = availableP2PKPrivateKey(key)
+        val primaryStorageKey = secureP2PKPrivateKey(id)
+        val fallbackStorageKey = secureP2PKRemovalFallback(id)
+        val previousPendingIds = p2pkStore.pendingDeletionIds
+        val pendingIdsAfterCleanup = previousPendingIds - id
+        val pendingIds = previousPendingIds + id
+
+        try {
+            p2pkStore.pendingDeletionIds = pendingIds
+        } catch (error: Throwable) {
+            throw P2PKStorageException("Could not prepare the key removal.", error)
+        }
+
+        try {
+            if (privateKey != null) {
+                secureStorage.saveString(fallbackStorageKey, privateKey)
+            }
+            secureStorage.delete(primaryStorageKey)
+        } catch (error: Throwable) {
+            val fallbackWasRemoved = runCatching { secureStorage.delete(fallbackStorageKey) }.isSuccess
+            if (fallbackWasRemoved) {
+                runCatching { p2pkStore.pendingDeletionIds = pendingIdsAfterCleanup }
+            }
+            throw P2PKStorageException("Could not remove the encrypted key.", error)
+        }
+
+        val previousLegacySecret = pendingLegacyP2PKSecrets.remove(id)
+        try {
+            p2pkStore.saveKeys(
+                keys = p2pkStore.keys.filterNot { it.id == id },
+                preservingLegacySecrets = pendingLegacyP2PKSecrets,
+            )
+            mutableState.value = loadState()
+        } catch (error: Throwable) {
+            if (previousLegacySecret != null) pendingLegacyP2PKSecrets[id] = previousLegacySecret
+            val primaryWasRestored = privateKey == null || runCatching {
+                secureStorage.saveString(primaryStorageKey, privateKey)
+            }.isSuccess
+            if (primaryWasRestored) {
+                val fallbackWasRemoved = runCatching { secureStorage.delete(fallbackStorageKey) }.isSuccess
+                if (fallbackWasRemoved) {
+                    runCatching { p2pkStore.pendingDeletionIds = pendingIdsAfterCleanup }
+                }
+            }
+            throw P2PKStorageException("Could not save the key removal.", error)
+        }
+
+        val fallbackWasRemoved = runCatching { secureStorage.delete(fallbackStorageKey) }.isSuccess
+        if (fallbackWasRemoved) {
+            runCatching { p2pkStore.pendingDeletionIds = pendingIdsAfterCleanup }
+        }
     }
 
     fun p2pkSigningKeysFor(pubkeys: List<String>): List<String> {
@@ -309,12 +395,12 @@ class SettingsManager(
         val primary = primaryP2PKKey()
         val primaryMatches = primary != null &&
             normalizeP2PKForComparison(primary.publicKey) in tokenPubkeys
-        val availableKeys = settingsStore.p2pkKeys
+        val availableKeys = p2pkStore.keys
         val matching = availableKeys.filter { normalizeP2PKForComparison(it.publicKey) in tokenPubkeys }
         require(primaryMatches || matching.isNotEmpty()) {
             "This token is locked to a P2PK key that is not stored on this device."
         }
-        require(primaryMatches || matching.any { secureStorage.loadString(secureP2PKPrivateKey(it.id)) != null }) {
+        require(primaryMatches || matching.any { availableP2PKPrivateKey(it) != null }) {
             "Missing encrypted P2PK private key."
         }
         // Pass the full signing set (primary + device keys) and let CDK pick,
@@ -324,25 +410,27 @@ class SettingsManager(
 
     /** Primary seed-derived key + every device key with a stored secret, deduped (iOS parity). */
     fun allP2PKSigningKeyHexes(): List<String> {
-        val stored = settingsStore.p2pkKeys.mapNotNull {
-            secureStorage.loadString(secureP2PKPrivateKey(it.id))
-        }
+        val stored = p2pkStore.keys.mapNotNull(::availableP2PKPrivateKey)
         return (listOfNotNull(primaryP2PKKey()?.privateKeyHex) + stored).distinct()
     }
 
-    fun markP2PKKeyUsed(publicKey: String) = update {
+    fun markP2PKKeyUsed(publicKey: String) {
         val comparable = normalizeP2PKForComparison(publicKey)
-        settingsStore.p2pkKeys = settingsStore.p2pkKeys.map {
-            if (normalizeP2PKForComparison(it.publicKey) == comparable) {
+        val updated = p2pkStore.keys.map {
+            if (availableP2PKPrivateKey(it) != null &&
+                normalizeP2PKForComparison(it.publicKey) == comparable
+            ) {
                 it.copy(used = true, usedCount = it.usedCount + 1)
             } else {
                 it
             }
         }
+        persistP2PKMetadata(updated)
     }
 
     fun resetWalletScopedData() = update {
         deleteWalletScopedSecrets(snapshotWalletScopedData(), deleteNostrPrivateKey = true)
+        pendingLegacyP2PKSecrets.clear()
         settingsStore.clearWalletScopedData()
     }
 
@@ -358,10 +446,12 @@ class SettingsManager(
     internal fun snapshotWalletScopedData(): SettingsWalletScopedSnapshot =
         SettingsWalletScopedSnapshot(
             preferences = settingsStore.snapshotWalletScopedData(),
-            p2pkKeys = settingsStore.p2pkKeys,
+            p2pkKeys = p2pkStore.keys,
+            pendingP2PKDeletionIds = p2pkStore.pendingDeletionIds,
         )
 
     internal fun prepareForWalletReplacement() = update {
+        pendingLegacyP2PKSecrets.clear()
         settingsStore.clearWalletScopedData()
         settingsStore.nostrSignerType = NostrSignerType.Seed.rawValue
     }
@@ -375,7 +465,12 @@ class SettingsManager(
         snapshot: SettingsWalletScopedSnapshot,
         deleteNostrPrivateKey: Boolean,
     ) {
-        snapshot.p2pkKeys.forEach { secureStorage.delete(secureP2PKPrivateKey(it.id)) }
+        val p2pkIds = snapshot.p2pkKeys.mapTo(mutableSetOf()) { it.id }
+            .apply { addAll(snapshot.pendingP2PKDeletionIds) }
+        p2pkIds.forEach {
+            secureStorage.delete(secureP2PKPrivateKey(it))
+            secureStorage.delete(secureP2PKRemovalFallback(it))
+        }
         if (deleteNostrPrivateKey) secureStorage.delete(StorageKeys.secureNostrPrivateKey)
     }
 
@@ -384,8 +479,17 @@ class SettingsManager(
             p2pkRecords = settingsStore.loadP2PKKeysWithLegacySecrets(),
             loadSecret = secureStorage::loadString,
             saveSecret = secureStorage::saveString,
+            isUsableSecret = ::isUsableP2PKSecret,
         )
-        migration.p2pkKeysToPersist?.let { settingsStore.p2pkKeys = it }
+        pendingLegacyP2PKSecrets.clear()
+        pendingLegacyP2PKSecrets.putAll(migration.pendingLegacySecrets)
+        migration.p2pkKeysToPersist?.let { keys ->
+            runCatching {
+                p2pkStore.saveKeys(keys, pendingLegacyP2PKSecrets)
+            }.onFailure {
+                AppLogger.security.error("Failed to sanitize legacy P2PK metadata", it)
+            }
+        }
     }
 
     private fun update(block: () -> Unit) {
@@ -414,29 +518,140 @@ class SettingsManager(
         nostrSignerType = settingsStore.nostrSignerType,
         nostrRelays = settingsStore.nostrRelays,
         nostrMintBackupEnabled = settingsStore.nostrMintBackupEnabled,
-        p2pkKeys = settingsStore.p2pkKeys,
+        p2pkKeys = p2pkStore.keys,
+        p2pkUnavailableKeyIds = p2pkStore.keys
+            .filter { availableP2PKPrivateKey(it) == null }
+            .mapTo(mutableSetOf()) { it.id },
     )
 
     private fun normalizeP2PKForComparison(pubkey: String): String {
         return normalizeP2PKPublicKeyForComparison(pubkey)
     }
 
-    private fun addP2PKPrivateKey(privateKey: ByteArray) {
+    private fun addP2PKPrivateKey(privateKey: ByteArray): P2PKKeyInfo {
         require(privateKey.size == 32) { "Invalid nsec format." }
         val privateKeyHex = privateKey.toHex()
         val publicKey = "02${NostrService.publicKeyHex(privateKeyHex)}"
         val comparable = normalizeP2PKForComparison(publicKey)
-        require(settingsStore.p2pkKeys.none { normalizeP2PKForComparison(it.publicKey) == comparable }) {
+        val existingKey = p2pkStore.keys.firstOrNull {
+            normalizeP2PKForComparison(it.publicKey) == comparable
+        }
+        require(existingKey == null || availableP2PKPrivateKey(existingKey) == null) {
             "Key already exists."
         }
-        val id = UUID.randomUUID().toString()
-        val key = P2PKKeyInfo(
-            id = id,
+        val key = existingKey ?: P2PKKeyInfo(
+            id = UUID.randomUUID().toString(),
             publicKey = publicKey,
             label = "P2PK key",
         )
-        secureStorage.saveString(secureP2PKPrivateKey(id), privateKeyHex)
-        update { settingsStore.p2pkKeys = settingsStore.p2pkKeys + key }
+        val isRepair = existingKey != null
+
+        try {
+            secureStorage.saveString(secureP2PKPrivateKey(key.id), privateKeyHex)
+        } catch (error: Throwable) {
+            throw P2PKStorageException("Could not save the encrypted key.", error)
+        }
+
+        try {
+            if (isRepair) {
+                persistP2PKMetadata(p2pkStore.keys)
+            } else {
+                persistP2PKMetadata(p2pkStore.keys + key)
+            }
+        } catch (error: Throwable) {
+            if (!isRepair) {
+                runCatching { secureStorage.delete(secureP2PKPrivateKey(key.id)) }
+            }
+            throw P2PKStorageException("Could not save the key metadata.", error)
+        }
+        return key
+    }
+
+    private fun persistP2PKMetadata(keys: List<P2PKKeyInfo>) {
+        retryPendingLegacyP2PKSecrets(keys)
+        p2pkStore.saveKeys(keys, pendingLegacyP2PKSecrets)
+        mutableState.value = loadState()
+    }
+
+    private fun retryPendingLegacyP2PKSecrets(keys: List<P2PKKeyInfo>) {
+        val metadataById = keys.associateBy { it.id }
+        val iterator = pendingLegacyP2PKSecrets.iterator()
+        while (iterator.hasNext()) {
+            val (id, secret) = iterator.next()
+            val metadata = metadataById[id]
+            if (metadata == null || !isUsableP2PKSecret(metadata, secret)) {
+                iterator.remove()
+                continue
+            }
+            if (runCatching { secureStorage.saveString(secureP2PKPrivateKey(id), secret) }.isSuccess) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private fun availableP2PKPrivateKey(key: P2PKKeyInfo): String? {
+        val secureSecret = runCatching {
+            secureStorage.loadString(secureP2PKPrivateKey(key.id))
+        }.getOrNull()
+        if (secureSecret != null && isUsableP2PKSecret(key, secureSecret)) return secureSecret
+
+        pendingLegacyP2PKSecrets[key.id]?.let { legacySecret ->
+            if (isUsableP2PKSecret(key, legacySecret)) return legacySecret
+        }
+
+        if (key.id in runCatching { p2pkStore.pendingDeletionIds }.getOrDefault(emptySet())) {
+            val fallbackSecret = runCatching {
+                secureStorage.loadString(secureP2PKRemovalFallback(key.id))
+            }.getOrNull()
+            if (fallbackSecret != null && isUsableP2PKSecret(key, fallbackSecret)) return fallbackSecret
+        }
+        return null
+    }
+
+    private fun isUsableP2PKSecret(key: P2PKKeyInfo, secret: String): Boolean {
+        val normalizedSecret = secret.trim().lowercase()
+        if (normalizedSecret.length != 64 || normalizedSecret.any { it !in '0'..'9' && it !in 'a'..'f' }) {
+            return false
+        }
+        val derivedPublicKey = runCatching {
+            "02${NostrService.publicKeyHex(normalizedSecret)}"
+        }.getOrNull() ?: return false
+        return normalizeP2PKForComparison(derivedPublicKey) ==
+            normalizeP2PKForComparison(key.publicKey)
+    }
+
+    private fun recoverInterruptedP2PKRemovals() {
+        val pendingIds = runCatching { p2pkStore.pendingDeletionIds }.getOrDefault(emptySet())
+        if (pendingIds.isEmpty()) return
+        val metadataById = p2pkStore.keys.associateBy { it.id }
+        val unresolvedIds = pendingIds.toMutableSet()
+
+        pendingIds.forEach { id ->
+            val key = metadataById[id]
+            val primaryStorageKey = secureP2PKPrivateKey(id)
+            val fallbackStorageKey = secureP2PKRemovalFallback(id)
+            if (key == null) {
+                val primaryRemoved = runCatching { secureStorage.delete(primaryStorageKey) }.isSuccess
+                val fallbackRemoved = runCatching { secureStorage.delete(fallbackStorageKey) }.isSuccess
+                if (primaryRemoved && fallbackRemoved) unresolvedIds.remove(id)
+                return@forEach
+            }
+
+            val primarySecret = runCatching { secureStorage.loadString(primaryStorageKey) }.getOrNull()
+            val primaryIsUsable = primarySecret != null && isUsableP2PKSecret(key, primarySecret)
+            val fallbackSecret = runCatching { secureStorage.loadString(fallbackStorageKey) }.getOrNull()
+            val fallbackIsUsable = fallbackSecret != null && isUsableP2PKSecret(key, fallbackSecret)
+            val restored = primaryIsUsable || (fallbackIsUsable && runCatching {
+                secureStorage.saveString(primaryStorageKey, fallbackSecret)
+            }.isSuccess)
+            if (restored && runCatching { secureStorage.delete(fallbackStorageKey) }.isSuccess) {
+                unresolvedIds.remove(id)
+            }
+        }
+
+        if (unresolvedIds != pendingIds) {
+            runCatching { p2pkStore.pendingDeletionIds = unresolvedIds }
+        }
     }
 
     private fun generateRandomPrivateKey(): ByteArray {
@@ -451,6 +666,9 @@ class SettingsManager(
 
     private fun secureP2PKPrivateKey(id: String): String =
         LegacySettingsSecretMigrator.secureP2PKPrivateKey(id)
+
+    private fun secureP2PKRemovalFallback(id: String): String =
+        "${secureP2PKPrivateKey(id)}.removalFallback"
 
     private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
 }

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -2,6 +2,7 @@ package com.cashu.me.Core
 
 import android.content.Context
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -160,7 +161,35 @@ class SettingsStore(
 
     var p2pkKeys: List<P2PKKeyInfo>
         get() = loadList(StorageKeys.settingsP2PKKeys, P2PKKeyInfo.serializer())
-        set(value) = saveList(StorageKeys.settingsP2PKKeys, P2PKKeyInfo.serializer(), value)
+        set(value) = saveP2PKKeys(value)
+
+    internal fun saveP2PKKeys(
+        keys: List<P2PKKeyInfo>,
+        preservingLegacySecrets: Map<String, String> = emptyMap(),
+    ) {
+        val records = keys.map { key ->
+            P2PKSettingsRecord(
+                id = key.id,
+                publicKey = key.publicKey,
+                label = key.label,
+                createdAtEpochMillis = key.createdAtEpochMillis,
+                used = key.used,
+                usedCount = key.usedCount,
+                privateKey = preservingLegacySecrets[key.id],
+            )
+        }
+        saveList(StorageKeys.settingsP2PKKeys, P2PKSettingsRecord.serializer(), records)
+    }
+
+    internal var p2pkPendingDeletionIds: Set<String>
+        get() = loadList(StorageKeys.settingsP2PKPendingDeletionIds, String.serializer()).toSet()
+        set(value) {
+            if (value.isEmpty()) {
+                store.remove(StorageKeys.settingsP2PKPendingDeletionIds)
+            } else {
+                saveList(StorageKeys.settingsP2PKPendingDeletionIds, String.serializer(), value.sorted())
+            }
+        }
 
     internal fun loadP2PKKeysWithLegacySecrets(): List<LegacyP2PKKeyRecord> =
         LegacySettingsSecretParser.p2pkKeys(store.string(StorageKeys.settingsP2PKKeys))
@@ -252,6 +281,7 @@ class SettingsStore(
         StorageKeys.settingsEnablePaymentRequests,
         StorageKeys.settingsReceivePaymentRequestsAutomatically,
         StorageKeys.settingsP2PKKeys,
+        StorageKeys.settingsP2PKPendingDeletionIds,
         StorageKeys.settingsNostrSignerType,
         StorageKeys.settingsNostrMintBackupEnabled,
         StorageKeys.cashuRequestsProcessedNip17Ids,
@@ -266,6 +296,17 @@ class SettingsStore(
         StorageKeys.onboardingCompleted,
     )
 }
+
+@Serializable
+private data class P2PKSettingsRecord(
+    val id: String,
+    val publicKey: String,
+    val label: String,
+    val createdAtEpochMillis: Long,
+    val used: Boolean,
+    val usedCount: Int,
+    val privateKey: String? = null,
+)
 
 internal data class LegacyP2PKKeyRecord(
     val metadata: P2PKKeyInfo,

--- a/android/app/src/main/java/com/cashu/me/ui/settings/AdvancedKeysScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/AdvancedKeysScreen.kt
@@ -89,9 +89,10 @@ fun AdvancedKeysScreen(
                 showChevron = false,
                 onClick = {
                     actionError = null
-                    if (!settingsManager.generateP2PKKey()) {
-                        actionError = "Couldn't generate a key. Please try again."
-                    }
+                    runCatching { settingsManager.generateP2PKKey() }
+                        .onFailure {
+                            actionError = it.message ?: "Couldn't generate a key. Please try again."
+                        }
                 },
             )
             NavRow(
@@ -131,7 +132,11 @@ fun AdvancedKeysScreen(
                         .animateContentSize(spring(stiffness = Spring.StiffnessMediumLow)),
                 ) {
                     settings.p2pkKeys.forEachIndexed { index, key ->
-                        DeviceKeyRow(key = key, onClick = { onOpenKey(key.id) })
+                        DeviceKeyRow(
+                            key = key,
+                            isUsable = key.id !in settings.p2pkUnavailableKeyIds,
+                            onClick = { onOpenKey(key.id) },
+                        )
                     }
                 }
                 SettingsFooterText(
@@ -146,8 +151,6 @@ fun AdvancedKeysScreen(
         ImportP2PKDialog(
             onImport = { nsec ->
                 runCatching { settingsManager.importP2PKNsec(nsec) }
-                    .onSuccess { showImport = false }
-                    .onFailure { actionError = it.message ?: "Could not import key." }
             },
             onDismiss = { showImport = false },
         )
@@ -155,12 +158,12 @@ fun AdvancedKeysScreen(
 }
 
 @Composable
-private fun DeviceKeyRow(key: P2PKKeyInfo, onClick: () -> Unit) {
+private fun DeviceKeyRow(key: P2PKKeyInfo, isUsable: Boolean, onClick: () -> Unit) {
     NavRow(
         title = key.label.ifBlank { P2PKKeyDisplay.shortLabel(key.publicKey) },
         subtitle = buildString {
-            append("Device only")
-            if (key.usedCount > 0) {
+            append(if (isUsable) "Device only" else "Repair required")
+            if (isUsable && key.usedCount > 0) {
                 append(" · ")
                 append(if (key.usedCount == 1) "Used once" else "Used ${key.usedCount} times")
             }
@@ -173,7 +176,7 @@ private fun DeviceKeyRow(key: P2PKKeyInfo, onClick: () -> Unit) {
 /** nsec import dialog (iOS ImportP2PKSheet). */
 @Composable
 internal fun ImportP2PKDialog(
-    onImport: (String) -> Unit,
+    onImport: (String) -> Result<Unit>,
     onDismiss: () -> Unit,
 ) {
     var input by remember { mutableStateOf("") }
@@ -207,6 +210,8 @@ internal fun ImportP2PKDialog(
                     return@TextButton
                 }
                 onImport(trimmed)
+                    .onSuccess { onDismiss() }
+                    .onFailure { inputError = it.message ?: "Could not import key." }
             }) { Text("Import") }
         },
         dismissButton = {

--- a/android/app/src/main/java/com/cashu/me/ui/settings/DeviceKeyDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/DeviceKeyDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material.icons.outlined.FileDownload
 import androidx.compose.material.icons.outlined.Key
 import androidx.compose.material.icons.outlined.QrCode
 import androidx.compose.material3.AlertDialog
@@ -35,6 +36,8 @@ import com.cashu.me.Core.AppLockManager
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.ui.components.CashuTextField
 import com.cashu.me.ui.components.DestructiveTextButton
+import com.cashu.me.ui.components.InlineNotice
+import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.SectionHeader
 import com.cashu.me.ui.components.SettingsFooterText
 import com.cashu.me.ui.components.ToolbarIcon
@@ -60,6 +63,8 @@ fun DeviceKeyDetailScreen(
     var activeQr by remember { mutableStateOf<String?>(null) }
     var showPrivateKeyBackup by remember { mutableStateOf(false) }
     var showRemoveConfirm by remember { mutableStateOf(false) }
+    var showRepair by remember { mutableStateOf(false) }
+    var actionError by remember { mutableStateOf<String?>(null) }
 
     // Pop when the key is removed underneath us (iOS onChange dismiss).
     LaunchedEffect(key == null) {
@@ -68,6 +73,7 @@ fun DeviceKeyDetailScreen(
     if (key == null) return
 
     val displayName = key.label.ifBlank { "Device key" }
+    val isUsable = key.id !in settings.p2pkUnavailableKeyIds
 
     Scaffold(
         topBar = {
@@ -94,17 +100,50 @@ fun DeviceKeyDetailScreen(
             KeyCard(
                 title = displayName,
                 pubkey = key.publicKey,
-                status = KeyCardStatus.DeviceOnly,
-                actions = listOf(
-                    KeyCardAction("Show QR", Icons.Outlined.QrCode) {
-                        activeQr = P2PKKeyDisplay.canonical(key.publicKey)
-                    },
-                    KeyCardAction("Back up key", Icons.Outlined.Key) {
-                        showPrivateKeyBackup = true
-                    },
-                ),
+                status = if (isUsable) KeyCardStatus.DeviceOnly else KeyCardStatus.RepairRequired,
+                actions = if (isUsable) {
+                    listOf(
+                        KeyCardAction("Show QR", Icons.Outlined.QrCode) {
+                            activeQr = P2PKKeyDisplay.canonical(key.publicKey)
+                        },
+                        KeyCardAction("Back up key", Icons.Outlined.Key) {
+                            showPrivateKeyBackup = true
+                        },
+                    )
+                } else {
+                    listOf(
+                        KeyCardAction("Repair key", Icons.Outlined.FileDownload) {
+                            actionError = null
+                            showRepair = true
+                        },
+                    )
+                },
+                copyEnabled = isUsable,
                 modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable),
             )
+
+            if (!isUsable) {
+                InlineNotice(
+                    text = "This key's encrypted private key is unavailable. Import its nsec to " +
+                        "repair it before sharing the public key or receiving locked ecash.",
+                    modifier = Modifier.padding(
+                        horizontal = CashuTheme.spacing.comfortable,
+                        vertical = CashuTheme.spacing.snug,
+                    ),
+                    severity = NoticeSeverity.Error,
+                )
+            }
+
+            actionError?.let { error ->
+                InlineNotice(
+                    text = error,
+                    modifier = Modifier.padding(
+                        horizontal = CashuTheme.spacing.comfortable,
+                        vertical = CashuTheme.spacing.snug,
+                    ),
+                    severity = NoticeSeverity.Error,
+                )
+            }
 
             Spacer(Modifier.height(CashuTheme.spacing.default))
             SectionHeader("Name")
@@ -112,7 +151,10 @@ fun DeviceKeyDetailScreen(
                 value = nameText,
                 onValueChange = {
                     nameText = it
-                    settingsManager.setP2PKKeyNickname(key.id, it)
+                    runCatching { settingsManager.setP2PKKeyNickname(key.id, it) }
+                        .onFailure { error ->
+                            actionError = error.message ?: "Could not rename the key."
+                        }
                 },
                 label = "Add a name",
                 modifier = Modifier
@@ -149,6 +191,12 @@ fun DeviceKeyDetailScreen(
             onDismiss = { showPrivateKeyBackup = false },
         )
     }
+    if (showRepair) {
+        ImportP2PKDialog(
+            onImport = { nsec -> runCatching { settingsManager.importP2PKNsec(nsec) } },
+            onDismiss = { showRepair = false },
+        )
+    }
     if (showRemoveConfirm) {
         AlertDialog(
             onDismissRequest = { showRemoveConfirm = false },
@@ -162,7 +210,11 @@ fun DeviceKeyDetailScreen(
             confirmButton = {
                 TextButton(onClick = {
                     showRemoveConfirm = false
-                    settingsManager.removeP2PKKey(key.id)
+                    actionError = null
+                    runCatching { settingsManager.removeP2PKKey(key.id) }
+                        .onFailure { error ->
+                            actionError = error.message ?: "Could not remove the key."
+                        }
                 }) {
                     Text("Remove Key", color = MaterialTheme.colorScheme.error)
                 }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/P2PKComponents.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/P2PKComponents.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -129,6 +130,7 @@ enum class KeyCardStatus(val text: String?) {
     SeedBacked("Backed up by your seed phrase"),
     Custom(null),
     DeviceOnly("On this device only — not in your seed backup"),
+    RepairRequired("Repair required before this key can be used"),
 }
 
 data class KeyCardAction(
@@ -161,6 +163,7 @@ fun KeyCard(
     actions: List<KeyCardAction>,
     modifier: Modifier = Modifier,
     copyOptions: List<KeyCardCopyOption> = emptyList(),
+    copyEnabled: Boolean = true,
 ) {
     val clipboard = LocalClipboardManager.current
     val confirmationToastController = LocalConfirmationToastController.current
@@ -207,11 +210,15 @@ fun KeyCard(
                         val statusTint = when (status) {
                             KeyCardStatus.SeedBacked -> MaterialTheme.colorScheme.onSurfaceVariant
                             KeyCardStatus.Custom, KeyCardStatus.DeviceOnly -> CashuTheme.colors.pending
+                            KeyCardStatus.RepairRequired -> MaterialTheme.colorScheme.error
                         }
                         Icon(
                             imageVector = when (status) {
                                 KeyCardStatus.SeedBacked -> Icons.Filled.Verified
-                                KeyCardStatus.Custom, KeyCardStatus.DeviceOnly -> Icons.Filled.Warning
+                                KeyCardStatus.Custom,
+                                KeyCardStatus.DeviceOnly,
+                                KeyCardStatus.RepairRequired,
+                                -> Icons.Filled.Warning
                             },
                             contentDescription = null,
                             tint = statusTint,
@@ -235,7 +242,16 @@ fun KeyCard(
                     .fillMaxWidth()
                     .then(
                         if (copyOptions.isEmpty()) {
-                            Modifier.clickable {
+                            Modifier
+                                .semantics {
+                                    contentDescription = if (copyEnabled) {
+                                        "Copy this key"
+                                    } else {
+                                        "Key unavailable"
+                                    }
+                                    if (!copyEnabled) disabled()
+                                }
+                                .clickable(enabled = copyEnabled) {
                                 clipboard.setText(AnnotatedString(P2PKKeyDisplay.canonical(pubkey)))
                                 confirmationToastController?.show("Copied key")
                             }
@@ -246,6 +262,7 @@ fun KeyCard(
                                         "$title. Long press for more copy options."
                                 }
                                 .combinedClickable(
+                                    enabled = copyEnabled,
                                     onClick = {
                                         clipboard.setText(
                                             AnnotatedString(P2PKKeyDisplay.canonical(pubkey)),
@@ -272,8 +289,12 @@ fun KeyCard(
                 )
                 Icon(
                     imageVector = Icons.Outlined.ContentCopy,
-                    contentDescription = "Copy this key",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    contentDescription = if (copyEnabled) "Copy this key" else "Key unavailable",
+                    tint = if (copyEnabled) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.38f)
+                    },
                     modifier = Modifier.size(CashuTheme.spacing.comfortable),
                 )
             }

--- a/android/app/src/test/java/com/cashu/me/Core/SettingsLegacySecretMigrationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/SettingsLegacySecretMigrationTest.kt
@@ -84,6 +84,7 @@ class SettingsLegacySecretMigrationTest {
             p2pkRecords = p2pk,
             loadSecret = secureValues::get,
             saveSecret = { key, value -> secureValues[key] = value },
+            isUsableSecret = { _, _ -> true },
         )
 
         assertEquals(
@@ -96,5 +97,62 @@ class SettingsLegacySecretMigrationTest {
         )
         assertNotNull(migration.p2pkKeysToPersist)
         assertEquals(listOf("p2pk-1", "p2pk-2"), migration.p2pkKeysToPersist?.map { it.id })
+        assertTrue(migration.pendingLegacySecrets.isEmpty())
+    }
+
+    @Test
+    fun migratorRetainsUsableLegacySecretOnlyWhenSecureWriteFails() {
+        val p2pk = LegacySettingsSecretParser.p2pkKeys(
+            """
+                [
+                  {
+                    "id": "p2pk-1",
+                    "publicKey": "02${"c".repeat(64)}",
+                    "privateKey": "legacy-p2pk-private",
+                    "used": false,
+                    "usedCount": 0
+                  }
+                ]
+            """.trimIndent(),
+        )
+
+        val migration = LegacySettingsSecretMigrator.migrate(
+            p2pkRecords = p2pk,
+            loadSecret = { null },
+            saveSecret = { _, _ -> error("secure storage unavailable") },
+            isUsableSecret = { _, secret -> secret == "legacy-p2pk-private" },
+        )
+
+        assertEquals(
+            mapOf("p2pk-1" to "legacy-p2pk-private"),
+            migration.pendingLegacySecrets,
+        )
+    }
+
+    @Test
+    fun migratorDoesNotRetainMalformedLegacySecret() {
+        val p2pk = LegacySettingsSecretParser.p2pkKeys(
+            """
+                [
+                  {
+                    "id": "p2pk-1",
+                    "publicKey": "02${"c".repeat(64)}",
+                    "privateKey": "not-the-matching-key",
+                    "used": false,
+                    "usedCount": 0
+                  }
+                ]
+            """.trimIndent(),
+        )
+
+        val migration = LegacySettingsSecretMigrator.migrate(
+            p2pkRecords = p2pk,
+            loadSecret = { null },
+            saveSecret = { _, _ -> error("must not be called") },
+            isUsableSecret = { _, _ -> false },
+        )
+
+        assertTrue(migration.pendingLegacySecrets.isEmpty())
+        assertNotNull(migration.p2pkKeysToPersist)
     }
 }

--- a/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -120,6 +120,7 @@ enum StorageKeys {
     static let receivePaymentRequestsAutomatically = "settings.receivePaymentRequestsAutomatically"
     static let showP2PKButtonInDrawer = "settings.showP2PKButtonInDrawer"
     static let p2pkKeys = "settings.p2pkKeys"
+    static let p2pkPendingDeletionIDs = "settings.p2pkPendingDeletionIDs"
     static let checkIncomingInvoices = "settings.checkIncomingInvoices"
     static let periodicallyCheckIncomingInvoices = "settings.periodicallyCheckIncomingInvoices"
     static let nostrRelays = "settings.nostrRelays"
@@ -252,6 +253,7 @@ enum StorageKeys {
         receivePaymentRequestsAutomatically,
         showP2PKButtonInDrawer,
         p2pkKeys,
+        p2pkPendingDeletionIDs,
         nostrSignerType,
         nostrMintBackupEnabled,
         npcEnabled,

--- a/ios/CashuWallet/Core/SettingsManager.swift
+++ b/ios/CashuWallet/Core/SettingsManager.swift
@@ -173,6 +173,10 @@ class SettingsManager: ObservableObject {
     ) {
         self.settingsStore = settingsStore
         self.secureStorage = secureStorage
+        Self.recoverInterruptedP2PKRemovals(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
         let loadedP2PKKeys = Self.loadP2PKKeys(
             settingsStore: settingsStore,
             secureStorage: secureStorage
@@ -294,6 +298,7 @@ class SettingsManager: ObservableObject {
         guard let storedKey = p2pkKeys.first(where: { $0.id == key.id }) else { return }
 
         let storageKey = Self.secureP2PKPrivateKey(storedKey.id)
+        let fallbackStorageKey = Self.secureP2PKRemovalFallback(storedKey.id)
         let fallbackSecret: String?
         if !storedKey.privateKey.isEmpty {
             fallbackSecret = storedKey.privateKey
@@ -310,31 +315,39 @@ class SettingsManager: ObservableObject {
             }
         }
 
-        // Stage a recoverable copy before touching Keychain. If the process is
-        // interrupted after deletion, the next launch migrates this legacy field
-        // back into secure storage instead of silently losing the private key.
-        var stagedLegacySecrets = pendingLegacyP2PKSecrets
-        if let fallbackSecret, !fallbackSecret.isEmpty {
-            stagedLegacySecrets[storedKey.id] = fallbackSecret
-        }
+        // Journal only the identifier in regular settings. Rollback material
+        // remains under Keychain's ThisDeviceOnly protection at every point.
+        var pendingDeletionIDs = settingsStore.p2pkPendingDeletionIDs
+        pendingDeletionIDs.insert(storedKey.id)
         do {
-            try settingsStore.saveP2PKKeys(
-                p2pkKeys,
-                preservingLegacySecrets: stagedLegacySecrets
-            )
+            try settingsStore.saveP2PKPendingDeletionIDs(pendingDeletionIDs)
         } catch {
             AppLogger.security.error(
-                "Failed to stage P2PK key removal fallback error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                "Failed to journal P2PK key removal error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
             throw SettingsFeatureError.keyRemovalFailed
         }
-        pendingLegacyP2PKSecrets = stagedLegacySecrets
+
+        if let fallbackSecret, !fallbackSecret.isEmpty {
+            do {
+                try secureStorage.saveSecret(fallbackSecret, forKey: fallbackStorageKey)
+            } catch {
+                if (try? secureStorage.deleteSecret(forKey: fallbackStorageKey)) != nil {
+                    try? clearP2PKRemovalJournal(for: storedKey.id)
+                }
+                AppLogger.security.error(
+                    "Failed to stage secure P2PK key removal fallback error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+                throw SettingsFeatureError.keyRemovalFailed
+            }
+        }
 
         do {
             try secureStorage.deleteSecret(forKey: storageKey)
         } catch {
-            // The staged metadata row remains authoritative and observable state
-            // is unchanged, so the user can retry without losing the key.
+            if (try? secureStorage.deleteSecret(forKey: fallbackStorageKey)) != nil {
+                try? clearP2PKRemovalJournal(for: storedKey.id)
+            }
             AppLogger.security.error(
                 "Failed to delete P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
@@ -342,7 +355,7 @@ class SettingsManager: ObservableObject {
         }
 
         let updatedKeys = p2pkKeys.filter { $0.id != storedKey.id }
-        var updatedLegacySecrets = stagedLegacySecrets
+        var updatedLegacySecrets = pendingLegacyP2PKSecrets
         updatedLegacySecrets.removeValue(forKey: storedKey.id)
         do {
             try settingsStore.saveP2PKKeys(
@@ -350,11 +363,20 @@ class SettingsManager: ObservableObject {
                 preservingLegacySecrets: updatedLegacySecrets
             )
         } catch {
-            // The first metadata write still contains the complete row and its
-            // fallback secret. Restore Keychain when possible as an additional
-            // runtime recovery path, but never discard that durable fallback.
+            var restored = fallbackSecret == nil || fallbackSecret?.isEmpty == true
             if let fallbackSecret, !fallbackSecret.isEmpty {
-                try? secureStorage.saveSecret(fallbackSecret, forKey: storageKey)
+                do {
+                    try secureStorage.saveSecret(fallbackSecret, forKey: storageKey)
+                    restored = true
+                } catch {
+                    // Keep both the secure fallback and journal for launch-time
+                    // recovery if Keychain is temporarily unavailable.
+                }
+            }
+            if restored {
+                if (try? secureStorage.deleteSecret(forKey: fallbackStorageKey)) != nil {
+                    try? clearP2PKRemovalJournal(for: storedKey.id)
+                }
             }
             AppLogger.security.error(
                 "Failed to finalize P2PK key removal error_type=\(String(reflecting: type(of: error)), privacy: .public)"
@@ -364,11 +386,24 @@ class SettingsManager: ObservableObject {
 
         pendingLegacyP2PKSecrets = updatedLegacySecrets
         p2pkKeys = updatedKeys
+
+        // Metadata removal is the commit point. Cleanup is idempotent and the
+        // journal lets the next launch finish it if either operation fails.
+        do {
+            try secureStorage.deleteSecret(forKey: fallbackStorageKey)
+            try clearP2PKRemovalJournal(for: storedKey.id)
+        } catch {
+            AppLogger.security.error(
+                "Failed to finalize P2PK removal cleanup error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+        }
     }
 
     func resetWalletScopedData(resetRuntimeServices: Bool = true) {
-        for key in p2pkKeys {
-            try? secureStorage.deleteSecret(forKey: Self.secureP2PKPrivateKey(key.id))
+        let p2pkIDs = Set(p2pkKeys.map(\.id)).union(settingsStore.p2pkPendingDeletionIDs)
+        for id in p2pkIDs {
+            try? secureStorage.deleteSecret(forKey: Self.secureP2PKPrivateKey(id))
+            try? secureStorage.deleteSecret(forKey: Self.secureP2PKRemovalFallback(id))
         }
 
         try? KeychainService().deleteNostrPrivateKey()
@@ -439,10 +474,6 @@ class SettingsManager: ObservableObject {
                             "Failed to migrate legacy P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
                         )
                     }
-                } else {
-                    // Preserve malformed legacy data verbatim for compatibility,
-                    // but never expose it as a signing key.
-                    pendingLegacySecrets[key.id] = legacySecret
                 }
             }
 
@@ -461,6 +492,58 @@ class SettingsManager: ObservableObject {
             pendingLegacySecrets: pendingLegacySecrets,
             encounteredLegacySecrets: encounteredLegacySecrets
         )
+    }
+
+    private static func recoverInterruptedP2PKRemovals(
+        settingsStore: SettingsStore,
+        secureStorage: SecureStorageProtocol
+    ) {
+        let pendingIDs = settingsStore.p2pkPendingDeletionIDs
+        guard !pendingIDs.isEmpty else { return }
+
+        let persistedKeys = Dictionary(
+            uniqueKeysWithValues: settingsStore.p2pkKeys.map { ($0.id, $0) }
+        )
+        var unresolvedIDs = pendingIDs
+
+        for id in pendingIDs {
+            let storageKey = secureP2PKPrivateKey(id)
+            let fallbackStorageKey = secureP2PKRemovalFallback(id)
+            do {
+                if let persistedKey = persistedKeys[id] {
+                    let currentSecret = try secureStorage.loadSecret(forKey: storageKey)
+                    let currentIsUsable = currentSecret.map {
+                        hasUsablePrivateKey(publicKey: persistedKey.publicKey, privateKey: $0)
+                    } ?? false
+                    let fallbackSecret = try secureStorage.loadSecret(forKey: fallbackStorageKey)
+                    let fallbackIsUsable = fallbackSecret.map {
+                        hasUsablePrivateKey(publicKey: persistedKey.publicKey, privateKey: $0)
+                    } ?? false
+                    if !currentIsUsable, fallbackIsUsable, let fallbackSecret {
+                        try secureStorage.saveSecret(fallbackSecret, forKey: storageKey)
+                    }
+                    guard currentIsUsable || fallbackIsUsable else { continue }
+                    try secureStorage.deleteSecret(forKey: fallbackStorageKey)
+                } else {
+                    try secureStorage.deleteSecret(forKey: storageKey)
+                    try secureStorage.deleteSecret(forKey: fallbackStorageKey)
+                }
+                unresolvedIDs.remove(id)
+            } catch {
+                AppLogger.security.error(
+                    "Failed to recover interrupted P2PK removal error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+            }
+        }
+
+        guard unresolvedIDs != pendingIDs else { return }
+        do {
+            try settingsStore.saveP2PKPendingDeletionIDs(unresolvedIDs)
+        } catch {
+            AppLogger.security.error(
+                "Failed to persist P2PK removal recovery state error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+        }
     }
 
     /// Store the secret before either durable metadata or observable state. If
@@ -554,6 +637,16 @@ class SettingsManager: ObservableObject {
 
     private static func secureP2PKPrivateKey(_ id: UUID) -> String {
         "settings.p2pk.\(id.uuidString).privateKey"
+    }
+
+    private static func secureP2PKRemovalFallback(_ id: UUID) -> String {
+        "\(secureP2PKPrivateKey(id)).removalFallback"
+    }
+
+    private func clearP2PKRemovalJournal(for id: UUID) throws {
+        var pendingIDs = settingsStore.p2pkPendingDeletionIDs
+        pendingIDs.remove(id)
+        try settingsStore.saveP2PKPendingDeletionIDs(pendingIDs)
     }
 
     private func generateRandomPrivateKeyBytes() throws -> [UInt8] {
@@ -782,6 +875,11 @@ extension SettingsManager {
         let trimmed = nickname?.trimmingCharacters(in: .whitespacesAndNewlines)
         p2pkKeys[index].nickname = (trimmed?.isEmpty == false) ? trimmed : nil
         persistP2PKMetadata()
+    }
+
+    func isP2PKKeyUsable(_ id: UUID) -> Bool {
+        guard let key = p2pkKeys.first(where: { $0.id == id }) else { return false }
+        return Self.hasUsablePrivateKey(key)
     }
 }
 

--- a/ios/CashuWallet/Core/SettingsManager.swift
+++ b/ios/CashuWallet/Core/SettingsManager.swift
@@ -6,7 +6,12 @@ import P256K
 @MainActor
 class SettingsManager: ObservableObject {
     static let shared = SettingsManager()
-    private let settingsStore = SettingsStore.shared
+    private let settingsStore: SettingsStore
+    private let secureStorage: SecureStorageProtocol
+    /// Legacy UserDefaults secrets that must remain encoded until their secure
+    /// storage migration succeeds. This is intentionally separate from the
+    /// published model so metadata updates cannot accidentally erase them.
+    private var pendingLegacyP2PKSecrets: [UUID: String]
     private var suppressPaymentRequestSideEffects = false
     
     static let supportedFiatCurrencies: [String] = [
@@ -68,11 +73,7 @@ class SettingsManager: ObservableObject {
         }
     }
 
-    @Published var p2pkKeys: [P2PKKey] {
-        didSet {
-            persistP2PKKeys()
-        }
-    }
+    @Published private(set) var p2pkKeys: [P2PKKey]
 
     @Published var checkIncomingInvoices: Bool {
         didSet {
@@ -166,7 +167,17 @@ class SettingsManager: ObservableObject {
 
     // MARK: - Initialization
     
-    init() {
+    init(
+        settingsStore: SettingsStore = .shared,
+        secureStorage: SecureStorageProtocol = KeychainService()
+    ) {
+        self.settingsStore = settingsStore
+        self.secureStorage = secureStorage
+        let loadedP2PKKeys = Self.loadP2PKKeys(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        self.pendingLegacyP2PKSecrets = loadedP2PKKeys.pendingLegacySecrets
         self.useBitcoinSymbol = settingsStore.useBitcoinSymbol
         self.showFiatBalance = settingsStore.showFiatBalance
         self.bitcoinPriceCurrency = settingsStore.bitcoinPriceCurrency
@@ -174,7 +185,7 @@ class SettingsManager: ObservableObject {
         self.autoPasteEcashReceive = settingsStore.autoPasteEcashReceive
         self.useWebsockets = settingsStore.useWebsockets
         self.showP2PKButtonInDrawer = settingsStore.showP2PKButtonInDrawer
-        self.p2pkKeys = Self.loadP2PKKeys()
+        self.p2pkKeys = loadedP2PKKeys.keys
         self.checkIncomingInvoices = settingsStore.checkIncomingInvoices
         self.periodicallyCheckIncomingInvoices = settingsStore.periodicallyCheckIncomingInvoices
         self.enablePaymentRequests = settingsStore.enablePaymentRequests
@@ -186,7 +197,20 @@ class SettingsManager: ObservableObject {
         self.appLockEnabled = settingsStore.appLockEnabled
         self.sentryEnabled = settingsStore.sentryEnabled
 
-        persistP2PKKeys()
+        if loadedP2PKKeys.encounteredLegacySecrets {
+            do {
+                try settingsStore.saveP2PKKeys(
+                    p2pkKeys,
+                    preservingLegacySecrets: pendingLegacyP2PKSecrets
+                )
+            } catch {
+                // The existing record still contains every legacy secret, so a
+                // failed cleanup is safe to retry on the next metadata change.
+                AppLogger.security.error(
+                    "Failed to finalize P2PK secure-storage migration error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+            }
+        }
         
         let priceService = PriceService.shared
         if !priceService.isEnabled, priceService.currencyCode != bitcoinPriceCurrency {
@@ -214,14 +238,10 @@ class SettingsManager: ObservableObject {
     }
 
     @discardableResult
-    func generateP2PKKey() -> Bool {
-        do {
-            let key = try createP2PKKey(privateKeyBytes: generateRandomPrivateKeyBytes())
-            p2pkKeys.append(key)
-            return true
-        } catch {
-            return false
-        }
+    func generateP2PKKey() throws -> P2PKKey {
+        let key = try createP2PKKey(privateKeyBytes: generateRandomPrivateKeyBytes())
+        try storeP2PKKey(key)
+        return key
     }
 
     func importP2PKNsec(_ nsec: String) throws {
@@ -234,37 +254,127 @@ class SettingsManager: ObservableObject {
         let key = try createP2PKKey(privateKeyBytes: privateKeyBytes)
         let normalizedImportedKey = normalizeP2PKPublicKeyForComparison(key.publicKey)
 
-        guard !p2pkKeys.contains(where: { normalizeP2PKPublicKeyForComparison($0.publicKey) == normalizedImportedKey }) else {
-            throw SettingsFeatureError.duplicateP2PKKey
+        if let existingIndex = p2pkKeys.firstIndex(where: {
+            normalizeP2PKPublicKeyForComparison($0.publicKey) == normalizedImportedKey
+        }) {
+            let existing = p2pkKeys[existingIndex]
+            guard !Self.hasUsablePrivateKey(existing) else {
+                throw SettingsFeatureError.duplicateP2PKKey
+            }
+
+            // A metadata-only row must not prevent its owner from repairing it
+            // by importing the corresponding private key.
+            let repaired = P2PKKey(
+                id: existing.id,
+                publicKey: key.publicKey,
+                privateKey: key.privateKey,
+                used: existing.used,
+                usedCount: existing.usedCount,
+                nickname: existing.nickname
+            )
+            try storeP2PKKey(repaired, replacing: existingIndex)
+            return
         }
 
-        p2pkKeys.append(key)
+        try storeP2PKKey(key)
     }
 
     func markP2PKKeyUsed(publicKey: String) {
         let normalizedTargetKey = normalizeP2PKPublicKeyForComparison(publicKey)
         guard let index = p2pkKeys.firstIndex(where: {
-            normalizeP2PKPublicKeyForComparison($0.publicKey) == normalizedTargetKey
+            Self.hasUsablePrivateKey($0)
+                && normalizeP2PKPublicKeyForComparison($0.publicKey) == normalizedTargetKey
         }) else { return }
         p2pkKeys[index].used = true
         p2pkKeys[index].usedCount += 1
+        persistP2PKMetadata()
     }
 
-    func removeP2PKKey(_ key: P2PKKey) {
-        try? KeychainService().deleteSecret(forKey: Self.secureP2PKPrivateKey(key.id))
-        p2pkKeys.removeAll { $0.id == key.id }
+    func removeP2PKKey(_ key: P2PKKey) throws {
+        guard let storedKey = p2pkKeys.first(where: { $0.id == key.id }) else { return }
+
+        let storageKey = Self.secureP2PKPrivateKey(storedKey.id)
+        let fallbackSecret: String?
+        if !storedKey.privateKey.isEmpty {
+            fallbackSecret = storedKey.privateKey
+        } else if let pendingSecret = pendingLegacyP2PKSecrets[storedKey.id] {
+            fallbackSecret = pendingSecret
+        } else {
+            do {
+                fallbackSecret = try secureStorage.loadSecret(forKey: storageKey)
+            } catch {
+                AppLogger.security.error(
+                    "Failed to load P2PK private key before removal error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+                throw SettingsFeatureError.keyRemovalFailed
+            }
+        }
+
+        // Stage a recoverable copy before touching Keychain. If the process is
+        // interrupted after deletion, the next launch migrates this legacy field
+        // back into secure storage instead of silently losing the private key.
+        var stagedLegacySecrets = pendingLegacyP2PKSecrets
+        if let fallbackSecret, !fallbackSecret.isEmpty {
+            stagedLegacySecrets[storedKey.id] = fallbackSecret
+        }
+        do {
+            try settingsStore.saveP2PKKeys(
+                p2pkKeys,
+                preservingLegacySecrets: stagedLegacySecrets
+            )
+        } catch {
+            AppLogger.security.error(
+                "Failed to stage P2PK key removal fallback error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            throw SettingsFeatureError.keyRemovalFailed
+        }
+        pendingLegacyP2PKSecrets = stagedLegacySecrets
+
+        do {
+            try secureStorage.deleteSecret(forKey: storageKey)
+        } catch {
+            // The staged metadata row remains authoritative and observable state
+            // is unchanged, so the user can retry without losing the key.
+            AppLogger.security.error(
+                "Failed to delete P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            throw SettingsFeatureError.keyRemovalFailed
+        }
+
+        let updatedKeys = p2pkKeys.filter { $0.id != storedKey.id }
+        var updatedLegacySecrets = stagedLegacySecrets
+        updatedLegacySecrets.removeValue(forKey: storedKey.id)
+        do {
+            try settingsStore.saveP2PKKeys(
+                updatedKeys,
+                preservingLegacySecrets: updatedLegacySecrets
+            )
+        } catch {
+            // The first metadata write still contains the complete row and its
+            // fallback secret. Restore Keychain when possible as an additional
+            // runtime recovery path, but never discard that durable fallback.
+            if let fallbackSecret, !fallbackSecret.isEmpty {
+                try? secureStorage.saveSecret(fallbackSecret, forKey: storageKey)
+            }
+            AppLogger.security.error(
+                "Failed to finalize P2PK key removal error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            throw SettingsFeatureError.keyRemovalFailed
+        }
+
+        pendingLegacyP2PKSecrets = updatedLegacySecrets
+        p2pkKeys = updatedKeys
     }
 
     func resetWalletScopedData(resetRuntimeServices: Bool = true) {
-        let keychain = KeychainService()
-
         for key in p2pkKeys {
-            try? keychain.deleteSecret(forKey: Self.secureP2PKPrivateKey(key.id))
+            try? secureStorage.deleteSecret(forKey: Self.secureP2PKPrivateKey(key.id))
         }
 
-        try? keychain.deleteNostrPrivateKey()
+        try? KeychainService().deleteNostrPrivateKey()
 
         showP2PKButtonInDrawer = false
+        pendingLegacyP2PKSecrets = [:]
         p2pkKeys = []
         nostrMintBackupEnabled = true
         let previousSuppression = suppressPaymentRequestSideEffects
@@ -281,15 +391,61 @@ class SettingsManager: ObservableObject {
         settingsStore.clearWalletScopedData()
     }
     
-    private static func loadP2PKKeys() -> [P2PKKey] {
-        let decoded = SettingsStore.shared.p2pkKeys
-        let keychain = KeychainService()
-        return decoded.map { key in
-            let privateKey = secureSecret(
-                key: secureP2PKPrivateKey(key.id),
-                legacyValue: key.privateKey,
-                keychain: keychain
-            )
+    private struct LoadedP2PKKeys {
+        let keys: [P2PKKey]
+        let pendingLegacySecrets: [UUID: String]
+        let encounteredLegacySecrets: Bool
+    }
+
+    private static func loadP2PKKeys(
+        settingsStore: SettingsStore,
+        secureStorage: SecureStorageProtocol
+    ) -> LoadedP2PKKeys {
+        let decoded = settingsStore.p2pkKeys
+        var pendingLegacySecrets: [UUID: String] = [:]
+        var encounteredLegacySecrets = false
+
+        let keys = decoded.map { key in
+            let storageKey = secureP2PKPrivateKey(key.id)
+            var privateKey = ""
+
+            do {
+                if let storedSecret = try secureStorage.loadSecret(forKey: storageKey),
+                   hasUsablePrivateKey(publicKey: key.publicKey, privateKey: storedSecret) {
+                    privateKey = storedSecret
+                }
+            } catch {
+                AppLogger.security.error(
+                    "Failed to load P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+            }
+
+            let legacySecret = key.privateKey
+            if !legacySecret.isEmpty {
+                encounteredLegacySecrets = true
+            }
+
+            if privateKey.isEmpty, !legacySecret.isEmpty {
+                if hasUsablePrivateKey(publicKey: key.publicKey, privateKey: legacySecret) {
+                    do {
+                        try secureStorage.saveSecret(legacySecret, forKey: storageKey)
+                        privateKey = legacySecret
+                    } catch {
+                        // Keep the legacy field in UserDefaults and the usable
+                        // value in memory. A later metadata write retries migration.
+                        privateKey = legacySecret
+                        pendingLegacySecrets[key.id] = legacySecret
+                        AppLogger.security.error(
+                            "Failed to migrate legacy P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                        )
+                    }
+                } else {
+                    // Preserve malformed legacy data verbatim for compatibility,
+                    // but never expose it as a signing key.
+                    pendingLegacySecrets[key.id] = legacySecret
+                }
+            }
+
             return P2PKKey(
                 id: key.id,
                 publicKey: key.publicKey,
@@ -299,24 +455,101 @@ class SettingsManager: ObservableObject {
                 nickname: key.nickname
             )
         }
+
+        return LoadedP2PKKeys(
+            keys: keys,
+            pendingLegacySecrets: pendingLegacySecrets,
+            encounteredLegacySecrets: encounteredLegacySecrets
+        )
     }
 
-    private func persistP2PKKeys() {
-        let keychain = KeychainService()
-        for key in p2pkKeys {
-            try? keychain.saveSecret(key.privateKey, forKey: Self.secureP2PKPrivateKey(key.id))
+    /// Store the secret before either durable metadata or observable state. If
+    /// metadata persistence fails, remove the newly-written secret so the caller
+    /// receives a failure instead of an unreachable half-created key.
+    private func storeP2PKKey(_ key: P2PKKey, replacing index: Int? = nil) throws {
+        guard Self.hasUsablePrivateKey(key) else {
+            throw SettingsFeatureError.invalidNsec
         }
-        settingsStore.p2pkKeys = p2pkKeys
+
+        let storageKey = Self.secureP2PKPrivateKey(key.id)
+        do {
+            try secureStorage.saveSecret(key.privateKey, forKey: storageKey)
+        } catch {
+            AppLogger.security.error(
+                "Failed to store P2PK private key error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            throw SettingsFeatureError.secureStorageUnavailable
+        }
+
+        var updatedKeys = p2pkKeys
+        let replacedPendingLegacySecret = pendingLegacyP2PKSecrets[key.id]
+        if let index {
+            updatedKeys[index] = key
+            pendingLegacyP2PKSecrets.removeValue(forKey: key.id)
+        } else {
+            updatedKeys.append(key)
+        }
+
+        migratePendingLegacyP2PKSecrets(using: updatedKeys)
+        do {
+            try settingsStore.saveP2PKKeys(
+                updatedKeys,
+                preservingLegacySecrets: pendingLegacyP2PKSecrets
+            )
+        } catch {
+            // Only a brand-new key needs rollback deletion. A repair reuses an
+            // existing metadata row and storage identifier, so deleting here
+            // could destroy a secret that predated this attempt (for example,
+            // after a transient Keychain read failure).
+            if index == nil {
+                try? secureStorage.deleteSecret(forKey: storageKey)
+            }
+            if let replacedPendingLegacySecret {
+                pendingLegacyP2PKSecrets[key.id] = replacedPendingLegacySecret
+            }
+            AppLogger.security.error(
+                "Failed to store P2PK metadata error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
+            throw SettingsFeatureError.settingsPersistenceUnavailable
+        }
+
+        p2pkKeys = updatedKeys
     }
 
-    private static func secureSecret(key: String, legacyValue: String, keychain: KeychainService) -> String {
-        if let secret = try? keychain.loadSecret(forKey: key) {
-            return secret
+    private func persistP2PKMetadata() {
+        migratePendingLegacyP2PKSecrets(using: p2pkKeys)
+        do {
+            try settingsStore.saveP2PKKeys(
+                p2pkKeys,
+                preservingLegacySecrets: pendingLegacyP2PKSecrets
+            )
+        } catch {
+            AppLogger.security.error(
+                "Failed to persist P2PK metadata error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+            )
         }
-        if !legacyValue.isEmpty {
-            try? keychain.saveSecret(legacyValue, forKey: key)
+    }
+
+    private func migratePendingLegacyP2PKSecrets(using keys: [P2PKKey]) {
+        var migratedIDs: [UUID] = []
+        for (id, legacySecret) in pendingLegacyP2PKSecrets {
+            guard let key = keys.first(where: { $0.id == id }),
+                  Self.hasUsablePrivateKey(publicKey: key.publicKey, privateKey: legacySecret) else {
+                continue
+            }
+            do {
+                try secureStorage.saveSecret(
+                    legacySecret,
+                    forKey: Self.secureP2PKPrivateKey(id)
+                )
+                migratedIDs.append(id)
+            } catch {
+                // Retain the legacy value in the next metadata write.
+            }
         }
-        return legacyValue
+        for id in migratedIDs {
+            pendingLegacyP2PKSecrets.removeValue(forKey: id)
+        }
     }
 
     private static func secureP2PKPrivateKey(_ id: UUID) -> String {
@@ -360,12 +593,39 @@ class SettingsManager: ObservableObject {
         return (privateKeyHex: privateKeyHex, publicKeyHex: publicKeyHex)
     }
 
-    private func normalizeP2PKPublicKeyForComparison(_ publicKey: String) -> String {
+    private static func hasUsablePrivateKey(_ key: P2PKKey) -> Bool {
+        hasUsablePrivateKey(publicKey: key.publicKey, privateKey: key.privateKey)
+    }
+
+    private static func hasUsablePrivateKey(publicKey: String, privateKey: String) -> Bool {
+        guard privateKey.count == 64 else { return false }
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(32)
+        var offset = privateKey.startIndex
+        for _ in 0..<32 {
+            let next = privateKey.index(offset, offsetBy: 2)
+            guard let byte = UInt8(privateKey[offset..<next], radix: 16) else { return false }
+            bytes.append(byte)
+            offset = next
+        }
+        guard let secret = try? P256K.Schnorr.PrivateKey(dataRepresentation: bytes) else {
+            return false
+        }
+        let derivedPublicKey = "02" + secret.xonly.bytes.map { String(format: "%02x", $0) }.joined()
+        return normalizeP2PKPublicKeyForComparison(derivedPublicKey)
+            == normalizeP2PKPublicKeyForComparison(publicKey)
+    }
+
+    private static func normalizeP2PKPublicKeyForComparison(_ publicKey: String) -> String {
         let normalized = publicKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if normalized.count == 66, normalized.hasPrefix("02") || normalized.hasPrefix("03") {
             return String(normalized.dropFirst(2))
         }
         return normalized
+    }
+
+    private func normalizeP2PKPublicKeyForComparison(_ publicKey: String) -> String {
+        Self.normalizeP2PKPublicKeyForComparison(publicKey)
     }
     
     // MARK: - Formatting Helpers
@@ -493,7 +753,10 @@ extension SettingsManager {
     func allP2PKSigningKeyHexes() -> [String] {
         var seen = Set<String>()
         var result: [String] = []
-        for hex in [primaryP2PKPrivateKeyHex].compactMap({ $0 }) + p2pkKeys.map({ $0.privateKey }) {
+        let storedKeys = p2pkKeys.compactMap { key in
+            Self.hasUsablePrivateKey(key) ? key.privateKey : nil
+        }
+        for hex in [primaryP2PKPrivateKeyHex].compactMap({ $0 }) + storedKeys {
             guard !hex.isEmpty, seen.insert(hex.lowercased()).inserted else { continue }
             result.append(hex)
         }
@@ -507,7 +770,10 @@ extension SettingsManager {
            normalizeP2PKPublicKeyForComparison(primary) == target {
             return true
         }
-        return p2pkKeys.contains { normalizeP2PKPublicKeyForComparison($0.publicKey) == target }
+        return p2pkKeys.contains {
+            Self.hasUsablePrivateKey($0)
+                && normalizeP2PKPublicKeyForComparison($0.publicKey) == target
+        }
     }
 
     /// Assign or clear a human label for a stored key.
@@ -515,6 +781,7 @@ extension SettingsManager {
         guard let index = p2pkKeys.firstIndex(where: { $0.id == id }) else { return }
         let trimmed = nickname?.trimmingCharacters(in: .whitespacesAndNewlines)
         p2pkKeys[index].nickname = (trimmed?.isEmpty == false) ? trimmed : nil
+        persistP2PKMetadata()
     }
 }
 
@@ -527,10 +794,13 @@ enum AmountDisplayPrimary: String, Codable {
     }
 }
 
-enum SettingsFeatureError: LocalizedError {
+enum SettingsFeatureError: LocalizedError, Equatable {
     case invalidNsec
     case duplicateP2PKKey
     case randomGenerationFailed
+    case secureStorageUnavailable
+    case settingsPersistenceUnavailable
+    case keyRemovalFailed
 
     var errorDescription: String? {
         switch self {
@@ -540,6 +810,12 @@ enum SettingsFeatureError: LocalizedError {
             return "Key already exists"
         case .randomGenerationFailed:
             return "Failed to generate secure key"
+        case .secureStorageUnavailable:
+            return "Couldn't store the private key securely. Unlock your device and try again."
+        case .settingsPersistenceUnavailable:
+            return "Couldn't save the key. Please try again."
+        case .keyRemovalFailed:
+            return "Couldn't remove the key safely. It is still available; please try again."
         }
     }
 }

--- a/ios/CashuWallet/Core/SettingsStore.swift
+++ b/ios/CashuWallet/Core/SettingsStore.swift
@@ -80,6 +80,21 @@ final class SettingsStore {
         try storage.set(records, forKey: StorageKeys.p2pkKeys)
     }
 
+    var p2pkPendingDeletionIDs: Set<UUID> {
+        Set(value(StorageKeys.p2pkPendingDeletionIDs) ?? [UUID]())
+    }
+
+    func saveP2PKPendingDeletionIDs(_ ids: Set<UUID>) throws {
+        if ids.isEmpty {
+            try storage.remove(forKey: StorageKeys.p2pkPendingDeletionIDs)
+        } else {
+            try storage.set(
+                ids.sorted { $0.uuidString < $1.uuidString },
+                forKey: StorageKeys.p2pkPendingDeletionIDs
+            )
+        }
+    }
+
     var checkIncomingInvoices: Bool {
         get { bool(StorageKeys.checkIncomingInvoices, legacy: StorageKeys.Legacy.checkIncomingInvoices, default: true) }
         set { set(newValue, forKey: StorageKeys.checkIncomingInvoices) }

--- a/ios/CashuWallet/Core/SettingsStore.swift
+++ b/ios/CashuWallet/Core/SettingsStore.swift
@@ -51,7 +51,33 @@ final class SettingsStore {
 
     var p2pkKeys: [P2PKKey] {
         get { value(StorageKeys.p2pkKeys, legacy: StorageKeys.Legacy.p2pkKeys) ?? [] }
-        set { set(newValue, forKey: StorageKeys.p2pkKeys) }
+        set {
+            do {
+                try saveP2PKKeys(newValue)
+            } catch {
+                AppLogger.wallet.error("Failed to save P2PK key metadata: \(error)")
+            }
+        }
+    }
+
+    /// Persist public P2PK metadata while retaining only legacy private keys that
+    /// could not yet be migrated to secure storage. Callers that need an atomic
+    /// secure-write → metadata-write flow use the throwing form directly.
+    func saveP2PKKeys(
+        _ keys: [P2PKKey],
+        preservingLegacySecrets legacySecrets: [UUID: String] = [:]
+    ) throws {
+        let records = keys.map { key in
+            P2PKSettingsRecord(
+                id: key.id,
+                publicKey: key.publicKey,
+                privateKey: legacySecrets[key.id],
+                used: key.used,
+                usedCount: key.usedCount,
+                nickname: key.nickname
+            )
+        }
+        try storage.set(records, forKey: StorageKeys.p2pkKeys)
     }
 
     var checkIncomingInvoices: Bool {
@@ -283,4 +309,16 @@ final class SettingsStore {
             }
         }
     }
+}
+
+/// Storage-only representation. New secrets are omitted; a private key is
+/// encoded solely while a legacy migration is pending, preventing a failed
+/// Keychain write from destroying the user's only copy.
+private struct P2PKSettingsRecord: Codable {
+    let id: UUID
+    let publicKey: String
+    let privateKey: String?
+    let used: Bool
+    let usedCount: Int
+    let nickname: String?
 }

--- a/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
@@ -426,8 +426,10 @@ private struct AdvancedKeysView: View {
     private func generateKey() {
         actionError = nil
         HapticFeedback.selection()
-        if !settings.generateP2PKKey() {
-            actionError = "Couldn't generate a key. Please try again."
+        do {
+            try settings.generateP2PKKey()
+        } catch {
+            actionError = error.localizedDescription
         }
     }
 
@@ -458,6 +460,7 @@ private struct DeviceKeyDetailView: View {
     @State private var privateKeyReveal: PrivateKeyReveal?
     @State private var nameText = ""
     @State private var showRemoveConfirm = false
+    @State private var actionError: String?
 
     private var key: P2PKKey? { settings.p2pkKeys.first { $0.id == keyId } }
 
@@ -490,7 +493,10 @@ private struct DeviceKeyDetailView: View {
                     }
 
                     SettingsSectionGroup(nil) {
-                        Button(role: .destructive, action: { showRemoveConfirm = true }) {
+                        Button(role: .destructive, action: {
+                            actionError = nil
+                            showRemoveConfirm = true
+                        }) {
                             HStack(spacing: 14) {
                                 SettingsRowIcon(systemName: "trash", tint: .red)
                                 Text("Remove Key")
@@ -507,6 +513,13 @@ private struct DeviceKeyDetailView: View {
                     SettingsSectionFooter {
                         Text("Ecash locked to this key can only be claimed with it. Removing it can't be undone — back it up first if you might still receive to it.")
                     }
+
+                    if let actionError {
+                        InlineNotice(message: actionError, severity: .error)
+                            .padding(.horizontal, 6)
+                            .padding(.top, 4)
+                            .transition(.opacity)
+                    }
                 }
                 .padding(.horizontal)
                 .padding(.bottom, 32)
@@ -518,6 +531,7 @@ private struct DeviceKeyDetailView: View {
         .onAppear { nameText = key?.nickname ?? "" }
         .onDisappear { saveName() }
         .onChange(of: key == nil) { _, removed in if removed { dismiss() } }
+        .animation(.easeInOut(duration: 0.2), value: actionError)
         .backdropSheet(item: $activeQR) { payload in
             QRCodeDetailSheet(title: payload.title, content: payload.content)
         }
@@ -526,7 +540,13 @@ private struct DeviceKeyDetailView: View {
         }
         .alert("Remove this key?", isPresented: $showRemoveConfirm) {
             Button("Remove Key", role: .destructive) {
-                if let key { settings.removeP2PKKey(key) }
+                guard let key else { return }
+                actionError = nil
+                do {
+                    try settings.removeP2PKKey(key)
+                } catch {
+                    actionError = error.localizedDescription
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/P2PKSettingsSection.swift
@@ -206,6 +206,7 @@ struct KeyCard: View {
         case seedBacked     // recoverable from the seed phrase
         case custom         // a custom key the user must back up themselves
         case deviceOnly     // a random device-only key, not in the seed backup
+        case repairRequired // metadata exists but the matching secret is unavailable
 
         /// nil renders no status line — a custom key's backup burden is carried
         /// by the import confirmation, not a permanent orange badge on the card.
@@ -214,18 +215,20 @@ struct KeyCard: View {
             case .seedBacked: return "Backed up by your seed phrase"
             case .custom:     return nil
             case .deviceOnly: return "On this device only — not in your seed backup"
+            case .repairRequired: return "Repair required before this key can be used"
             }
         }
         var systemImage: String {
             switch self {
             case .seedBacked: return "checkmark.seal.fill"
-            case .custom, .deviceOnly: return "exclamationmark.triangle.fill"
+            case .custom, .deviceOnly, .repairRequired: return "exclamationmark.triangle.fill"
             }
         }
         var tint: Color {
             switch self {
             case .seedBacked: return .secondary
             case .custom, .deviceOnly: return .orange
+            case .repairRequired: return .red
             }
         }
     }
@@ -242,6 +245,7 @@ struct KeyCard: View {
     let status: Status
     let onCopy: () -> Void
     let actions: [Action]
+    var isCopyEnabled = true
     /// Overrides the displayed short value. The Nostr hub passes a pre-truncated
     /// npub so a bech32 key isn't routed through the P2PK compressed-hex formatter.
     var displayLabel: String? = nil
@@ -285,7 +289,12 @@ struct KeyCard: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Copy this key")
+            .disabled(!isCopyEnabled)
+            .accessibilityLabel(
+                isCopyEnabled
+                    ? "Copy this key"
+                    : "Key unavailable. Import its private key to repair it."
+            )
 
             if !actions.isEmpty {
                 HStack(spacing: 0) {
@@ -321,7 +330,6 @@ private struct AdvancedKeysView: View {
     @ObservedObject private var settings = SettingsManager.shared
 
     @State private var showImport = false
-    @State private var importText = ""
     @State private var actionError: String?
 
     var body: some View {
@@ -333,7 +341,7 @@ private struct AdvancedKeysView: View {
                     }
                     .buttonStyle(.plain)
 
-                    Button(action: { actionError = nil; importText = ""; showImport = true }) {
+                    Button(action: { actionError = nil; showImport = true }) {
                         actionRow("Import a key", systemImage: "square.and.arrow.down")
                     }
                     .buttonStyle(.plain)
@@ -370,7 +378,9 @@ private struct AdvancedKeysView: View {
         .animation(.easeInOut(duration: 0.2), value: settings.p2pkKeys)
         .animation(.easeInOut(duration: 0.2), value: actionError)
         .backdropSheet(isPresented: $showImport) {
-            ImportP2PKSheet(nsecText: $importText) { importKey() }
+            ImportP2PKSheet { nsec in
+                try settings.importP2PKNsec(nsec)
+            }
         }
         .bottomSheetBackdropHost()
     }
@@ -389,7 +399,8 @@ private struct AdvancedKeysView: View {
     }
 
     private func keyRow(_ key: P2PKKey) -> some View {
-        NavigationLink {
+        let isUsable = settings.isP2PKKeyUsable(key.id)
+        return NavigationLink {
             DeviceKeyDetailView(keyId: key.id)
         } label: {
             HStack(spacing: 14) {
@@ -401,8 +412,8 @@ private struct AdvancedKeysView: View {
                         .lineLimit(1)
                         .truncationMode(.middle)
                     HStack(spacing: 6) {
-                        Text("Device only")
-                        if key.usedCount > 0 {
+                        Text(isUsable ? "Device only" : "Repair required")
+                        if isUsable, key.usedCount > 0 {
                             Text("·")
                             Text(key.usedCount == 1 ? "Used once" : "Used \(key.usedCount) times")
                         }
@@ -433,16 +444,6 @@ private struct AdvancedKeysView: View {
         }
     }
 
-    private func importKey() {
-        actionError = nil
-        do {
-            try settings.importP2PKNsec(importText)
-            importText = ""
-            showImport = false
-        } catch {
-            actionError = error.localizedDescription
-        }
-    }
 }
 
 // MARK: - Device key detail
@@ -460,9 +461,11 @@ private struct DeviceKeyDetailView: View {
     @State private var privateKeyReveal: PrivateKeyReveal?
     @State private var nameText = ""
     @State private var showRemoveConfirm = false
+    @State private var showRepair = false
     @State private var actionError: String?
 
     private var key: P2PKKey? { settings.p2pkKeys.first { $0.id == keyId } }
+    private var isUsable: Bool { settings.isP2PKKeyUsable(keyId) }
 
     var body: some View {
         ScrollView {
@@ -471,16 +474,32 @@ private struct DeviceKeyDetailView: View {
                     KeyCard(
                         title: key.nickname?.isEmpty == false ? key.nickname! : "Device key",
                         pubkey: key.publicKey,
-                        status: .deviceOnly,
+                        status: isUsable ? .deviceOnly : .repairRequired,
                         onCopy: { copy(P2PKKeyDisplay.canonical(forPubkey: key.publicKey), label: key.publicKey) },
-                        actions: [
-                            .init(title: "Show QR", systemImage: "qrcode") {
-                                activeQR = QRPayload(title: "Key", content: P2PKKeyDisplay.canonical(forPubkey: key.publicKey))
-                            },
-                            .init(title: "Back up key", systemImage: "key") { backUp(key) },
-                        ]
+                        actions: isUsable
+                            ? [
+                                .init(title: "Show QR", systemImage: "qrcode") {
+                                    activeQR = QRPayload(title: "Key", content: P2PKKeyDisplay.canonical(forPubkey: key.publicKey))
+                                },
+                                .init(title: "Back up key", systemImage: "key") { backUp(key) },
+                            ]
+                            : [
+                                .init(title: "Repair key", systemImage: "square.and.arrow.down") {
+                                    showRepair = true
+                                },
+                            ],
+                        isCopyEnabled: isUsable
                     )
                     .padding(.top, 8)
+
+                    if !isUsable {
+                        InlineNotice(
+                            message: "This key's private key is unavailable. Import its nsec to repair it before sharing or receiving locked ecash.",
+                            severity: .error
+                        )
+                        .padding(.horizontal, 6)
+                        .padding(.top, 12)
+                    }
 
                     SettingsSectionGroup("Name") {
                         TextField("Add a name", text: $nameText)
@@ -537,6 +556,11 @@ private struct DeviceKeyDetailView: View {
         }
         .backdropSheet(item: $privateKeyReveal) { reveal in
             PrivateKeyRevealSheet(title: reveal.title, nsec: reveal.nsec)
+        }
+        .backdropSheet(isPresented: $showRepair) {
+            ImportP2PKSheet { nsec in
+                try settings.importP2PKNsec(nsec)
+            }
         }
         .alert("Remove this key?", isPresented: $showRemoveConfirm) {
             Button("Remove Key", role: .destructive) {

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -1301,10 +1301,10 @@ struct QRCodeDetailSheet: View {
 // MARK: - Import P2PK Sheet
 
 struct ImportP2PKSheet: View {
-    @Binding var nsecText: String
-    let onImport: () -> Void
+    let onImport: (String) throws -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @State private var nsecText = ""
     @State private var validationError: String?
 
     private var trimmed: String {
@@ -1353,7 +1353,7 @@ struct ImportP2PKSheet: View {
 
                 Spacer(minLength: 0)
 
-                Button(action: { if validate() { onImport() } }) {
+                Button(action: importKey) {
                     Text("Import key")
                 }
                 .glassButton()
@@ -1385,6 +1385,16 @@ struct ImportP2PKSheet: View {
         HapticFeedback.selection()
         nsecText = ""
         validationError = nil
+    }
+
+    private func importKey() {
+        guard validate() else { return }
+        do {
+            try onImport(trimmed)
+            dismiss()
+        } catch {
+            validationError = error.localizedDescription
+        }
     }
 
     private func validate() -> Bool {

--- a/ios/CashuWalletTests/TokenServiceTests.swift
+++ b/ios/CashuWalletTests/TokenServiceTests.swift
@@ -221,6 +221,373 @@ final class TokenServiceTests: XCTestCase {
 }
 
 @MainActor
+final class SettingsManagerP2PKStorageTests: XCTestCase {
+    private let privateKeyHex = String(repeating: "0", count: 63) + "1"
+    private let publicKeyHex = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+    func testGenerateDoesNotPublishMetadataWhenSecureWriteFails() {
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        secureStorage.failSaves = true
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        XCTAssertThrowsError(try manager.generateP2PKKey()) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .secureStorageUnavailable)
+        }
+        XCTAssertTrue(manager.p2pkKeys.isEmpty)
+        XCTAssertTrue(settingsStore.p2pkKeys.isEmpty)
+        XCTAssertTrue(secureStorage.secrets.isEmpty)
+    }
+
+    func testImportWritesSecureSecretBeforePublishingSanitizedMetadata() throws {
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        XCTAssertEqual(key.privateKey, privateKeyHex)
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testMetadataWriteFailureRollsBackNewSecureSecretAndPublishedState() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        storage.failP2PKWrites = true
+
+        XCTAssertThrowsError(try manager.importP2PKNsec(nsecForPrivateKeyOne())) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .settingsPersistenceUnavailable)
+        }
+        XCTAssertTrue(manager.p2pkKeys.isEmpty)
+        XCTAssertTrue(secureStorage.secrets.isEmpty)
+        XCTAssertTrue(settingsStore.p2pkKeys.isEmpty)
+    }
+
+    func testFailedMetadataRepairDoesNotDeleteExistingSecureSecret() throws {
+        let id = UUID()
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        try settingsStore.saveP2PKKeys([
+            P2PKKey(
+                id: id,
+                publicKey: publicKeyHex,
+                privateKey: "",
+                used: false,
+                usedCount: 0
+            )
+        ])
+        let secureStorage = P2PKTestSecureStorage()
+        let storageKey = secureStorageKey(for: id)
+        try secureStorage.saveSecret(privateKeyHex, forKey: storageKey)
+        secureStorage.failLoads = true
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        storage.failP2PKWrites = true
+
+        XCTAssertThrowsError(try manager.importP2PKNsec(nsecForPrivateKeyOne())) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .settingsPersistenceUnavailable)
+        }
+        XCTAssertEqual(secureStorage.secrets[storageKey], privateKeyHex)
+        XCTAssertFalse(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testFailedLegacyMigrationPreservesOnlyCopyAcrossMetadataUpdates() throws {
+        let id = UUID()
+        let storage = InMemoryStorage()
+        try storage.set(
+            [legacyRecord(id: id, privateKey: privateKeyHex)],
+            forKey: StorageKeys.p2pkKeys
+        )
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        secureStorage.failSaves = true
+
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        XCTAssertEqual(manager.p2pkKeys.first?.privateKey, privateKeyHex)
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, privateKeyHex)
+
+        manager.setP2PKKeyNickname("Legacy", for: id)
+
+        let persisted = try XCTUnwrap(settingsStore.p2pkKeys.first)
+        XCTAssertEqual(persisted.nickname, "Legacy")
+        XCTAssertEqual(persisted.privateKey, privateKeyHex)
+    }
+
+    func testSuccessfulLegacyMigrationMovesSecretAndScrubsMetadata() throws {
+        let id = UUID()
+        let storage = InMemoryStorage()
+        try storage.set(
+            [legacyRecord(id: id, privateKey: privateKeyHex)],
+            forKey: StorageKeys.p2pkKeys
+        )
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        XCTAssertEqual(secureStorage.secrets[secureStorageKey(for: id)], privateKeyHex)
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testKnownKeyCheckRejectsMetadataWithoutUsableSecret() throws {
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        try settingsStore.saveP2PKKeys([
+            P2PKKey(
+                publicKey: publicKeyHex,
+                privateKey: "",
+                used: false,
+                usedCount: 0
+            )
+        ])
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: P2PKTestSecureStorage()
+        )
+
+        XCTAssertFalse(manager.isKnownP2PKPublicKey(publicKeyHex))
+        XCTAssertFalse(manager.allP2PKSigningKeyHexes().contains(privateKeyHex))
+    }
+
+    func testImportRepairsMatchingMetadataOnlyKeyWithoutDuplicatingIt() throws {
+        let id = UUID()
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        try settingsStore.saveP2PKKeys([
+            P2PKKey(
+                id: id,
+                publicKey: publicKeyHex,
+                privateKey: "",
+                used: true,
+                usedCount: 2,
+                nickname: "Recovered"
+            )
+        ])
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        XCTAssertFalse(manager.isKnownP2PKPublicKey(publicKeyHex))
+
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+
+        XCTAssertEqual(manager.p2pkKeys.count, 1)
+        let repaired = try XCTUnwrap(manager.p2pkKeys.first)
+        XCTAssertEqual(repaired.id, id)
+        XCTAssertEqual(repaired.usedCount, 2)
+        XCTAssertEqual(repaired.nickname, "Recovered")
+        XCTAssertEqual(secureStorage.secrets[secureStorageKey(for: id)], privateKeyHex)
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testRemovalFirstMetadataWriteFailureKeepsPublishedAndSecureKey() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        storage.failP2PKWriteNumbers = [2]
+
+        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
+        }
+
+        XCTAssertEqual(manager.p2pkKeys, [key])
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testRemovalSecureDeleteFailureKeepsDurableFallbackAndPublishedKey() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        secureStorage.failDeletes = true
+
+        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
+        }
+
+        XCTAssertEqual(manager.p2pkKeys, [key])
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, privateKeyHex)
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testRemovalFinalMetadataWriteFailureRestoresRecoverableKey() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        storage.failP2PKWriteNumbers = [3]
+
+        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
+        }
+
+        XCTAssertEqual(manager.p2pkKeys, [key])
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, privateKeyHex)
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+
+        let reloaded = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        XCTAssertTrue(reloaded.isKnownP2PKPublicKey(publicKeyHex))
+        XCTAssertEqual(reloaded.p2pkKeys.first?.privateKey, privateKeyHex)
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+    }
+
+    private func nsecForPrivateKeyOne() throws -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        bytes[31] = 1
+        return try Bech32.encode(hrp: "nsec", data: Data(bytes))
+    }
+
+    private func secureStorageKey(for id: UUID) -> String {
+        "settings.p2pk.\(id.uuidString).privateKey"
+    }
+
+    private func legacyRecord(id: UUID, privateKey: String) -> P2PKLegacyTestRecord {
+        P2PKLegacyTestRecord(
+            id: id,
+            publicKey: publicKeyHex,
+            privateKey: privateKey,
+            used: false,
+            usedCount: 0,
+            nickname: nil
+        )
+    }
+}
+
+private enum P2PKTestFailure: Error {
+    case expected
+}
+
+private final class P2PKTestSecureStorage: SecureStorageProtocol {
+    private(set) var secrets: [String: String] = [:]
+    var failLoads = false
+    var failSaves = false
+    var failDeletes = false
+
+    func saveSecret(_ secret: String, forKey key: String) throws {
+        if failSaves { throw P2PKTestFailure.expected }
+        secrets[key] = secret
+    }
+
+    func loadSecret(forKey key: String) throws -> String? {
+        if failLoads { throw P2PKTestFailure.expected }
+        return secrets[key]
+    }
+
+    func deleteSecret(forKey key: String) throws {
+        if failDeletes { throw P2PKTestFailure.expected }
+        secrets.removeValue(forKey: key)
+    }
+
+    func hasSecret(forKey key: String) -> Bool {
+        secrets[key] != nil
+    }
+}
+
+private final class P2PKFailingStorage: StorageProtocol {
+    private let backing = InMemoryStorage()
+    var failP2PKWrites = false
+    var failP2PKWriteNumbers: Set<Int> = []
+    private(set) var p2pkWriteCount = 0
+
+    func set<T: Codable>(_ value: T, forKey key: String) throws {
+        if key == StorageKeys.p2pkKeys {
+            p2pkWriteCount += 1
+            if failP2PKWrites || failP2PKWriteNumbers.contains(p2pkWriteCount) {
+                throw P2PKTestFailure.expected
+            }
+        }
+        try backing.set(value, forKey: key)
+    }
+
+    func get<T: Codable>(forKey key: String) throws -> T? {
+        try backing.get(forKey: key)
+    }
+
+    func remove(forKey key: String) throws {
+        try backing.remove(forKey: key)
+    }
+
+    func exists(forKey key: String) -> Bool {
+        backing.exists(forKey: key)
+    }
+
+    func keys(withPrefix prefix: String) -> [String] {
+        backing.keys(withPrefix: prefix)
+    }
+}
+
+private struct P2PKLegacyTestRecord: Codable {
+    let id: UUID
+    let publicKey: String
+    let privateKey: String
+    let used: Bool
+    let usedCount: Int
+    let nickname: String?
+}
+
+@MainActor
 final class WalletOperationCoordinatorTests: XCTestCase {
     private enum TestFailure: Error { case expected }
 

--- a/ios/CashuWalletTests/TokenServiceTests.swift
+++ b/ios/CashuWalletTests/TokenServiceTests.swift
@@ -411,7 +411,64 @@ final class SettingsManagerP2PKStorageTests: XCTestCase {
         XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
     }
 
-    func testRemovalFirstMetadataWriteFailureKeepsPublishedAndSecureKey() throws {
+    func testRemovalJournalWriteFailureKeepsPublishedAndSecureKey() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        storage.failP2PKJournalWrites = true
+
+        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
+        }
+
+        XCTAssertEqual(manager.p2pkKeys, [key])
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+        XCTAssertTrue(settingsStore.p2pkPendingDeletionIDs.isEmpty)
+        XCTAssertNil(secureStorage.secrets[secureRemovalFallbackKey(for: key.id)])
+    }
+
+    func testRemovalSecureDeleteFailureKeepsDurableFallbackAndPublishedKey() throws {
+        let storage = P2PKFailingStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        let secureStorage = P2PKTestSecureStorage()
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+        try manager.importP2PKNsec(nsecForPrivateKeyOne())
+        let key = try XCTUnwrap(manager.p2pkKeys.first)
+        secureStorage.failDeletes = true
+
+        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
+            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
+        }
+
+        XCTAssertEqual(manager.p2pkKeys, [key])
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+        XCTAssertEqual(
+            secureStorage.secrets[secureStorageKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertEqual(
+            secureStorage.secrets[secureRemovalFallbackKey(for: key.id)],
+            privateKeyHex
+        )
+        XCTAssertEqual(settingsStore.p2pkPendingDeletionIDs, [key.id])
+        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
+    }
+
+    func testRemovalFinalMetadataWriteFailureRestoresRecoverableKey() throws {
         let storage = P2PKFailingStorage()
         let settingsStore = SettingsStore(storage: storage)
         let secureStorage = P2PKTestSecureStorage()
@@ -433,56 +490,8 @@ final class SettingsManagerP2PKStorageTests: XCTestCase {
             secureStorage.secrets[secureStorageKey(for: key.id)],
             privateKeyHex
         )
-        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
-    }
-
-    func testRemovalSecureDeleteFailureKeepsDurableFallbackAndPublishedKey() throws {
-        let storage = P2PKFailingStorage()
-        let settingsStore = SettingsStore(storage: storage)
-        let secureStorage = P2PKTestSecureStorage()
-        let manager = SettingsManager(
-            settingsStore: settingsStore,
-            secureStorage: secureStorage
-        )
-        try manager.importP2PKNsec(nsecForPrivateKeyOne())
-        let key = try XCTUnwrap(manager.p2pkKeys.first)
-        secureStorage.failDeletes = true
-
-        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
-            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
-        }
-
-        XCTAssertEqual(manager.p2pkKeys, [key])
-        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, privateKeyHex)
-        XCTAssertEqual(
-            secureStorage.secrets[secureStorageKey(for: key.id)],
-            privateKeyHex
-        )
-        XCTAssertTrue(manager.isKnownP2PKPublicKey(publicKeyHex))
-    }
-
-    func testRemovalFinalMetadataWriteFailureRestoresRecoverableKey() throws {
-        let storage = P2PKFailingStorage()
-        let settingsStore = SettingsStore(storage: storage)
-        let secureStorage = P2PKTestSecureStorage()
-        let manager = SettingsManager(
-            settingsStore: settingsStore,
-            secureStorage: secureStorage
-        )
-        try manager.importP2PKNsec(nsecForPrivateKeyOne())
-        let key = try XCTUnwrap(manager.p2pkKeys.first)
-        storage.failP2PKWriteNumbers = [3]
-
-        XCTAssertThrowsError(try manager.removeP2PKKey(key)) { error in
-            XCTAssertEqual(error as? SettingsFeatureError, .keyRemovalFailed)
-        }
-
-        XCTAssertEqual(manager.p2pkKeys, [key])
-        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, privateKeyHex)
-        XCTAssertEqual(
-            secureStorage.secrets[secureStorageKey(for: key.id)],
-            privateKeyHex
-        )
+        XCTAssertNil(secureStorage.secrets[secureRemovalFallbackKey(for: key.id)])
+        XCTAssertTrue(settingsStore.p2pkPendingDeletionIDs.isEmpty)
 
         let reloaded = SettingsManager(
             settingsStore: settingsStore,
@@ -493,6 +502,53 @@ final class SettingsManagerP2PKStorageTests: XCTestCase {
         XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
     }
 
+    func testInterruptedRemovalRecoveryRestoresSecureSecretWithoutUsingMetadata() throws {
+        let id = UUID()
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        try settingsStore.saveP2PKKeys([
+            P2PKKey(
+                id: id,
+                publicKey: publicKeyHex,
+                privateKey: "",
+                used: false,
+                usedCount: 0
+            )
+        ])
+        try settingsStore.saveP2PKPendingDeletionIDs([id])
+        let secureStorage = P2PKTestSecureStorage()
+        try secureStorage.saveSecret(privateKeyHex, forKey: secureRemovalFallbackKey(for: id))
+
+        let manager = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        XCTAssertEqual(secureStorage.secrets[secureStorageKey(for: id)], privateKeyHex)
+        XCTAssertNil(secureStorage.secrets[secureRemovalFallbackKey(for: id)])
+        XCTAssertTrue(settingsStore.p2pkPendingDeletionIDs.isEmpty)
+        XCTAssertTrue(manager.isP2PKKeyUsable(id))
+        XCTAssertEqual(settingsStore.p2pkKeys.first?.privateKey, "")
+    }
+
+    func testInterruptedCommittedRemovalRecoveryDeletesSecureFallback() throws {
+        let id = UUID()
+        let storage = InMemoryStorage()
+        let settingsStore = SettingsStore(storage: storage)
+        try settingsStore.saveP2PKPendingDeletionIDs([id])
+        let secureStorage = P2PKTestSecureStorage()
+        try secureStorage.saveSecret(privateKeyHex, forKey: secureRemovalFallbackKey(for: id))
+
+        _ = SettingsManager(
+            settingsStore: settingsStore,
+            secureStorage: secureStorage
+        )
+
+        XCTAssertTrue(secureStorage.secrets.isEmpty)
+        XCTAssertTrue(settingsStore.p2pkPendingDeletionIDs.isEmpty)
+        XCTAssertTrue(settingsStore.p2pkKeys.isEmpty)
+    }
+
     private func nsecForPrivateKeyOne() throws -> String {
         var bytes = [UInt8](repeating: 0, count: 32)
         bytes[31] = 1
@@ -501,6 +557,10 @@ final class SettingsManagerP2PKStorageTests: XCTestCase {
 
     private func secureStorageKey(for id: UUID) -> String {
         "settings.p2pk.\(id.uuidString).privateKey"
+    }
+
+    private func secureRemovalFallbackKey(for id: UUID) -> String {
+        "\(secureStorageKey(for: id)).removalFallback"
     }
 
     private func legacyRecord(id: UUID, privateKey: String) -> P2PKLegacyTestRecord {
@@ -549,9 +609,13 @@ private final class P2PKFailingStorage: StorageProtocol {
     private let backing = InMemoryStorage()
     var failP2PKWrites = false
     var failP2PKWriteNumbers: Set<Int> = []
+    var failP2PKJournalWrites = false
     private(set) var p2pkWriteCount = 0
 
     func set<T: Codable>(_ value: T, forKey key: String) throws {
+        if key == StorageKeys.p2pkPendingDeletionIDs, failP2PKJournalWrites {
+            throw P2PKTestFailure.expected
+        }
         if key == StorageKeys.p2pkKeys {
             p2pkWriteCount += 1
             if failP2PKWrites || failP2PKWriteNumbers.contains(p2pkWriteCount) {


### PR DESCRIPTION
## Summary

- Make P2PK key creation, import, migration, and removal transactional on both iOS and Android.
- Keep removal rollback material in Keychain/Android secure storage; regular settings contain only a non-secret recovery journal.
- Recover interrupted removals at launch and preserve the last usable private-key copy when persistence fails.
- Treat metadata-only keys as repair-required: disable copy/QR/backup until the matching nsec is imported.
- Keep import and removal errors visible in their active UI instead of dismissing or hiding them.

## Why

This is a security and data-integrity fix, not a feature enhancement. Partial secure-storage or metadata failures could otherwise expose a private key in regular settings, publish an unusable identity, or lose the last recoverable copy. The behavior and UX now have iOS/Android parity.

## Testing

- iOS `SettingsManagerP2PKStorageTests`: 13 tests passed.
- Android full debug unit test suite passed.
- Android P2PK managed-device transaction suite: 6 tests passed on API 35.
- Android `lintDebug` and `assembleDebug` passed.
