### PR TITLE
fix(ios): quiesce Cashu Request work at wallet boundaries

### DIFF
--- a/ios/CashuWallet/App/CashuWalletApp.swift
+++ b/ios/CashuWallet/App/CashuWalletApp.swift
@@ -79,7 +79,7 @@ struct CashuWalletApp: App {
                         await walletManager.initialize()
                         guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
                         CashuRequestListener.shared.attach(walletManager: walletManager)
-                        await CashuRequestListener.shared.start()
+                        CashuRequestListener.shared.requestStart()
                         if SettingsManager.shared.checkSentTokens {
                             await walletManager.checkAllPendingTokens()
                         }
@@ -112,7 +112,7 @@ struct CashuWalletApp: App {
                 switch newPhase {
                 case .active:
                     appLockManager.appBecameActive()
-                    Task { await CashuRequestListener.shared.start() }
+                    CashuRequestListener.shared.requestStart()
                     if SettingsManager.shared.checkSentTokens {
                         Task { await walletManager.checkAllPendingTokens() }
                     }
@@ -131,7 +131,7 @@ struct CashuWalletApp: App {
                     appLockManager.appResignedActive()
                 case .background:
                     appLockManager.appResignedActive()
-                    Task { await CashuRequestListener.shared.stop() }
+                    CashuRequestListener.shared.requestStop()
                     // Quiesce the timers so no fresh mint network + wallet-DB write kicks
                     // off during the brief background-transition window before suspension.
                     NPCService.shared.stopBackgroundRefresh()

--- a/ios/CashuWallet/Core/CashuRequestListener.swift
+++ b/ios/CashuWallet/Core/CashuRequestListener.swift
@@ -1,6 +1,305 @@
 import Foundation
 import SwiftUI
 
+protocol CashuRequestInboxClient: AnyObject, Sendable {
+    func start() async
+    func stop() async
+}
+
+extension NostrInboxClient: CashuRequestInboxClient {}
+
+/// Preserves the latest lifecycle intent even when the unstructured task for
+/// an earlier scene or setting transition has not started yet.
+@MainActor
+final class CashuRequestListenerLifecycleScheduler {
+    enum Intent: Equatable {
+        case start
+        case stop
+    }
+
+    private var requestGeneration: UInt = 0
+    private var currentIntent: Intent?
+    private var task: Task<Void, Never>?
+
+    @discardableResult
+    func submit(
+        _ intent: Intent,
+        _ operation: @escaping @MainActor () async -> Void
+    ) -> Task<Void, Never> {
+        if currentIntent == intent, let task {
+            return task
+        }
+
+        requestGeneration &+= 1
+        let submittedGeneration = requestGeneration
+        task?.cancel()
+        currentIntent = intent
+
+        let submittedTask = Task { @MainActor [weak self] in
+            guard let self,
+                  !Task.isCancelled,
+                  self.requestGeneration == submittedGeneration else { return }
+            await operation()
+            guard self.requestGeneration == submittedGeneration else { return }
+            self.currentIntent = nil
+            self.task = nil
+        }
+        task = submittedTask
+        return submittedTask
+    }
+
+    func invalidate() {
+        requestGeneration &+= 1
+        task?.cancel()
+        currentIntent = nil
+        task = nil
+    }
+}
+
+/// Owns exactly one inbox client across async start/stop/reset races. The
+/// candidate is published before its first suspension point so overlapping
+/// starts share one owner, while the generation prevents stale completions
+/// from becoming running again after a wallet boundary.
+@MainActor
+final class CashuRequestListenerClientSlot {
+    private var generation: UInt = 0
+    private var client: (any CashuRequestInboxClient)?
+    private var retiringClients: [ObjectIdentifier: any CashuRequestInboxClient] = [:]
+    private var retirementWaiters: [CheckedContinuation<Void, Never>] = []
+    private let onRunningChange: (Bool) -> Void
+
+    private(set) var isRunning = false
+
+    init(onRunningChange: @escaping (Bool) -> Void = { _ in }) {
+        self.onRunningChange = onRunningChange
+    }
+
+    @discardableResult
+    func start(
+        makeClient: (UInt) -> any CashuRequestInboxClient
+    ) async -> Bool {
+        guard !Task.isCancelled, client == nil else { return false }
+        await waitUntilRetired()
+        guard !Task.isCancelled, client == nil else { return false }
+
+        generation &+= 1
+        let startGeneration = generation
+        let candidate = makeClient(startGeneration)
+        client = candidate
+
+        await candidate.start()
+
+        let stillOwnsCandidate: Bool
+        if let current = client {
+            stillOwnsCandidate = generation == startGeneration
+                && ObjectIdentifier(current) == ObjectIdentifier(candidate)
+        } else {
+            stillOwnsCandidate = false
+        }
+        guard !Task.isCancelled, stillOwnsCandidate else {
+            if stillOwnsCandidate {
+                let displaced = invalidate()
+                await retireAndWaitForAll(displaced)
+            }
+            return false
+        }
+
+        setRunning(true)
+        return true
+    }
+
+    /// Event callbacks capture the generation that created their client. A
+    /// stop, reset, or replacement invalidates that ownership synchronously,
+    /// before the old client's asynchronous shutdown can finish.
+    func owns(_ candidateGeneration: UInt) -> Bool {
+        generation == candidateGeneration && client != nil
+    }
+
+    /// Invalidates callback ownership synchronously and returns the displaced
+    /// client so callers can choose whether to await or detach its shutdown.
+    @discardableResult
+    func invalidate() -> (any CashuRequestInboxClient)? {
+        generation &+= 1
+        let previous = client
+        client = nil
+        setRunning(false)
+        return previous
+    }
+
+    func stop() async {
+        let previous = invalidate()
+        await retireAndWaitForAll(previous)
+    }
+
+    func reset() {
+        guard let previous = invalidate() else { return }
+        let identifier = beginRetirement(previous)
+        Task { [weak self] in
+            await previous.stop()
+            self?.finishRetirement(identifier)
+        }
+    }
+
+    private func retire(_ retiringClient: any CashuRequestInboxClient) async {
+        let identifier = beginRetirement(retiringClient)
+        await retiringClient.stop()
+        finishRetirement(identifier)
+    }
+
+    func retireAndWaitForAll(
+        _ displacedClient: (any CashuRequestInboxClient)?
+    ) async {
+        if let displacedClient {
+            await retire(displacedClient)
+        }
+        await waitUntilRetired()
+    }
+
+    private func beginRetirement(
+        _ retiringClient: any CashuRequestInboxClient
+    ) -> ObjectIdentifier {
+        let identifier = ObjectIdentifier(retiringClient)
+        retiringClients[identifier] = retiringClient
+        return identifier
+    }
+
+    private func finishRetirement(_ identifier: ObjectIdentifier) {
+        retiringClients[identifier] = nil
+        guard retiringClients.isEmpty else { return }
+
+        let waiters = retirementWaiters
+        retirementWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func waitUntilRetired() async {
+        guard !retiringClients.isEmpty else { return }
+        await withCheckedContinuation { continuation in
+            retirementWaiters.append(continuation)
+        }
+    }
+
+    private func setRunning(_ running: Bool) {
+        guard isRunning != running else { return }
+        isRunning = running
+        onRunningChange(running)
+    }
+}
+
+/// A non-cancelling drain for wallet work owned by the request listener.
+///
+/// A wallet boundary first closes this gate, then waits for every lease that
+/// was already admitted. This is deliberately different from task
+/// cancellation: once CDK starts redeeming a token, cancellation cannot prove
+/// whether the mint consumed it, so the complete receive workflow (including
+/// transaction attribution and balance/history refreshes) must finish before
+/// the wallet database can be moved or removed.
+@MainActor
+final class CashuRequestListenerWorkGate {
+    private var drainWaiters: [CheckedContinuation<Void, Never>] = []
+
+    private(set) var acceptsNewWork = true
+    private(set) var activeWorkCount = 0
+
+    func begin() -> Bool {
+        guard acceptsNewWork else { return false }
+        activeWorkCount += 1
+        return true
+    }
+
+    func end() {
+        guard activeWorkCount > 0 else {
+            assertionFailure("Cashu request listener work gate underflow")
+            return
+        }
+        activeWorkCount -= 1
+        guard activeWorkCount == 0 else { return }
+
+        let waiters = drainWaiters
+        drainWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    /// Synchronous so no new held-payment or callback work can enter between
+    /// client invalidation and the first suspension of wallet reset.
+    func suspend() {
+        acceptsNewWork = false
+    }
+
+    func waitUntilDrained() async {
+        guard activeWorkCount > 0 else { return }
+        await withCheckedContinuation { continuation in
+            drainWaiters.append(continuation)
+        }
+    }
+
+    /// A new wallet explicitly reopens the gate only after it is attached.
+    func resume() {
+        guard activeWorkCount == 0 else { return }
+        acceptsNewWork = true
+    }
+}
+
+/// Mirrors Android's processed-event tracker: terminal gift wraps persist in a
+/// bounded history, while an in-flight set prevents the same relay event from
+/// entering a second receive workflow before the first one finishes.
+@MainActor
+final class ProcessedNIP17EventTracker {
+    private let load: () -> [String]
+    private let save: ([String]) -> Void
+    private let maxProcessedIds: Int
+    private var processedIds: Set<String> = []
+    private var processedOrder: [String] = []
+    private var inFlightIds: Set<String> = []
+
+    init(
+        load: @escaping () -> [String],
+        save: @escaping ([String]) -> Void,
+        maxProcessedIds: Int = 1_000
+    ) {
+        precondition(maxProcessedIds > 0, "maxProcessedIds must be positive")
+        self.load = load
+        self.save = save
+        self.maxProcessedIds = maxProcessedIds
+    }
+
+    func reload() {
+        var seen: Set<String> = []
+        let stored = load().filter { seen.insert($0).inserted }
+        processedOrder = Array(stored.suffix(maxProcessedIds))
+        processedIds = Set(processedOrder)
+        inFlightIds = []
+    }
+
+    func clear() {
+        processedIds = []
+        processedOrder = []
+        inFlightIds = []
+    }
+
+    func begin(_ eventId: String) -> Bool {
+        guard !processedIds.contains(eventId),
+              inFlightIds.insert(eventId).inserted else { return false }
+        return true
+    }
+
+    func finish(_ eventId: String, terminalOutcome: Bool) {
+        inFlightIds.remove(eventId)
+        guard terminalOutcome, processedIds.insert(eventId).inserted else { return }
+
+        processedOrder.append(eventId)
+        if processedOrder.count > maxProcessedIds {
+            let removed = processedOrder.removeFirst()
+            processedIds.remove(removed)
+        }
+        save(processedOrder)
+    }
+}
+
 /// NUT-18 receive-side listener. Foreground-only: opens a NIP-17 relay subscription
 /// at app launch, decrypts gift wraps, parses PaymentRequestPayload from the inner
 /// rumor, and forwards to the auto-claim path in WalletManager.
@@ -20,8 +319,21 @@ final class CashuRequestListener: ObservableObject {
     /// pending-receive store and stays claimable from History.
     @Published private(set) var heldForApproval: PendingReceiveToken?
 
-    private var client: NostrInboxClient?
+    private lazy var clientSlot = CashuRequestListenerClientSlot { [weak self] running in
+        self?.isRunning = running
+    }
+    private let lifecycleScheduler = CashuRequestListenerLifecycleScheduler()
+    private let workGate = CashuRequestListenerWorkGate()
     private weak var walletManager: WalletManager?
+
+    private enum WalletBoundaryState: Equatable {
+        case active
+        case resetting
+        case suspended
+    }
+
+    private var walletBoundaryState: WalletBoundaryState = .active
+    private var walletBoundaryResetWaiters: [CheckedContinuation<Void, Never>] = []
 
     // Gift wraps are fetched over a generous fixed lookback window. NIP-59
     // backdates each gift wrap's `created_at` up to ~2 days, so a tight or
@@ -30,20 +342,49 @@ final class CashuRequestListener: ObservableObject {
     // the gift-wrap event ids we've already handled.
     private let lookbackWindow: TimeInterval = 7 * 24 * 60 * 60
     private let processedIdsKey = StorageKeys.cashuRequestsProcessedNIP17Ids
-    private let maxProcessedIds = 1000
-    private var processedIds: Set<String> = []
-    private var processedOrder: [String] = []
+    private lazy var processedEvents = ProcessedNIP17EventTracker(
+        load: {
+            UserDefaults.standard.stringArray(
+                forKey: StorageKeys.cashuRequestsProcessedNIP17Ids
+            ) ?? []
+        },
+        save: {
+            UserDefaults.standard.set(
+                $0,
+                forKey: StorageKeys.cashuRequestsProcessedNIP17Ids
+            )
+        }
+    )
 
     private init() {}
 
     func attach(walletManager: WalletManager) {
         self.walletManager = walletManager
+        guard walletBoundaryState != .resetting else { return }
+        walletBoundaryState = .active
+        workGate.resume()
+    }
+
+    func requestStart() {
+        lifecycleScheduler.submit(.start) { [weak self] in
+            await self?.start()
+        }
+    }
+
+    func requestStop() {
+        lifecycleScheduler.submit(.stop) { [weak self] in
+            await self?.stop()
+        }
     }
 
     func start() async {
-        guard !isRunning else { return }
+        guard walletBoundaryState == .active, workGate.acceptsNewWork else {
+            AppLogger.wallet.notice("CashuRequestListener: wallet boundary in progress — not starting")
+            return
+        }
         guard SettingsManager.shared.enablePaymentRequests else {
             AppLogger.wallet.notice("CashuRequestListener: payment requests disabled in settings — not starting")
+            await clientSlot.stop()
             return
         }
         let nostr = NostrService.shared
@@ -61,51 +402,107 @@ final class CashuRequestListener: ObservableObject {
             AppLogger.wallet.error("CashuRequestListener: no Nostr relays configured — cannot receive Cashu Request payments")
             return
         }
-        loadProcessedIds()
         let since = Int64(Date().timeIntervalSince1970 - lookbackWindow)
 
         let pubkeyHex = nostr.publicKeyHex
-        let client = NostrInboxClient(
-            pubkeyHex: pubkeyHex,
-            relays: relays,
-            since: since
-        ) { [weak self] event in
-            await self?.handle(event: event, recipientPrivateKey: privateKey)
+        let started = await clientSlot.start { generation in
+            processedEvents.reload()
+            return NostrInboxClient(
+                pubkeyHex: pubkeyHex,
+                relays: relays,
+                since: since
+            ) { [weak self] event in
+                await self?.handleTracked(
+                    event: event,
+                    recipientPrivateKey: privateKey,
+                    generation: generation
+                )
+            }
         }
-        self.client = client
-        await client.start()
-        isRunning = true
+        guard started else { return }
         AppLogger.wallet.notice(
             "CashuRequestListener: started relays=\(relays.count, privacy: .public) pubkey=\(WalletOperationCoordinator.privacySafeIdentifier(pubkeyHex), privacy: .public) since=\(since, privacy: .public)"
         )
     }
 
     func stop() async {
-        guard let client else { return }
-        await client.stop()
-        self.client = nil
-        isRunning = false
+        await clientSlot.stop()
     }
 
-    /// Forget processed gift-wrap ids at a wallet boundary. The ids belong to
-    /// the previous wallet's Nostr inbox; a new wallet has a new keypair, and a
-    /// re-restored seed should re-attempt claims rather than skip them.
-    func resetForWalletBoundary() {
-        let oldClient = client
-        client = nil
-        isRunning = false
-        processedIds = []
-        processedOrder = []
+    /// Quiesce listener-owned wallet mutations before forgetting the previous
+    /// wallet's inbox state. The gate remains suspended until `attach` installs
+    /// the next wallet, preventing foreground/start tasks from reopening intake
+    /// while lifecycle code moves or removes the database.
+    func resetForWalletBoundary() async {
+        lifecycleScheduler.invalidate()
+        switch walletBoundaryState {
+        case .resetting:
+            // Waiting only for active wallet work is insufficient: the reset
+            // owner may still be stopping the client or clearing listener state.
+            await withCheckedContinuation { continuation in
+                walletBoundaryResetWaiters.append(continuation)
+            }
+            return
+        case .suspended:
+            return
+        case .active:
+            break
+        }
+
+        walletBoundaryState = .resetting
+
+        // Invalidate callback ownership before the first await. A callback that
+        // has not entered the gate is now rejected; one already inside is
+        // allowed to finish its full, potentially ambiguous receive workflow.
+        let previousClient = clientSlot.invalidate()
+        workGate.suspend()
+
+        await clientSlot.retireAndWaitForAll(previousClient)
+        await workGate.waitUntilDrained()
+
+        processedEvents.clear()
         heldForApproval = nil
         UserDefaults.standard.removeObject(forKey: processedIdsKey)
-        Task { await oldClient?.stop() }
+        walletBoundaryState = .suspended
+
+        let resetWaiters = walletBoundaryResetWaiters
+        walletBoundaryResetWaiters.removeAll()
+        for waiter in resetWaiters {
+            waiter.resume()
+        }
     }
 
     // MARK: - Event handling
 
-    private func handle(event: NostrIncomingEvent, recipientPrivateKey: Data) async {
+    private func handleTracked(
+        event: NostrIncomingEvent,
+        recipientPrivateKey: Data,
+        generation: UInt
+    ) async {
+        guard clientSlot.owns(generation), workGate.begin() else { return }
+        defer { workGate.end() }
+        await handle(
+            event: event,
+            recipientPrivateKey: recipientPrivateKey,
+            generation: generation
+        )
+    }
+
+    private func handle(
+        event: NostrIncomingEvent,
+        recipientPrivateKey: Data,
+        generation: UInt
+    ) async {
+        guard clientSlot.owns(generation) else { return }
         guard event.kind == 1059 else { return }
-        guard !processedIds.contains(event.id) else { return }
+        guard processedEvents.begin(event.id) else { return }
+        var terminalOutcome = false
+        defer {
+            processedEvents.finish(
+                event.id,
+                terminalOutcome: terminalOutcome && clientSlot.owns(generation)
+            )
+        }
         AppLogger.wallet.notice(
             "CashuRequestListener: gift wrap received event=\(WalletOperationCoordinator.privacySafeIdentifier(event.id), privacy: .public) created_at=\(event.createdAt, privacy: .public)"
         )
@@ -119,19 +516,23 @@ final class CashuRequestListener: ObservableObject {
             AppLogger.wallet.notice(
                 "CashuRequestListener: NIP-17 unwrap failed event=\(WalletOperationCoordinator.privacySafeIdentifier(event.id), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
-            markProcessed(event.id)
+            terminalOutcome = true
             return
         }
         guard rumor.kind == 14 else {
-            markProcessed(event.id)
+            terminalOutcome = true
             return
         }
-        switch await tryClaim(rumorContent: rumor.content, eventId: event.id) {
+        switch await tryClaim(
+            rumorContent: rumor.content,
+            eventId: event.id,
+            generation: generation
+        ) {
         case .claimed, .unclaimable, .held:
             // .held: the payment is persisted in the pending-receive store —
             // that store owns it now, so the relay event is done.
-            markProcessed(event.id)
-        case .transientFailure:
+            terminalOutcome = true
+        case .transientFailure, .stale:
             break  // leave unmarked so a later run retries
         }
     }
@@ -141,9 +542,15 @@ final class CashuRequestListener: ObservableObject {
         case unclaimable        // malformed / un-redeemable payload — never retry
         case transientFailure   // redeem failed (mint/network) — retry later
         case held               // persisted for an explicit user decision
+        case stale              // callback belongs to a stopped/replaced wallet
     }
 
-    private func tryClaim(rumorContent content: String, eventId: String) async -> ClaimOutcome {
+    private func tryClaim(
+        rumorContent content: String,
+        eventId: String,
+        generation: UInt
+    ) async -> ClaimOutcome {
+        guard clientSlot.owns(generation) else { return .stale }
         guard let data = content.data(using: .utf8),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return .unclaimable
@@ -174,21 +581,31 @@ final class CashuRequestListener: ObservableObject {
         let mintKnown = walletManager.isMintKnown(url: mintUrl)
         let autoClaim = SettingsManager.shared.receivePaymentRequestsAutomatically
         guard autoClaim && mintKnown else {
-            return holdForApproval(
+            return await holdForApproval(
                 tokenString: tokenString,
                 requestId: requestId,
                 mintUrl: mintUrl,
                 amount: proofsTotalAmount(proofs),
                 unit: PaymentRequestDecoder.unitDescription(PaymentRequestDecoder.currencyUnit(from: unit)),
                 memo: memo,
-                reason: mintKnown ? "auto-claim off" : "unknown mint"
+                reason: mintKnown ? "auto-claim off" : "unknown mint",
+                generation: generation
             )
         }
 
-        return await claimNow(tokenString: tokenString, requestId: requestId)
+        return await claimNow(
+            tokenString: tokenString,
+            requestId: requestId,
+            generation: generation
+        )
     }
 
-    private func claimNow(tokenString: String, requestId: String?) async -> ClaimOutcome {
+    private func claimNow(
+        tokenString: String,
+        requestId: String?,
+        generation: UInt
+    ) async -> ClaimOutcome {
+        guard clientSlot.owns(generation) else { return .stale }
         guard let walletManager else {
             AppLogger.wallet.error("CashuRequestListener: walletManager not attached")
             return .transientFailure
@@ -202,12 +619,14 @@ final class CashuRequestListener: ObservableObject {
                     requestId: requestId
                 )
             }
+            guard clientSlot.owns(generation) else { return .stale }
             let requestHash = requestId.map(WalletOperationCoordinator.privacySafeIdentifier) ?? "none"
             AppLogger.wallet.notice(
                 "CashuRequestListener: claimed payment request=\(requestHash, privacy: .public)"
             )
             return .claimed
         } catch {
+            guard clientSlot.owns(generation) else { return .stale }
             AppLogger.wallet.error(
                 "CashuRequestListener: redeem failed (will retry) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
@@ -235,8 +654,10 @@ final class CashuRequestListener: ObservableObject {
         amount: UInt64,
         unit: String,
         memo: String?,
-        reason: String
-    ) -> ClaimOutcome {
+        reason: String,
+        generation: UInt
+    ) async -> ClaimOutcome {
+        guard clientSlot.owns(generation) else { return .stale }
         guard let walletManager else { return .transientFailure }
 
         let existing = walletManager.pendingReceiveTokens
@@ -268,14 +689,16 @@ final class CashuRequestListener: ObservableObject {
         AppLogger.wallet.notice(
             "CashuRequestListener: payment held for approval resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintUrl), privacy: .public) reason=\(reason, privacy: .public)"
         )
-        Task { await walletManager.loadTransactions() }
-        return .held
+        await walletManager.loadTransactions()
+        return clientSlot.owns(generation) ? .held : .stale
     }
 
     /// User accepted (from the approval prompt): claim the held payment —
     /// this adds its mint to the wallet if needed — then silently claim any
     /// other held payments that no longer need a decision.
     func claimHeldPayment(_ pending: PendingReceiveToken) async throws -> UInt64 {
+        guard workGate.begin() else { throw WalletError.notInitialized }
+        defer { workGate.end() }
         guard let walletManager else { throw WalletError.notInitialized }
         let amount = try await withBackgroundWriteAssertion("cashu-request-claim") {
             try await walletManager.claimPendingReceiveToken(pending)
@@ -284,18 +707,23 @@ final class CashuRequestListener: ObservableObject {
         AppLogger.wallet.notice(
             "CashuRequestListener: user approved claim resource=\(WalletOperationCoordinator.privacySafeIdentifier(pending.mintUrl), privacy: .public)"
         )
-        await claimEligibleHeldPayments()
+        if workGate.acceptsNewWork {
+            await claimEligibleHeldPaymentsAssumingTrackedWork()
+        }
         return amount
     }
 
     /// User declined: drop the held payment permanently.
     func declineHeldPayment(_ pending: PendingReceiveToken) {
+        guard workGate.acceptsNewWork else { return }
         walletManager?.removePendingReceiveToken(tokenId: pending.tokenId)
         if heldForApproval?.tokenId == pending.tokenId { heldForApproval = nil }
         AppLogger.wallet.notice(
             "CashuRequestListener: user declined payment resource=\(WalletOperationCoordinator.privacySafeIdentifier(pending.mintUrl), privacy: .public)"
         )
-        Task { await walletManager?.loadTransactions() }
+        Task { [weak self] in
+            await self?.refreshTransactionsAfterHeldPaymentChange()
+        }
     }
 
     /// "Not now": hide the prompt. The payment stays in the pending-receive
@@ -310,12 +738,21 @@ final class CashuRequestListener: ObservableObject {
     /// mode — there every payment gets its own confirmation. Only touches
     /// listener-held entries, never manually parked "Receive Later" tokens.
     func claimEligibleHeldPayments() async {
+        guard workGate.begin() else { return }
+        defer { workGate.end() }
+        await claimEligibleHeldPaymentsAssumingTrackedWork()
+    }
+
+    private func claimEligibleHeldPaymentsAssumingTrackedWork() async {
         guard SettingsManager.shared.receivePaymentRequestsAutomatically else { return }
         guard let walletManager else { return }
         let eligible = walletManager.pendingReceiveTokens.filter {
             $0.cashuRequestId != nil && walletManager.isMintKnown(url: $0.mintUrl)
         }
         for pending in eligible {
+            // Finish an already-started receive, but never begin another after
+            // a wallet boundary has requested the drain.
+            guard workGate.acceptsNewWork else { return }
             do {
                 _ = try await withBackgroundWriteAssertion("cashu-request-claim") {
                     try await walletManager.claimPendingReceiveToken(pending)
@@ -332,30 +769,17 @@ final class CashuRequestListener: ObservableObject {
         }
     }
 
+    private func refreshTransactionsAfterHeldPaymentChange() async {
+        guard workGate.begin() else { return }
+        defer { workGate.end() }
+        await walletManager?.loadTransactions()
+    }
+
     private func proofsTotalAmount(_ proofs: [[String: Any]]) -> UInt64 {
         proofs.reduce(UInt64(0)) { total, proof in
             let amount = (proof["amount"] as? NSNumber)?.uint64Value ?? 0
             return total &+ amount
         }
-    }
-
-    // MARK: - De-duplication
-
-    private func loadProcessedIds() {
-        let stored = UserDefaults.standard.stringArray(forKey: processedIdsKey) ?? []
-        processedOrder = stored
-        processedIds = Set(stored)
-    }
-
-    private func markProcessed(_ id: String) {
-        guard processedIds.insert(id).inserted else { return }
-        processedOrder.append(id)
-        if processedOrder.count > maxProcessedIds {
-            let overflow = processedOrder.count - maxProcessedIds
-            for removed in processedOrder.prefix(overflow) { processedIds.remove(removed) }
-            processedOrder.removeFirst(overflow)
-        }
-        UserDefaults.standard.set(processedOrder, forKey: processedIdsKey)
     }
 
     /// Build a NUT-00 V3 cashu token string from a mint + proofs payload.

--- a/ios/CashuWallet/Core/SettingsManager.swift
+++ b/ios/CashuWallet/Core/SettingsManager.swift
@@ -95,12 +95,10 @@ class SettingsManager: ObservableObject {
             settingsStore.enablePaymentRequests = enablePaymentRequests
             guard !suppressPaymentRequestSideEffects else { return }
             guard enablePaymentRequests != oldValue else { return }
-            Task { @MainActor in
-                if enablePaymentRequests {
-                    await CashuRequestListener.shared.start()
-                } else {
-                    await CashuRequestListener.shared.stop()
-                }
+            if enablePaymentRequests {
+                CashuRequestListener.shared.requestStart()
+            } else {
+                CashuRequestListener.shared.requestStop()
             }
         }
     }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -548,7 +548,7 @@ extension WalletManager {
         needsOnboarding = false
         guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
         CashuRequestListener.shared.attach(walletManager: self)
-        Task { await CashuRequestListener.shared.start() }
+        CashuRequestListener.shared.requestStart()
     }
 
     /// Legacy restore for backward compatibility (initializes + completes without NUT-09)
@@ -561,6 +561,9 @@ extension WalletManager {
         isLoading = true
         defer { isLoading = false }
 
+        // Stop accepting listener work and let an already-started token receive
+        // finish all attribution/cache side effects before removing its wallet.
+        await CashuRequestListener.shared.resetForWalletBoundary()
         resetRuntimeState()
         try keychainService.deleteMnemonic()
         try? keychainService.deleteNostrPrivateKey()
@@ -570,7 +573,6 @@ extension WalletManager {
         SettingsManager.shared.resetWalletScopedData()
         NWCManager.shared.resetForWalletBoundary()
         CashuRequestStore.shared.resetForWalletBoundary()
-        CashuRequestListener.shared.resetForWalletBoundary()
         MintLogoCache.shared.clear()
         processedQuotes.removeAll()
         // iCloud backup survives a local deletion — the user can restore it from
@@ -594,7 +596,21 @@ extension WalletManager {
             previousMnemonic = try keychainService.loadMnemonic()
         }
         let defaultsSnapshot = walletBoundaryDefaultsSnapshot()
-        let fileBackups = try backupWalletDatabaseFiles()
+
+        // The database backup is a mutation too: drain listener-owned receives
+        // before any live wallet file can be displaced.
+        await CashuRequestListener.shared.resetForWalletBoundary()
+        let fileBackups: [WalletFileBackup]
+        do {
+            fileBackups = try backupWalletDatabaseFiles()
+        } catch {
+            // The transactional backup helper restores any files moved before
+            // the failure. Runtime state has not changed, so reopen listener
+            // intake for the still-attached wallet.
+            restoreWalletBoundaryDefaults(defaultsSnapshot)
+            resumeCashuRequestListenerAfterWalletBoundaryRollback()
+            throw error
+        }
 
         do {
             resetRuntimeState()
@@ -605,7 +621,6 @@ extension WalletManager {
             NPCService.shared.resetForWalletBoundary()
             NWCManager.shared.resetForWalletBoundary()
             CashuRequestStore.shared.resetForWalletBoundary()
-            CashuRequestListener.shared.resetForWalletBoundary()
             SettingsStore.shared.clearWalletScopedData()
 
             try initializeWalletForCreation(mnemonic: newMnemonic)
@@ -642,6 +657,7 @@ extension WalletManager {
                 SentryService.capture(error)
             }
 
+            var reopenedPreviousWallet = false
             if rollbackSucceeded {
                 restoreWalletBoundaryDefaults(defaultsSnapshot)
                 CashuRequestStore.shared.reloadFromDefaults()
@@ -651,10 +667,15 @@ extension WalletManager {
                     do {
                         try initializeWalletForLaunch(mnemonic: previousMnemonic)
                         startDeferredStartupMaintenance()
+                        reopenedPreviousWallet = true
                     } catch {
                         AppLogger.wallet.error("Failed to reopen previous wallet after replacement error: \(error)")
                     }
                 }
+            }
+
+            if reopenedPreviousWallet {
+                resumeCashuRequestListenerAfterWalletBoundaryRollback()
             }
 
             throw error
@@ -673,6 +694,13 @@ extension WalletManager {
         if !IntegrationTestConfig.shouldUseDeterministicUIRuntime {
             performICloudBackup()
         }
+    }
+
+    private func resumeCashuRequestListenerAfterWalletBoundaryRollback() {
+        guard walletRepository != nil else { return }
+        CashuRequestListener.shared.attach(walletManager: self)
+        guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
+        CashuRequestListener.shared.requestStart()
     }
 
     /// Open only local state needed for an immediately usable wallet. Network
@@ -1137,12 +1165,9 @@ extension WalletManager {
 
     private func startDeferredStartupMaintenance() {
         // Arm the foreground quote poll from the runtime path that provably
-        // runs on every launch. App-level wiring alone is not enough: the
-        // scenePhase `.active` onChange is unreliable at cold launch (hence the
-        // duplicated CashuRequestListener start), and the ContentView `.task`
-        // chain parks behind `await CashuRequestListener.shared.start()` (a
-        // Nostr connect that can hang), so anything queued after it may never
-        // run. Guard-protected — the scenePhase handler only stops/restarts it.
+        // runs on every launch. App-level wiring alone is not enough because
+        // scenePhase `.active` onChange is unreliable at cold launch.
+        // Guard-protected — the scenePhase handler only stops/restarts it.
         startPendingQuoteForegroundPolling()
         guard startupMaintenanceTask == nil else { return }
 

--- a/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestRouteExplanationTests.swift
@@ -135,3 +135,499 @@ final class CashuRequestNostrReadinessTests: XCTestCase {
         )
     }
 }
+
+@MainActor
+final class CashuRequestListenerClientSlotTests: XCTestCase {
+    private actor SuspendedInboxClient: CashuRequestInboxClient {
+        private var startContinuation: CheckedContinuation<Void, Never>?
+        private(set) var startCount = 0
+        private(set) var stopCount = 0
+
+        func start() async {
+            startCount += 1
+            await withCheckedContinuation { continuation in
+                startContinuation = continuation
+            }
+        }
+
+        func stop() async {
+            stopCount += 1
+        }
+
+        func releaseStart() {
+            startContinuation?.resume()
+            startContinuation = nil
+        }
+
+        func counts() -> (starts: Int, stops: Int) {
+            (startCount, stopCount)
+        }
+    }
+
+    private actor ImmediateInboxClient: CashuRequestInboxClient {
+        private(set) var startCount = 0
+        private(set) var stopCount = 0
+
+        func start() async {
+            startCount += 1
+        }
+
+        func stop() async {
+            stopCount += 1
+        }
+
+        func counts() -> (starts: Int, stops: Int) {
+            (startCount, stopCount)
+        }
+    }
+
+    private actor SuspendedStopInboxClient: CashuRequestInboxClient {
+        private var stopContinuation: CheckedContinuation<Void, Never>?
+        private(set) var stopCount = 0
+
+        func start() async {}
+
+        func stop() async {
+            stopCount += 1
+            await withCheckedContinuation { continuation in
+                stopContinuation = continuation
+            }
+        }
+
+        func releaseStop() {
+            stopContinuation?.resume()
+            stopContinuation = nil
+        }
+
+        func stops() -> Int {
+            stopCount
+        }
+    }
+
+    func testConcurrentStartsCreateOnlyOneClient() async {
+        let slot = CashuRequestListenerClientSlot()
+        let client = SuspendedInboxClient()
+        var factoryCalls = 0
+
+        let firstStart = Task {
+            await slot.start { _ in
+                factoryCalls += 1
+                return client
+            }
+        }
+        await waitUntilStarted(client)
+
+        let duplicateStarted = await slot.start { _ in
+            factoryCalls += 1
+            return SuspendedInboxClient()
+        }
+
+        XCTAssertFalse(duplicateStarted)
+        XCTAssertEqual(factoryCalls, 1)
+        await client.releaseStart()
+        let firstResult = await firstStart.value
+        XCTAssertTrue(firstResult)
+        XCTAssertTrue(slot.isRunning)
+        let counts = await client.counts()
+        XCTAssertEqual(counts.starts, 1)
+    }
+
+    func testStopDuringStartCannotPublishStaleRunningState() async {
+        let slot = CashuRequestListenerClientSlot()
+        let client = SuspendedInboxClient()
+        let start = Task { await slot.start { _ in client } }
+        await waitUntilStarted(client)
+
+        await slot.stop()
+        await client.releaseStart()
+
+        let startResult = await start.value
+        XCTAssertFalse(startResult)
+        XCTAssertFalse(slot.isRunning)
+        let counts = await client.counts()
+        XCTAssertEqual(counts.starts, 1)
+        XCTAssertGreaterThanOrEqual(counts.stops, 1)
+    }
+
+    func testCancellationDuringStartRetiresCandidateAndAllowsRestart() async {
+        let slot = CashuRequestListenerClientSlot()
+        let client = SuspendedInboxClient()
+        let start = Task { await slot.start { _ in client } }
+        await waitUntilStarted(client)
+
+        start.cancel()
+        await client.releaseStart()
+
+        let startResult = await start.value
+        XCTAssertFalse(startResult)
+        await waitUntilStopped(client)
+        XCTAssertFalse(slot.isRunning)
+
+        let replacement = ImmediateInboxClient()
+        let replacementStarted = await slot.start { _ in replacement }
+        XCTAssertTrue(replacementStarted)
+        XCTAssertTrue(slot.isRunning)
+    }
+
+    func testWalletResetDuringStartStopsStaleClient() async {
+        let slot = CashuRequestListenerClientSlot()
+        let client = SuspendedInboxClient()
+        let start = Task { await slot.start { _ in client } }
+        await waitUntilStarted(client)
+
+        slot.reset()
+        await client.releaseStart()
+        let startResult = await start.value
+        XCTAssertFalse(startResult)
+        await waitUntilStopped(client)
+
+        XCTAssertFalse(slot.isRunning)
+        let counts = await client.counts()
+        XCTAssertEqual(counts.starts, 1)
+        XCTAssertGreaterThanOrEqual(counts.stops, 1)
+    }
+
+    func testWalletResetInvalidatesOldCallbackGenerationAfterRestart() async {
+        let slot = CashuRequestListenerClientSlot()
+        let oldClient = ImmediateInboxClient()
+        var oldGeneration: UInt?
+
+        let oldStarted = await slot.start { generation in
+            oldGeneration = generation
+            return oldClient
+        }
+        XCTAssertTrue(oldStarted)
+        let capturedOldGeneration = try? XCTUnwrap(oldGeneration)
+        guard let capturedOldGeneration else { return }
+        XCTAssertTrue(slot.owns(capturedOldGeneration))
+
+        slot.reset()
+
+        let newClient = ImmediateInboxClient()
+        var newGeneration: UInt?
+        let newStarted = await slot.start { generation in
+            newGeneration = generation
+            return newClient
+        }
+        XCTAssertTrue(newStarted)
+        let capturedNewGeneration = try? XCTUnwrap(newGeneration)
+        guard let capturedNewGeneration else { return }
+
+        XCTAssertFalse(slot.owns(capturedOldGeneration))
+        XCTAssertTrue(slot.owns(capturedNewGeneration))
+        XCTAssertNotEqual(capturedOldGeneration, capturedNewGeneration)
+    }
+
+    func testRestartWaitsForRetiringClient() async {
+        let slot = CashuRequestListenerClientSlot()
+        let oldClient = SuspendedStopInboxClient()
+        let oldStarted = await slot.start { _ in oldClient }
+        XCTAssertTrue(oldStarted)
+
+        let stop = Task { await slot.stop() }
+        await waitUntilStopStarted(oldClient)
+
+        let newClient = ImmediateInboxClient()
+        var factoryCalls = 0
+        let restart = Task {
+            await slot.start { _ in
+                factoryCalls += 1
+                return newClient
+            }
+        }
+        await Task.yield()
+
+        XCTAssertEqual(factoryCalls, 0, "A replacement must wait for client retirement")
+        await oldClient.releaseStop()
+        await stop.value
+
+        let restarted = await restart.value
+        XCTAssertTrue(restarted)
+        XCTAssertEqual(factoryCalls, 1)
+        XCTAssertTrue(slot.isRunning)
+        let counts = await newClient.counts()
+        XCTAssertEqual(counts.starts, 1)
+    }
+
+    func testCancelledRestartDoesNotStartAfterRetirement() async {
+        let slot = CashuRequestListenerClientSlot()
+        let oldClient = SuspendedStopInboxClient()
+        let oldStarted = await slot.start { _ in oldClient }
+        XCTAssertTrue(oldStarted)
+
+        let stop = Task { await slot.stop() }
+        await waitUntilStopStarted(oldClient)
+
+        var factoryCalls = 0
+        let restart = Task {
+            await slot.start { _ in
+                factoryCalls += 1
+                return ImmediateInboxClient()
+            }
+        }
+        await Task.yield()
+        restart.cancel()
+        await oldClient.releaseStop()
+
+        await stop.value
+        let restarted = await restart.value
+        XCTAssertFalse(restarted)
+        XCTAssertEqual(factoryCalls, 0)
+        XCTAssertFalse(slot.isRunning)
+    }
+
+    private func waitUntilStarted(_ client: SuspendedInboxClient) async {
+        for _ in 0..<100 {
+            if (await client.counts()).starts == 1 { return }
+            await Task.yield()
+        }
+        XCTFail("Client start did not suspend in time")
+    }
+
+    private func waitUntilStopped(_ client: SuspendedInboxClient) async {
+        for _ in 0..<100 {
+            if (await client.counts()).stops >= 1 { return }
+            await Task.yield()
+        }
+        XCTFail("Client stop did not run in time")
+    }
+
+    private func waitUntilStopStarted(_ client: SuspendedStopInboxClient) async {
+        for _ in 0..<100 {
+            if await client.stops() == 1 { return }
+            await Task.yield()
+        }
+        XCTFail("Client stop did not suspend in time")
+    }
+}
+
+@MainActor
+final class CashuRequestListenerLifecycleSchedulerTests: XCTestCase {
+    private actor InboxClient: CashuRequestInboxClient {
+        private(set) var stopCount = 0
+
+        func start() async {}
+
+        func stop() async {
+            stopCount += 1
+        }
+
+        func stops() -> Int {
+            stopCount
+        }
+    }
+
+    private actor SuspendedStartInboxClient: CashuRequestInboxClient {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private(set) var startCount = 0
+
+        func start() async {
+            startCount += 1
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func stop() async {}
+
+        func releaseStart() {
+            continuation?.resume()
+            continuation = nil
+        }
+
+        func starts() -> Int {
+            startCount
+        }
+    }
+
+    func testLatestForegroundIntentWinsBeforeBackgroundTaskStarts() async {
+        let slot = CashuRequestListenerClientSlot()
+        let scheduler = CashuRequestListenerLifecycleScheduler()
+        let existingClient = InboxClient()
+        let existingStarted = await slot.start { _ in existingClient }
+        XCTAssertTrue(existingStarted)
+
+        let background = scheduler.submit(.stop) {
+            await slot.stop()
+        }
+        var replacementFactoryCalls = 0
+        let foreground = scheduler.submit(.start) {
+            _ = await slot.start { _ in
+                replacementFactoryCalls += 1
+                return InboxClient()
+            }
+        }
+
+        await background.value
+        await foreground.value
+
+        XCTAssertTrue(slot.isRunning)
+        let stopCount = await existingClient.stops()
+        XCTAssertEqual(stopCount, 0)
+        XCTAssertEqual(replacementFactoryCalls, 0)
+    }
+
+    func testLatestBackgroundIntentCancelsQueuedForegroundStart() async {
+        let slot = CashuRequestListenerClientSlot()
+        let scheduler = CashuRequestListenerLifecycleScheduler()
+        let existingClient = InboxClient()
+        let existingStarted = await slot.start { _ in existingClient }
+        XCTAssertTrue(existingStarted)
+
+        let foreground = scheduler.submit(.start) {
+            _ = await slot.start { _ in InboxClient() }
+        }
+        let background = scheduler.submit(.stop) {
+            await slot.stop()
+        }
+
+        await foreground.value
+        await background.value
+
+        XCTAssertFalse(slot.isRunning)
+        let stopCount = await existingClient.stops()
+        XCTAssertEqual(stopCount, 1)
+    }
+
+    func testDuplicateStartIntentSharesInFlightStart() async {
+        let slot = CashuRequestListenerClientSlot()
+        let scheduler = CashuRequestListenerLifecycleScheduler()
+        let client = SuspendedStartInboxClient()
+        var factoryCalls = 0
+
+        let first = scheduler.submit(.start) {
+            _ = await slot.start { _ in
+                factoryCalls += 1
+                return client
+            }
+        }
+        for _ in 0..<100 {
+            if await client.starts() == 1 { break }
+            await Task.yield()
+        }
+
+        let duplicate = scheduler.submit(.start) {
+            _ = await slot.start { _ in
+                factoryCalls += 1
+                return SuspendedStartInboxClient()
+            }
+        }
+        await Task.yield()
+        XCTAssertEqual(factoryCalls, 1)
+
+        await client.releaseStart()
+        await first.value
+        await duplicate.value
+        XCTAssertTrue(slot.isRunning)
+    }
+}
+
+@MainActor
+final class ProcessedNIP17EventTrackerTests: XCTestCase {
+    func testTransientEventCanRetryButTerminalEventPersists() {
+        var stored: [String] = []
+        let tracker = ProcessedNIP17EventTracker(
+            load: { stored },
+            save: { stored = $0 }
+        )
+        tracker.reload()
+
+        XCTAssertTrue(tracker.begin("retryable"))
+        tracker.finish("retryable", terminalOutcome: false)
+        XCTAssertTrue(tracker.begin("retryable"))
+
+        tracker.finish("retryable", terminalOutcome: true)
+        XCTAssertEqual(stored, ["retryable"])
+        XCTAssertFalse(tracker.begin("retryable"))
+
+        let reloaded = ProcessedNIP17EventTracker(
+            load: { stored },
+            save: { stored = $0 }
+        )
+        reloaded.reload()
+        XCTAssertFalse(reloaded.begin("retryable"))
+    }
+
+    func testConcurrentDuplicateIsSuppressedAndHistoryIsBounded() {
+        var stored: [String] = []
+        let tracker = ProcessedNIP17EventTracker(
+            load: { stored },
+            save: { stored = $0 },
+            maxProcessedIds: 2
+        )
+        tracker.reload()
+
+        XCTAssertTrue(tracker.begin("duplicate"))
+        XCTAssertFalse(tracker.begin("duplicate"))
+        tracker.finish("duplicate", terminalOutcome: true)
+
+        XCTAssertTrue(tracker.begin("second"))
+        tracker.finish("second", terminalOutcome: true)
+        XCTAssertTrue(tracker.begin("third"))
+        tracker.finish("third", terminalOutcome: true)
+
+        XCTAssertEqual(stored, ["second", "third"])
+        XCTAssertTrue(tracker.begin("duplicate"), "Evicted events may be reconsidered")
+        tracker.finish("duplicate", terminalOutcome: false)
+    }
+}
+
+@MainActor
+final class CashuRequestListenerWorkGateTests: XCTestCase {
+    private actor CompletionFlag {
+        private var completed = false
+
+        func markCompleted() {
+            completed = true
+        }
+
+        func isCompleted() -> Bool {
+            completed
+        }
+    }
+
+    func testSuspensionRejectsNewWorkAndWaitsForEveryExistingLease() async {
+        let gate = CashuRequestListenerWorkGate()
+        let drainCompleted = CompletionFlag()
+
+        XCTAssertTrue(gate.begin())
+        XCTAssertTrue(gate.begin())
+        XCTAssertEqual(gate.activeWorkCount, 2)
+
+        gate.suspend()
+        XCTAssertFalse(gate.acceptsNewWork)
+        XCTAssertFalse(gate.begin(), "A wallet boundary must reject late listener work")
+
+        let drain = Task { @MainActor in
+            await gate.waitUntilDrained()
+            await drainCompleted.markCompleted()
+        }
+        await Task.yield()
+        let completedBeforeRelease = await drainCompleted.isCompleted()
+        XCTAssertFalse(completedBeforeRelease)
+
+        gate.end()
+        await Task.yield()
+        XCTAssertEqual(gate.activeWorkCount, 1)
+        let completedAfterOneRelease = await drainCompleted.isCompleted()
+        XCTAssertFalse(completedAfterOneRelease, "One completed receive must not release another")
+
+        gate.end()
+        await drain.value
+        XCTAssertEqual(gate.activeWorkCount, 0)
+        let completedAfterDrain = await drainCompleted.isCompleted()
+        XCTAssertTrue(completedAfterDrain)
+    }
+
+    func testGateReopensOnlyAfterExplicitResume() async {
+        let gate = CashuRequestListenerWorkGate()
+
+        gate.suspend()
+        await gate.waitUntilDrained()
+        XCTAssertFalse(gate.begin())
+
+        gate.resume()
+        XCTAssertTrue(gate.begin())
+        gate.end()
+    }
+}


### PR DESCRIPTION
## Summary

- Enforce a single active iOS Cashu Request client across start, stop, reset, deletion, and replacement boundaries.
- Preserve the latest lifecycle intent when foreground/background transitions race, and wait for retiring clients before restarting.
- Track listener ownership by generation so stale callbacks cannot mutate a newly selected wallet.
- Suppress concurrent duplicate NIP-17 events while retaining bounded, persistent terminal-event history.
- Drain in-flight relay claims and their wallet post-effects before destructive wallet operations begin.
- Reattach and restart listener state after rollback while keeping ordinary foreground stops non-draining.

## Why

Overlapping listener lifecycles could apply claim or history work to the wrong wallet while a reset, deletion, or replacement was in progress. Independent scene-phase tasks could also lose the latest restart request, and duplicate relay delivery could process the same event concurrently.

This is a correctness fix, not a user-facing enhancement.

## Cross-platform parity

Android already defers restart until retiring clients stop, invalidates stale listener generations, serializes duplicate event handling, and bounds processed-event history. This change brings the iOS lifecycle and duplicate-delivery guarantees to the same level; no Android production-code change is required.

## Testing

- 7 `CashuRequestListenerClientSlotTests` passed.
- 3 `CashuRequestListenerLifecycleSchedulerTests` passed.
- 2 `ProcessedNIP17EventTrackerTests` passed.
- 2 `CashuRequestListenerWorkGateTests` passed.
- 12 `WalletReplacementSafetyTests` passed.
- Full local `CashuWalletTests` suite passed with live CDK/Nutshell integration suites skipped; GitHub CI provisions those external services.
