### PR TITLE
fix(mobile): make wallet database moves transactional

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
@@ -170,7 +170,10 @@ internal object WalletReplacementFiles {
                 } catch (error: Throwable) {
                     // The previous seed/database pair has committed. Cleanup
                     // failure must not trigger an unsafe rollback.
-                    AppLogger.wallet.error("Failed to remove a displaced replacement database", error)
+                    reportWalletCleanupFailure(
+                        "Failed to remove a displaced replacement database",
+                        error,
+                    )
                 }
             }
     }
@@ -242,6 +245,157 @@ internal object WalletReplacementFiles {
     }
 }
 
+internal data class WalletFileMove(
+    val source: File,
+    val destination: File,
+)
+
+internal object WalletFileMoves {
+    private data class StagedDestination(
+        val destination: File,
+        val displaced: File,
+    )
+
+    fun move(
+        moves: List<WalletFileMove>,
+        operations: WalletReplacementFileOperations = WalletReplacementFileOperations.live,
+        displacedFile: (File) -> File,
+    ) {
+        if (moves.isEmpty()) return
+        requireDistinctPaths(moves)
+        moves.forEach { move ->
+            if (!operations.exists(move.source)) {
+                throw IOException("A wallet database move source is missing.")
+            }
+        }
+
+        val stagedDestinations = mutableListOf<StagedDestination>()
+        val completedMoves = mutableListOf<WalletFileMove>()
+        try {
+            moves.forEach { move ->
+                if (!operations.exists(move.destination)) return@forEach
+                val staged = StagedDestination(
+                    destination = move.destination,
+                    displaced = displacedFile(move.destination),
+                )
+                if (operations.exists(staged.displaced)) {
+                    removeChecked(staged.displaced, operations)
+                }
+                try {
+                    moveChecked(staged.destination, staged.displaced, operations)
+                    stagedDestinations += staged
+                } catch (error: Throwable) {
+                    if (operations.exists(staged.displaced)) stagedDestinations += staged
+                    throw error
+                }
+            }
+
+            moves.forEach { move ->
+                try {
+                    moveChecked(move.source, move.destination, operations)
+                    completedMoves += move
+                } catch (error: Throwable) {
+                    if (operations.exists(move.destination)) completedMoves += move
+                    throw error
+                }
+            }
+        } catch (error: Throwable) {
+            rollBackMoves(completedMoves, operations, error)
+            restoreDestinations(stagedDestinations, operations, error)
+            throw error
+        }
+
+        stagedDestinations.forEach { staged ->
+            if (!operations.exists(staged.displaced)) return@forEach
+            try {
+                removeChecked(staged.displaced, operations)
+            } catch (error: Throwable) {
+                reportWalletCleanupFailure(
+                    "Failed to remove a displaced wallet database destination",
+                    error,
+                )
+            }
+        }
+    }
+
+    private fun requireDistinctPaths(moves: List<WalletFileMove>) {
+        val sources = moves.map { it.source.absolutePath }
+        val destinations = moves.map { it.destination.absolutePath }
+        if (sources.distinct().size != sources.size || destinations.distinct().size != destinations.size) {
+            throw IOException("Wallet database moves contain duplicate paths.")
+        }
+        if (sources.toSet().intersect(destinations.toSet()).isNotEmpty()) {
+            throw IOException("Wallet database moves contain overlapping source and destination paths.")
+        }
+    }
+
+    private fun rollBackMoves(
+        moves: List<WalletFileMove>,
+        operations: WalletReplacementFileOperations,
+        originalError: Throwable,
+    ) {
+        moves.asReversed().forEach { move ->
+            if (!operations.exists(move.destination)) return@forEach
+            try {
+                if (operations.exists(move.source)) {
+                    removeChecked(move.destination, operations)
+                } else {
+                    moveChecked(move.destination, move.source, operations)
+                }
+            } catch (rollbackError: Throwable) {
+                originalError.addSuppressed(rollbackError)
+            }
+        }
+    }
+
+    private fun restoreDestinations(
+        destinations: List<StagedDestination>,
+        operations: WalletReplacementFileOperations,
+        originalError: Throwable,
+    ) {
+        destinations.asReversed().forEach { staged ->
+            if (!operations.exists(staged.displaced)) return@forEach
+            try {
+                if (!operations.exists(staged.destination)) {
+                    moveChecked(staged.displaced, staged.destination, operations)
+                }
+            } catch (rollbackError: Throwable) {
+                originalError.addSuppressed(rollbackError)
+            }
+        }
+    }
+
+    private fun moveChecked(
+        source: File,
+        destination: File,
+        operations: WalletReplacementFileOperations,
+    ) {
+        if (!operations.exists(source) || operations.exists(destination)) {
+            throw IOException("A wallet database move has invalid source or destination state.")
+        }
+        operations.moveItem(source, destination)
+        if (operations.exists(source) || !operations.exists(destination)) {
+            throw IOException("A wallet database move did not reach its destination.")
+        }
+    }
+
+    private fun removeChecked(
+        file: File,
+        operations: WalletReplacementFileOperations,
+    ) {
+        operations.removeItem(file)
+        if (operations.exists(file)) {
+            throw IOException("A wallet database file could not be removed.")
+        }
+    }
+}
+
+private fun reportWalletCleanupFailure(message: String, error: Throwable) {
+    // Cleanup runs after the new database state has committed. Neither cleanup
+    // nor diagnostics may make that successful transaction appear to fail.
+    runCatching { AppLogger.wallet.error(message, error) }
+}
+
 internal class WalletDatabaseFiles(
     private val filesDir: File,
     private val walletDirectoryName: String = "cashu-kotlin",
@@ -311,16 +465,20 @@ internal class WalletDatabaseFiles(
         val database = databaseFile
         if (!operations.exists(database)) return null
         val backup = File(walletDirectory, "$walletDatabaseFilename.corrupt.${System.currentTimeMillis() / 1000}")
-        if (operations.exists(backup)) operations.removeItem(backup)
-        operations.moveItem(database, backup)
-        sidecars.forEach { suffix ->
-            val sidecar = File(database.absolutePath + suffix)
-            if (operations.exists(sidecar)) {
-                val backupSidecar = File(backup.absolutePath + suffix)
-                if (operations.exists(backupSidecar)) operations.removeItem(backupSidecar)
-                operations.moveItem(sidecar, backupSidecar)
+        val moves = buildList {
+            add(WalletFileMove(database, backup))
+            sidecars.forEach { suffix ->
+                val sidecar = File(database.absolutePath + suffix)
+                if (operations.exists(sidecar)) {
+                    add(WalletFileMove(sidecar, File(backup.absolutePath + suffix)))
+                }
             }
         }
+        WalletFileMoves.move(
+            moves = moves,
+            operations = operations,
+            displacedFile = ::displacedMoveDestination,
+        )
         return backup
     }
 
@@ -328,16 +486,26 @@ internal class WalletDatabaseFiles(
         val legacy = File(filesDir, legacyDatabaseFilename)
         val current = databaseFile
         if (!operations.exists(legacy) || operations.exists(current)) return
-        operations.moveItem(legacy, current)
-        sidecars.forEach { suffix ->
-            val legacySidecar = File(legacy.absolutePath + suffix)
-            if (operations.exists(legacySidecar)) {
-                val currentSidecar = File(current.absolutePath + suffix)
-                if (operations.exists(currentSidecar)) operations.removeItem(currentSidecar)
-                operations.moveItem(legacySidecar, currentSidecar)
+        val moves = buildList {
+            add(WalletFileMove(legacy, current))
+            sidecars.forEach { suffix ->
+                val legacySidecar = File(legacy.absolutePath + suffix)
+                if (operations.exists(legacySidecar)) {
+                    add(WalletFileMove(legacySidecar, File(current.absolutePath + suffix)))
+                }
             }
         }
+        WalletFileMoves.move(
+            moves = moves,
+            operations = operations,
+            displacedFile = ::displacedMoveDestination,
+        )
     }
+
+    private fun displacedMoveDestination(destination: File): File = File(
+        destination.parentFile,
+        "${destination.name}.move-displaced.${UUID.randomUUID()}",
+    )
 
     private fun walletBoundaryFiles(): List<File> {
         val legacy = File(filesDir, legacyDatabaseFilename)

--- a/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletDatabaseRecoveryTest.kt
@@ -2,9 +2,13 @@ package com.cashu.me.Core
 
 import java.io.File
 import com.cashu.me.Core.Platform.WalletDatabaseFiles
+import com.cashu.me.Core.Platform.WalletFileMove
+import com.cashu.me.Core.Platform.WalletFileMoves
+import com.cashu.me.Core.Platform.WalletReplacementFileOperations
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -94,4 +98,122 @@ class WalletDatabaseRecoveryTest {
             assertEquals("bad$suffix", File(backupFile.absolutePath + suffix).readText())
         }
     }
+
+    @Test
+    fun corruptedDatabaseBackupLaterMoveFailureRestoresDatabaseAndSidecars() {
+        lateinit var failingSource: File
+        val operations = operations(moveItem = { source, destination ->
+            if (source == failingSource) throw ForcedMoveFailure()
+            liveMove(source, destination)
+        })
+        val files = WalletDatabaseFiles(temporaryFolder.root, operations = operations)
+        files.databaseFile.writeText("bad-db")
+        val wal = File(files.databaseFile.absolutePath + "-wal").also {
+            it.writeText("bad-wal")
+        }
+        val shm = File(files.databaseFile.absolutePath + "-shm").also {
+            it.writeText("bad-shm")
+        }
+        failingSource = shm
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            files.backupCorruptedDatabase()
+        }
+
+        assertEquals("bad-db", files.databaseFile.readText())
+        assertEquals("bad-wal", wal.readText())
+        assertEquals("bad-shm", shm.readText())
+        assertNoMoveArtifacts(files.walletDirectory)
+    }
+
+    @Test
+    fun corruptedDatabaseBackupFailureReportedAfterMoveRestoresEverySource() {
+        lateinit var failingSource: File
+        val operations = operations(moveItem = { source, destination ->
+            liveMove(source, destination)
+            if (source == failingSource) throw ForcedMoveFailure()
+        })
+        val files = WalletDatabaseFiles(temporaryFolder.root, operations = operations)
+        files.databaseFile.writeText("bad-db")
+        val wal = File(files.databaseFile.absolutePath + "-wal").also {
+            it.writeText("bad-wal")
+        }
+        failingSource = wal
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            files.backupCorruptedDatabase()
+        }
+
+        assertEquals("bad-db", files.databaseFile.readText())
+        assertEquals("bad-wal", wal.readText())
+        assertNoMoveArtifacts(files.walletDirectory)
+    }
+
+    @Test
+    fun legacyMigrationMoveFailureRestoresSourcesAndExistingDestination() {
+        lateinit var failingSource: File
+        val operations = operations(moveItem = { source, destination ->
+            if (source == failingSource) throw ForcedMoveFailure()
+            liveMove(source, destination)
+        })
+        val files = WalletDatabaseFiles(temporaryFolder.root, operations = operations)
+        val legacy = File(temporaryFolder.root, "cashu_wallet.db").also {
+            it.writeText("legacy-db")
+        }
+        val wal = File(legacy.absolutePath + "-wal").also { it.writeText("legacy-wal") }
+        val currentWal = File(files.databaseFile.absolutePath + "-wal").also {
+            it.writeText("preexisting-current-wal")
+        }
+        failingSource = wal
+
+        assertThrows(ForcedMoveFailure::class.java) {
+            files.databasePathAfterLegacyMigration()
+        }
+
+        assertEquals("legacy-db", legacy.readText())
+        assertEquals("legacy-wal", wal.readText())
+        assertFalse(files.databaseFile.exists())
+        assertEquals("preexisting-current-wal", currentWal.readText())
+        assertNoMoveArtifacts(files.walletDirectory)
+    }
+
+    @Test
+    fun committedMoveKeepsNewDestinationWhenCleanupFails() {
+        val source = temporaryFolder.newFile("source.db").also { it.writeText("new") }
+        val destination = temporaryFolder.newFile("destination.db").also { it.writeText("old") }
+        val displaced = File(temporaryFolder.root, "destination.db.displaced")
+        val operations = operations(
+            removeItem = { throw ForcedDeleteFailure() },
+        )
+
+        WalletFileMoves.move(
+            moves = listOf(WalletFileMove(source, destination)),
+            operations = operations,
+            displacedFile = { displaced },
+        )
+
+        assertFalse(source.exists())
+        assertEquals("new", destination.readText())
+        assertEquals("old", displaced.readText())
+    }
+
+    private fun assertNoMoveArtifacts(directory: File) {
+        assertTrue(directory.listFiles().orEmpty().none { ".move-displaced." in it.name })
+    }
+
+    private fun operations(
+        moveItem: (File, File) -> Unit = liveMove,
+        removeItem: (File) -> Unit = { file -> check(file.deleteRecursively()) },
+    ) = WalletReplacementFileOperations(
+        exists = File::exists,
+        moveItem = moveItem,
+        removeItem = removeItem,
+    )
+
+    private val liveMove: (File, File) -> Unit = { source, destination ->
+        check(source.renameTo(destination))
+    }
+
+    private class ForcedMoveFailure : RuntimeException()
+    private class ForcedDeleteFailure : RuntimeException()
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -21,11 +21,15 @@ struct WalletReplacementFileOperations {
     let moveItem: (URL, URL) throws -> Void
     let removeItem: (URL) throws -> Void
 
-    static let live = WalletReplacementFileOperations(
-        fileExists: { FileManager.default.fileExists(atPath: $0.path) },
-        moveItem: { try FileManager.default.moveItem(at: $0, to: $1) },
-        removeItem: { try FileManager.default.removeItem(at: $0) }
-    )
+    static func using(_ fileManager: FileManager) -> WalletReplacementFileOperations {
+        WalletReplacementFileOperations(
+            fileExists: { fileManager.fileExists(atPath: $0.path) },
+            moveItem: { try fileManager.moveItem(at: $0, to: $1) },
+            removeItem: { try fileManager.removeItem(at: $0) }
+        )
+    }
+
+    static let live = WalletReplacementFileOperations.using(.default)
 }
 
 enum WalletReplacementFiles {
@@ -231,6 +235,169 @@ enum WalletReplacementFiles {
             try operations.removeItem(backup.backupURL)
         }
     }
+}
+
+struct WalletFileMove: Equatable {
+    let sourceURL: URL
+    let destinationURL: URL
+}
+
+enum WalletFileMoves {
+    private struct StagedDestination {
+        let destinationURL: URL
+        let displacedURL: URL
+    }
+
+    static func move(
+        _ moves: [WalletFileMove],
+        operations: WalletReplacementFileOperations = .live,
+        displacedURL: (URL) -> URL
+    ) throws {
+        guard !moves.isEmpty else { return }
+        try requireDistinctPaths(moves)
+        guard moves.allSatisfy({ operations.fileExists($0.sourceURL) }) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        var stagedDestinations: [StagedDestination] = []
+        var completedMoves: [WalletFileMove] = []
+        do {
+            for move in moves where operations.fileExists(move.destinationURL) {
+                let staged = StagedDestination(
+                    destinationURL: move.destinationURL,
+                    displacedURL: displacedURL(move.destinationURL)
+                )
+                if operations.fileExists(staged.displacedURL) {
+                    try removeChecked(staged.displacedURL, operations: operations)
+                }
+                do {
+                    try moveChecked(
+                        staged.destinationURL,
+                        staged.displacedURL,
+                        operations: operations
+                    )
+                    stagedDestinations.append(staged)
+                } catch {
+                    if operations.fileExists(staged.displacedURL) {
+                        stagedDestinations.append(staged)
+                    }
+                    throw error
+                }
+            }
+
+            for move in moves {
+                do {
+                    try moveChecked(
+                        move.sourceURL,
+                        move.destinationURL,
+                        operations: operations
+                    )
+                    completedMoves.append(move)
+                } catch {
+                    if operations.fileExists(move.destinationURL) {
+                        completedMoves.append(move)
+                    }
+                    throw error
+                }
+            }
+        } catch {
+            rollBackMoves(completedMoves, operations: operations)
+            restoreDestinations(stagedDestinations, operations: operations)
+            throw error
+        }
+
+        for staged in stagedDestinations where operations.fileExists(staged.displacedURL) {
+            do {
+                try removeChecked(staged.displacedURL, operations: operations)
+            } catch {
+                AppLogger.wallet.error("Failed to remove a displaced wallet database destination: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    private static func requireDistinctPaths(_ moves: [WalletFileMove]) throws {
+        let sources = moves.map { $0.sourceURL.standardizedFileURL.path }
+        let destinations = moves.map { $0.destinationURL.standardizedFileURL.path }
+        guard Set(sources).count == sources.count,
+              Set(destinations).count == destinations.count,
+              Set(sources).isDisjoint(with: Set(destinations)) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func rollBackMoves(
+        _ moves: [WalletFileMove],
+        operations: WalletReplacementFileOperations
+    ) {
+        for move in moves.reversed() where operations.fileExists(move.destinationURL) {
+            do {
+                if operations.fileExists(move.sourceURL) {
+                    try removeChecked(move.destinationURL, operations: operations)
+                } else {
+                    try moveChecked(
+                        move.destinationURL,
+                        move.sourceURL,
+                        operations: operations
+                    )
+                }
+            } catch {
+                AppLogger.wallet.error("Failed to roll back a wallet database move: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    private static func restoreDestinations(
+        _ destinations: [StagedDestination],
+        operations: WalletReplacementFileOperations
+    ) {
+        for staged in destinations.reversed() where operations.fileExists(staged.displacedURL) {
+            do {
+                if !operations.fileExists(staged.destinationURL) {
+                    try moveChecked(
+                        staged.displacedURL,
+                        staged.destinationURL,
+                        operations: operations
+                    )
+                }
+            } catch {
+                AppLogger.wallet.error("Failed to restore a displaced wallet database destination: \(error)")
+                SentryService.capture(error)
+            }
+        }
+    }
+
+    private static func moveChecked(
+        _ sourceURL: URL,
+        _ destinationURL: URL,
+        operations: WalletReplacementFileOperations
+    ) throws {
+        guard operations.fileExists(sourceURL), !operations.fileExists(destinationURL) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        try operations.moveItem(sourceURL, destinationURL)
+        guard !operations.fileExists(sourceURL), operations.fileExists(destinationURL) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func removeChecked(
+        _ url: URL,
+        operations: WalletReplacementFileOperations
+    ) throws {
+        try operations.removeItem(url)
+        guard !operations.fileExists(url) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+}
+
+private func walletMoveDisplacedURL(_ destinationURL: URL) -> URL {
+    destinationURL.deletingLastPathComponent()
+        .appendingPathComponent(
+            "\(destinationURL.lastPathComponent).move-displaced.\(UUID().uuidString)"
+        )
 }
 
 enum WalletMnemonicRollback {
@@ -1036,17 +1203,27 @@ extension WalletManager {
     ) throws {
         guard fileManager.fileExists(atPath: legacyURL.path) else { return }
         guard !fileManager.fileExists(atPath: databaseURL.path) else { return }
-        try fileManager.moveItem(at: legacyURL, to: databaseURL)
+        var moves = [
+            WalletFileMove(sourceURL: legacyURL, destinationURL: databaseURL)
+        ]
 
         for suffix in ["-wal", "-shm", "-journal"] {
             let legacySidecarURL = URL(fileURLWithPath: legacyURL.path + suffix)
             guard fileManager.fileExists(atPath: legacySidecarURL.path) else { continue }
             let currentSidecarURL = URL(fileURLWithPath: databaseURL.path + suffix)
-            if fileManager.fileExists(atPath: currentSidecarURL.path) {
-                try fileManager.removeItem(at: currentSidecarURL)
-            }
-            try fileManager.moveItem(at: legacySidecarURL, to: currentSidecarURL)
+            moves.append(
+                WalletFileMove(
+                    sourceURL: legacySidecarURL,
+                    destinationURL: currentSidecarURL
+                )
+            )
         }
+
+        try WalletFileMoves.move(
+            moves,
+            operations: .using(fileManager),
+            displacedURL: walletMoveDisplacedURL
+        )
     }
 
     nonisolated private static func shouldRecoverLaunchDatabase(
@@ -1068,20 +1245,27 @@ extension WalletManager {
         let timestamp = Int(Date().timeIntervalSince1970)
         let backupURL = databaseURL.deletingLastPathComponent()
             .appendingPathComponent("\(databaseFilename).corrupt.\(timestamp)")
-        if fileManager.fileExists(atPath: backupURL.path) {
-            try fileManager.removeItem(at: backupURL)
-        }
-        try fileManager.moveItem(at: databaseURL, to: backupURL)
+        var moves = [
+            WalletFileMove(sourceURL: databaseURL, destinationURL: backupURL)
+        ]
 
         for suffix in ["-wal", "-shm", "-journal"] {
             let sidecarURL = URL(fileURLWithPath: databaseURL.path + suffix)
             guard fileManager.fileExists(atPath: sidecarURL.path) else { continue }
             let backupSidecarURL = URL(fileURLWithPath: backupURL.path + suffix)
-            if fileManager.fileExists(atPath: backupSidecarURL.path) {
-                try fileManager.removeItem(at: backupSidecarURL)
-            }
-            try fileManager.moveItem(at: sidecarURL, to: backupSidecarURL)
+            moves.append(
+                WalletFileMove(
+                    sourceURL: sidecarURL,
+                    destinationURL: backupSidecarURL
+                )
+            )
         }
+
+        try WalletFileMoves.move(
+            moves,
+            operations: .using(fileManager),
+            displacedURL: walletMoveDisplacedURL
+        )
         return backupURL
     }
 
@@ -1099,24 +1283,26 @@ extension WalletManager {
         let timestamp = Int(Date().timeIntervalSince1970)
         let backupURL = databaseURL.deletingLastPathComponent()
             .appendingPathComponent("\(walletDatabaseFilename).corrupt.\(timestamp)")
-        
-        if FileManager.default.fileExists(atPath: backupURL.path) {
-            try FileManager.default.removeItem(at: backupURL)
-        }
-        
-        try FileManager.default.moveItem(at: databaseURL, to: backupURL)
-        
+        var moves = [
+            WalletFileMove(sourceURL: databaseURL, destinationURL: backupURL)
+        ]
+
         for suffix in ["-wal", "-shm", "-journal"] {
             let sidecarURL = URL(fileURLWithPath: databaseURL.path + suffix)
             guard FileManager.default.fileExists(atPath: sidecarURL.path) else { continue }
-            
             let sidecarBackupURL = URL(fileURLWithPath: backupURL.path + suffix)
-            if FileManager.default.fileExists(atPath: sidecarBackupURL.path) {
-                try FileManager.default.removeItem(at: sidecarBackupURL)
-            }
-            try FileManager.default.moveItem(at: sidecarURL, to: sidecarBackupURL)
+            moves.append(
+                WalletFileMove(
+                    sourceURL: sidecarURL,
+                    destinationURL: sidecarBackupURL
+                )
+            )
         }
-        
+
+        try WalletFileMoves.move(
+            moves,
+            displacedURL: walletMoveDisplacedURL
+        )
         return backupURL
     }
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -447,6 +447,7 @@ final class CashuRequestStoreTests: XCTestCase {
 
 final class WalletReplacementSafetyTests: XCTestCase {
     private enum TestError: Error {
+        case forcedDeleteFailure
         case forcedMoveFailure
         case forcedSeedFailure
     }
@@ -883,5 +884,148 @@ final class WalletReplacementSafetyTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: secondBackup), Data("old second".utf8))
         XCTAssertFalse(FileManager.default.fileExists(atPath: firstDisplaced.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: secondDisplaced.path))
+    }
+
+    func testLaterDatabaseMoveFailureRestoresSourcesAndExistingDestination() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstSource = directory.appendingPathComponent("first-source.db")
+        let secondSource = directory.appendingPathComponent("second-source.db")
+        let firstDestination = directory.appendingPathComponent("first-destination.db")
+        let secondDestination = directory.appendingPathComponent("second-destination.db")
+        let displaced = secondDestination.appendingPathExtension("displaced")
+        try Data("first source".utf8).write(to: firstSource)
+        try Data("second source".utf8).write(to: secondSource)
+        try Data("existing destination".utf8).write(to: secondDestination)
+
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                if source == secondSource {
+                    throw TestError.forcedMoveFailure
+                }
+                try FileManager.default.moveItem(at: source, to: destination)
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletFileMoves.move(
+                [
+                    WalletFileMove(
+                        sourceURL: firstSource,
+                        destinationURL: firstDestination
+                    ),
+                    WalletFileMove(
+                        sourceURL: secondSource,
+                        destinationURL: secondDestination
+                    ),
+                ],
+                operations: operations,
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+
+        XCTAssertEqual(try Data(contentsOf: firstSource), Data("first source".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondSource), Data("second source".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstDestination.path))
+        XCTAssertEqual(
+            try Data(contentsOf: secondDestination),
+            Data("existing destination".utf8)
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: displaced.path))
+    }
+
+    func testDatabaseMoveFailureReportedAfterMoveRestoresEverySource() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let firstSource = directory.appendingPathComponent("first-source.db")
+        let secondSource = directory.appendingPathComponent("second-source.db")
+        let firstDestination = directory.appendingPathComponent("first-destination.db")
+        let secondDestination = directory.appendingPathComponent("second-destination.db")
+        try Data("first source".utf8).write(to: firstSource)
+        try Data("second source".utf8).write(to: secondSource)
+
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { source, destination in
+                try FileManager.default.moveItem(at: source, to: destination)
+                if source == secondSource {
+                    throw TestError.forcedMoveFailure
+                }
+            },
+            removeItem: { try FileManager.default.removeItem(at: $0) }
+        )
+
+        XCTAssertThrowsError(
+            try WalletFileMoves.move(
+                [
+                    WalletFileMove(
+                        sourceURL: firstSource,
+                        destinationURL: firstDestination
+                    ),
+                    WalletFileMove(
+                        sourceURL: secondSource,
+                        destinationURL: secondDestination
+                    ),
+                ],
+                operations: operations,
+                displacedURL: { $0.appendingPathExtension("displaced") }
+            )
+        )
+
+        XCTAssertEqual(try Data(contentsOf: firstSource), Data("first source".utf8))
+        XCTAssertEqual(try Data(contentsOf: secondSource), Data("second source".utf8))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: firstDestination.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: secondDestination.path))
+    }
+
+    func testCommittedDatabaseMoveSurvivesDisplacedCleanupFailure() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let source = directory.appendingPathComponent("source.db")
+        let destination = directory.appendingPathComponent("destination.db")
+        let displaced = destination.appendingPathExtension("displaced")
+        try Data("new".utf8).write(to: source)
+        try Data("old".utf8).write(to: destination)
+
+        let operations = WalletReplacementFileOperations(
+            fileExists: { FileManager.default.fileExists(atPath: $0.path) },
+            moveItem: { try FileManager.default.moveItem(at: $0, to: $1) },
+            removeItem: { url in
+                if url == displaced {
+                    throw TestError.forcedDeleteFailure
+                }
+                try FileManager.default.removeItem(at: url)
+            }
+        )
+
+        try WalletFileMoves.move(
+            [WalletFileMove(sourceURL: source, destinationURL: destination)],
+            operations: operations,
+            displacedURL: { _ in displaced }
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: source.path))
+        XCTAssertEqual(try Data(contentsOf: destination), Data("new".utf8))
+        XCTAssertEqual(try Data(contentsOf: displaced), Data("old".utf8))
     }
 }


### PR DESCRIPTION
## Summary

- Rebase onto the latest main and preserve the wallet-replacement transaction safeguards already merged in #320.
- Make corrupted-database backup and legacy-database migration transactional on both Android and iOS.
- Preflight the complete database and SQLite sidecar set, stage existing destinations, and roll back partial or post-move failures.
- Keep cleanup after commit best effort so cleanup or diagnostic failures cannot invalidate a successful transaction.

## Why

The replacement-flow findings from the original PR were valid, but they were independently fixed in #320. The remaining useful change is filesystem resilience for corruption backup and legacy migration. This is a bug fix and hardening change, not a user-facing enhancement. The original Android-only implementation also left an iOS parity gap; this revision applies equivalent behavior and tests on both platforms.

## Testing

- Android full debug unit tests and lint: passed.
- Android wallet recovery and replacement safety tests: 18 passed.
- iOS WalletReplacementSafetyTests on an iPhone 17 Pro simulator: 15 passed.
