### PR TITLE
fix: preserve mints when removal fails

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -2,6 +2,7 @@ package com.cashu.me.test.fixtures
 
 import com.cashu.me.Core.CDK.ForeignNfcSettlement
 import com.cashu.me.Core.CDK.MeltConfirmation
+import com.cashu.me.Core.CDK.MultiUnitWalletRemovalException
 import com.cashu.me.Core.CDK.NfcReceiveReceipt
 import com.cashu.me.Core.CDK.NwcServiceHandle
 import com.cashu.me.Core.CDK.SagaRecoveryReport
@@ -37,6 +38,7 @@ class FakeWalletGateway(
 ) : WalletGateway {
     private val sequence = AtomicInteger(1)
     private val walletUrls = linkedSetOf<String>()
+    private val walletUnits = linkedMapOf<String, MutableSet<String>>()
     private val mintInfo = linkedMapOf<String, MintInfo>()
     private val balances = initialBalances.toMutableMap()
     private val transactions = initialTransactions.toMutableList()
@@ -102,15 +104,21 @@ class FakeWalletGateway(
         check(repositoryOpen) { "Fake wallet repository is not open." }
         val normalized = normalize(mintUrl)
         walletUrls += normalized
+        walletUnits.getOrPut(normalized) { linkedSetOf() } += unit.trim().lowercase()
         balances.putIfAbsent(normalized, 0)
         mintInfo.putIfAbsent(normalized, defaultMint(normalized))
     }
 
-    override suspend fun removeWallet(mintUrl: String, unit: String) {
+    override suspend fun removeWalletIfSingleUnit(mintUrl: String): Boolean {
         val normalized = normalize(mintUrl)
+        val registeredUnits = walletUnits[normalized].orEmpty().toList()
+        if (registeredUnits.size > 1) throw MultiUnitWalletRemovalException(registeredUnits)
+        if (registeredUnits.isEmpty()) return false
         walletUrls -= normalized
+        walletUnits -= normalized
         mintInfo -= normalized
         balances -= normalized
+        return true
     }
 
     override suspend fun fetchMintInfo(mintUrl: String): MintInfo? {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -1,5 +1,6 @@
 package com.cashu.me.Core.CDK
 
+import java.net.URI
 import kotlinx.coroutines.flow.Flow
 import org.cashudevkit.PendingMelt
 import com.cashu.me.Core.NPCQuote
@@ -29,7 +30,14 @@ interface CdkWalletGateway {
     /** NUT-27: fetch the newest mint-list backup for the open seed; returns the backed-up mint URLs. */
     suspend fun fetchMintBackup(relays: List<String>, timeoutSecs: ULong): List<String>
     suspend fun ensureWallet(mintUrl: String, unit: String = "sat")
-    suspend fun removeWallet(mintUrl: String, unit: String = "sat")
+
+    /**
+     * Atomically inspects the native repository and removes [mintUrl] only when
+     * it has at most one registered unit. Returns false when no native wallet
+     * existed and throws [MultiUnitWalletRemovalException] before changing the
+     * repository when multiple units are registered.
+     */
+    suspend fun removeWalletIfSingleUnit(mintUrl: String): Boolean
     suspend fun fetchMintInfo(mintUrl: String): MintInfo?
     suspend fun restoreMint(mintUrl: String): RestoreMintResult
     suspend fun totalBalance(mintUrl: String): Long
@@ -110,6 +118,34 @@ interface CdkWalletGateway {
     /** Extract the encoded token a send saga persists until the token is
      * claimed; null for non-send or already-finalized operations. */
     suspend fun pendingSendTokenFromSaga(operationId: String): String?
+}
+
+class MultiUnitWalletRemovalException(
+    val registeredUnits: List<String>,
+) : IllegalStateException(
+    "This mint uses multiple currency units and cannot be removed safely yet. Keep it connected and try again after updating the app.",
+)
+
+internal fun normalizedRegisteredWalletUnits(units: List<String>): List<String> =
+    units
+        .map { it.trim().lowercase() }
+        .filter(String::isNotEmpty)
+        .distinct()
+
+internal fun mintRemovalUrlsMatch(lhs: String, rhs: String): Boolean {
+    fun identity(raw: String): List<Any?>? = runCatching {
+        val uri = URI(raw.trim())
+        val scheme = uri.scheme?.lowercase() ?: return@runCatching null
+        val authority = uri.rawAuthority?.lowercase() ?: return@runCatching null
+        var path = uri.rawPath.orEmpty()
+        while (path.length > 1 && path.endsWith('/')) path = path.dropLast(1)
+        if (path == "/") path = ""
+        listOf(scheme, authority, path, uri.rawQuery, uri.rawFragment)
+    }.getOrNull()
+
+    val left = identity(lhs) ?: return lhs.trim() == rhs.trim()
+    val right = identity(rhs) ?: return false
+    return left == right
 }
 
 data class ForeignNfcSettlement(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -169,8 +169,24 @@ class CdkWalletGatewayImpl : WalletGateway {
         ensureWalletUnlocked(mintUrl, cdkUnit(unit))
     }
 
-    override suspend fun removeWallet(mintUrl: String, unit: String) = cdkCall {
-        requireRepository().removeWallet(CdkMintUrl(mintUrl), cdkUnit(unit))
+    override suspend fun removeWalletIfSingleUnit(mintUrl: String): Boolean = cdkCall {
+        val repository = requireRepository()
+        val registeredWallets = repository.getWallets()
+            .filter { wallet ->
+                mintRemovalUrlsMatch(wallet.mintUrl().url, mintUrl)
+            }
+        val registeredUnits = normalizedRegisteredWalletUnits(
+            registeredWallets.map { it.unit().toDomainUnit() },
+        )
+        if (registeredUnits.size > 1) {
+            throw MultiUnitWalletRemovalException(registeredUnits)
+        }
+        val registeredUnit = registeredUnits.singleOrNull() ?: return@cdkCall false
+        val wallet = registeredWallets.first { wallet ->
+            wallet.unit().toDomainUnit().trim().equals(registeredUnit, ignoreCase = true)
+        }
+        repository.removeWallet(wallet.mintUrl(), wallet.unit())
+        true
     }
 
     override suspend fun fetchMintInfo(mintUrl: String): MintInfo? = cdkCall {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/MintRemovalPolicy.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/MintRemovalPolicy.kt
@@ -1,0 +1,25 @@
+package com.cashu.me.Core
+
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/** Commit local mint metadata only after the native removal succeeds. */
+internal suspend fun removeMintWalletBeforeCommit(
+    mintUrl: String,
+    removeWalletIfSingleUnit: suspend (mintUrl: String) -> Boolean,
+    commitMetadata: () -> Unit,
+): Boolean {
+    currentCoroutineContext().ensureActive()
+    // Shield the native side effect and its local metadata commit from the
+    // cancellation hand-off performed by cdkCall's withContext(IO). Once CDK
+    // removes the wallet, metadata must follow before cancellation propagates.
+    val nativeWalletExisted = withContext(NonCancellable) {
+        val existed = removeWalletIfSingleUnit(mintUrl)
+        commitMetadata()
+        existed
+    }
+    currentCoroutineContext().ensureActive()
+    return nativeWalletExisted
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -413,14 +413,19 @@ class WalletManager(
 
     override suspend fun removeMint(mint: MintInfo) {
         withLoading {
-            runCatching { gateway.removeWallet(mint.url) }
-                .onFailure { AppLogger.wallet.error("CDK wallet removal is not available yet for ${mint.url}", it) }
-            val updated = mutableState.value.mints.filterNot { it.url == mint.url }
-            walletStore.saveMints(updated)
-            if (walletStore.activeMintURL == mint.url) {
-                walletStore.activeMintURL = updated.firstOrNull()?.url
+            val trackedMint = mutableState.value.mints.firstOrNull { it.url == mint.url }
+                ?: throw IllegalArgumentException("Mint is no longer tracked.")
+            removeMintWalletBeforeCommit(
+                mintUrl = trackedMint.url,
+                removeWalletIfSingleUnit = gateway::removeWalletIfSingleUnit,
+            ) {
+                val updated = mutableState.value.mints.filterNot { it.url == trackedMint.url }
+                walletStore.saveMints(updated)
+                if (walletStore.activeMintURL == trackedMint.url) {
+                    walletStore.activeMintURL = updated.firstOrNull()?.url
+                }
+                loadCachedState(needsOnboarding = false)
             }
-            loadCachedState(needsOnboarding = false)
             refreshBalance()
         }
         if (externalServicesEnabled) {

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -98,6 +98,7 @@ import com.cashu.me.ui.testing.UiTestTags
 import com.cashu.me.ui.theme.CapsuleShape
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withSlashedZero
+import kotlinx.coroutines.CancellationException
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -116,6 +117,8 @@ fun MintDetailScreen(
     var confirmingRemove by remember { mutableStateOf(false) }
     var settingDefault by remember(mintUrl) { mutableStateOf(false) }
     var setDefaultError by remember(mintUrl) { mutableStateOf<String?>(null) }
+    var removingMint by remember(mintUrl) { mutableStateOf(false) }
+    var removalError by remember(mintUrl) { mutableStateOf<String?>(null) }
 
     Scaffold(
         modifier = Modifier.testTag(UiTestTags.MintDetailScreen),
@@ -466,6 +469,9 @@ fun MintDetailScreen(
                 if (setDefaultError != null) {
                     InlineNotice(text = setDefaultError.orEmpty(), severity = NoticeSeverity.Error)
                 }
+                if (removalError != null) {
+                    InlineNotice(text = removalError.orEmpty(), severity = NoticeSeverity.Error)
+                }
                 if (!isActive) {
                     // iOS parity: progress disables the action while in flight
                     // and a failure renders inline without flipping the
@@ -490,6 +496,7 @@ fun MintDetailScreen(
                     text = "Remove mint",
                     onClick = { confirmingRemove = true },
                     modifier = Modifier.fillMaxWidth(),
+                    enabled = !removingMint,
                 )
             }
             Spacer(Modifier.height(CashuTheme.spacing.section))
@@ -509,8 +516,21 @@ fun MintDetailScreen(
             confirmButton = {
                 TextButton(onClick = {
                     confirmingRemove = false
-                    mint?.let { walletManager.launch { walletManager.removeMint(it) } }
-                    onClose()
+                    val target = mint ?: return@TextButton
+                    removingMint = true
+                    removalError = null
+                    walletManager.launch {
+                        try {
+                            walletManager.removeMint(target)
+                            onClose()
+                        } catch (cancellation: CancellationException) {
+                            throw cancellation
+                        } catch (error: Throwable) {
+                            removalError = error.userFacingWalletMessage
+                        } finally {
+                            removingMint = false
+                        }
+                    }
                 }) {
                     Text("Remove", color = MaterialTheme.colorScheme.error)
                 }

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintsScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintsScreen.kt
@@ -65,16 +65,20 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.MintDiscoveryManager
 import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Core.normalizeUserMintUrl
 import com.cashu.me.Core.shortenMintUrl
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.ui.components.MintAvatar
+import com.cashu.me.ui.components.InlineNotice
+import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.TabTopBar
 import com.cashu.me.ui.components.groupItemShape
 import com.cashu.me.ui.theme.CashuTheme
 import com.cashu.me.ui.theme.withMonoDigits
 import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.CancellationException
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -96,6 +100,7 @@ fun MintsScreen(
     var addMintOpen by remember { mutableStateOf(false) }
     var addMintInitialUrl by remember { mutableStateOf("") }
     var discoveryOpen by remember { mutableStateOf(false) }
+    var removalError by remember { mutableStateOf<String?>(null) }
 
     LaunchedEffect(scannedMintUrl) {
         val payload = scannedMintUrl?.trim().orEmpty()
@@ -140,6 +145,15 @@ fun MintsScreen(
                 bottom = CashuTheme.spacing.section,
             ),
         ) {
+            if (removalError != null) {
+                item("removal-error") {
+                    InlineNotice(
+                        text = removalError.orEmpty(),
+                        severity = NoticeSeverity.Error,
+                        modifier = Modifier.padding(bottom = CashuTheme.spacing.snug),
+                    )
+                }
+            }
             if (walletState.mints.isNotEmpty()) {
                 val mintCount = walletState.mints.size
                 itemsIndexed(walletState.mints, key = { _, mint -> mint.url }) { index, mint ->
@@ -253,7 +267,16 @@ fun MintsScreen(
                 TextButton(onClick = {
                     val target = mint
                     pendingRemoval = null
-                    scope.launch { walletManager.removeMint(target) }
+                    removalError = null
+                    scope.launch {
+                        try {
+                            walletManager.removeMint(target)
+                        } catch (cancellation: CancellationException) {
+                            throw cancellation
+                        } catch (error: Throwable) {
+                            removalError = error.userFacingWalletMessage
+                        }
+                    }
                 }) {
                     Text("Remove", color = MaterialTheme.colorScheme.error)
                 }

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkGatewayThreadingTest.kt
@@ -43,6 +43,24 @@ class CdkGatewayThreadingTest {
         assertTrue(source.contains("}.flowOn(Dispatchers.IO)"))
     }
 
+    @Test
+    fun safeMintRemovalEnumeratesAndRemovesInsideOneGatewayCall() {
+        val source = sourceFile(
+            "src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+            "app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt",
+        ).readText()
+        val methodStart = source.indexOf("override suspend fun removeWalletIfSingleUnit")
+        assertTrue(methodStart >= 0)
+        val methodEnd = source.indexOf("\n    override suspend fun", methodStart + 1)
+            .takeIf { it >= 0 }
+            ?: source.length
+        val method = source.substring(methodStart, methodEnd)
+
+        assertTrue(method.contains("= cdkCall {"))
+        assertTrue(method.contains("getWallets()"))
+        assertTrue(method.contains("repository.removeWallet("))
+    }
+
     private fun sourceFile(vararg candidates: String): File {
         val roots = generateSequence(File("").absoluteFile) { it.parentFile }
         return roots

--- a/android/app/src/test/java/com/cashu/me/Core/MintRemovalPolicyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintRemovalPolicyTest.kt
@@ -1,0 +1,161 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.CDK.MultiUnitWalletRemovalException
+import com.cashu.me.Core.CDK.mintRemovalUrlsMatch
+import com.cashu.me.Core.CDK.normalizedRegisteredWalletUnits
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class MintRemovalPolicyTest {
+    @Test
+    fun registeredUnitsAreNormalizedAndDeduplicated() {
+        assertEquals(
+            listOf("eur"),
+            normalizedRegisteredWalletUnits(listOf(" EUR ", "eur", "EuR", " ")),
+        )
+        assertTrue(normalizedRegisteredWalletUnits(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun mintIdentityFoldsAuthorityButPreservesEncodedAndCaseSensitivePaths() {
+        assertTrue(mintRemovalUrlsMatch(
+            "https://MINT.example.com/Mint/",
+            "HTTPS://mint.example.com/Mint",
+        ))
+        assertFalse(mintRemovalUrlsMatch(
+            "https://mint.example.com/Mint",
+            "https://mint.example.com/mint",
+        ))
+        assertFalse(mintRemovalUrlsMatch(
+            "https://mint.example.com/foo%2F",
+            "https://mint.example.com/foo/",
+        ))
+    }
+
+    @Test
+    fun multiUnitGatewayRefusalPreservesMetadata() = runBlocking {
+        var metadataCommitted = false
+
+        try {
+            removeMintWalletBeforeCommit(
+                mintUrl = MintUrl,
+                removeWalletIfSingleUnit = {
+                    throw MultiUnitWalletRemovalException(listOf("sat", "eur"))
+                },
+                commitMetadata = { metadataCommitted = true },
+            )
+            fail("Expected multi-unit removal to be refused")
+        } catch (_: MultiUnitWalletRemovalException) {
+            // Expected: the atomic gateway operation refused before removal.
+        }
+
+        assertFalse(metadataCommitted)
+    }
+
+    @Test
+    fun existingNativeWalletIsRemovedBeforeMetadataCommit() = runBlocking {
+        val events = mutableListOf<String>()
+
+        val existed = removeMintWalletBeforeCommit(
+            mintUrl = MintUrl,
+            removeWalletIfSingleUnit = { mintUrl ->
+                events += "remove:$mintUrl"
+                true
+            },
+            commitMetadata = { events += "commit" },
+        )
+
+        assertTrue(existed)
+        assertEquals(listOf("remove:$MintUrl", "commit"), events)
+    }
+
+    @Test
+    fun missingNativeWalletCommitsMetadataWithoutInventingSatWallet() = runBlocking {
+        val events = mutableListOf<String>()
+
+        val existed = removeMintWalletBeforeCommit(
+            mintUrl = MintUrl,
+            removeWalletIfSingleUnit = {
+                events += "atomic-check-and-remove"
+                false
+            },
+            commitMetadata = { events += "commit" },
+        )
+
+        assertFalse(existed)
+        assertEquals(listOf("atomic-check-and-remove", "commit"), events)
+    }
+
+    @Test
+    fun nativeFailurePreservesMetadata() = runBlocking {
+        var metadataCommitted = false
+
+        try {
+            removeMintWalletBeforeCommit(
+                mintUrl = MintUrl,
+                removeWalletIfSingleUnit = { throw RepositoryFailure() },
+                commitMetadata = { metadataCommitted = true },
+            )
+            fail("Expected native removal failure")
+        } catch (_: RepositoryFailure) {
+            // Expected.
+        }
+
+        assertFalse(metadataCommitted)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun cancellationIsPreservedWithoutMetadataCommit() {
+        runBlocking {
+            var metadataCommitted = false
+            try {
+                removeMintWalletBeforeCommit(
+                    mintUrl = MintUrl,
+                    removeWalletIfSingleUnit = { throw CancellationException("cancelled") },
+                    commitMetadata = { metadataCommitted = true },
+                )
+            } finally {
+                assertFalse(metadataCommitted)
+            }
+        }
+    }
+
+    @Test
+    fun cancellationDuringNativeSuccessStillCommitsMetadata() = runBlocking {
+        val nativeStarted = CompletableDeferred<Unit>()
+        val allowNativeReturn = CompletableDeferred<Unit>()
+        var metadataCommitted = false
+        val request = async {
+            removeMintWalletBeforeCommit(
+                mintUrl = MintUrl,
+                removeWalletIfSingleUnit = {
+                    nativeStarted.complete(Unit)
+                    allowNativeReturn.await()
+                    true
+                },
+                commitMetadata = { metadataCommitted = true },
+            )
+        }
+
+        nativeStarted.await()
+        request.cancel()
+        allowNativeReturn.complete(Unit)
+        request.join()
+
+        assertTrue(request.isCancelled)
+        assertTrue(metadataCommitted)
+    }
+
+    private class RepositoryFailure : IllegalStateException("repository unavailable")
+
+    private companion object {
+        const val MintUrl = "https://mint.example.com"
+    }
+}

--- a/ios/CashuWallet/Core/Services/MintService.swift
+++ b/ios/CashuWallet/Core/Services/MintService.swift
@@ -1,6 +1,94 @@
 import Foundation
 import Cdk
 
+enum MintRemovalPolicyError: LocalizedError {
+    case multipleUnits
+
+    var errorDescription: String? {
+        switch self {
+        case .multipleUnits:
+            return "This mint uses multiple currency units and cannot be removed safely yet. Keep it connected and try again after updating the app."
+        }
+    }
+}
+
+@MainActor
+enum MintRemovalPolicy {
+    static func normalizedUnits(_ registeredUnits: [String]) -> [String] {
+        let units = registeredUnits
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+        var seen = Set<String>()
+        let unique = units.filter { seen.insert($0).inserted }
+        return unique
+    }
+
+    /// The native repository has no atomic multi-unit removal API. Refuse
+    /// before touching it rather than leave only part of a mint removed.
+    static func removalUnit(registeredUnits: [String]) throws -> String? {
+        let units = normalizedUnits(registeredUnits)
+        guard units.count <= 1 else { throw MintRemovalPolicyError.multipleUnits }
+        return units.first
+    }
+
+    static func matches(_ lhs: String, _ rhs: String) -> Bool {
+        normalizedMintURL(lhs) == normalizedMintURL(rhs)
+    }
+
+    static func removingMint(withURL targetURL: String, from mints: [MintInfo]) -> [MintInfo] {
+        mints.filter { !matches($0.url, targetURL) }
+    }
+
+    private static func normalizedMintURL(_ url: String) -> String {
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
+              components.scheme != nil,
+              components.host != nil else {
+            return trimmed
+        }
+
+        // URL scheme and host are case-insensitive, but paths are not. Folding
+        // the whole string could remove a distinct mint at `/Mint` when the
+        // user selected `/mint`.
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        var path = components.percentEncodedPath
+        while path.count > 1 && path.hasSuffix("/") {
+            path.removeLast()
+        }
+        if path == "/" {
+            path = ""
+        }
+        components.percentEncodedPath = path
+        return components.string ?? trimmed
+    }
+
+    /// Commit local mint metadata only after the native removal succeeds.
+    static func removeBeforeCommit(
+        mint: MintInfo,
+        registeredUnits: [String],
+        removeWallet: @escaping (String, String) async throws -> Void,
+        commitMetadata: () -> Void
+    ) async throws {
+        let unit = try removalUnit(registeredUnits: registeredUnits)
+        try Task.checkCancellation()
+        if let unit {
+            // An unstructured child does not inherit later cancellation from
+            // this caller. Once native removal begins, await its definite
+            // result and mirror a success into metadata before cancellation
+            // can escape across the commit boundary.
+            let nativeRemoval = Task { @MainActor in
+                try await removeWallet(mint.url, unit)
+            }
+            try await nativeRemoval.value
+        }
+        // Native removal is the commit point. Mirror it into local metadata
+        // before propagating cancellation that arrived during the native call.
+        commitMetadata()
+        try Task.checkCancellation()
+    }
+}
+
 // MARK: - Mint Service
 
 /// Service responsible for mint management operations.
@@ -91,22 +179,45 @@ class MintService: ObservableObject {
         return mintInfo
     }
     
-    /// Remove mints at the specified offsets
-    func removeMint(at offsets: IndexSet) async {
-        guard let repo = walletRepository() else { return }
-        
-        for index in offsets {
-            let mint = mints[index]
-            if activeMint?.url == mint.url {
-                activeMint = mints.first { $0.url != mint.url }
-            }
-            
-            // Remove from wallet repository
-            let mintUrl = MintUrl(url: mint.url)
-            try? await repo.removeWallet(mintUrl: mintUrl, currencyUnit: .sat)
+    /// Remove one mint by stable identity. Array offsets can shift while this
+    /// operation waits in the repository coordinator.
+    func removeMint(_ requestedMint: MintInfo) async throws {
+        guard let repo = walletRepository() else {
+            throw WalletError.notInitialized
         }
-        mints.remove(atOffsets: offsets)
-        saveMints()
+
+        guard let mint = mints.first(where: {
+            MintRemovalPolicy.matches($0.url, requestedMint.url)
+        }) else {
+            throw WalletError.networkError("Mint is no longer tracked.")
+        }
+        let registeredUnits = await repo.getWallets()
+            .filter { wallet in
+                MintRemovalPolicy.matches(wallet.mintUrl().url, mint.url)
+            }
+            .map { PaymentRequestDecoder.unitDescription($0.unit()) }
+
+        try await MintRemovalPolicy.removeBeforeCommit(
+            mint: mint,
+            registeredUnits: registeredUnits,
+            removeWallet: { mintURL, unit in
+                try await repo.removeWallet(
+                    mintUrl: MintUrl(url: mintURL),
+                    currencyUnit: PaymentRequestDecoder.currencyUnit(from: unit)
+                )
+            },
+            commitMetadata: {
+                self.mints = MintRemovalPolicy.removingMint(
+                    withURL: mint.url,
+                    from: self.mints
+                )
+                if let activeMint = self.activeMint,
+                   MintRemovalPolicy.matches(activeMint.url, mint.url) {
+                    self.activeMint = self.mints.first
+                }
+                self.saveMints()
+            }
+        )
     }
     
     /// Set the active mint

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -56,22 +56,27 @@ extension WalletManager {
         }
     }
 
-    func removeMint(at offsets: IndexSet) async {
+    @discardableResult
+    func removeMint(_ mint: MintInfo) async -> Bool {
+        errorMessage = nil
         do {
-            try await operationCoordinator.perform(kind: .addMint) {
-                await self.mintService.removeMint(at: offsets)
+            try await operationCoordinator.perform(kind: .removeMint) {
+                try await self.mintService.removeMint(mint)
             }
         } catch is CancellationError {
-            return
+            return false
         } catch {
+            errorMessage = error.userFacingWalletMessage
             AppLogger.wallet.error(
                 "remove mint failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
+            return false
         }
         await refreshBalance()
         performICloudBackup()
         Task { await NostrMintBackupService.shared.backupCurrentMintsIfEnabled() }
         SentryService.breadcrumb("Mint removed", category: "wallet.mint")
+        return true
     }
 
     func setActiveMint(_ mint: MintInfo) async throws {

--- a/ios/CashuWallet/Core/Wallet/WalletOperationCoordinator.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletOperationCoordinator.swift
@@ -13,6 +13,7 @@ import UIKit
 actor WalletOperationCoordinator {
     enum Kind: String, Sendable {
         case addMint
+        case removeMint
         case balance
         case feeEstimate
         case history

--- a/ios/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/ios/CashuWallet/Views/Mints/MintDetailView.swift
@@ -17,6 +17,7 @@ struct MintDetailView: View {
     @State private var aboutExpanded = false
     @State private var showNavTitle = false
     @State private var isSettingDefault = false
+    @State private var isRemovingMint = false
     @State private var actionError: String?
     /// Balances for the mint's non-sat units, loaded on demand (the sat balance
     /// is the cached `mint.balance`). Where a freshly-minted eur/usd shows up.
@@ -548,13 +549,19 @@ struct MintDetailView: View {
             Button(role: .destructive) {
                 showRemoveConfirmation = true
             } label: {
-                Text("Remove Mint")
-                    .font(.body)
-                    .foregroundStyle(.red)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 14)
+                HStack(spacing: 8) {
+                    Text("Remove Mint")
+                    if isRemovingMint {
+                        ProgressView().tint(.red)
+                    }
+                }
+                .font(.body)
+                .foregroundStyle(.red)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
             }
             .buttonStyle(.plain)
+            .disabled(isRemovingMint)
         }
     }
 
@@ -683,9 +690,15 @@ struct MintDetailView: View {
 
     private func removeMint() {
         Task {
-            if let index = walletManager.mints.firstIndex(where: { $0.url == mint.url }) {
-                await walletManager.removeMint(at: IndexSet(integer: index))
+            isRemovingMint = true
+            actionError = nil
+            let removed = await walletManager.removeMint(mint)
+            isRemovingMint = false
+            if removed {
                 dismiss()
+            } else if !Task.isCancelled {
+                actionError = walletManager.errorMessage
+                    ?? "The mint could not be removed. Keep it connected and try again."
             }
         }
     }

--- a/ios/CashuWallet/Views/Mints/MintsListView.swift
+++ b/ios/CashuWallet/Views/Mints/MintsListView.swift
@@ -7,10 +7,16 @@ struct MintsListView: View {
     @State private var showRemoveConfirmation = false
     @State private var showAddMintSheet = false
     @State private var showDiscoverySheet = false
+    @State private var removalError: String?
 
     var body: some View {
         NavigationStack {
             List {
+                if let removalError {
+                    Section {
+                        InlineNotice(message: removalError, severity: .error)
+                    }
+                }
                 if !walletManager.mints.isEmpty {
                     Section {
                         ForEach(walletManager.mints) { mint in
@@ -182,8 +188,11 @@ struct MintsListView: View {
 
     private func removeMint(_ mint: MintInfo) {
         Task {
-            if let index = walletManager.mints.firstIndex(where: { $0.url == mint.url }) {
-                await walletManager.removeMint(at: IndexSet(integer: index))
+            removalError = nil
+            let removed = await walletManager.removeMint(mint)
+            if !removed, !Task.isCancelled {
+                removalError = walletManager.errorMessage
+                    ?? "The mint could not be removed. Keep it connected and try again."
             }
         }
     }

--- a/ios/CashuWalletTests/MintServiceTests.swift
+++ b/ios/CashuWalletTests/MintServiceTests.swift
@@ -3,6 +3,31 @@ import XCTest
 
 @MainActor
 final class MintServiceTests: XCTestCase {
+    private enum RepositoryFailure: Error {
+        case unavailable
+    }
+
+    private actor NativeRemovalGate {
+        private var started = false
+        private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+        func suspendUntilReleased() async {
+            started = true
+            await withCheckedContinuation { continuation in
+                releaseContinuation = continuation
+            }
+        }
+
+        func hasStarted() -> Bool {
+            started
+        }
+
+        func release() {
+            releaseContinuation?.resume()
+            releaseContinuation = nil
+        }
+    }
+
     private var service: MintService!
 
     override func setUp() {
@@ -114,6 +139,189 @@ final class MintServiceTests: XCTestCase {
         let s = MintService(walletRepository: { nil }, walletStore: ws)
         s.loadCachedMints()
         XCTAssertEqual(s.activeMint?.url, "https://mint1.example.com")
+    }
+
+    // MARK: - Safe mint removal
+
+    func testRegisteredRemovalUnitsNormalizeAndDeduplicate() {
+        XCTAssertEqual(
+            MintRemovalPolicy.normalizedUnits([" EUR ", "eur", "EuR", " "]),
+            ["eur"]
+        )
+        XCTAssertTrue(MintRemovalPolicy.normalizedUnits([]).isEmpty)
+    }
+
+    func testMintIdentityFoldsHostButPreservesCaseSensitivePath() {
+        XCTAssertTrue(MintRemovalPolicy.matches(
+            "https://MINT.example.com/Mint/",
+            "HTTPS://mint.example.com/Mint"
+        ))
+        XCTAssertFalse(MintRemovalPolicy.matches(
+            "https://mint.example.com/Mint",
+            "https://mint.example.com/mint"
+        ))
+        XCTAssertFalse(MintRemovalPolicy.matches(
+            "https://mint.example.com/foo%2F",
+            "https://mint.example.com/foo/"
+        ))
+
+        let upperPath = mint("https://mint.example.com/Mint", name: "Upper")
+        let lowerPath = mint("https://mint.example.com/mint", name: "Lower")
+        XCTAssertEqual(
+            MintRemovalPolicy.removingMint(withURL: upperPath.url, from: [upperPath, lowerPath]),
+            [lowerPath]
+        )
+    }
+
+    func testMultiUnitRemovalRefusesBeforeNativeCallOrMetadataCommit() async {
+        var multiUnitMint = mint("https://mint.example.com", name: "Test")
+        multiUnitMint.units = ["sat", " EUR ", "eur"]
+        var nativeCalls: [String] = []
+        var metadataCommitted = false
+
+        do {
+            try await MintRemovalPolicy.removeBeforeCommit(
+                mint: multiUnitMint,
+                registeredUnits: ["sat", " EUR ", "eur"],
+                removeWallet: { _, unit in nativeCalls.append(unit) },
+                commitMetadata: { metadataCommitted = true }
+            )
+            XCTFail("Expected multi-unit removal to be refused")
+        } catch MintRemovalPolicyError.multipleUnits {
+            // Expected: validation runs before the repository is touched.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(nativeCalls.isEmpty)
+        XCTAssertFalse(metadataCommitted)
+    }
+
+    func testSingleNonSatUnitIsRemovedBeforeMetadataCommit() async throws {
+        var euroMint = mint("https://mint.example.com", name: "Test")
+        // Advertised metadata can differ from wallets actually registered in CDK.
+        euroMint.units = ["sat"]
+        var events: [String] = []
+
+        try await MintRemovalPolicy.removeBeforeCommit(
+            mint: euroMint,
+            registeredUnits: [" EUR ", "eur"],
+            removeWallet: { _, unit in events.append("remove:\(unit)") },
+            commitMetadata: { events.append("commit") }
+        )
+
+        XCTAssertEqual(events, ["remove:eur", "commit"])
+    }
+
+    func testMissingNativeWalletCommitsMetadataWithoutInventingSatWallet() async throws {
+        let advertisedSatMint = mint("https://mint.example.com", name: "Test")
+        var events: [String] = []
+
+        try await MintRemovalPolicy.removeBeforeCommit(
+            mint: advertisedSatMint,
+            registeredUnits: [],
+            removeWallet: { _, unit in events.append("remove:\(unit)") },
+            commitMetadata: { events.append("commit") }
+        )
+
+        XCTAssertEqual(events, ["commit"])
+    }
+
+    func testNativeRemovalFailurePreservesMetadata() async {
+        var dollarMint = mint("https://mint.example.com", name: "Test")
+        dollarMint.units = ["usd"]
+        var metadataCommitted = false
+
+        do {
+            try await MintRemovalPolicy.removeBeforeCommit(
+                mint: dollarMint,
+                registeredUnits: ["usd"],
+                removeWallet: { _, _ in throw RepositoryFailure.unavailable },
+                commitMetadata: { metadataCommitted = true }
+            )
+            XCTFail("Expected repository failure")
+        } catch RepositoryFailure.unavailable {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(metadataCommitted)
+    }
+
+    func testRemovalPreservesCancellationWithoutMetadataCommit() async {
+        let satMint = mint("https://mint.example.com", name: "Test")
+        var metadataCommitted = false
+
+        do {
+            try await MintRemovalPolicy.removeBeforeCommit(
+                mint: satMint,
+                registeredUnits: ["sat"],
+                removeWallet: { _, _ in throw CancellationError() },
+                commitMetadata: { metadataCommitted = true }
+            )
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertFalse(metadataCommitted)
+    }
+
+    func testCancellationAfterNativeSuccessStillCommitsMetadata() async {
+        let satMint = mint("https://mint.example.com", name: "Test")
+        let gate = NativeRemovalGate()
+        var metadataCommitted = false
+
+        let request = Task { @MainActor in
+            try await MintRemovalPolicy.removeBeforeCommit(
+                mint: satMint,
+                registeredUnits: ["sat"],
+                removeWallet: { _, _ in
+                    await gate.suspendUntilReleased()
+                },
+                commitMetadata: { metadataCommitted = true }
+            )
+        }
+
+        for _ in 0..<100 {
+            if await gate.hasStarted() { break }
+            await Task.yield()
+        }
+        let nativeRemovalStarted = await gate.hasStarted()
+        XCTAssertTrue(nativeRemovalStarted)
+        request.cancel()
+        await gate.release()
+
+        do {
+            try await request.value
+            XCTFail("Expected cancellation after the commit boundary")
+        } catch is CancellationError {
+            // Expected after the local metadata follows the native commit.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertTrue(metadataCommitted)
+    }
+
+    func testStableMintIdentityDoesNotShiftAfterEarlierRemoval() {
+        let first = mint("https://first.example.com", name: "First")
+        let second = mint("https://second.example.com", name: "Second")
+        let third = mint("https://third.example.com", name: "Third")
+
+        let afterFirst = MintRemovalPolicy.removingMint(
+            withURL: first.url,
+            from: [first, second, third]
+        )
+        let afterSecond = MintRemovalPolicy.removingMint(
+            withURL: second.url,
+            from: afterFirst
+        )
+
+        XCTAssertEqual(afterSecond.map(\.url), [third.url])
     }
 
     // MARK: - updateMintBalances


### PR DESCRIPTION
## Summary

- Preserve mint metadata on Android and iOS when native wallet removal fails.
- Validate actual native repository units atomically and refuse unsupported multi-unit removal without partial mutation.
- Treat a missing native wallet as metadata-only cleanup.
- Stabilize mint identity across URL normalization and surface removal failures inline in both native UIs.

## Why

Removing metadata before native state was safely committed could hide a mint whose wallet data still existed, making recovery and retry difficult.

## Testing

- Android `:app:testDebugUnitTest` passed.
- Android `:app:compileDebugAndroidTestKotlin` passed.
- iOS `MintServiceTests`: 32 tests passed.

