### PR TITLE
fix(mobile): ignore stale price refresh responses

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
@@ -116,6 +116,35 @@ class StorageDataStoreInstrumentedTest {
     }
 
     @Test
+    fun legacyGlobalPriceCacheMigratesOnceToSelectedCurrency() {
+        val storeName = uniqueStoreName("settings_store")
+        val rawStore = DataStorePreferenceStore(context, storeName)
+        rawStore.putString(StorageKeys.priceCachedBTC, "100000.0")
+        rawStore.putLong(StorageKeys.priceCachedBTCDate, 1_234L)
+        val store = SettingsStore(context, storeName)
+
+        assertEquals(100_000.0, store.cachedPrice("USD") ?: 0.0, 0.0)
+        assertEquals(1_234L, store.cachedPriceDate("USD"))
+        assertNull(rawStore.string(StorageKeys.priceCachedBTC))
+        assertEquals(Long.MIN_VALUE, rawStore.long(StorageKeys.priceCachedBTCDate, Long.MIN_VALUE))
+        assertNull(store.cachedPrice("EUR"))
+        assertNull(store.cachedPriceDate("EUR"))
+
+        rawStore.putString(StorageKeys.priceCachedBTC, "95000.0")
+        rawStore.putLong(StorageKeys.priceCachedBTCDate, 1_999L)
+        assertEquals(100_000.0, store.cachedPrice("USD") ?: 0.0, 0.0)
+        assertEquals(1_234L, store.cachedPriceDate("USD"))
+        assertNull(rawStore.string(StorageKeys.priceCachedBTC))
+        assertEquals(Long.MIN_VALUE, rawStore.long(StorageKeys.priceCachedBTCDate, Long.MIN_VALUE))
+
+        store.setCachedPrice(90_000.0, "EUR")
+        store.setCachedPriceDate(2_345L, "EUR")
+
+        assertNull(store.cachedPrice("GBP"))
+        assertNull(store.cachedPriceDate("GBP"))
+    }
+
+    @Test
     fun enablingAutomaticCashuRequestClaimsDrainsEligibleHeldPaymentsOnce() {
         val store = SettingsStore(context, uniqueStoreName("settings_store"))
         store.receivePaymentRequestsAutomatically = false

--- a/android/app/src/main/java/com/cashu/me/Core/PriceService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PriceService.kt
@@ -2,6 +2,7 @@ package com.cashu.me.Core
 
 import java.net.HttpURLConnection
 import java.net.URL
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -26,23 +27,52 @@ data class PriceState(
     val errorMessage: String? = null,
 )
 
-class PriceService(private val settingsStore: SettingsStore) {
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+interface PriceSettingsStore {
+    var showFiatBalance: Boolean
+    var bitcoinPriceCurrency: String
+    var priceEnabled: Boolean
+    var priceCurrencyCode: String
+
+    fun cachedPrice(currency: String): Double?
+    fun setCachedPrice(price: Double, currency: String)
+    fun cachedPriceDate(currency: String): Long?
+    fun setCachedPriceDate(epochMillis: Long, currency: String)
+}
+
+class PriceService internal constructor(
+    private val settingsStore: PriceSettingsStore,
+    private val priceFetcher: suspend (String) -> Double = { currency ->
+        withContext(Dispatchers.IO) { fetchCoinbasePrice(currency) }
+    },
+    private val nowEpochMillis: () -> Long = System::currentTimeMillis,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+    private val enableAutoRefresh: Boolean = true,
+) {
     private val mutableState = MutableStateFlow(loadStateFromStore())
     val state: StateFlow<PriceState> = mutableState.asStateFlow()
     private var refreshJob: Job? = null
+    private val requestLock = Any()
+    private var requestGeneration = 0L
 
     init {
-        if (mutableState.value.isEnabled) startAutoRefresh()
+        if (enableAutoRefresh && mutableState.value.isEnabled) startAutoRefresh()
     }
 
     fun syncFromSettings(refresh: Boolean = false) {
-        val updated = loadStateFromStore().copy(
-            isFetching = mutableState.value.isFetching,
-            errorMessage = mutableState.value.errorMessage,
-        )
-        mutableState.value = updated
-        if (updated.isEnabled) {
+        val loaded = loadStateFromStore()
+        val updated = synchronized(requestLock) {
+            val previous = mutableState.value
+            val requestContextChanged =
+                loaded.currencyCode != previous.currencyCode || loaded.isEnabled != previous.isEnabled
+            if (requestContextChanged) requestGeneration += 1
+            loaded.copy(
+                isFetching = previous.isFetching && loaded.isEnabled && !requestContextChanged,
+                errorMessage = previous.errorMessage.takeIf {
+                    loaded.isEnabled && !requestContextChanged
+                },
+            ).also { mutableState.value = it }
+        }
+        if (enableAutoRefresh && updated.isEnabled) {
             startAutoRefresh()
         } else {
             stopAutoRefresh()
@@ -56,21 +86,35 @@ class PriceService(private val settingsStore: SettingsStore) {
 
     suspend fun refreshBitcoinPrice(): Double? {
         syncFromSettings(refresh = false)
-        val current = mutableState.value
-        if (!current.isEnabled) return null
-        mutableState.value = current.copy(isFetching = true, errorMessage = null)
-
-        val result = runCatching {
-            withContext(Dispatchers.IO) {
-                fetchCoinbasePrice(current.currencyCode)
+        val request = synchronized(requestLock) {
+            val current = mutableState.value
+            if (!current.isEnabled) {
+                null
+            } else {
+                PriceRequest(
+                    generation = ++requestGeneration,
+                    currencyCode = current.currencyCode,
+                ).also {
+                    mutableState.value = current.copy(isFetching = true, errorMessage = null)
+                }
             }
+        } ?: return null
+
+        val price = try {
+            priceFetcher(request.currencyCode)
+        } catch (error: CancellationException) {
+            finishCancelledRequest(request)
+            throw error
+        } catch (error: Throwable) {
+            publishFailure(request, error)
+            return null
         }
 
-        return result.fold(
-            onSuccess = { price ->
-                val now = System.currentTimeMillis()
-                settingsStore.setCachedPrice(price, current.currencyCode)
-                settingsStore.setCachedPriceDate(now, current.currencyCode)
+        return synchronized(requestLock) {
+            if (isCurrentRequest(request)) {
+                val now = nowEpochMillis()
+                settingsStore.setCachedPrice(price, request.currencyCode)
+                settingsStore.setCachedPriceDate(now, request.currencyCode)
                 mutableState.value = mutableState.value.copy(
                     btcPrice = price,
                     isFetching = false,
@@ -78,15 +122,34 @@ class PriceService(private val settingsStore: SettingsStore) {
                     errorMessage = null,
                 )
                 price
-            },
-            onFailure = { error ->
-                mutableState.value = mutableState.value.copy(
-                    isFetching = false,
-                    errorMessage = error.message ?: "Could not fetch BTC price.",
-                )
+            } else {
                 null
-            },
-        )
+            }
+        }
+    }
+
+    private fun publishFailure(request: PriceRequest, error: Throwable) {
+        synchronized(requestLock) {
+            if (!isCurrentRequest(request)) return
+            mutableState.value = mutableState.value.copy(
+                isFetching = false,
+                errorMessage = error.message ?: "Could not fetch BTC price.",
+            )
+        }
+    }
+
+    private fun finishCancelledRequest(request: PriceRequest) {
+        synchronized(requestLock) {
+            if (!isCurrentRequest(request)) return
+            mutableState.value = mutableState.value.copy(isFetching = false)
+        }
+    }
+
+    private fun isCurrentRequest(request: PriceRequest): Boolean {
+        val current = mutableState.value
+        return request.generation == requestGeneration &&
+            current.isEnabled &&
+            current.currencyCode == request.currencyCode
     }
 
     private fun loadStateFromStore(): PriceState {
@@ -116,24 +179,29 @@ class PriceService(private val settingsStore: SettingsStore) {
         refreshJob?.cancel()
         refreshJob = null
     }
+}
 
-    private fun fetchCoinbasePrice(currency: String): Double {
-        val connection = (URL("https://api.coinbase.com/v2/prices/BTC-$currency/spot").openConnection() as HttpURLConnection)
-        connection.connectTimeout = 10_000
-        connection.readTimeout = 10_000
-        return try {
-            if (connection.responseCode !in 200..299) error("Invalid response from Coinbase.")
-            val body = connection.inputStream.bufferedReader().use { it.readText() }
-            Json.parseToJsonElement(body)
-                .jsonObject["data"]
-                ?.jsonObject
-                ?.get("amount")
-                ?.jsonPrimitive
-                ?.content
-                ?.toDoubleOrNull()
-                ?: error("Could not parse price data.")
-        } finally {
-            connection.disconnect()
-        }
+private data class PriceRequest(
+    val generation: Long,
+    val currencyCode: String,
+)
+
+private fun fetchCoinbasePrice(currency: String): Double {
+    val connection = (URL("https://api.coinbase.com/v2/prices/BTC-$currency/spot").openConnection() as HttpURLConnection)
+    connection.connectTimeout = 10_000
+    connection.readTimeout = 10_000
+    return try {
+        if (connection.responseCode !in 200..299) error("Invalid response from Coinbase.")
+        val body = connection.inputStream.bufferedReader().use { it.readText() }
+        Json.parseToJsonElement(body)
+            .jsonObject["data"]
+            ?.jsonObject
+            ?.get("amount")
+            ?.jsonPrimitive
+            ?.content
+            ?.toDoubleOrNull()
+            ?: error("Could not parse price data.")
+    } finally {
+        connection.disconnect()
     }
 }

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -202,28 +202,41 @@ class SettingsStore(
 
     override fun cachedPrice(currency: String): Double? {
         val normalized = currency.uppercase()
-        return store.string(StorageKeys.priceCachedBTC(normalized))?.toDoubleOrNull()
-            ?: store.string(StorageKeys.priceCachedBTC)?.toDoubleOrNull()
+        val key = StorageKeys.priceCachedBTC(normalized)
+        store.string(key)?.toDoubleOrNull()?.let {
+            store.removeKeys(listOf(StorageKeys.priceCachedBTC))
+            return it
+        }
+
+        val legacy = store.string(StorageKeys.priceCachedBTC)?.toDoubleOrNull() ?: return null
+        store.putString(key, legacy.toString())
+        store.removeKeys(listOf(StorageKeys.priceCachedBTC))
+        return legacy
     }
 
     override fun setCachedPrice(price: Double, currency: String) {
         val normalized = currency.uppercase()
         store.putString(StorageKeys.priceCachedBTC(normalized), price.toString())
-        store.putString(StorageKeys.priceCachedBTC, price.toString())
     }
 
     override fun cachedPriceDate(currency: String): Long? {
         val normalized = currency.uppercase()
-        val dated = store.long(StorageKeys.priceCachedBTCDate(normalized), Long.MIN_VALUE)
-        if (dated != Long.MIN_VALUE) return dated
+        val key = StorageKeys.priceCachedBTCDate(normalized)
+        val dated = store.long(key, Long.MIN_VALUE)
+        if (dated != Long.MIN_VALUE) {
+            store.removeKeys(listOf(StorageKeys.priceCachedBTCDate))
+            return dated
+        }
         val legacy = store.long(StorageKeys.priceCachedBTCDate, Long.MIN_VALUE)
-        return legacy.takeIf { it != Long.MIN_VALUE }
+        if (legacy == Long.MIN_VALUE) return null
+        store.putLong(key, legacy)
+        store.removeKeys(listOf(StorageKeys.priceCachedBTCDate))
+        return legacy
     }
 
     override fun setCachedPriceDate(epochMillis: Long, currency: String) {
         val normalized = currency.uppercase()
         store.putLong(StorageKeys.priceCachedBTCDate(normalized), epochMillis)
-        store.putLong(StorageKeys.priceCachedBTCDate, epochMillis)
     }
 
     private fun <T> loadList(key: String, serializer: KSerializer<T>): List<T> {

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -22,7 +22,7 @@ interface NostrSignerSettings {
 class SettingsStore(
     context: Context,
     storeName: String = "settings_store",
-) : NostrSignerSettings {
+) : NostrSignerSettings, PriceSettingsStore {
     companion object {
         val defaultNostrRelays = listOf(
             "wss://relay.damus.io",
@@ -38,11 +38,11 @@ class SettingsStore(
         get() = store.boolean(StorageKeys.settingsUseBitcoinSymbol, true)
         set(value) = store.putBoolean(StorageKeys.settingsUseBitcoinSymbol, value)
 
-    var showFiatBalance: Boolean
+    override var showFiatBalance: Boolean
         get() = store.boolean(StorageKeys.settingsShowFiatBalance, false)
         set(value) = store.putBoolean(StorageKeys.settingsShowFiatBalance, value)
 
-    var bitcoinPriceCurrency: String
+    override var bitcoinPriceCurrency: String
         get() = store.string(StorageKeys.settingsBitcoinPriceCurrency) ?: "USD"
         set(value) = store.putString(StorageKeys.settingsBitcoinPriceCurrency, value)
 
@@ -192,27 +192,27 @@ class SettingsStore(
         nostrRelays = defaultNostrRelays
     }
 
-    var priceEnabled: Boolean
+    override var priceEnabled: Boolean
         get() = store.boolean(StorageKeys.priceEnabled, showFiatBalance)
         set(value) = store.putBoolean(StorageKeys.priceEnabled, value)
 
-    var priceCurrencyCode: String
+    override var priceCurrencyCode: String
         get() = store.string(StorageKeys.priceCurrencyCode) ?: bitcoinPriceCurrency
         set(value) = store.putString(StorageKeys.priceCurrencyCode, value.uppercase())
 
-    fun cachedPrice(currency: String): Double? {
+    override fun cachedPrice(currency: String): Double? {
         val normalized = currency.uppercase()
         return store.string(StorageKeys.priceCachedBTC(normalized))?.toDoubleOrNull()
             ?: store.string(StorageKeys.priceCachedBTC)?.toDoubleOrNull()
     }
 
-    fun setCachedPrice(price: Double, currency: String) {
+    override fun setCachedPrice(price: Double, currency: String) {
         val normalized = currency.uppercase()
         store.putString(StorageKeys.priceCachedBTC(normalized), price.toString())
         store.putString(StorageKeys.priceCachedBTC, price.toString())
     }
 
-    fun cachedPriceDate(currency: String): Long? {
+    override fun cachedPriceDate(currency: String): Long? {
         val normalized = currency.uppercase()
         val dated = store.long(StorageKeys.priceCachedBTCDate(normalized), Long.MIN_VALUE)
         if (dated != Long.MIN_VALUE) return dated
@@ -220,7 +220,7 @@ class SettingsStore(
         return legacy.takeIf { it != Long.MIN_VALUE }
     }
 
-    fun setCachedPriceDate(epochMillis: Long, currency: String) {
+    override fun setCachedPriceDate(epochMillis: Long, currency: String) {
         val normalized = currency.uppercase()
         store.putLong(StorageKeys.priceCachedBTCDate(normalized), epochMillis)
         store.putLong(StorageKeys.priceCachedBTCDate, epochMillis)

--- a/android/app/src/test/java/com/cashu/me/Core/PriceServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PriceServiceTest.kt
@@ -1,0 +1,129 @@
+package com.cashu.me.Core
+
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PriceServiceTest {
+    @Test
+    fun staleUsdResponseCannotOverwriteNewerEurPrice() = runBlocking {
+        val settings = FakePriceSettings(priceEnabled = true, priceCurrencyCode = "USD")
+        val fetcher = ControlledPriceFetcher()
+        val service = PriceService(
+            settingsStore = settings,
+            priceFetcher = fetcher::fetch,
+            nowEpochMillis = { 1_234L },
+            enableAutoRefresh = false,
+        )
+
+        val usdRequest = async { service.refreshBitcoinPrice() }
+        assertEquals("USD", fetcher.started.receive())
+        settings.priceCurrencyCode = "EUR"
+        val eurRequest = async { service.refreshBitcoinPrice() }
+        assertEquals("EUR", fetcher.started.receive())
+
+        fetcher.complete("EUR", 90_000.0)
+        assertEquals(90_000.0, requireNotNull(eurRequest.await()), 0.0)
+        fetcher.complete("USD", 100_000.0)
+        assertNull(usdRequest.await())
+
+        assertEquals("EUR", service.state.value.currencyCode)
+        assertEquals(90_000.0, service.state.value.btcPrice, 0.0)
+        assertEquals(1_234L, service.state.value.lastUpdatedEpochMillis)
+        assertEquals(90_000.0, settings.cachedPrice("EUR") ?: 0.0, 0.0)
+        assertNull(settings.cachedPrice("USD"))
+        assertFalse(service.state.value.isFetching)
+    }
+
+    @Test
+    fun responseIsIgnoredAfterPricesAreDisabled() = runBlocking {
+        val settings = FakePriceSettings(priceEnabled = true, priceCurrencyCode = "USD")
+        val fetcher = ControlledPriceFetcher()
+        val service = PriceService(
+            settingsStore = settings,
+            priceFetcher = fetcher::fetch,
+            enableAutoRefresh = false,
+        )
+
+        val request = async { service.refreshBitcoinPrice() }
+        assertEquals("USD", fetcher.started.receive())
+        settings.priceEnabled = false
+        service.syncFromSettings()
+
+        assertFalse(service.state.value.isEnabled)
+        assertFalse(service.state.value.isFetching)
+        fetcher.complete("USD", 100_000.0)
+        assertNull(request.await())
+
+        assertFalse(service.state.value.isEnabled)
+        assertEquals(0.0, service.state.value.btcPrice, 0.0)
+        assertNull(settings.cachedPrice("USD"))
+    }
+
+    @Test
+    fun cancellingRefreshRemainsCancellationAndClearsFetchingState() = runBlocking {
+        val settings = FakePriceSettings(priceEnabled = true, priceCurrencyCode = "USD")
+        val started = CompletableDeferred<Unit>()
+        val service = PriceService(
+            settingsStore = settings,
+            priceFetcher = {
+                started.complete(Unit)
+                awaitCancellation()
+            },
+            enableAutoRefresh = false,
+        )
+
+        val request = async { service.refreshBitcoinPrice() }
+        started.await()
+        request.cancel()
+        request.join()
+
+        assertTrue(request.isCancelled)
+        assertFalse(service.state.value.isFetching)
+        assertNull(service.state.value.errorMessage)
+    }
+
+    private class ControlledPriceFetcher {
+        val started = Channel<String>(Channel.UNLIMITED)
+        private val responses = ConcurrentHashMap<String, CompletableDeferred<Double>>()
+
+        suspend fun fetch(currency: String): Double {
+            started.send(currency)
+            return responses.getOrPut(currency) { CompletableDeferred() }.await()
+        }
+
+        fun complete(currency: String, price: Double) {
+            responses.getOrPut(currency) { CompletableDeferred() }.complete(price)
+        }
+    }
+
+    private class FakePriceSettings(
+        override var priceEnabled: Boolean,
+        override var priceCurrencyCode: String,
+    ) : PriceSettingsStore {
+        override var showFiatBalance: Boolean = false
+        override var bitcoinPriceCurrency: String = priceCurrencyCode
+        private val prices = mutableMapOf<String, Double>()
+        private val dates = mutableMapOf<String, Long>()
+
+        override fun cachedPrice(currency: String): Double? = prices[currency]
+
+        override fun setCachedPrice(price: Double, currency: String) {
+            prices[currency] = price
+        }
+
+        override fun cachedPriceDate(currency: String): Long? = dates[currency]
+
+        override fun setCachedPriceDate(epochMillis: Long, currency: String) {
+            dates[currency] = epochMillis
+        }
+    }
+}

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		323A00000000000000000001 /* PriceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A00000000000000000002 /* PriceServiceTests.swift */; };
 		1100000000000001 /* CashuWalletApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000001 /* CashuWalletApp.swift */; };
 		1100000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000002 /* ContentView.swift */; };
 		1100000000000004 /* WalletManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000004 /* WalletManager.swift */; };
@@ -188,6 +189,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		323A00000000000000000002 /* PriceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriceServiceTests.swift; path = CashuWalletTests/PriceServiceTests.swift; sourceTree = "<group>"; };
 		0100000000000001 /* CashuWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CashuWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2100000000000001 /* CashuWalletApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletApp.swift; sourceTree = "<group>"; };
 		2100000000000002 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -383,6 +385,7 @@
 		172BA94269E4241413C46309 /* CashuWalletTests */ = {
 			isa = PBXGroup;
 			children = (
+				323A00000000000000000002 /* PriceServiceTests.swift */,
 				F1CF8C0C2E1379BCD23CF8C6 /* IntegrationTestBase.swift */,
 				72DD529F60A8D9D1A81E3FBB /* NutshellIntegrationTests.swift */,
 				T1B0000000000001 /* InMemoryStorage.swift */,
@@ -969,6 +972,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				323A00000000000000000001 /* PriceServiceTests.swift in Sources */,
 				BF36C01CE0AB810E1B462448 /* IntegrationTestBase.swift in Sources */,
 				349E3802577110813AC1A9E3 /* NutshellIntegrationTests.swift in Sources */,
 				T2B0000000000001 /* InMemoryStorage.swift in Sources */,

--- a/ios/CashuWallet/Core/PriceService.swift
+++ b/ios/CashuWallet/Core/PriceService.swift
@@ -16,7 +16,9 @@ class PriceService: ObservableObject {
         didSet {
             guard currencyCode != oldValue else { return }
             settingsStore.priceCurrencyCode = currencyCode
-            if isEnabled {
+            invalidatePendingRequests()
+            loadCachedPrice()
+            if enableAutoRefresh && isEnabled {
                 startAutoRefresh()
             }
         }
@@ -27,7 +29,8 @@ class PriceService: ObservableObject {
         didSet {
             guard isEnabled != oldValue else { return }
             settingsStore.priceEnabled = isEnabled
-            if isEnabled {
+            invalidatePendingRequests()
+            if enableAutoRefresh && isEnabled {
                 startAutoRefresh()
             } else {
                 stopAutoRefresh()
@@ -46,27 +49,30 @@ class PriceService: ObservableObject {
     
     // MARK: - Private Properties
     
-    private var coinbaseSpotURL: String {
-        "https://api.coinbase.com/v2/prices/BTC-\(currencyCode)/spot"
-    }
-    private let settingsStore = SettingsStore.shared
+    private let settingsStore: SettingsStore
+    private let priceFetcher: (String) async throws -> Double
+    private let now: () -> Date
+    private let enableAutoRefresh: Bool
     private var refreshTimer: Timer?
     private var initialFetchTask: Task<Void, Never>?
     private let refreshInterval: TimeInterval = 60 // Refresh every 60 seconds
+    private var requestGeneration = 0
 
     // MARK: - Initialization
     
-    init() {
+    init(
+        settingsStore: SettingsStore = .shared,
+        priceFetcher: @escaping (String) async throws -> Double = fetchCoinbasePrice,
+        now: @escaping () -> Date = Date.init,
+        enableAutoRefresh: Bool = true
+    ) {
+        self.settingsStore = settingsStore
+        self.priceFetcher = priceFetcher
+        self.now = now
+        self.enableAutoRefresh = enableAutoRefresh
         self.isEnabled = settingsStore.priceEnabled
         self.currencyCode = settingsStore.priceCurrencyCode
-
-        if let cachedPrice = settingsStore.cachedPrice(currency: currencyCode) {
-            self.btcPriceUSD = cachedPrice
-        }
-
-        if let cachedDate = settingsStore.cachedPriceDate(currency: currencyCode) {
-            self.lastUpdated = cachedDate
-        }
+        loadCachedPrice()
         
         // The first network refresh is started by SettingsManager after the
         // initial wallet UI has had a chance to render cached values.
@@ -77,42 +83,53 @@ class PriceService: ObservableObject {
     /// Fetch current BTC price from Coinbase
     func fetchPrice() async {
         guard isEnabled else { return }
-        
+
+        requestGeneration += 1
+        let request = PriceRequest(
+            generation: requestGeneration,
+            currencyCode: currencyCode
+        )
         isFetching = true
         errorMessage = nil
-        
-        defer { isFetching = false }
-        
+
         do {
-            guard let url = URL(string: coinbaseSpotURL) else {
-                throw PriceError.invalidURL
-            }
-            
-            let (data, response) = try await URLSession.shared.data(from: url)
-            
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else {
-                throw PriceError.invalidResponse
-            }
-            
-            let priceResponse = try JSONDecoder().decode(CoinbasePriceResponse.self, from: data)
-            
-            guard let price = Double(priceResponse.data.amount) else {
-                throw PriceError.invalidData
-            }
-            
+            let price = try await priceFetcher(request.currencyCode)
+            guard isCurrent(request) else { return }
+
             btcPriceUSD = price
-            let now = Date()
-            lastUpdated = now
-            
+            let updatedAt = now()
+            lastUpdated = updatedAt
+            isFetching = false
+
             // Cache the price
-            settingsStore.setCachedPrice(price, currency: currencyCode)
-            settingsStore.setCachedPriceDate(now, currency: currencyCode)
-            
+            settingsStore.setCachedPrice(price, currency: request.currencyCode)
+            settingsStore.setCachedPriceDate(updatedAt, currency: request.currencyCode)
         } catch {
+            guard isCurrent(request) else { return }
+            isFetching = false
+            if error is CancellationError || (error as? URLError)?.code == .cancelled || Task.isCancelled {
+                return
+            }
             errorMessage = error.localizedDescription
             print("Price fetch error: \(error)")
         }
+    }
+
+    private func invalidatePendingRequests() {
+        requestGeneration += 1
+        isFetching = false
+        errorMessage = nil
+    }
+
+    private func isCurrent(_ request: PriceRequest) -> Bool {
+        request.generation == requestGeneration &&
+            isEnabled &&
+            currencyCode == request.currencyCode
+    }
+
+    private func loadCachedPrice() {
+        btcPriceUSD = settingsStore.cachedPrice(currency: currencyCode) ?? 0
+        lastUpdated = settingsStore.cachedPriceDate(currency: currencyCode)
     }
     
     /// Convert satoshis to selected fiat currency
@@ -171,6 +188,32 @@ class PriceService: ObservableObject {
         initialFetchTask?.cancel()
         refreshTimer?.invalidate()
     }
+}
+
+private struct PriceRequest {
+    let generation: Int
+    let currencyCode: String
+}
+
+private func fetchCoinbasePrice(currency: String) async throws -> Double {
+    guard let url = URL(string: "https://api.coinbase.com/v2/prices/BTC-\(currency)/spot") else {
+        throw PriceError.invalidURL
+    }
+
+    let (data, response) = try await URLSession.shared.data(from: url)
+
+    guard let httpResponse = response as? HTTPURLResponse,
+          httpResponse.statusCode == 200 else {
+        throw PriceError.invalidResponse
+    }
+
+    let priceResponse = try JSONDecoder().decode(CoinbasePriceResponse.self, from: data)
+
+    guard let price = Double(priceResponse.data.amount) else {
+        throw PriceError.invalidData
+    }
+
+    return price
 }
 
 // MARK: - Error Types

--- a/ios/CashuWallet/Core/SettingsStore.swift
+++ b/ios/CashuWallet/Core/SettingsStore.swift
@@ -180,33 +180,49 @@ final class SettingsStore {
     }
 
     func cachedPrice(currency: String) -> Double? {
-        value(
-            StorageKeys.cachedBTCPrice(currency: currency),
-            legacyKeys: [
-                StorageKeys.Legacy.cachedBTCPrice(currency: currency),
-                StorageKeys.Legacy.cachedBTCPrice
-            ]
-        )
+        let key = StorageKeys.cachedBTCPrice(currency: currency)
+        if let cached: Double = value(
+            key,
+            legacy: StorageKeys.Legacy.cachedBTCPrice(currency: currency)
+        ) {
+            remove(keys: [StorageKeys.cachedBTCPrice, StorageKeys.Legacy.cachedBTCPrice])
+            return cached
+        }
+
+        guard let legacy: Double = try? storage.get(forKey: StorageKeys.Legacy.cachedBTCPrice) else {
+            return nil
+        }
+        set(legacy, forKey: key)
+        remove(keys: [StorageKeys.cachedBTCPrice, StorageKeys.Legacy.cachedBTCPrice])
+        return legacy
     }
 
     func setCachedPrice(_ price: Double, currency: String) {
         set(price, forKey: StorageKeys.cachedBTCPrice(currency: currency))
-        set(price, forKey: StorageKeys.cachedBTCPrice)
+        remove(keys: [StorageKeys.cachedBTCPrice, StorageKeys.Legacy.cachedBTCPrice])
     }
 
     func cachedPriceDate(currency: String) -> Date? {
-        value(
-            StorageKeys.cachedBTCPriceDate(currency: currency),
-            legacyKeys: [
-                StorageKeys.Legacy.cachedBTCPriceDate(currency: currency),
-                StorageKeys.Legacy.cachedBTCPriceDate
-            ]
-        )
+        let key = StorageKeys.cachedBTCPriceDate(currency: currency)
+        if let cached: Date = value(
+            key,
+            legacy: StorageKeys.Legacy.cachedBTCPriceDate(currency: currency)
+        ) {
+            remove(keys: [StorageKeys.cachedBTCPriceDate, StorageKeys.Legacy.cachedBTCPriceDate])
+            return cached
+        }
+
+        guard let legacy: Date = try? storage.get(forKey: StorageKeys.Legacy.cachedBTCPriceDate) else {
+            return nil
+        }
+        set(legacy, forKey: key)
+        remove(keys: [StorageKeys.cachedBTCPriceDate, StorageKeys.Legacy.cachedBTCPriceDate])
+        return legacy
     }
 
     func setCachedPriceDate(_ date: Date, currency: String) {
         set(date, forKey: StorageKeys.cachedBTCPriceDate(currency: currency))
-        set(date, forKey: StorageKeys.cachedBTCPriceDate)
+        remove(keys: [StorageKeys.cachedBTCPriceDate, StorageKeys.Legacy.cachedBTCPriceDate])
     }
 
     func clearWalletScopedData() {

--- a/ios/CashuWalletTests/PriceServiceTests.swift
+++ b/ios/CashuWalletTests/PriceServiceTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class PriceServiceTests: XCTestCase {
+    func testStaleUSDResponseCannotOverwriteNewerEURPrice() async throws {
+        let settings = makeSettings(currency: "USD")
+        let fetcher = ControlledPriceFetcher()
+        let updatedAt = Date(timeIntervalSince1970: 1_234)
+        let service = PriceService(
+            settingsStore: settings,
+            priceFetcher: fetcher.fetch,
+            now: { updatedAt },
+            enableAutoRefresh: false
+        )
+
+        let usdRequest = Task { await service.fetchPrice() }
+        let firstCurrency = await fetcher.nextStarted()
+        XCTAssertEqual(firstCurrency, "USD")
+
+        service.currencyCode = "EUR"
+        let eurRequest = Task { await service.fetchPrice() }
+        let secondCurrency = await fetcher.nextStarted()
+        XCTAssertEqual(secondCurrency, "EUR")
+
+        fetcher.complete(currency: "EUR", price: 90_000)
+        await eurRequest.value
+        fetcher.complete(currency: "USD", price: 100_000)
+        await usdRequest.value
+
+        XCTAssertEqual(service.currencyCode, "EUR")
+        XCTAssertEqual(service.btcPriceUSD, 90_000, accuracy: 0)
+        XCTAssertEqual(service.lastUpdated, updatedAt)
+        XCTAssertEqual(
+            try XCTUnwrap(settings.cachedPrice(currency: "EUR")),
+            90_000,
+            accuracy: 0
+        )
+        XCTAssertNil(settings.cachedPrice(currency: "USD"))
+        XCTAssertFalse(service.isFetching)
+    }
+
+    func testResponseIsIgnoredAfterPricesAreDisabled() async {
+        let settings = makeSettings(currency: "USD")
+        let fetcher = ControlledPriceFetcher()
+        let service = PriceService(
+            settingsStore: settings,
+            priceFetcher: fetcher.fetch,
+            enableAutoRefresh: false
+        )
+
+        let request = Task { await service.fetchPrice() }
+        let startedCurrency = await fetcher.nextStarted()
+        XCTAssertEqual(startedCurrency, "USD")
+
+        service.isEnabled = false
+        fetcher.complete(currency: "USD", price: 100_000)
+        await request.value
+
+        XCTAssertFalse(service.isEnabled)
+        XCTAssertFalse(service.isFetching)
+        XCTAssertEqual(service.btcPriceUSD, 0, accuracy: 0)
+        XCTAssertNil(settings.cachedPrice(currency: "USD"))
+    }
+
+    func testCancellingRefreshClearsFetchingWithoutPublishingAnError() async {
+        let settings = makeSettings(currency: "USD")
+        let fetcher = ControlledPriceFetcher()
+        let service = PriceService(
+            settingsStore: settings,
+            priceFetcher: fetcher.fetch,
+            enableAutoRefresh: false
+        )
+
+        let request = Task { await service.fetchPrice() }
+        let startedCurrency = await fetcher.nextStarted()
+        XCTAssertEqual(startedCurrency, "USD")
+
+        request.cancel()
+        await request.value
+
+        XCTAssertTrue(request.isCancelled)
+        XCTAssertFalse(service.isFetching)
+        XCTAssertNil(service.errorMessage)
+    }
+
+    func testLegacyGlobalCacheMigratesOnceToTheSelectedCurrency() throws {
+        let storage = InMemoryStorage()
+        let cachedAt = Date(timeIntervalSince1970: 1_234)
+        try storage.set(100_000.0, forKey: StorageKeys.Legacy.cachedBTCPrice)
+        try storage.set(cachedAt, forKey: StorageKeys.Legacy.cachedBTCPriceDate)
+        let settings = SettingsStore(storage: storage)
+
+        XCTAssertEqual(
+            try XCTUnwrap(settings.cachedPrice(currency: "USD")),
+            100_000,
+            accuracy: 0
+        )
+        XCTAssertEqual(settings.cachedPriceDate(currency: "USD"), cachedAt)
+        XCTAssertFalse(storage.exists(forKey: StorageKeys.Legacy.cachedBTCPrice))
+        XCTAssertFalse(storage.exists(forKey: StorageKeys.Legacy.cachedBTCPriceDate))
+        XCTAssertNil(settings.cachedPrice(currency: "EUR"))
+        XCTAssertNil(settings.cachedPriceDate(currency: "EUR"))
+
+        try storage.set(95_000.0, forKey: StorageKeys.Legacy.cachedBTCPrice)
+        try storage.set(cachedAt.addingTimeInterval(30), forKey: StorageKeys.Legacy.cachedBTCPriceDate)
+        XCTAssertEqual(
+            try XCTUnwrap(settings.cachedPrice(currency: "USD")),
+            100_000,
+            accuracy: 0
+        )
+        XCTAssertEqual(settings.cachedPriceDate(currency: "USD"), cachedAt)
+        XCTAssertFalse(storage.exists(forKey: StorageKeys.Legacy.cachedBTCPrice))
+        XCTAssertFalse(storage.exists(forKey: StorageKeys.Legacy.cachedBTCPriceDate))
+
+        settings.setCachedPrice(90_000, currency: "EUR")
+        settings.setCachedPriceDate(cachedAt.addingTimeInterval(60), currency: "EUR")
+
+        XCTAssertNil(settings.cachedPrice(currency: "GBP"))
+        XCTAssertNil(settings.cachedPriceDate(currency: "GBP"))
+    }
+
+    private func makeSettings(currency: String) -> SettingsStore {
+        let settings = SettingsStore(storage: InMemoryStorage())
+        settings.priceEnabled = true
+        settings.priceCurrencyCode = currency
+        return settings
+    }
+}
+
+@MainActor
+private final class ControlledPriceFetcher {
+    private var startedCurrencies: [String] = []
+    private var startedWaiters: [CheckedContinuation<String, Never>] = []
+    private var responses: [String: CheckedContinuation<Double, Error>] = [:]
+
+    func fetch(currency: String) async throws -> Double {
+        announceStarted(currency)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                responses[currency] = continuation
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancel(currency: currency)
+            }
+        }
+    }
+
+    func nextStarted() async -> String {
+        if !startedCurrencies.isEmpty {
+            return startedCurrencies.removeFirst()
+        }
+        return await withCheckedContinuation { continuation in
+            startedWaiters.append(continuation)
+        }
+    }
+
+    func complete(currency: String, price: Double) {
+        responses.removeValue(forKey: currency)?.resume(returning: price)
+    }
+
+    private func announceStarted(_ currency: String) {
+        if !startedWaiters.isEmpty {
+            startedWaiters.removeFirst().resume(returning: currency)
+        } else {
+            startedCurrencies.append(currency)
+        }
+    }
+
+    private func cancel(currency: String) {
+        responses.removeValue(forKey: currency)?.resume(throwing: CancellationError())
+    }
+}


### PR DESCRIPTION
## Summary

- Associate Android and iOS price refreshes with a generation and selected currency.
- Ignore responses that arrive after a newer refresh, currency change, or price display being disabled.
- Preserve task and coroutine cancellation without publishing it as an error.
- Scope cached prices and timestamps to their fiat currency, migrating the old global cache only once.
- Add regression coverage for refresh ordering, disabling, cancellation, and cache migration.

## Why

Slow network responses could overwrite newer price data or repopulate a price after the feature was disabled. The global cache fallback could also display a value fetched for one fiat currency under a different currency code.

This is a correctness fix rather than a new user-facing enhancement. Android and iOS now use equivalent behavior while retaining their native implementations.

## Testing

- iOS: `PriceServiceTests` — 4 passed.
- Android JVM: `PriceServiceTest` — passed.
- Android managed device API 35: focused `StorageDataStoreInstrumentedTest` cache migration — passed.