### PR TITLE
fix: make wallet replacement rollback transactional

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
@@ -1,7 +1,9 @@
 package com.cashu.me.Core.Platform
 
 import android.content.Context
+import com.cashu.me.Core.AppLogger
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 
 class WalletDatabasePathManager(context: Context) {
@@ -17,7 +19,11 @@ class WalletDatabasePathManager(context: Context) {
 
     fun backupWalletDatabaseFiles(): List<WalletFileBackup> = files.backupWalletDatabaseFiles()
 
-    fun restoreWalletFileBackups(backups: List<WalletFileBackup>) = files.restoreWalletFileBackups(backups)
+    fun restoreWalletFileBackups(
+        backups: List<WalletFileBackup>,
+        beforeCommit: () -> Unit = {},
+        onRollback: () -> Unit = {},
+    ) = files.restoreWalletFileBackups(backups, beforeCommit, onRollback)
 
     fun removeWalletFileBackups(backups: List<WalletFileBackup>) = files.removeWalletFileBackups(backups)
 
@@ -26,15 +32,233 @@ class WalletDatabasePathManager(context: Context) {
     fun backupCorruptedDatabase(): File? = files.backupCorruptedDatabase()
 }
 
+internal class WalletReplacementFileOperations(
+    val exists: (File) -> Boolean,
+    val moveItem: (File, File) -> Unit,
+    val removeItem: (File) -> Unit,
+) {
+    companion object {
+        val live = WalletReplacementFileOperations(
+            exists = File::exists,
+            moveItem = { source, destination ->
+                if (!source.renameTo(destination)) {
+                    throw IOException("Failed to move a wallet boundary item.")
+                }
+            },
+            removeItem = { file ->
+                if (file.exists() && !file.deleteRecursively()) {
+                    throw IOException("Failed to remove a wallet boundary item.")
+                }
+            },
+        )
+    }
+}
+
+internal object WalletReplacementFiles {
+    private data class StagedReplacement(
+        val original: File,
+        val displaced: File,
+    )
+
+    fun backup(
+        files: List<File>,
+        operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
+        backupFile: (File) -> File,
+    ): List<WalletFileBackup> {
+        val backups = mutableListOf<WalletFileBackup>()
+
+        try {
+            files.filter(operations.exists).forEach { original ->
+                val candidate = backupFile(original)
+                if (operations.exists(candidate)) operations.removeItem(candidate)
+
+                val backup = WalletFileBackup(original, candidate)
+                try {
+                    operations.moveItem(original, candidate)
+                    backups += backup
+                } catch (error: Throwable) {
+                    // Track an item that reached its destination before the
+                    // move reported failure so it participates in rollback.
+                    if (operations.exists(candidate)) backups += backup
+                    throw error
+                }
+            }
+        } catch (error: Throwable) {
+            backups.asReversed()
+                .filter { operations.exists(it.backup) }
+                .forEach { backup ->
+                    try {
+                        if (operations.exists(backup.original)) operations.removeItem(backup.original)
+                        operations.moveItem(backup.backup, backup.original)
+                    } catch (rollbackError: Throwable) {
+                        error.addSuppressed(rollbackError)
+                    }
+                }
+            throw error
+        }
+
+        return backups
+    }
+
+    fun restore(
+        files: List<File>,
+        backups: List<WalletFileBackup>,
+        operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
+        displacedFile: (File) -> File,
+        beforeCommit: () -> Unit = {},
+        onRollback: () -> Unit = {},
+    ) {
+        val missingBackupError = backups
+            .firstOrNull { !operations.exists(it.backup) }
+            ?.let { IOException("A wallet database backup is missing.") }
+        if (missingBackupError != null) {
+            performExternalRollback(missingBackupError, onRollback)
+            throw missingBackupError
+        }
+
+        val restorationFiles = (files + backups.map(WalletFileBackup::original))
+            .distinctBy(File::getAbsolutePath)
+        val stagedReplacements = mutableListOf<StagedReplacement>()
+
+        try {
+            restorationFiles.filter(operations.exists).forEach { original ->
+                val displaced = displacedFile(original)
+                if (operations.exists(displaced)) operations.removeItem(displaced)
+
+                val replacement = StagedReplacement(original, displaced)
+                try {
+                    operations.moveItem(original, displaced)
+                    stagedReplacements += replacement
+                } catch (error: Throwable) {
+                    if (operations.exists(displaced)) stagedReplacements += replacement
+                    throw error
+                }
+            }
+        } catch (error: Throwable) {
+            restoreStagedReplacements(stagedReplacements, operations, error)
+            performExternalRollback(error, onRollback)
+            throw error
+        }
+
+        val restoredBackups = mutableListOf<WalletFileBackup>()
+        try {
+            backups.asReversed().forEach { backup ->
+                try {
+                    operations.moveItem(backup.backup, backup.original)
+                    restoredBackups += backup
+                } catch (error: Throwable) {
+                    if (operations.exists(backup.original)) restoredBackups += backup
+                    throw error
+                }
+            }
+
+            // Keep the replacement files recoverable until the previous seed
+            // has committed. A seed failure therefore rolls the files forward.
+            beforeCommit()
+        } catch (error: Throwable) {
+            rollBackRestoredBackups(restoredBackups, operations, error)
+            restoreStagedReplacements(stagedReplacements, operations, error)
+            performExternalRollback(error, onRollback)
+            throw error
+        }
+
+        stagedReplacements
+            .filter { operations.exists(it.displaced) }
+            .forEach { replacement ->
+                try {
+                    operations.removeItem(replacement.displaced)
+                } catch (error: Throwable) {
+                    // The previous seed/database pair has committed. Cleanup
+                    // failure must not trigger an unsafe rollback.
+                    AppLogger.wallet.error("Failed to remove a displaced replacement database", error)
+                }
+            }
+    }
+
+    fun removeBackups(
+        backups: List<WalletFileBackup>,
+        operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
+    ) {
+        backups.filter { operations.exists(it.backup) }
+            .forEach { operations.removeItem(it.backup) }
+    }
+
+    fun removeAll(
+        files: List<File>,
+        operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
+    ) {
+        files.filter(operations.exists).forEach(operations.removeItem)
+    }
+
+    private fun rollBackRestoredBackups(
+        backups: List<WalletFileBackup>,
+        operations: WalletReplacementFileOperations,
+        originalError: Throwable,
+    ) {
+        backups.asReversed()
+            .filter { operations.exists(it.original) }
+            .forEach { backup ->
+                try {
+                    if (operations.exists(backup.backup)) {
+                        operations.removeItem(backup.original)
+                    } else {
+                        operations.moveItem(backup.original, backup.backup)
+                    }
+                } catch (rollbackError: Throwable) {
+                    originalError.addSuppressed(rollbackError)
+                }
+            }
+    }
+
+    private fun restoreStagedReplacements(
+        replacements: List<StagedReplacement>,
+        operations: WalletReplacementFileOperations,
+        originalError: Throwable,
+    ) {
+        replacements.asReversed()
+            .filter { operations.exists(it.displaced) }
+            .forEach { replacement ->
+                try {
+                    if (operations.exists(replacement.original)) {
+                        operations.removeItem(replacement.displaced)
+                    } else {
+                        operations.moveItem(replacement.displaced, replacement.original)
+                    }
+                } catch (rollbackError: Throwable) {
+                    originalError.addSuppressed(rollbackError)
+                }
+            }
+    }
+
+    private fun performExternalRollback(
+        originalError: Throwable,
+        onRollback: () -> Unit,
+    ) {
+        try {
+            onRollback()
+        } catch (rollbackError: Throwable) {
+            originalError.addSuppressed(rollbackError)
+        }
+    }
+}
+
 internal class WalletDatabaseFiles(
     private val filesDir: File,
     private val walletDirectoryName: String = "cashu-kotlin",
     private val walletDatabaseFilename: String = "wallet.db",
     private val legacyDatabaseFilename: String = "cashu_wallet.db",
     private val sidecars: List<String> = listOf("-wal", "-shm", "-journal"),
+    private val operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
 ) {
+    private val walletDirectoryFile: File
+        get() = File(filesDir, walletDirectoryName)
+
     val walletDirectory: File
-        get() = File(filesDir, walletDirectoryName).also { it.mkdirs() }
+        get() = walletDirectoryFile.also { directory ->
+            if (!directory.exists() && !directory.mkdirs()) {
+                throw IOException("Failed to create the wallet database directory.")
+            }
+        }
 
     val databaseFile: File
         get() = File(walletDirectory, walletDatabaseFilename)
@@ -46,43 +270,56 @@ internal class WalletDatabaseFiles(
 
     fun backupWalletDatabaseFiles(): List<WalletFileBackup> {
         val timestamp = System.currentTimeMillis() / 1000
-        return walletBoundaryFiles()
-            .filter { it.exists() }
-            .map { original ->
-                val backup = File(
+        return WalletReplacementFiles.backup(
+            files = walletBoundaryFiles(),
+            operations = operations,
+            backupFile = { original ->
+                File(
                     original.parentFile,
                     "${original.name}.replacing.$timestamp.${UUID.randomUUID()}",
                 )
-                if (backup.exists()) backup.deleteRecursively()
-                original.renameTo(backup)
-                WalletFileBackup(original, backup)
-            }
+            },
+        )
     }
 
-    fun restoreWalletFileBackups(backups: List<WalletFileBackup>) {
-        backups.asReversed().forEach { backup ->
-            if (backup.original.exists()) backup.original.deleteRecursively()
-            if (backup.backup.exists()) backup.backup.renameTo(backup.original)
-        }
+    fun restoreWalletFileBackups(
+        backups: List<WalletFileBackup>,
+        beforeCommit: () -> Unit = {},
+        onRollback: () -> Unit = {},
+    ) {
+        WalletReplacementFiles.restore(
+            files = walletBoundaryFiles(),
+            backups = backups,
+            operations = operations,
+            displacedFile = { original ->
+                File(original.parentFile, "${original.name}.rollback.${UUID.randomUUID()}")
+            },
+            beforeCommit = beforeCommit,
+            onRollback = onRollback,
+        )
     }
 
     fun removeWalletFileBackups(backups: List<WalletFileBackup>) {
-        backups.forEach { if (it.backup.exists()) it.backup.deleteRecursively() }
+        WalletReplacementFiles.removeBackups(backups, operations)
     }
 
     fun removeWalletDatabaseFiles() {
-        walletBoundaryFiles().forEach { if (it.exists()) it.deleteRecursively() }
+        WalletReplacementFiles.removeAll(walletBoundaryFiles(), operations)
     }
 
     fun backupCorruptedDatabase(): File? {
         val database = databaseFile
-        if (!database.exists()) return null
+        if (!operations.exists(database)) return null
         val backup = File(walletDirectory, "$walletDatabaseFilename.corrupt.${System.currentTimeMillis() / 1000}")
-        if (backup.exists()) backup.delete()
-        database.renameTo(backup)
+        if (operations.exists(backup)) operations.removeItem(backup)
+        operations.moveItem(database, backup)
         sidecars.forEach { suffix ->
             val sidecar = File(database.absolutePath + suffix)
-            if (sidecar.exists()) sidecar.renameTo(File(backup.absolutePath + suffix))
+            if (operations.exists(sidecar)) {
+                val backupSidecar = File(backup.absolutePath + suffix)
+                if (operations.exists(backupSidecar)) operations.removeItem(backupSidecar)
+                operations.moveItem(sidecar, backupSidecar)
+            }
         }
         return backup
     }
@@ -90,21 +327,21 @@ internal class WalletDatabaseFiles(
     private fun migrateLegacyDatabaseIfNeeded() {
         val legacy = File(filesDir, legacyDatabaseFilename)
         val current = databaseFile
-        if (!legacy.exists() || current.exists()) return
-        legacy.renameTo(current)
+        if (!operations.exists(legacy) || operations.exists(current)) return
+        operations.moveItem(legacy, current)
         sidecars.forEach { suffix ->
             val legacySidecar = File(legacy.absolutePath + suffix)
-            if (legacySidecar.exists()) {
+            if (operations.exists(legacySidecar)) {
                 val currentSidecar = File(current.absolutePath + suffix)
-                if (currentSidecar.exists()) currentSidecar.delete()
-                legacySidecar.renameTo(currentSidecar)
+                if (operations.exists(currentSidecar)) operations.removeItem(currentSidecar)
+                operations.moveItem(legacySidecar, currentSidecar)
             }
         }
     }
 
     private fun walletBoundaryFiles(): List<File> {
         val legacy = File(filesDir, legacyDatabaseFilename)
-        return listOf(walletDirectory, legacy) + sidecars.map { File(legacy.absolutePath + it) }
+        return listOf(walletDirectoryFile, legacy) + sidecars.map { File(legacy.absolutePath + it) }
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -1234,7 +1234,7 @@ class WalletManager(
         val settingsSnapshot = replacementSnapshot.settings
         val nwcSnapshot = replacementSnapshot.nwc
 
-        runCatching {
+        try {
             // NwcService retains the native CDK wallet, so it must stop before
             // the repository/database it is backed by is closed.
             nwcManager.resetForWalletBoundary()
@@ -1249,43 +1249,73 @@ class WalletManager(
             secureStorage.saveString(StorageKeys.secureWalletMnemonic, mnemonic)
             settingsManager.deleteWalletScopedSecrets(settingsSnapshot, deleteNostrPrivateKey = true)
             nostrMintBackupService.resetForWalletBoundary()
-            databasePathManager.removeWalletFileBackups(backups)
             loadCachedState(needsOnboarding = needsOnboarding)
             // A wallet installed during first-launch onboarding is incomplete
             // until completeOnboarding(); installs from Settings skip
             // onboarding entirely and are complete immediately.
             settingsManager.onboardingCompleted = !needsOnboarding
-        }.onFailure { error ->
+        } catch (installError: Throwable) {
             gateway.closeWalletRepository()
-            walletStore.restoreWalletScopedData(walletSnapshot)
-            cashuRequestStore.reload()
-            settingsManager.restoreWalletScopedData(settingsSnapshot)
-            nwcManager.restoreWalletScopedData(nwcSnapshot)
-            nostrMintBackupService.reloadStoredState()
-            databasePathManager.removeWalletDatabaseFiles()
-            databasePathManager.restoreWalletFileBackups(backups)
-            if (previousMnemonic != null) {
-                secureStorage.saveString(StorageKeys.secureWalletMnemonic, previousMnemonic)
-                runCatching {
-                    openWalletRepositoryWithRecovery(previousMnemonic)
-                    deriveNostrKey(previousMnemonic)
-                    loadCachedState(needsOnboarding = false)
-                    if (startNwc) nwcManager.startIfEnabled()
+            val rollbackSucceeded = try {
+                databasePathManager.restoreWalletFileBackups(
+                    backups = backups,
+                    beforeCommit = {
+                        if (previousMnemonic != null) {
+                            secureStorage.saveString(StorageKeys.secureWalletMnemonic, previousMnemonic)
+                        } else {
+                            secureStorage.delete(StorageKeys.secureWalletMnemonic)
+                        }
+                    },
+                    onRollback = {
+                        secureStorage.saveString(StorageKeys.secureWalletMnemonic, mnemonic)
+                    },
+                )
+                true
+            } catch (rollbackError: Throwable) {
+                installError.addSuppressed(rollbackError)
+                AppLogger.wallet.error("Failed to restore the previous wallet transaction", rollbackError)
+                false
+            }
+
+            if (rollbackSucceeded) {
+                walletStore.restoreWalletScopedData(walletSnapshot)
+                cashuRequestStore.reload()
+                settingsManager.restoreWalletScopedData(settingsSnapshot)
+                nwcManager.restoreWalletScopedData(nwcSnapshot)
+                nostrMintBackupService.reloadStoredState()
+                if (previousMnemonic != null) {
+                    runCatching {
+                        openWalletRepositoryWithRecovery(previousMnemonic)
+                        deriveNostrKey(previousMnemonic)
+                        loadCachedState(needsOnboarding = false)
+                        if (startNwc) nwcManager.startIfEnabled()
+                    }
+                    cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled)
+                } else {
+                    update {
+                        WalletState(
+                            isInitialized = true,
+                            isRuntimeReady = true,
+                            needsOnboarding = true,
+                            canExitOnboarding = false,
+                        )
+                    }
+                    cashuRequestListener?.resetForWalletBoundary(restart = false)
                 }
-                cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled)
             } else {
-                secureStorage.delete(StorageKeys.secureWalletMnemonic)
-                update {
-                    WalletState(
-                        isInitialized = true,
-                        isRuntimeReady = true,
-                        needsOnboarding = true,
-                        canExitOnboarding = false,
-                    )
-                }
+                // The replacement seed/files were rolled forward as far as
+                // possible. Do not publish snapshots from the previous wallet.
                 cashuRequestListener?.resetForWalletBoundary(restart = false)
             }
-            throw error
+            throw installError
+        }
+
+        // Backup cleanup is post-commit. A cleanup error must not turn a valid
+        // replacement into a rollback after old backups were partly deleted.
+        try {
+            databasePathManager.removeWalletFileBackups(backups)
+        } catch (cleanupError: Throwable) {
+            AppLogger.wallet.error("Failed to remove committed wallet replacement backups", cleanupError)
         }
         cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled && !needsOnboarding)
     }

--- a/android/app/src/test/java/com/cashu/me/Core/WalletReplacementSafetyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletReplacementSafetyTest.kt
@@ -1,0 +1,250 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Platform.WalletFileBackup
+import com.cashu.me.Core.Platform.WalletReplacementFileOperations
+import com.cashu.me.Core.Platform.WalletReplacementFiles
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class WalletReplacementSafetyTest {
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    private class ForcedMoveFailure : RuntimeException()
+    private class ForcedSeedFailure : RuntimeException()
+
+    private val liveMove: (File, File) -> Unit = { source, destination ->
+        check(source.renameTo(destination))
+    }
+
+    private fun operations(
+        moveItem: (File, File) -> Unit = liveMove,
+    ) = WalletReplacementFileOperations(
+        exists = File::exists,
+        moveItem = moveItem,
+        removeItem = { file -> check(!file.exists() || file.deleteRecursively()) },
+    )
+
+    @Test
+    fun partialBackupFailureRestoresEveryMovedOriginal() {
+        val first = temporaryFolder.newFile("first.db").also { it.writeText("first") }
+        val second = temporaryFolder.newFile("second.db").also { it.writeText("second") }
+        var forwardMoveCount = 0
+        val operations = operations { source, destination ->
+            if (!source.name.endsWith(".backup")) {
+                forwardMoveCount += 1
+                if (forwardMoveCount == 2) throw ForcedMoveFailure()
+            }
+            liveMove(source, destination)
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.backup(
+                files = listOf(first, second),
+                operations = operations,
+                backupFile = { File(it.parentFile, "${it.name}.backup") },
+            )
+        }
+
+        assertEquals("first", first.readText())
+        assertEquals("second", second.readText())
+        assertFalse(File(first.parentFile, "${first.name}.backup").exists())
+    }
+
+    @Test
+    fun partialBackupFailureReportedAfterMoveRestoresCurrentOriginal() {
+        val first = temporaryFolder.newFile("first.db").also { it.writeText("first") }
+        val second = temporaryFolder.newFile("second.db").also { it.writeText("second") }
+        val operations = operations { source, destination ->
+            liveMove(source, destination)
+            if (source == second) throw ForcedMoveFailure()
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.backup(
+                files = listOf(first, second),
+                operations = operations,
+                backupFile = { File(it.parentFile, "${it.name}.backup") },
+            )
+        }
+
+        assertEquals("first", first.readText())
+        assertEquals("second", second.readText())
+        assertFalse(File(first.parentFile, "${first.name}.backup").exists())
+        assertFalse(File(second.parentFile, "${second.name}.backup").exists())
+    }
+
+    @Test
+    fun missingBackupNeverDisplacesReplacementDatabase() {
+        val original = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+        val missingBackup = File(original.parentFile, "wallet.db.backup")
+
+        assertThrows(Exception::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(original),
+                backups = listOf(WalletFileBackup(original, missingBackup)),
+                displacedFile = { File(it.parentFile, "${it.name}.displaced") },
+            )
+        }
+
+        assertEquals("replacement", original.readText())
+    }
+
+    @Test
+    fun committedRestoreRemovesReplacementWithoutAnOriginalBackup() {
+        val replacement = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+
+        WalletReplacementFiles.restore(
+            files = listOf(replacement),
+            backups = emptyList(),
+            displacedFile = { File(it.parentFile, "${it.name}.displaced") },
+        )
+
+        assertFalse(replacement.exists())
+    }
+
+    @Test
+    fun restoreMoveFailurePutsReplacementDatabaseBack() {
+        val original = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+        val backup = temporaryFolder.newFile("wallet.db.backup").also { it.writeText("original") }
+        var moveCount = 0
+        val operations = operations { source, destination ->
+            moveCount += 1
+            if (moveCount == 2) throw ForcedMoveFailure()
+            liveMove(source, destination)
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(original),
+                backups = listOf(WalletFileBackup(original, backup)),
+                operations = operations,
+                displacedFile = { File(it.parentFile, "${it.name}.displaced") },
+            )
+        }
+
+        assertEquals("replacement", original.readText())
+        assertEquals("original", backup.readText())
+    }
+
+    @Test
+    fun displacementFailureReportedAfterMoveRestoresReplacement() {
+        val original = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+        val backup = temporaryFolder.newFile("wallet.db.backup").also { it.writeText("original") }
+        val displaced = File(original.parentFile, "wallet.db.displaced")
+        val operations = operations { source, destination ->
+            liveMove(source, destination)
+            if (source == original && destination == displaced) throw ForcedMoveFailure()
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(original),
+                backups = listOf(WalletFileBackup(original, backup)),
+                operations = operations,
+                displacedFile = { displaced },
+            )
+        }
+
+        assertEquals("replacement", original.readText())
+        assertEquals("original", backup.readText())
+        assertFalse(displaced.exists())
+    }
+
+    @Test
+    fun restoreFailureReportedAfterMoveRestoresReplacementAndBackup() {
+        val original = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+        val backup = temporaryFolder.newFile("wallet.db.backup").also { it.writeText("original") }
+        val displaced = File(original.parentFile, "wallet.db.displaced")
+        var didFail = false
+        val operations = operations { source, destination ->
+            liveMove(source, destination)
+            if (source == backup && !didFail) {
+                didFail = true
+                throw ForcedMoveFailure()
+            }
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(original),
+                backups = listOf(WalletFileBackup(original, backup)),
+                operations = operations,
+                displacedFile = { displaced },
+            )
+        }
+
+        assertEquals("replacement", original.readText())
+        assertEquals("original", backup.readText())
+        assertFalse(displaced.exists())
+    }
+
+    @Test
+    fun seedCommitFailureRollsFilesAndSeedForwardToReplacement() {
+        val original = temporaryFolder.newFile("wallet.db").also { it.writeText("replacement") }
+        val backup = temporaryFolder.newFile("wallet.db.backup").also { it.writeText("original") }
+        val displaced = File(original.parentFile, "wallet.db.displaced")
+        var activeSeed = "replacement seed"
+
+        assertThrows(ForcedSeedFailure::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(original),
+                backups = listOf(WalletFileBackup(original, backup)),
+                displacedFile = { displaced },
+                beforeCommit = {
+                    activeSeed = "original seed"
+                    throw ForcedSeedFailure()
+                },
+                onRollback = {
+                    activeSeed = "replacement seed"
+                },
+            )
+        }
+
+        assertEquals("replacement seed", activeSeed)
+        assertEquals("replacement", original.readText())
+        assertEquals("original", backup.readText())
+        assertFalse(displaced.exists())
+    }
+
+    @Test
+    fun laterRestoreFailureRestoresEveryReplacementAndBackup() {
+        val firstOriginal = temporaryFolder.newFile("first.db").also { it.writeText("new first") }
+        val firstBackup = temporaryFolder.newFile("first.db.backup").also { it.writeText("old first") }
+        val secondOriginal = temporaryFolder.newFile("second.db").also { it.writeText("new second") }
+        val secondBackup = temporaryFolder.newFile("second.db.backup").also { it.writeText("old second") }
+        var backupMoveCount = 0
+        val operations = operations { source, destination ->
+            if (source.name.endsWith(".backup")) {
+                backupMoveCount += 1
+                if (backupMoveCount == 2) throw ForcedMoveFailure()
+            }
+            liveMove(source, destination)
+        }
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            WalletReplacementFiles.restore(
+                files = listOf(firstOriginal, secondOriginal),
+                backups = listOf(
+                    WalletFileBackup(firstOriginal, firstBackup),
+                    WalletFileBackup(secondOriginal, secondBackup),
+                ),
+                operations = operations,
+                displacedFile = { File(it.parentFile, "${it.name}.displaced") },
+            )
+        }
+
+        assertEquals(2, backupMoveCount)
+        assertEquals("new first", firstOriginal.readText())
+        assertEquals("old first", firstBackup.readText())
+        assertEquals("new second", secondOriginal.readText())
+        assertEquals("old second", secondBackup.readText())
+        assertFalse(File(firstOriginal.parentFile, "${firstOriginal.name}.displaced").exists())
+        assertFalse(File(secondOriginal.parentFile, "${secondOriginal.name}.displaced").exists())
+    }
+}

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -11,6 +11,207 @@ private enum WalletStartupInstrumentation {
     static let signposter = OSSignposter(subsystem: "com.cashu.me", category: "wallet.startup")
 }
 
+struct WalletFileBackup: Equatable {
+    let originalURL: URL
+    let backupURL: URL
+}
+
+struct WalletReplacementFileOperations {
+    let fileExists: (URL) -> Bool
+    let moveItem: (URL, URL) throws -> Void
+    let removeItem: (URL) throws -> Void
+
+    static let live = WalletReplacementFileOperations(
+        fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+        moveItem: { try FileManager.default.moveItem(at: $0, to: $1) },
+        removeItem: { try FileManager.default.removeItem(at: $0) }
+    )
+}
+
+enum WalletReplacementFiles {
+    private struct StagedReplacement {
+        let originalURL: URL
+        let displacedURL: URL
+    }
+
+    static func backup(
+        urls: [URL],
+        operations: WalletReplacementFileOperations = .live,
+        backupURL: (URL) -> URL
+    ) throws -> [WalletFileBackup] {
+        var backups: [WalletFileBackup] = []
+
+        do {
+            for originalURL in urls where operations.fileExists(originalURL) {
+                let candidate = backupURL(originalURL)
+                if operations.fileExists(candidate) {
+                    try operations.removeItem(candidate)
+                }
+
+                try operations.moveItem(originalURL, candidate)
+                backups.append(WalletFileBackup(
+                    originalURL: originalURL,
+                    backupURL: candidate
+                ))
+            }
+        } catch {
+            for backup in backups.reversed() where operations.fileExists(backup.backupURL) {
+                do {
+                    if operations.fileExists(backup.originalURL) {
+                        try operations.removeItem(backup.originalURL)
+                    }
+                    try operations.moveItem(backup.backupURL, backup.originalURL)
+                } catch {
+                    AppLogger.wallet.error("Failed to roll back a partial wallet database backup: \(error)")
+                    SentryService.capture(error)
+                }
+            }
+            throw error
+        }
+
+        return backups
+    }
+
+    static func restore(
+        _ backups: [WalletFileBackup],
+        operations: WalletReplacementFileOperations = .live,
+        displacedURL: (URL) -> URL
+    ) throws {
+        guard backups.allSatisfy({ operations.fileExists($0.backupURL) }) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        let restorationOrder = Array(backups.reversed())
+        var stagedReplacements: [StagedReplacement] = []
+
+        do {
+            for backup in restorationOrder where operations.fileExists(backup.originalURL) {
+                let displaced = displacedURL(backup.originalURL)
+                if operations.fileExists(displaced) {
+                    try operations.removeItem(displaced)
+                }
+                try operations.moveItem(backup.originalURL, displaced)
+                stagedReplacements.append(StagedReplacement(
+                    originalURL: backup.originalURL,
+                    displacedURL: displaced
+                ))
+            }
+        } catch {
+            restoreStagedReplacements(stagedReplacements, operations: operations)
+            throw error
+        }
+
+        var restoredBackups: [WalletFileBackup] = []
+        do {
+            for backup in restorationOrder {
+                do {
+                    try operations.moveItem(backup.backupURL, backup.originalURL)
+                    restoredBackups.append(backup)
+                } catch {
+                    // FileManager moves are atomic, but injected or future
+                    // implementations may report failure after moving. Include
+                    // that backup in state-based rollback when its live path
+                    // appeared before the error surfaced.
+                    if operations.fileExists(backup.originalURL) {
+                        restoredBackups.append(backup)
+                    }
+                    throw error
+                }
+            }
+        } catch {
+            rollBackRestoredBackups(restoredBackups, operations: operations)
+            restoreStagedReplacements(stagedReplacements, operations: operations)
+            throw error
+        }
+
+        for replacement in stagedReplacements where operations.fileExists(replacement.displacedURL) {
+            do {
+                try operations.removeItem(replacement.displacedURL)
+            } catch {
+                AppLogger.wallet.error("Failed to remove a displaced replacement database: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    private static func rollBackRestoredBackups(
+        _ backups: [WalletFileBackup],
+        operations: WalletReplacementFileOperations
+    ) {
+        for backup in backups.reversed() where operations.fileExists(backup.originalURL) {
+            do {
+                if operations.fileExists(backup.backupURL) {
+                    // A move implementation may have copied before throwing.
+                    // The backup already survives, so remove only the restored
+                    // live copy before putting the replacement back.
+                    try operations.removeItem(backup.originalURL)
+                } else {
+                    try operations.moveItem(backup.originalURL, backup.backupURL)
+                }
+            } catch {
+                AppLogger.wallet.error("Failed to roll back a restored wallet database backup: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    private static func restoreStagedReplacements(
+        _ replacements: [StagedReplacement],
+        operations: WalletReplacementFileOperations
+    ) {
+        for replacement in replacements.reversed()
+        where operations.fileExists(replacement.displacedURL) {
+            do {
+                guard !operations.fileExists(replacement.originalURL) else {
+                    throw CocoaError(.fileWriteFileExists)
+                }
+                try operations.moveItem(replacement.displacedURL, replacement.originalURL)
+            } catch {
+                AppLogger.wallet.error("Failed to restore a displaced replacement database: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    static func removeUnbackedReplacements(
+        at urls: [URL],
+        backups: [WalletFileBackup],
+        operations: WalletReplacementFileOperations = .live
+    ) throws {
+        let backedPaths = Set(backups.map { $0.originalURL.standardizedFileURL.path })
+
+        for url in urls where !backedPaths.contains(url.standardizedFileURL.path) {
+            guard operations.fileExists(url) else { continue }
+            try operations.removeItem(url)
+        }
+    }
+
+    static func removeBackups(
+        _ backups: [WalletFileBackup],
+        operations: WalletReplacementFileOperations = .live
+    ) throws {
+        for backup in backups where operations.fileExists(backup.backupURL) {
+            try operations.removeItem(backup.backupURL)
+        }
+    }
+}
+
+enum WalletMnemonicRollback {
+    static func restore(
+        previousMnemonic: String?,
+        secureStorage: SecureStorageProtocol
+    ) throws {
+        if let previousMnemonic {
+            try secureStorage.saveSecret(
+                previousMnemonic,
+                forKey: StorageKeys.Secure.mnemonic
+            )
+        } else {
+            try secureStorage.deleteSecret(forKey: StorageKeys.Secure.mnemonic)
+        }
+    }
+}
+
 enum WalletStartupPolicy {
     /// Keysets are persisted by CDK. Refresh them periodically in the
     /// background instead of making every cold launch depend on every mint.
@@ -326,13 +527,13 @@ extension WalletManager {
         let values: [String: Any]
     }
 
-    private struct WalletFileBackup {
-        let originalURL: URL
-        let backupURL: URL
-    }
-
     private func installCleanWallet(mnemonic newMnemonic: String) async throws {
-        let previousMnemonic = mnemonic ?? (try? keychainService.loadMnemonic())
+        let previousMnemonic: String?
+        if let mnemonic {
+            previousMnemonic = mnemonic
+        } else {
+            previousMnemonic = try keychainService.loadMnemonic()
+        }
         let defaultsSnapshot = walletBoundaryDefaultsSnapshot()
         let fileBackups = try backupWalletDatabaseFiles()
 
@@ -355,29 +556,62 @@ extension WalletManager {
             // completeOnboarding()/completeRestore() may flip this to done.
             OnboardingCompletionState.setCompleted(false)
             SettingsManager.shared.resetWalletScopedData(resetRuntimeServices: false)
-            try removeWalletFileBackups(fileBackups)
-            if !IntegrationTestConfig.shouldUseDeterministicUIRuntime {
-                performICloudBackup()
-            }
         } catch {
             SentryService.capture(error)
             resetRuntimeState()
-            restoreWalletBoundaryDefaults(defaultsSnapshot)
-            CashuRequestStore.shared.reloadFromDefaults()
-            try? removeWalletDatabaseFiles()
-            try? restoreWalletFileBackups(fileBackups)
+            var rollbackSucceeded = true
+            do {
+                try WalletMnemonicRollback.restore(
+                    previousMnemonic: previousMnemonic,
+                    secureStorage: keychainService
+                )
+            } catch {
+                rollbackSucceeded = false
+                AppLogger.wallet.error("Failed to restore the previous wallet seed: \(error)")
+                SentryService.capture(error)
+            }
 
-            if let previousMnemonic {
-                mnemonic = previousMnemonic
+            if rollbackSucceeded {
                 do {
-                    try initializeWalletForLaunch(mnemonic: previousMnemonic)
-                    startDeferredStartupMaintenance()
+                    try removeUnbackedWalletDatabaseFiles(fileBackups)
+                    try restoreWalletFileBackups(fileBackups)
                 } catch {
-                    AppLogger.wallet.error("Failed to reopen previous wallet after replacement error: \(error)")
+                    rollbackSucceeded = false
+                    AppLogger.wallet.error("Failed to restore wallet database backups: \(error)")
+                    SentryService.capture(error)
+                }
+            }
+
+            if rollbackSucceeded {
+                restoreWalletBoundaryDefaults(defaultsSnapshot)
+                CashuRequestStore.shared.reloadFromDefaults()
+                mnemonic = previousMnemonic
+
+                if let previousMnemonic {
+                    do {
+                        try initializeWalletForLaunch(mnemonic: previousMnemonic)
+                        startDeferredStartupMaintenance()
+                    } catch {
+                        AppLogger.wallet.error("Failed to reopen previous wallet after replacement error: \(error)")
+                    }
                 }
             }
 
             throw error
+        }
+
+        // The new seed/database pair is committed. Backup cleanup must never
+        // turn an otherwise successful replacement into a rollback after some
+        // of the only old-wallet backups have already been deleted.
+        do {
+            try removeWalletFileBackups(fileBackups)
+        } catch {
+            AppLogger.wallet.error("Failed to remove committed wallet replacement backups: \(error)")
+            SentryService.capture(error)
+        }
+
+        if !IntegrationTestConfig.shouldUseDeterministicUIRuntime {
+            performICloudBackup()
         }
     }
 
@@ -604,47 +838,31 @@ extension WalletManager {
     }
 
     private func backupWalletDatabaseFiles() throws -> [WalletFileBackup] {
-        let fileManager = FileManager.default
         let timestamp = Int(Date().timeIntervalSince1970)
-        var backups: [WalletFileBackup] = []
-
-        for originalURL in try walletDatabaseBoundaryURLs() {
-            guard fileManager.fileExists(atPath: originalURL.path) else { continue }
-
-            let backupURL = originalURL.deletingLastPathComponent()
+        return try WalletReplacementFiles.backup(urls: walletDatabaseBoundaryURLs()) { originalURL in
+            originalURL.deletingLastPathComponent()
                 .appendingPathComponent("\(originalURL.lastPathComponent).replacing.\(timestamp).\(UUID().uuidString)")
-
-            if fileManager.fileExists(atPath: backupURL.path) {
-                try fileManager.removeItem(at: backupURL)
-            }
-
-            try fileManager.moveItem(at: originalURL, to: backupURL)
-            backups.append(WalletFileBackup(originalURL: originalURL, backupURL: backupURL))
         }
-
-        return backups
     }
 
     private func restoreWalletFileBackups(_ backups: [WalletFileBackup]) throws {
-        let fileManager = FileManager.default
-
-        for backup in backups.reversed() {
-            if fileManager.fileExists(atPath: backup.originalURL.path) {
-                try fileManager.removeItem(at: backup.originalURL)
-            }
-
-            guard fileManager.fileExists(atPath: backup.backupURL.path) else { continue }
-            try fileManager.moveItem(at: backup.backupURL, to: backup.originalURL)
+        try WalletReplacementFiles.restore(backups) { originalURL in
+            originalURL.deletingLastPathComponent()
+                .appendingPathComponent("\(originalURL.lastPathComponent).rollback.\(UUID().uuidString)")
         }
     }
 
-    private func removeWalletFileBackups(_ backups: [WalletFileBackup]) throws {
-        let fileManager = FileManager.default
+    private func removeUnbackedWalletDatabaseFiles(
+        _ backups: [WalletFileBackup]
+    ) throws {
+        try WalletReplacementFiles.removeUnbackedReplacements(
+            at: walletDatabaseBoundaryURLs(),
+            backups: backups
+        )
+    }
 
-        for backup in backups {
-            guard fileManager.fileExists(atPath: backup.backupURL.path) else { continue }
-            try fileManager.removeItem(at: backup.backupURL)
-        }
+    private func removeWalletFileBackups(_ backups: [WalletFileBackup]) throws {
+        try WalletReplacementFiles.removeBackups(backups)
     }
 
     private func removeWalletDatabaseFiles() throws {

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -48,11 +48,22 @@ enum WalletReplacementFiles {
                     try operations.removeItem(candidate)
                 }
 
-                try operations.moveItem(originalURL, candidate)
-                backups.append(WalletFileBackup(
+                let backup = WalletFileBackup(
                     originalURL: originalURL,
                     backupURL: candidate
-                ))
+                )
+                do {
+                    try operations.moveItem(originalURL, candidate)
+                    backups.append(backup)
+                } catch {
+                    // A move implementation may report failure after the item
+                    // reached its destination. Track the observed state so the
+                    // current item participates in partial-backup rollback.
+                    if operations.fileExists(candidate) {
+                        backups.append(backup)
+                    }
+                    throw error
+                }
             }
         } catch {
             for backup in backups.reversed() where operations.fileExists(backup.backupURL) {
@@ -73,31 +84,47 @@ enum WalletReplacementFiles {
     }
 
     static func restore(
+        at urls: [URL],
         _ backups: [WalletFileBackup],
         operations: WalletReplacementFileOperations = .live,
-        displacedURL: (URL) -> URL
+        displacedURL: (URL) -> URL,
+        beforeCommit: () throws -> Void = {},
+        onRollback: () throws -> Void = {}
     ) throws {
         guard backups.allSatisfy({ operations.fileExists($0.backupURL) }) else {
+            performExternalRollback(onRollback)
             throw CocoaError(.fileNoSuchFile)
         }
 
         let restorationOrder = Array(backups.reversed())
         var stagedReplacements: [StagedReplacement] = []
+        let restorationURLs = uniqueURLs(urls + backups.map(\.originalURL))
 
         do {
-            for backup in restorationOrder where operations.fileExists(backup.originalURL) {
-                let displaced = displacedURL(backup.originalURL)
+            for originalURL in restorationURLs where operations.fileExists(originalURL) {
+                let displaced = displacedURL(originalURL)
                 if operations.fileExists(displaced) {
                     try operations.removeItem(displaced)
                 }
-                try operations.moveItem(backup.originalURL, displaced)
-                stagedReplacements.append(StagedReplacement(
-                    originalURL: backup.originalURL,
+                let replacement = StagedReplacement(
+                    originalURL: originalURL,
                     displacedURL: displaced
-                ))
+                )
+                do {
+                    try operations.moveItem(originalURL, displaced)
+                    stagedReplacements.append(replacement)
+                } catch {
+                    // Account for moves that completed before reporting an
+                    // error, just as the backup-restoration phase does below.
+                    if operations.fileExists(displaced) {
+                        stagedReplacements.append(replacement)
+                    }
+                    throw error
+                }
             }
         } catch {
             restoreStagedReplacements(stagedReplacements, operations: operations)
+            performExternalRollback(onRollback)
             throw error
         }
 
@@ -118,9 +145,15 @@ enum WalletReplacementFiles {
                     throw error
                 }
             }
+
+            // Keep every replacement file displaced until the previous seed
+            // has committed. If this throws, the catch below rolls the files
+            // forward to the replacement wallet before compensating its seed.
+            try beforeCommit()
         } catch {
             rollBackRestoredBackups(restoredBackups, operations: operations)
             restoreStagedReplacements(stagedReplacements, operations: operations)
+            performExternalRollback(onRollback)
             throw error
         }
 
@@ -132,6 +165,11 @@ enum WalletReplacementFiles {
                 SentryService.capture(error)
             }
         }
+    }
+
+    private static func uniqueURLs(_ urls: [URL]) -> [URL] {
+        var paths: Set<String> = []
+        return urls.filter { paths.insert($0.standardizedFileURL.path).inserted }
     }
 
     private static func rollBackRestoredBackups(
@@ -162,10 +200,13 @@ enum WalletReplacementFiles {
         for replacement in replacements.reversed()
         where operations.fileExists(replacement.displacedURL) {
             do {
-                guard !operations.fileExists(replacement.originalURL) else {
-                    throw CocoaError(.fileWriteFileExists)
+                if operations.fileExists(replacement.originalURL) {
+                    // A copy-style move may leave both paths present before
+                    // throwing. The live replacement already survives.
+                    try operations.removeItem(replacement.displacedURL)
+                } else {
+                    try operations.moveItem(replacement.displacedURL, replacement.originalURL)
                 }
-                try operations.moveItem(replacement.displacedURL, replacement.originalURL)
             } catch {
                 AppLogger.wallet.error("Failed to restore a displaced replacement database: \(error)")
                 SentryService.capture(error)
@@ -173,16 +214,12 @@ enum WalletReplacementFiles {
         }
     }
 
-    static func removeUnbackedReplacements(
-        at urls: [URL],
-        backups: [WalletFileBackup],
-        operations: WalletReplacementFileOperations = .live
-    ) throws {
-        let backedPaths = Set(backups.map { $0.originalURL.standardizedFileURL.path })
-
-        for url in urls where !backedPaths.contains(url.standardizedFileURL.path) {
-            guard operations.fileExists(url) else { continue }
-            try operations.removeItem(url)
+    private static func performExternalRollback(_ rollback: () throws -> Void) {
+        do {
+            try rollback()
+        } catch {
+            AppLogger.wallet.error("Failed to restore the replacement wallet seed: \(error)")
+            SentryService.capture(error)
         }
     }
 
@@ -559,27 +596,28 @@ extension WalletManager {
         } catch {
             SentryService.capture(error)
             resetRuntimeState()
-            var rollbackSucceeded = true
+            let rollbackSucceeded: Bool
             do {
-                try WalletMnemonicRollback.restore(
-                    previousMnemonic: previousMnemonic,
-                    secureStorage: keychainService
+                try restoreWalletFileBackups(
+                    fileBackups,
+                    beforeCommit: {
+                        try WalletMnemonicRollback.restore(
+                            previousMnemonic: previousMnemonic,
+                            secureStorage: keychainService
+                        )
+                    },
+                    onRollback: {
+                        try WalletMnemonicRollback.restore(
+                            previousMnemonic: newMnemonic,
+                            secureStorage: keychainService
+                        )
+                    }
                 )
+                rollbackSucceeded = true
             } catch {
                 rollbackSucceeded = false
-                AppLogger.wallet.error("Failed to restore the previous wallet seed: \(error)")
+                AppLogger.wallet.error("Failed to restore the previous wallet transaction: \(error)")
                 SentryService.capture(error)
-            }
-
-            if rollbackSucceeded {
-                do {
-                    try removeUnbackedWalletDatabaseFiles(fileBackups)
-                    try restoreWalletFileBackups(fileBackups)
-                } catch {
-                    rollbackSucceeded = false
-                    AppLogger.wallet.error("Failed to restore wallet database backups: \(error)")
-                    SentryService.capture(error)
-                }
             }
 
             if rollbackSucceeded {
@@ -845,19 +883,20 @@ extension WalletManager {
         }
     }
 
-    private func restoreWalletFileBackups(_ backups: [WalletFileBackup]) throws {
-        try WalletReplacementFiles.restore(backups) { originalURL in
-            originalURL.deletingLastPathComponent()
-                .appendingPathComponent("\(originalURL.lastPathComponent).rollback.\(UUID().uuidString)")
-        }
-    }
-
-    private func removeUnbackedWalletDatabaseFiles(
-        _ backups: [WalletFileBackup]
+    private func restoreWalletFileBackups(
+        _ backups: [WalletFileBackup],
+        beforeCommit: () throws -> Void,
+        onRollback: () throws -> Void
     ) throws {
-        try WalletReplacementFiles.removeUnbackedReplacements(
+        try WalletReplacementFiles.restore(
             at: walletDatabaseBoundaryURLs(),
-            backups: backups
+            backups,
+            displacedURL: { originalURL in
+                originalURL.deletingLastPathComponent()
+                    .appendingPathComponent("\(originalURL.lastPathComponent).rollback.\(UUID().uuidString)")
+            },
+            beforeCommit: beforeCommit,
+            onRollback: onRollback
         )
     }
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -407,3 +407,280 @@ final class CashuRequestStoreTests: XCTestCase {
         XCTAssertEqual(reloaded.request(withId: "request-id")?.unit, "eur")
     }
 }
+
+final class WalletReplacementSafetyTests: XCTestCase {
+    private enum TestError: Error {
+        case forcedMoveFailure
+    }
+
+    private final class SecureStorageSpy: SecureStorageProtocol {
+        var secrets: [String: String] = [:]
+
+        func saveSecret(_ secret: String, forKey key: String) throws {
+            secrets[key] = secret
+        }
+
+        func loadSecret(forKey key: String) throws -> String? {
+            secrets[key]
+        }
+
+        func deleteSecret(forKey key: String) throws {
+            secrets.removeValue(forKey: key)
+        }
+
+        func hasSecret(forKey key: String) -> Bool {
+            secrets[key] != nil
+        }
+    }
+
+    func testMnemonicRollbackRestoresPreviousSeed() throws {
+        let storage = SecureStorageSpy()
+        storage.secrets[StorageKeys.Secure.mnemonic] = "replacement seed"
+
+        try WalletMnemonicRollback.restore(
+            previousMnemonic: "original seed",
+            secureStorage: storage
+        )
+
+        XCTAssertEqual(
+            storage.secrets[StorageKeys.Secure.mnemonic],
+            "original seed"
+        )
+    }
+
+    func testMnemonicRollbackDeletesReplacementWhenNoSeedExisted() throws {
+        let storage = SecureStorageSpy()
+        storage.secrets[StorageKeys.Secure.mnemonic] = "replacement seed"
+
+        try WalletMnemonicRollback.restore(
+            previousMnemonic: nil,
+            secureStorage: storage
+        )
+
+        XCTAssertNil(storage.secrets[StorageKeys.Secure.mnemonic])
+    }
+
+    func testPartialBackupFailureRestoresEveryMovedOriginal() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = directory.appendingPathComponent("first.db")
+        let second = directory.appendingPathComponent("second.db")
+        try Data("first".utf8).write(to: first)
+        try Data("second".utf8).write(to: second)
+
+        var forwardMoveCount = 0
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                if !source.lastPathComponent.hasSuffix(".backup") {
+                    forwardMoveCount += 1
+                    if forwardMoveCount == 2 {
+                        throw TestError.forcedMoveFailure
+                    }
+                }
+                try FileManager.default.moveItem(at: source, to: destination)
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.backup(
+                urls: [first, second],
+                operations: operations,
+                backupURL: { $0.appendingPathExtension("backup") }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: first), Data("first".utf8))
+        XCTAssertEqual(try Data(contentsOf: second), Data("second".utf8))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: first.appendingPathExtension("backup").path
+            )
+        )
+    }
+
+    func testMissingBackupNeverDeletesReplacementDatabase() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("wallet.db")
+        let missingBackup = directory.appendingPathComponent("wallet.db.backup")
+        try Data("replacement".utf8).write(to: original)
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                [WalletFileBackup(originalURL: original, backupURL: missingBackup)],
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
+    }
+
+    func testRestorePreflightsEveryBackupBeforeMovingAnyDatabase() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstOriginal = directory.appendingPathComponent("first.db")
+        let firstMissingBackup = directory.appendingPathComponent("first.db.backup")
+        let secondOriginal = directory.appendingPathComponent("second.db")
+        let secondBackup = directory.appendingPathComponent("second.db.backup")
+        try Data("new first".utf8).write(to: firstOriginal)
+        try Data("new second".utf8).write(to: secondOriginal)
+        try Data("old second".utf8).write(to: secondBackup)
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                [
+                    WalletFileBackup(
+                        originalURL: firstOriginal,
+                        backupURL: firstMissingBackup
+                    ),
+                    WalletFileBackup(
+                        originalURL: secondOriginal,
+                        backupURL: secondBackup
+                    ),
+                ],
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: secondOriginal), Data("new second".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondBackup), Data("old second".utf8))
+    }
+
+    func testRollbackRemovesDatabaseCreatedWithoutAnOriginalBackup() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let newlyCreatedDatabase = directory.appendingPathComponent("wallet.db")
+        try Data("replacement".utf8).write(to: newlyCreatedDatabase)
+
+        try WalletReplacementFiles.removeUnbackedReplacements(
+            at: [newlyCreatedDatabase],
+            backups: []
+        )
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: newlyCreatedDatabase.path)
+        )
+    }
+
+    func testFailedRestoreMovePutsReplacementDatabaseBack() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("wallet.db")
+        let backup = directory.appendingPathComponent("wallet.db.backup")
+        try Data("replacement".utf8).write(to: original)
+        try Data("original".utf8).write(to: backup)
+
+        var moveCount = 0
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                moveCount += 1
+                if moveCount == 2 {
+                    throw TestError.forcedMoveFailure
+                }
+                try FileManager.default.moveItem(at: source, to: destination)
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                [WalletFileBackup(originalURL: original, backupURL: backup)],
+                operations: operations,
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
+        XCTAssertEqual(try Data(contentsOf: backup), Data("original".utf8))
+    }
+
+    func testLaterRestoreFailureRestoresEveryReplacementAndBackup() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstOriginal = directory.appendingPathComponent("first.db")
+        let firstBackup = directory.appendingPathComponent("first.db.backup")
+        let secondOriginal = directory.appendingPathComponent("second.db")
+        let secondBackup = directory.appendingPathComponent("second.db.backup")
+        let firstDisplaced = firstOriginal.appendingPathExtension("displaced")
+        let secondDisplaced = secondOriginal.appendingPathExtension("displaced")
+        try Data("new first".utf8).write(to: firstOriginal)
+        try Data("old first".utf8).write(to: firstBackup)
+        try Data("new second".utf8).write(to: secondOriginal)
+        try Data("old second".utf8).write(to: secondBackup)
+
+        var backupMoveCount = 0
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                if source.pathExtension == "backup" {
+                    backupMoveCount += 1
+                    if backupMoveCount == 2 {
+                        throw TestError.forcedMoveFailure
+                    }
+                }
+                try FileManager.default.moveItem(at: source, to: destination)
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                [
+                    WalletFileBackup(
+                        originalURL: firstOriginal,
+                        backupURL: firstBackup
+                    ),
+                    WalletFileBackup(
+                        originalURL: secondOriginal,
+                        backupURL: secondBackup
+                    ),
+                ],
+                operations: operations,
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+
+        XCTAssertEqual(backupMoveCount, 2)
+        XCTAssertEqual(try Data(contentsOf: firstOriginal), Data("new first".utf8))
+        XCTAssertEqual(try Data(contentsOf: firstBackup), Data("old first".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondOriginal), Data("new second".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondBackup), Data("old second".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstDisplaced.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondDisplaced.path))
+    }
+}

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -411,6 +411,7 @@ final class CashuRequestStoreTests: XCTestCase {
 final class WalletReplacementSafetyTests: XCTestCase {
     private enum TestError: Error {
         case forcedMoveFailure
+        case forcedSeedFailure
     }
 
     private final class SecureStorageSpy: SecureStorageProtocol {
@@ -505,6 +506,48 @@ final class WalletReplacementSafetyTests: XCTestCase {
         )
     }
 
+    func testPartialBackupFailureReportedAfterMoveRestoresCurrentOriginal() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = directory.appendingPathComponent("first.db")
+        let second = directory.appendingPathComponent("second.db")
+        try Data("first".utf8).write(to: first)
+        try Data("second".utf8).write(to: second)
+
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                try FileManager.default.moveItem(at: source, to: destination)
+                if source == second {
+                    throw TestError.forcedMoveFailure
+                }
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.backup(
+                urls: [first, second],
+                operations: operations,
+                backupURL: { $0.appendingPathExtension("backup") }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: first), Data("first".utf8))
+        XCTAssertEqual(try Data(contentsOf: second), Data("second".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: first.appendingPathExtension("backup").path
+        ))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: second.appendingPathExtension("backup").path
+        ))
+    }
+
     func testMissingBackupNeverDeletesReplacementDatabase() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -520,6 +563,7 @@ final class WalletReplacementSafetyTests: XCTestCase {
 
         XCTAssertThrowsError(
             try WalletReplacementFiles.restore(
+                at: [original],
                 [WalletFileBackup(originalURL: original, backupURL: missingBackup)],
                 displacedURL: { $0.appendingPathExtension("displaced") }
             )
@@ -546,6 +590,7 @@ final class WalletReplacementSafetyTests: XCTestCase {
 
         XCTAssertThrowsError(
             try WalletReplacementFiles.restore(
+                at: [firstOriginal, secondOriginal],
                 [
                     WalletFileBackup(
                         originalURL: firstOriginal,
@@ -563,7 +608,7 @@ final class WalletReplacementSafetyTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: secondBackup), Data("old second".utf8))
     }
 
-    func testRollbackRemovesDatabaseCreatedWithoutAnOriginalBackup() throws {
+    func testCommittedRestoreRemovesDatabaseCreatedWithoutAnOriginalBackup() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(
@@ -575,9 +620,10 @@ final class WalletReplacementSafetyTests: XCTestCase {
         let newlyCreatedDatabase = directory.appendingPathComponent("wallet.db")
         try Data("replacement".utf8).write(to: newlyCreatedDatabase)
 
-        try WalletReplacementFiles.removeUnbackedReplacements(
+        try WalletReplacementFiles.restore(
             at: [newlyCreatedDatabase],
-            backups: []
+            [],
+            displacedURL: { $0.appendingPathExtension("displaced") }
         )
 
         XCTAssertFalse(
@@ -614,6 +660,7 @@ final class WalletReplacementSafetyTests: XCTestCase {
 
         XCTAssertThrowsError(
             try WalletReplacementFiles.restore(
+                at: [original],
                 [WalletFileBackup(originalURL: original, backupURL: backup)],
                 operations: operations,
                 displacedURL: { $0.appendingPathExtension("displaced") }
@@ -621,6 +668,122 @@ final class WalletReplacementSafetyTests: XCTestCase {
         )
         XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
         XCTAssertEqual(try Data(contentsOf: backup), Data("original".utf8))
+    }
+
+    func testDisplacementFailureReportedAfterMoveRestoresReplacement() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("wallet.db")
+        let backup = directory.appendingPathComponent("wallet.db.backup")
+        let displaced = original.appendingPathExtension("displaced")
+        try Data("replacement".utf8).write(to: original)
+        try Data("original".utf8).write(to: backup)
+
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                try FileManager.default.moveItem(at: source, to: destination)
+                if source == original && destination == displaced {
+                    throw TestError.forcedMoveFailure
+                }
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                at: [original],
+                [WalletFileBackup(originalURL: original, backupURL: backup)],
+                operations: operations,
+                displacedURL: { _ in displaced }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
+        XCTAssertEqual(try Data(contentsOf: backup), Data("original".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: displaced.path))
+    }
+
+    func testRestoreFailureReportedAfterMoveRestoresReplacementAndBackup() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("wallet.db")
+        let backup = directory.appendingPathComponent("wallet.db.backup")
+        let displaced = original.appendingPathExtension("displaced")
+        try Data("replacement".utf8).write(to: original)
+        try Data("original".utf8).write(to: backup)
+
+        var didFail = false
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                try FileManager.default.moveItem(at: source, to: destination)
+                if source == backup && !didFail {
+                    didFail = true
+                    throw TestError.forcedMoveFailure
+                }
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                at: [original],
+                [WalletFileBackup(originalURL: original, backupURL: backup)],
+                operations: operations,
+                displacedURL: { _ in displaced }
+            )
+        )
+        XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
+        XCTAssertEqual(try Data(contentsOf: backup), Data("original".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: displaced.path))
+    }
+
+    func testSeedCommitFailureRollsFilesAndSeedForwardToReplacement() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let original = directory.appendingPathComponent("wallet.db")
+        let backup = directory.appendingPathComponent("wallet.db.backup")
+        let displaced = original.appendingPathExtension("displaced")
+        try Data("replacement".utf8).write(to: original)
+        try Data("original".utf8).write(to: backup)
+        var activeSeed = "replacement seed"
+
+        XCTAssertThrowsError(
+            try WalletReplacementFiles.restore(
+                at: [original],
+                [WalletFileBackup(originalURL: original, backupURL: backup)],
+                displacedURL: { _ in displaced },
+                beforeCommit: {
+                    activeSeed = "original seed"
+                    throw TestError.forcedSeedFailure
+                },
+                onRollback: {
+                    activeSeed = "replacement seed"
+                }
+            )
+        )
+        XCTAssertEqual(activeSeed, "replacement seed")
+        XCTAssertEqual(try Data(contentsOf: original), Data("replacement".utf8))
+        XCTAssertEqual(try Data(contentsOf: backup), Data("original".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: displaced.path))
     }
 
     func testLaterRestoreFailureRestoresEveryReplacementAndBackup() throws {
@@ -660,6 +823,7 @@ final class WalletReplacementSafetyTests: XCTestCase {
 
         XCTAssertThrowsError(
             try WalletReplacementFiles.restore(
+                at: [firstOriginal, secondOriginal],
                 [
                     WalletFileBackup(
                         originalURL: firstOriginal,


### PR DESCRIPTION
## Summary

- Make wallet replacement a checked multi-file transaction on both iOS and Android.
- Keep replacement files recoverable until the previous seed and database have committed.
- Preflight every backup and compensate file and seed state on failures, including errors reported after a move completed.
- Treat backup cleanup as post-commit work so cleanup failures cannot trigger a destructive rollback.

## Why

A failure partway through wallet replacement could leave a mixed set of old and new database files or pair a database with the wrong seed. Android also ignored failed `renameTo` and recursive-delete results, leaving the same data-integrity gap there.

## Testing

- iOS `WalletReplacementSafetyTests`: 12 tests passed.
- iOS non-integration unit target: passed.
- Android `WalletReplacementSafetyTest`: 9 tests passed.
- Android `:app:testDebugUnitTest`: passed.
- Android `:app:lintDebug`: passed.
- Android `:app:assembleRelease`: passed.
