### PR TITLE
feat(android): complete Cashu Request mint funding

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -343,6 +343,8 @@ class FakeWalletGateway(
 
     override suspend fun calculateReceiveFee(tokenString: String): Long = 0
 
+    override suspend fun activeMintInputFeePpk(mintUrl: String): Long? = 0
+
     override suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long = 0
 
     override suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean = true

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -71,6 +71,9 @@ interface CdkWalletGateway {
     suspend fun settleForeignNfcToken(tokenString: String, settlementMintUrl: String): ForeignNfcSettlement
     suspend fun calculateReceiveFee(tokenString: String): Long
 
+    /** Active sat keyset input fee in parts per thousand, or null when unavailable. */
+    suspend fun activeMintInputFeePpk(mintUrl: String): Long?
+
     /**
      * Exact input fee for paying a Cashu Request from [mintUrl].
      *

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -40,6 +40,7 @@ import org.cashudevkit.BackupOptions as CdkBackupOptions
 import org.cashudevkit.BitcoinNetwork as CdkBitcoinNetwork
 import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
 import org.cashudevkit.FinalizedMelt as CdkFinalizedMelt
+import org.cashudevkit.KeysetLoadPolicy as CdkKeysetLoadPolicy
 import org.cashudevkit.MeltConfirmOutcome as CdkMeltConfirmOutcome
 import org.cashudevkit.MeltQuote as CdkMeltQuote
 import org.cashudevkit.MintInfo as CdkMintInfo
@@ -646,6 +647,13 @@ class CdkWalletGatewayImpl : WalletGateway {
             }
             (totalPpk + 999) / 1000
         }.getOrDefault(0L)
+    }
+
+    override suspend fun activeMintInputFeePpk(mintUrl: String): Long? = cdkCall {
+        val keysets = walletFor(mintUrl, CdkCurrencyUnit.Sat)
+            .keysets(CdkKeysetLoadPolicy.REFRESH)
+        val active = keysets.firstOrNull { it.active == true } ?: keysets.firstOrNull()
+        active?.inputFeePpk?.toLong()
     }
 
     override suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long = cdkCall {

--- a/android/app/src/main/java/com/cashu/me/Core/CashuPaymentRequestMintSelector.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuPaymentRequestMintSelector.kt
@@ -5,8 +5,12 @@ import com.cashu.me.Models.MintInfo
 internal sealed interface CashuPaymentRequestRoute {
     data class PayWithEcash(val mint: MintInfo, val amountSats: Long) : CashuPaymentRequestRoute
     data class PayBolt11Fallback(val lightningRequest: String) : CashuPaymentRequestRoute
-    data class AddMintToPay(val mintUrls: List<String>, val amountSats: Long) : CashuPaymentRequestRoute
-    data class NeedsExternalTopUp(val mintUrl: String?, val amountSats: Long) : CashuPaymentRequestRoute
+    data class AcquireThenPay(
+        val mintUrls: List<String>,
+        val targetMintUrl: String?,
+        val amountSats: Long,
+        val addsNewMint: Boolean,
+    ) : CashuPaymentRequestRoute
     data class UnsupportedUnit(val unit: String?) : CashuPaymentRequestRoute
     data object MissingAmount : CashuPaymentRequestRoute
 }
@@ -52,6 +56,7 @@ internal fun routeForCashuPaymentRequest(
     selectedMintUrl: String?,
     activeMintUrl: String?,
     amountSats: Long?,
+    selectedTargetMintUrl: String? = null,
 ): CashuPaymentRequestRoute {
     if (!request.isSatUnit) {
         return CashuPaymentRequestRoute.UnsupportedUnit(request.unit)
@@ -74,22 +79,27 @@ internal fun routeForCashuPaymentRequest(
     }
 
     val requestedMintUrls = request.mints
-        .mapNotNull(::normalizedMintUrlForSelection)
-        .toList()
+        .filter { normalizedMintUrlForSelection(it) != null }
+        .distinctBy(::normalizedMintUrlForSelection)
     val trackedCompatible = compatibleMintsForCashuPaymentRequest(request, mints)
-    if (requestedMintUrls.isNotEmpty() && trackedCompatible.isEmpty()) {
-        return CashuPaymentRequestRoute.AddMintToPay(mintUrls = request.mints, amountSats = amount)
+
+    val trackedTarget = trackedCompatible.firstOrNull { mint ->
+        normalizedMintUrlForSelection(mint.url) == normalizedMintUrlForSelection(selectedMintUrl)
+    }?.url ?: trackedCompatible.firstOrNull { mint ->
+        normalizedMintUrlForSelection(mint.url) == normalizedMintUrlForSelection(activeMintUrl)
+    }?.url ?: trackedCompatible.maxByOrNull { it.balance }?.url
+
+    val selectedRequestedTarget = requestedMintUrls.firstOrNull {
+        normalizedMintUrlForSelection(it) == normalizedMintUrlForSelection(selectedTargetMintUrl)
     }
+    val requestedTarget = selectedRequestedTarget ?: requestedMintUrls.singleOrNull()
+    val targetMintUrl = trackedTarget ?: requestedTarget
 
-    val topUpTarget = selectedMintUrl?.takeIf { selected ->
-        trackedCompatible.any { normalizedMintUrlForSelection(it.url) == normalizedMintUrlForSelection(selected) }
-    } ?: activeMintUrl?.takeIf { active ->
-        trackedCompatible.any { normalizedMintUrlForSelection(it.url) == normalizedMintUrlForSelection(active) }
-    } ?: trackedCompatible.maxByOrNull { it.balance }?.url
-
-    return CashuPaymentRequestRoute.NeedsExternalTopUp(
-        mintUrl = topUpTarget ?: request.mints.firstOrNull(),
+    return CashuPaymentRequestRoute.AcquireThenPay(
+        mintUrls = requestedMintUrls,
+        targetMintUrl = targetMintUrl,
         amountSats = amount,
+        addsNewMint = trackedTarget == null && targetMintUrl != null,
     )
 }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletCashuRequestPayment.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletCashuRequestPayment.kt
@@ -1,5 +1,55 @@
 package com.cashu.me.Core
 
+import com.cashu.me.Models.MeltPaymentResult
+import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.PaymentMethodKind
+
+internal const val CASHU_REQUEST_MAX_INPUT_PROOFS = 32L
+
+internal sealed interface CashuRequestAcquireResult {
+    data class Paid(val fundingResult: MeltPaymentResult?) : CashuRequestAcquireResult
+
+    data class NeedsExternalTopUp(
+        val quote: MintQuoteInfo,
+        val targetMintUrl: String,
+        val requestedAmountSats: Long,
+    ) : CashuRequestAcquireResult
+}
+
+internal class CashuRequestMintSettling : Exception(
+    "The mint is still settling this payment. Try again in a moment.",
+)
+
+internal fun cashuRequestTopUpAmount(
+    requestedAmountSats: Long,
+    inputFeePpk: Long?,
+    maximumInputProofs: Long = CASHU_REQUEST_MAX_INPUT_PROOFS,
+): Long {
+    require(requestedAmountSats > 0) { "Cashu Request top-up amount must be positive." }
+    require(maximumInputProofs > 0) { "Cashu Request input-proof limit must be positive." }
+    val ppk = inputFeePpk?.coerceAtLeast(0L) ?: 0L
+    if (ppk == 0L) return requestedAmountSats
+    val totalPpk = Math.multiplyExact(ppk, maximumInputProofs)
+    val feeBuffer = Math.addExact(totalPpk, 999L) / 1_000L
+    return Math.addExact(requestedAmountSats, feeBuffer.coerceAtLeast(1L))
+}
+
+internal fun selectCashuRequestFundingSource(
+    mints: List<MintInfo>,
+    targetMintUrl: String,
+    requiredAmountSats: Long,
+): MintInfo? {
+    val normalizedTarget = normalizedMintUrlForSelection(targetMintUrl)
+    return mints
+        .asSequence()
+        .filter { normalizedMintUrlForSelection(it.url) != normalizedTarget }
+        .filter { PaymentMethodKind.Bolt11 in it.effectiveMeltMethods }
+        .filter { it.balance >= requiredAmountSats }
+        .sortedWith(compareByDescending<MintInfo> { it.balance }.thenBy { it.name.lowercase() })
+        .firstOrNull()
+}
+
 internal suspend fun payCashuPaymentRequestAndRefresh(
     encoded: String,
     customAmountSats: Long?,
@@ -9,21 +59,6 @@ internal suspend fun payCashuPaymentRequestAndRefresh(
     loadTransactions: suspend () -> Unit,
 ) {
     payCashuPaymentRequest(encoded, customAmountSats, preferredMintURL)
-    refreshBalance()
-    loadTransactions()
-}
-
-internal suspend fun addMintAndPayCashuPaymentRequestAndRefresh(
-    encoded: String,
-    customAmountSats: Long?,
-    mintUrl: String,
-    ensureMintTracked: suspend (mintUrl: String) -> String,
-    payCashuPaymentRequest: suspend (encoded: String, customAmountSats: Long?, preferredMintURL: String?) -> Unit,
-    refreshBalance: suspend () -> Unit,
-    loadTransactions: suspend () -> Unit,
-) {
-    val trackedMintUrl = ensureMintTracked(mintUrl)
-    payCashuPaymentRequest(encoded, customAmountSats, trackedMintUrl)
     refreshBalance()
     loadTransactions()
 }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -33,11 +33,13 @@ import com.cashu.me.Core.Platform.WalletFileBackup
 import com.cashu.me.Core.Protocols.SecureStorage
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Core.Protocols.WalletServiceProtocol
+import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Models.MeltPaymentResult
 import com.cashu.me.Models.MeltQuoteInfo
 import com.cashu.me.Models.MeltQuoteState
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.Models.PendingReceiveToken
 import com.cashu.me.Models.RestoreMintResult
@@ -1152,20 +1154,142 @@ class WalletManager(
         }
     }
 
-    suspend fun addMintAndPayCashuPaymentRequest(encoded: String, customAmountSats: Long?, mintUrl: String) {
-        withLoading {
-            addMintAndPayCashuPaymentRequestAndRefresh(
-                encoded = encoded,
-                customAmountSats = customAmountSats,
-                mintUrl = mintUrl,
-                ensureMintTracked = { ensureMintTracked(it) },
-                payCashuPaymentRequest = { request, amount, trackedMintUrl ->
-                    gateway.payCashuPaymentRequest(request, amount, trackedMintUrl)
-                },
-                refreshBalance = { refreshBalance() },
-                loadTransactions = { loadTransactions() },
+    /**
+     * Acquire ecash at the requested mint, then pay the Cashu Request.
+     *
+     * A different held mint funds the target over BOLT11 when possible. If no
+     * held mint can cover the transfer and its fee reserve, return the already
+     * created target quote so the UI can collect an explicit external top-up.
+     */
+    internal suspend fun acquireAndPayCashuPaymentRequest(
+        encoded: String,
+        amountSats: Long,
+        targetMintUrl: String,
+    ): CashuRequestAcquireResult = withLoadingResult {
+        val trackedTargetMintUrl = ensureMintTracked(targetMintUrl)
+        val inputFeePpk = try {
+            gateway.activeMintInputFeePpk(trackedTargetMintUrl)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Throwable) {
+            null
+        }
+        val mintAmount = cashuRequestTopUpAmount(amountSats, inputFeePpk)
+        val targetQuote = gateway.createMintQuote(
+            amount = mintAmount,
+            method = PaymentMethodKind.Bolt11,
+            mintUrl = trackedTargetMintUrl,
+            unit = "sat",
+        ).also { mintQuoteSyncService.rememberMintQuoteTimestamp(it.id) }
+
+        val source = selectCashuRequestFundingSource(
+            mints = mutableState.value.mints,
+            targetMintUrl = trackedTargetMintUrl,
+            requiredAmountSats = mintAmount,
+        ) ?: return@withLoadingResult CashuRequestAcquireResult.NeedsExternalTopUp(
+            quote = targetQuote,
+            targetMintUrl = trackedTargetMintUrl,
+            requestedAmountSats = amountSats,
+        )
+
+        val sourceMeltQuote = try {
+            gateway.createMeltQuote(
+                request = targetQuote.request,
+                amountSats = null,
+                preferredMintURL = source.url,
+            )
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Throwable) {
+            if (failure.isInsufficientBalance) {
+                return@withLoadingResult CashuRequestAcquireResult.NeedsExternalTopUp(
+                    quote = targetQuote,
+                    targetMintUrl = trackedTargetMintUrl,
+                    requestedAmountSats = amountSats,
+                )
+            }
+            throw failure
+        }
+
+        if (sourceMeltQuote.totalAmount > source.balance) {
+            return@withLoadingResult CashuRequestAcquireResult.NeedsExternalTopUp(
+                quote = targetQuote,
+                targetMintUrl = trackedTargetMintUrl,
+                requestedAmountSats = amountSats,
             )
         }
+
+        val fundingConfirmation = gateway.meltTokens(sourceMeltQuote.id, source.url)
+        fundingConfirmation.pendingMelt?.let { watchPendingMelt(it, sourceMeltQuote.id) }
+        refreshBalance()
+        loadTransactions()
+
+        finishCashuRequestTopUpAndPayInternal(
+            encoded = encoded,
+            amountSats = amountSats,
+            targetMintUrl = trackedTargetMintUrl,
+            quoteId = targetQuote.id,
+        )
+        CashuRequestAcquireResult.Paid(fundingConfirmation.result)
+    }
+
+    /** Finish an externally-paid target quote, then pay the pending request. */
+    internal suspend fun finishCashuRequestTopUpAndPay(
+        encoded: String,
+        amountSats: Long,
+        targetMintUrl: String,
+        quoteId: String,
+    ) {
+        withLoading {
+            finishCashuRequestTopUpAndPayInternal(encoded, amountSats, targetMintUrl, quoteId)
+        }
+    }
+
+    private suspend fun finishCashuRequestTopUpAndPayInternal(
+        encoded: String,
+        amountSats: Long,
+        targetMintUrl: String,
+        quoteId: String,
+    ) {
+        mintCashuRequestTopUpWithRetries(quoteId)
+        try {
+            gateway.payCashuPaymentRequest(encoded, amountSats, targetMintUrl)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (failure: Throwable) {
+            if (failure.isInsufficientBalance) throw CashuRequestMintSettling()
+            throw failure
+        }
+        refreshBalance()
+        loadTransactions()
+    }
+
+    private suspend fun mintCashuRequestTopUpWithRetries(quoteId: String) {
+        repeat(8) { attempt ->
+            val quote = try {
+                gateway.checkMintQuote(quoteId)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Throwable) {
+                null
+            }
+            when (quote?.state) {
+                MintQuoteState.Issued -> return
+                MintQuoteState.Paid -> {
+                    try {
+                        gateway.mintTokens(quoteId)
+                        return
+                    } catch (cancellation: CancellationException) {
+                        throw cancellation
+                    } catch (failure: Throwable) {
+                        if (mintQuoteSyncService.isAlreadyIssuedMintError(failure)) return
+                    }
+                }
+                else -> Unit
+            }
+            if (attempt < 7) delay(2_500)
+        }
+        throw CashuRequestMintSettling()
     }
 
     suspend fun loadTransactions() {

--- a/android/app/src/main/java/com/cashu/me/ui/components/MintPickerSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/MintPickerSheet.kt
@@ -57,6 +57,7 @@ fun MintPickerSheet(
     onDismiss: () -> Unit,
     title: String = "Choose mint",
     allowAnyMint: Boolean = false,
+    mintSubtitle: ((MintInfo) -> String)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val formatter = remember { AmountFormatter() }
@@ -89,7 +90,8 @@ fun MintPickerSheet(
                     items(mints, key = { it.url }) { mint ->
                         MintPickerMintRow(
                             mint = mint,
-                            balanceText = formatter.formatSats(mint.balance),
+                            balanceText = mintSubtitle?.invoke(mint)
+                                ?: formatter.formatSats(mint.balance),
                             selected = mint.url == activeMintUrl,
                             onClick = { onSelect(mint) },
                         )

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendCashuRequestTopUp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendCashuRequestTopUp.kt
@@ -1,21 +1,28 @@
 package com.cashu.me.ui.send
 
-import com.cashu.me.Models.MintQuoteInfo
-import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.Core.CashuPaymentRequestRoute
+import java.net.URI
 
-internal suspend fun createExternalTopUpQuote(
-    mintUrl: String,
-    requestedAmountSats: Long,
-    createMintQuoteForMint: suspend (
-        mintUrl: String,
-        amount: Long?,
-        method: PaymentMethodKind,
-        unit: String,
-    ) -> MintQuoteInfo,
-): MintQuoteInfo =
-    createMintQuoteForMint(
-        mintUrl,
-        requestedAmountSats,
-        PaymentMethodKind.Bolt11,
-        "sat",
-    )
+internal fun isCashuRequestPayEnabled(route: CashuPaymentRequestRoute?): Boolean =
+    route == null ||
+        route is CashuPaymentRequestRoute.PayWithEcash ||
+        route is CashuPaymentRequestRoute.PayBolt11Fallback ||
+        (route is CashuPaymentRequestRoute.AcquireThenPay &&
+            (route.targetMintUrl != null || route.mintUrls.isNotEmpty()))
+
+internal fun cashuRequestPayButtonText(route: CashuPaymentRequestRoute?, fallback: String): String {
+    if (route !is CashuPaymentRequestRoute.AcquireThenPay) return fallback
+    if (route.targetMintUrl == null && route.mintUrls.size > 1) return "Add a mint & pay"
+    val target = route.targetMintUrl?.let(::cashuRequestMintDisplayName)
+    return if (route.addsNewMint) {
+        target?.let { "Add $it & pay" } ?: "Add mint & pay"
+    } else {
+        target?.let { "Fund $it & pay" } ?: "Fund mint & pay"
+    }
+}
+
+internal fun cashuRequestMintDisplayName(url: String): String =
+    runCatching { URI(url).host }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
+        ?: url

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendPaymentDetails.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendPaymentDetails.kt
@@ -117,7 +117,7 @@ internal data class SendPaymentDetails(
  * - Melt rails: Method, on-chain Destination when applicable, Amount,
  *   Network fee, and Mint.
  * - Cashu Request: Method, Amount, Input/Network fee context, Mint when known,
- *   Memo when supplied, and a Route row when payment changes rails or adds a mint.
+ *   Memo when supplied, and a Route row when payment changes rails or needs a top-up.
  */
 internal fun buildSendPaymentDetails(
     rail: LockedRail,
@@ -198,12 +198,13 @@ private fun buildCashuRequestDetails(
     add(textRow(SendPaymentDetailKey.Method, "Method", "Cashu Request"))
     add(satsRow(SendPaymentDetailKey.Amount, "Amount", amountSats))
 
-    val fallback = route is CashuPaymentRequestRoute.PayBolt11Fallback
+    val networkRoute = route is CashuPaymentRequestRoute.PayBolt11Fallback ||
+        route is CashuPaymentRequestRoute.AcquireThenPay
     add(
         SendPaymentDetailRow(
-            key = if (fallback) SendPaymentDetailKey.NetworkFee else SendPaymentDetailKey.InputFee,
-            label = if (fallback) "Network fee" else "Input fee",
-            value = if (fallback) {
+            key = if (networkRoute) SendPaymentDetailKey.NetworkFee else SendPaymentDetailKey.InputFee,
+            label = if (networkRoute) "Network fee" else "Input fee",
+            value = if (networkRoute) {
                 SendPaymentDetailValue.Pending
             } else {
                 inputFeeSats
@@ -250,10 +251,8 @@ private fun cashuRequestMintValue(
 ): SendPaymentDetailValue? = when (route) {
     is CashuPaymentRequestRoute.PayWithEcash ->
         SendPaymentDetailValue.Text(route.mint.name)
-    is CashuPaymentRequestRoute.AddMintToPay ->
-        route.mintUrls.firstOrNull()?.let(::mintDisplayName)?.let(SendPaymentDetailValue::Text)
-    is CashuPaymentRequestRoute.NeedsExternalTopUp ->
-        route.mintUrl?.let(::mintDisplayName)?.let(SendPaymentDetailValue::Text)
+    is CashuPaymentRequestRoute.AcquireThenPay ->
+        route.targetMintUrl?.let(::mintDisplayName)?.let(SendPaymentDetailValue::Text)
     is CashuPaymentRequestRoute.PayBolt11Fallback -> SendPaymentDetailValue.Pending
     is CashuPaymentRequestRoute.UnsupportedUnit,
     CashuPaymentRequestRoute.MissingAmount,
@@ -262,8 +261,8 @@ private fun cashuRequestMintValue(
 
 private fun cashuRequestRouteName(route: CashuPaymentRequestRoute?): String? = when (route) {
     is CashuPaymentRequestRoute.PayBolt11Fallback -> "Lightning fallback"
-    is CashuPaymentRequestRoute.AddMintToPay -> "Add requested mint"
-    is CashuPaymentRequestRoute.NeedsExternalTopUp -> "Top up target mint"
+    is CashuPaymentRequestRoute.AcquireThenPay ->
+        if (route.addsNewMint) "Add requested mint" else "Fund target mint"
     is CashuPaymentRequestRoute.PayWithEcash,
     is CashuPaymentRequestRoute.UnsupportedUnit,
     CashuPaymentRequestRoute.MissingAmount,

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -69,6 +69,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.CashuRequestAcquireResult
+import com.cashu.me.Core.CashuRequestMintSettling
 import com.cashu.me.Core.CashuPaymentRequestRoute
 import com.cashu.me.Core.MintDiscoveryManager
 import com.cashu.me.Core.PaymentRequestDecodeResult
@@ -76,10 +78,12 @@ import com.cashu.me.Core.PaymentRequestDecoder
 import com.cashu.me.Core.PriceService
 import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.Wallet.WalletMessage
+import com.cashu.me.Core.Wallet.WalletMessageSeverity
 import com.cashu.me.Core.Wallet.isInsufficientBalance
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.Wallet.walletMessage
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.compatibleMintsForCashuPaymentRequest
 import com.cashu.me.Core.normalizedMintUrlForSelection
 import com.cashu.me.Core.routeForCashuPaymentRequest
 import com.cashu.me.Models.MeltPaymentResult
@@ -87,6 +91,7 @@ import com.cashu.me.Models.MeltQuoteInfo
 import com.cashu.me.Models.MeltSettlement
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.R
 import com.cashu.me.ui.components.AmountFlipDisplay
 import com.cashu.me.ui.components.AmountText
@@ -148,6 +153,16 @@ internal sealed interface SendStatus {
     ) : SendStatus
 }
 
+private data class CashuRequestTopUpContext(
+    val encodedRequest: String,
+    val requestedAmountSats: Long,
+    val targetMintUrl: String,
+    val quote: MintQuoteInfo,
+    val details: SendPaymentDetails,
+)
+
+private enum class CashuRequestTopUpPhase { AwaitingPayment, PayingRequest, Failed, Done }
+
 /**
  * The Send surface (iOS UnifiedSendView): one destination field that infers the
  * rail, a Scan · Ecash · Tap ways-to-send row, then amount → confirm → status.
@@ -199,10 +214,11 @@ fun UnifiedSendScreen(
     var cameFromAmount by remember { mutableStateOf(false) }
     var selectedMintUrl by remember { mutableStateOf<String?>(null) }
     var mintPickerOpen by remember { mutableStateOf(false) }
+    var cashuTargetPickerOpen by remember { mutableStateOf(false) }
+    var cashuTargetMintPreviews by remember { mutableStateOf<List<MintInfo>>(emptyList()) }
+    var selectedCashuTargetMintUrl by remember { mutableStateOf<String?>(null) }
     var meltQuote by remember { mutableStateOf<MeltQuoteInfo?>(null) }
-    var topUpQuote by remember { mutableStateOf<MintQuoteInfo?>(null) }
-    var topUpLoading by remember { mutableStateOf(false) }
-    var topUpError by remember { mutableStateOf<String?>(null) }
+    var topUpContext by remember { mutableStateOf<CashuRequestTopUpContext?>(null) }
     var quoteError by remember { mutableStateOf<String?>(null) }
     // Structured companion to quoteError: whether the failure was the mint
     // refusing for balance — that state gets a real recovery CTA, never a
@@ -237,10 +253,19 @@ fun UnifiedSendScreen(
             selectedMintUrl = selectedMintUrl,
             activeMintUrl = walletState.activeMint?.url,
             amountSats = confirmAmount,
+            selectedTargetMintUrl = selectedCashuTargetMintUrl,
         )
     }
+    val paymentMintChoices = (locked as? LockedRail.Creq)?.let { rail ->
+        compatibleMintsForCashuPaymentRequest(rail.decoded.summary, walletState.mints)
+    } ?: walletState.mints
     val activeMint = when (val route = cashuRoute) {
         is CashuPaymentRequestRoute.PayWithEcash -> route.mint
+        is CashuPaymentRequestRoute.AcquireThenPay -> route.targetMintUrl?.let { target ->
+            walletState.mints.firstOrNull {
+                normalizedMintUrlForSelection(it.url) == normalizedMintUrlForSelection(target)
+            }
+        }
         else -> walletState.mints.firstOrNull { it.url == activeMintUrl } ?: walletState.activeMint
     }
     val cashuRequestFeeKey = (locked as? LockedRail.Creq)?.let { rail ->
@@ -267,9 +292,10 @@ fun UnifiedSendScreen(
         locked = null
         amount = ""
         meltQuote = null
-        topUpQuote = null
-        topUpLoading = false
-        topUpError = null
+        topUpContext = null
+        cashuTargetPickerOpen = false
+        cashuTargetMintPreviews = emptyList()
+        selectedCashuTargetMintUrl = null
         quoteError = null
         confirmError = null
         cashuRequestFeeEstimate = CashuRequestFeeEstimate.Unrequested
@@ -321,11 +347,24 @@ fun UnifiedSendScreen(
         }
     }
 
-    fun pay() {
+    fun pay(acquireTargetOverride: String? = null) {
         val rail = locked ?: return
+        val route = when (val current = cashuRoute) {
+            is CashuPaymentRequestRoute.AcquireThenPay -> current.copy(
+                targetMintUrl = acquireTargetOverride ?: current.targetMintUrl,
+            )
+            else -> current
+        }
+        if (rail is LockedRail.Creq &&
+            route is CashuPaymentRequestRoute.AcquireThenPay &&
+            route.targetMintUrl == null
+        ) {
+            if (route.mintUrls.isNotEmpty()) cashuTargetPickerOpen = true
+            return
+        }
         var paymentDetails = buildSendPaymentDetails(
             rail = rail,
-            cashuRoute = cashuRoute,
+            cashuRoute = route,
             amountSats = confirmAmount,
             mint = activeMint,
             meltQuote = meltQuote,
@@ -342,7 +381,7 @@ fun UnifiedSendScreen(
                         status = SendStatus.Sent(paymentDetails, result)
                     }
                     is LockedRail.Creq -> {
-                        when (val route = cashuRoute) {
+                        when (route) {
                             is CashuPaymentRequestRoute.PayWithEcash -> {
                                 walletManager.payCashuPaymentRequest(rail.raw, route.amountSats, route.mint.url)
                             }
@@ -365,17 +404,32 @@ fun UnifiedSendScreen(
                                 status = SendStatus.Sent(paymentDetails, result)
                                 return@launch
                             }
-                            is CashuPaymentRequestRoute.AddMintToPay -> {
-                                val mintUrl = route.mintUrls.firstOrNull()
-                                    ?: error("No compatible mint was supplied.")
-                                walletManager.addMintAndPayCashuPaymentRequest(
-                                    encoded = rail.raw,
-                                    customAmountSats = route.amountSats,
-                                    mintUrl = mintUrl,
-                                )
-                            }
-                            is CashuPaymentRequestRoute.NeedsExternalTopUp -> {
-                                error("Top up the target mint before paying this Cashu Request.")
+                            is CashuPaymentRequestRoute.AcquireThenPay -> {
+                                val targetMintUrl = requireNotNull(route.targetMintUrl)
+                                when (
+                                    val result = walletManager.acquireAndPayCashuPaymentRequest(
+                                        encoded = rail.raw,
+                                        amountSats = route.amountSats,
+                                        targetMintUrl = targetMintUrl,
+                                    )
+                                ) {
+                                    is CashuRequestAcquireResult.Paid -> {
+                                        paymentDetails = result.fundingResult
+                                            ?.let(paymentDetails::withMeltResult)
+                                            ?: paymentDetails.resolvingFailed()
+                                    }
+                                    is CashuRequestAcquireResult.NeedsExternalTopUp -> {
+                                        topUpContext = CashuRequestTopUpContext(
+                                            encodedRequest = rail.raw,
+                                            requestedAmountSats = result.requestedAmountSats,
+                                            targetMintUrl = result.targetMintUrl,
+                                            quote = result.quote,
+                                            details = paymentDetails.resolvingFailed(),
+                                        )
+                                        status = null
+                                        return@launch
+                                    }
+                                }
                             }
                             CashuPaymentRequestRoute.MissingAmount -> {
                                 error("Enter an amount before paying this Cashu Request.")
@@ -392,6 +446,14 @@ fun UnifiedSendScreen(
                 }
             } catch (cancellation: CancellationException) {
                 throw cancellation
+            } catch (settling: CashuRequestMintSettling) {
+                status = SendStatus.Failed(
+                    paymentDetails.resolvingFailed(),
+                    WalletMessage(
+                        text = settling.message.orEmpty(),
+                        severity = WalletMessageSeverity.Caution,
+                    ),
+                )
             } catch (t: Throwable) {
                 status = SendStatus.Failed(paymentDetails.resolvingFailed(), t.walletMessage)
             }
@@ -489,6 +551,31 @@ fun UnifiedSendScreen(
             walletManager.estimateCashuPaymentRequestFee(amountSats, mintUrl)
         }
         cashuRequestFeeEstimate = cashuRequestFeeEstimate.acceptIfCurrent(result)
+    }
+
+    val requestedTargetMintUrls =
+        (cashuRoute as? CashuPaymentRequestRoute.AcquireThenPay)?.mintUrls.orEmpty()
+    LaunchedEffect(cashuTargetPickerOpen, requestedTargetMintUrls) {
+        if (!cashuTargetPickerOpen) return@LaunchedEffect
+        cashuTargetMintPreviews = requestedTargetMintUrls.map { url ->
+            MintInfo(url = url, name = cashuRequestMintDisplayName(url))
+        }
+        requestedTargetMintUrls.forEach { url ->
+            val preview = try {
+                walletManager.fetchLiveMintInfo(url)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Throwable) {
+                null
+            } ?: return@forEach
+            cashuTargetMintPreviews = cashuTargetMintPreviews.map { current ->
+                if (normalizedMintUrlForSelection(current.url) == normalizedMintUrlForSelection(url)) {
+                    preview
+                } else {
+                    current
+                }
+            }
+        }
     }
 
     // Block sheet dismissal while the melt is in flight — a stray swipe must
@@ -640,7 +727,7 @@ fun UnifiedSendScreen(
                                 // One mint means nothing to choose between, so the row
                                 // drops its chevron and stops opening a picker.
                                 onPickMint = { mintPickerOpen = true }
-                                    .takeIf { walletState.mints.size > 1 },
+                                    .takeIf { paymentMintChoices.size > 1 },
                                 onUseMax = {
                                     activeMint?.balance?.takeIf { it > 0 }?.let {
                                         amount = UnifiedSendAmountEntry.maxRawForBalance(it, entryContext)
@@ -669,32 +756,9 @@ fun UnifiedSendScreen(
                                 onPickMint = { mintPickerOpen = true },
                                 // One mint means nothing to choose between, so the row
                                 // drops its chevron and stops opening a picker.
-                                canPickMint = walletState.mints.size > 1,
-                                onCreateTopUp = { mintUrl, requestedAmount ->
-                                    topUpError = null
-                                    topUpLoading = true
-                                    scope.launch {
-                                        try {
-                                            topUpQuote = createExternalTopUpQuote(
-                                                mintUrl = mintUrl,
-                                                requestedAmountSats = requestedAmount,
-                                            ) { targetMintUrl, amount, method, unit ->
-                                                walletManager.createMintQuoteForMint(
-                                                    mintUrl = targetMintUrl,
-                                                    amount = amount,
-                                                    method = method,
-                                                    unit = unit,
-                                                )
-                                            }
-                                        } catch (cancellation: CancellationException) {
-                                            throw cancellation
-                                        } catch (failure: Throwable) {
-                                            topUpError = failure.userFacingWalletMessage
-                                        } finally {
-                                            topUpLoading = false
-                                        }
-                                    }
-                                },
+                                canPickMint = paymentMintChoices.size > 1 &&
+                                    (cashuRoute as? CashuPaymentRequestRoute.AcquireThenPay)
+                                        ?.addsNewMint != true,
                                 quote = meltQuote,
                                 cashuRequestFeeEstimate = displayedCashuRequestFeeEstimate,
                                 quoteError = quoteError,
@@ -719,9 +783,7 @@ fun UnifiedSendScreen(
                                 showFiat = settings.showFiatBalance,
                                 btcPrice = priceState.btcPrice,
                                 currencyCode = priceState.currencyCode,
-                                topUpLoading = topUpLoading,
-                                topUpError = topUpError,
-                                onPay = ::pay,
+                                onPay = { pay() },
                             )
                         }
                     }
@@ -732,7 +794,7 @@ fun UnifiedSendScreen(
 
     if (mintPickerOpen) {
         MintPickerSheet(
-            mints = walletState.mints,
+            mints = paymentMintChoices,
             activeMintUrl = activeMintUrl,
             onSelect = { mint ->
                 mint?.let { selectedMintUrl = it.url }
@@ -742,12 +804,34 @@ fun UnifiedSendScreen(
         )
     }
 
-    topUpQuote?.let { quote ->
+    if (cashuTargetPickerOpen) {
+        MintPickerSheet(
+            mints = cashuTargetMintPreviews,
+            activeMintUrl = selectedCashuTargetMintUrl,
+            title = "Add a mint to pay",
+            mintSubtitle = { "Not in your wallet yet" },
+            onSelect = { mint ->
+                if (mint != null) {
+                    selectedCashuTargetMintUrl = mint.url
+                    cashuTargetPickerOpen = false
+                    pay(mint.url)
+                }
+            },
+            onDismiss = { cashuTargetPickerOpen = false },
+        )
+    }
+
+    topUpContext?.let { context ->
         TopUpQuoteSheet(
-            quote = quote,
+            context = context,
+            walletManager = walletManager,
             formatter = formatter,
             useBitcoinSymbol = settings.useBitcoinSymbol,
-            onDismiss = { topUpQuote = null },
+            onComplete = {
+                topUpContext = null
+                status = SendStatus.Sent(context.details, null)
+            },
+            onDismiss = { topUpContext = null },
         )
     }
 }
@@ -1106,7 +1190,6 @@ private fun ConfirmFace(
     mint: MintInfo?,
     onPickMint: () -> Unit,
     canPickMint: Boolean,
-    onCreateTopUp: (mintUrl: String, requestedAmountSats: Long) -> Unit,
     quote: MeltQuoteInfo?,
     cashuRequestFeeEstimate: CashuRequestFeeEstimate,
     quoteError: String?,
@@ -1125,8 +1208,6 @@ private fun ConfirmFace(
     showFiat: Boolean,
     btcPrice: Double?,
     currencyCode: String,
-    topUpLoading: Boolean,
-    topUpError: String?,
     onPay: () -> Unit,
 ) {
     val isMelt = rail is LockedRail.Melt
@@ -1134,13 +1215,9 @@ private fun ConfirmFace(
     val cashuAmountLabel = (rail as? LockedRail.Creq)?.decoded?.summary?.let(PaymentRequestDecoder::amountLabel)
     val amountUnit = (rail as? LockedRail.Creq)?.decoded?.summary?.unit ?: "sat"
     val creqDescription = (rail as? LockedRail.Creq)?.decoded?.summary?.description
-    val hideCreqDestination = (rail as? LockedRail.Creq)?.fromScan == true
     val total = quote?.totalAmount ?: amountSats
     val insufficient = isMelt && quote != null && total > mintBalance
-    val canPayCashuRequest = cashuRoute == null ||
-        cashuRoute is CashuPaymentRequestRoute.PayWithEcash ||
-        cashuRoute is CashuPaymentRequestRoute.PayBolt11Fallback ||
-        cashuRoute is CashuPaymentRequestRoute.AddMintToPay
+    val canPayCashuRequest = isCashuRequestPayEnabled(cashuRoute)
     val unsupportedCashuRequestUnit =
         stringResource(R.string.send_cashu_request_unsupported_unit)
     val lightningFallback =
@@ -1277,11 +1354,11 @@ private fun ConfirmFace(
                     is CashuPaymentRequestRoute.PayBolt11Fallback -> {
                         InspectorRow(label = "Route", value = "Use Lightning fallback")
                     }
-                    is CashuPaymentRequestRoute.AddMintToPay -> {
-                        InspectorRow(label = "Route", value = "Add requested mint")
-                    }
-                    is CashuPaymentRequestRoute.NeedsExternalTopUp -> {
-                        InspectorRow(label = "Route", value = "Top up target mint")
+                    is CashuPaymentRequestRoute.AcquireThenPay -> {
+                        InspectorRow(
+                            label = "Route",
+                            value = if (route.addsNewMint) "Add requested mint" else "Fund target mint",
+                        )
                     }
                     CashuPaymentRequestRoute.MissingAmount,
                     is CashuPaymentRequestRoute.UnsupportedUnit,
@@ -1304,27 +1381,28 @@ private fun ConfirmFace(
                     severity = NoticeSeverity.Caution,
                 )
             }
-            is CashuPaymentRequestRoute.AddMintToPay -> {
+            is CashuPaymentRequestRoute.AcquireThenPay -> {
                 Spacer(Modifier.height(CashuTheme.spacing.default))
                 InlineNotice(
-                    text = "This request asks for a mint you have not added yet. It will be added before payment.",
-                    severity = NoticeSeverity.Info,
+                    text = when {
+                        cashuRoute.targetMintUrl == null && cashuRoute.mintUrls.isEmpty() ->
+                            "This request does not name a mint and no wallet mint can fund it."
+                        cashuRoute.addsNewMint ->
+                            "The requested mint will be added and funded before payment."
+                        else ->
+                            "The target mint will be funded before payment."
+                    },
+                    severity = if (
+                        cashuRoute.targetMintUrl == null && cashuRoute.mintUrls.isEmpty()
+                    ) {
+                        NoticeSeverity.Caution
+                    } else {
+                        NoticeSeverity.Info
+                    },
                 )
-            }
-            is CashuPaymentRequestRoute.NeedsExternalTopUp -> {
-                Spacer(Modifier.height(CashuTheme.spacing.default))
-                InlineNotice(
-                    text = "The compatible mint does not hold enough ecash for this request.",
-                    severity = NoticeSeverity.Caution,
-                )
-                cashuRoute.mintUrl?.let { mintUrl ->
-                    GhostButton(
-                        text = if (topUpLoading) "Creating top-up..." else "Create top-up QR",
-                        onClick = { onCreateTopUp(mintUrl, cashuRoute.amountSats) },
-                        enabled = !topUpLoading,
-                    )
+                if (!cashuRoute.addsNewMint && canPickMint) {
+                    GhostButton(text = "Choose another mint", onClick = onPickMint)
                 }
-                GhostButton(text = "Choose another mint", onClick = onPickMint)
             }
             is CashuPaymentRequestRoute.PayBolt11Fallback -> {
                 Spacer(Modifier.height(CashuTheme.spacing.default))
@@ -1335,10 +1413,6 @@ private fun ConfirmFace(
             }
             is CashuPaymentRequestRoute.PayWithEcash,
             null -> Unit
-        }
-        if (topUpError != null) {
-            Spacer(Modifier.height(CashuTheme.spacing.default))
-            InlineNotice(text = topUpError, severity = NoticeSeverity.Error)
         }
         if (confirmError != null) {
             Spacer(Modifier.height(CashuTheme.spacing.default))
@@ -1376,7 +1450,10 @@ private fun ConfirmFace(
                 onClick = onRetryQuote,
             )
             else -> PrimaryButton(
-                text = "Pay ${cashuAmountLabel ?: formatter.formatWalletSats(amountSats, useBitcoinSymbol)}",
+                text = cashuRequestPayButtonText(
+                    route = cashuRoute,
+                    fallback = "Pay ${cashuAmountLabel ?: formatter.formatWalletSats(amountSats, useBitcoinSymbol)}",
+                ),
                 onClick = onPay,
                 modifier = Modifier.testTag(UiTestTags.SendPaymentSubmit),
                 enabled = if (isMelt) {
@@ -1455,14 +1532,76 @@ private fun ConfirmCautionFace(message: String, detail: String? = null) {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun TopUpQuoteSheet(
-    quote: MintQuoteInfo,
+    context: CashuRequestTopUpContext,
+    walletManager: WalletManager,
     formatter: AmountFormatter,
     useBitcoinSymbol: Boolean,
+    onComplete: () -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var liveQuote by remember(context.quote.id) { mutableStateOf(context.quote) }
+    var phase by remember(context.quote.id) {
+        mutableStateOf(CashuRequestTopUpPhase.AwaitingPayment)
+    }
+    var errorMessage by remember(context.quote.id) { mutableStateOf<String?>(null) }
+    var errorSeverity by remember(context.quote.id) { mutableStateOf(NoticeSeverity.Error) }
+    var retryGeneration by remember(context.quote.id) { mutableStateOf(0) }
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { phase != CashuRequestTopUpPhase.PayingRequest },
+    )
+
+    LaunchedEffect(context.quote.id, retryGeneration) {
+        phase = CashuRequestTopUpPhase.AwaitingPayment
+        errorMessage = null
+        val delaysMs = listOf(3_000L, 3_000L, 4_000L, 5_000L, 5_000L, 6_000L, 8_000L)
+        var delayIndex = 0
+        while (liveQuote.state != MintQuoteState.Paid && liveQuote.state != MintQuoteState.Issued) {
+            delay(delaysMs.getOrElse(delayIndex) { 10_000L })
+            delayIndex += 1
+            liveQuote = try {
+                walletManager.pollMintQuote(context.quote.id)
+            } catch (cancellation: CancellationException) {
+                throw cancellation
+            } catch (_: Throwable) {
+                continue
+            }
+            if (liveQuote.state == MintQuoteState.Failed || liveQuote.isExpired) {
+                errorMessage = "This top-up quote is no longer payable. Close it and try again."
+                phase = CashuRequestTopUpPhase.Failed
+                return@LaunchedEffect
+            }
+        }
+
+        phase = CashuRequestTopUpPhase.PayingRequest
+        try {
+            walletManager.finishCashuRequestTopUpAndPay(
+                encoded = context.encodedRequest,
+                amountSats = context.requestedAmountSats,
+                targetMintUrl = context.targetMintUrl,
+                quoteId = context.quote.id,
+            )
+            phase = CashuRequestTopUpPhase.Done
+            delay(1_000)
+            onComplete()
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (settling: CashuRequestMintSettling) {
+            errorMessage = settling.message
+            errorSeverity = NoticeSeverity.Caution
+            phase = CashuRequestTopUpPhase.Failed
+        } catch (failure: Throwable) {
+            errorMessage = failure.userFacingWalletMessage
+            errorSeverity = NoticeSeverity.Error
+            phase = CashuRequestTopUpPhase.Failed
+        }
+    }
+
+    BackHandler(enabled = phase == CashuRequestTopUpPhase.PayingRequest) {}
     ModalBottomSheet(
-        onDismissRequest = onDismiss,
+        onDismissRequest = {
+            if (phase != CashuRequestTopUpPhase.PayingRequest) onDismiss()
+        },
         sheetState = sheetState,
     ) {
         Column(
@@ -1479,19 +1618,46 @@ private fun TopUpQuoteSheet(
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            quote.amount?.let { amount ->
+            liveQuote.amount?.let { amount ->
                 AmountText(
                     text = formatter.formatWalletSats(amount, useBitcoinSymbol),
                     style = MaterialTheme.typography.headlineSmall.withMonoDigits(),
                 )
             }
-            QrCard(content = quote.request, shareSubject = "Top-up request", staticOnly = true)
+            QrCard(content = liveQuote.request, shareSubject = "Top-up request", staticOnly = true)
             Text(
-                text = "Pay this invoice, then try the Cashu Request again after the mint settles.",
+                text = "Pay this invoice to fund the mint and complete the Cashu Request.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
             )
-            PrimaryButton(text = "Done", onClick = onDismiss)
+            Text(
+                text = when (phase) {
+                    CashuRequestTopUpPhase.AwaitingPayment -> "Waiting for payment…"
+                    CashuRequestTopUpPhase.PayingRequest -> "Payment received — paying request…"
+                    CashuRequestTopUpPhase.Failed -> "Cashu Request payment is not complete."
+                    CashuRequestTopUpPhase.Done -> "Payment sent"
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+            )
+            errorMessage?.let {
+                InlineNotice(text = it, severity = errorSeverity)
+            }
+            when (phase) {
+                CashuRequestTopUpPhase.AwaitingPayment -> PrimaryButton(text = "Done", onClick = onDismiss)
+                CashuRequestTopUpPhase.PayingRequest -> PrimaryButton(
+                    text = "Completing payment…",
+                    onClick = {},
+                    enabled = false,
+                )
+                CashuRequestTopUpPhase.Failed -> PrimaryButton(
+                    text = "Try again",
+                    onClick = { retryGeneration += 1 },
+                )
+                CashuRequestTopUpPhase.Done -> PrimaryButton(text = "Sent", onClick = {}, enabled = false)
+            }
         }
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/CashuPaymentRequestMintSelectorTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CashuPaymentRequestMintSelectorTest.kt
@@ -140,7 +140,7 @@ class CashuPaymentRequestMintSelectorTest {
     }
 
     @Test
-    fun routeOffersAddMintWhenRequestedMintIsNotTracked() {
+    fun routeRequestsTopUpWhenRequestedMintIsNotTracked() {
         val route = routeForCashuPaymentRequest(
             rawRequest = "creqa-test",
             request = request(mints = listOf("https://target.example.com")).copy(amount = 25),
@@ -151,7 +151,12 @@ class CashuPaymentRequestMintSelectorTest {
         )
 
         assertEquals(
-            CashuPaymentRequestRoute.AddMintToPay(listOf("https://target.example.com"), 25),
+            CashuPaymentRequestRoute.AcquireThenPay(
+                mintUrls = listOf("https://target.example.com"),
+                targetMintUrl = "https://target.example.com",
+                amountSats = 25,
+                addsNewMint = true,
+            ),
             route,
         )
     }
@@ -168,11 +173,63 @@ class CashuPaymentRequestMintSelectorTest {
             amountSats = null,
         )
 
-        assertEquals(CashuPaymentRequestRoute.NeedsExternalTopUp(mint.url, 25), route)
+        assertEquals(
+            CashuPaymentRequestRoute.AcquireThenPay(
+                mintUrls = listOf(mint.url),
+                targetMintUrl = mint.url,
+                amountSats = 25,
+                addsNewMint = false,
+            ),
+            route,
+        )
     }
 
     @Test
-    fun routeUsesLightningFallbackBeforeAddMint() {
+    fun routePreservesMultipleRequestedMintsUntilUserSelectsTarget() {
+        val first = "https://first.example.com"
+        val second = "https://second.example.com"
+        val request = request(mints = listOf(first, second)).copy(amount = 25)
+
+        val unselected = routeForCashuPaymentRequest(
+            rawRequest = "creqa-test",
+            request = request,
+            mints = emptyList(),
+            selectedMintUrl = null,
+            activeMintUrl = null,
+            amountSats = null,
+        )
+        val selected = routeForCashuPaymentRequest(
+            rawRequest = "creqa-test",
+            request = request,
+            mints = emptyList(),
+            selectedMintUrl = null,
+            activeMintUrl = null,
+            amountSats = null,
+            selectedTargetMintUrl = "$second/",
+        )
+
+        assertEquals(
+            CashuPaymentRequestRoute.AcquireThenPay(
+                mintUrls = listOf(first, second),
+                targetMintUrl = null,
+                amountSats = 25,
+                addsNewMint = false,
+            ),
+            unselected,
+        )
+        assertEquals(
+            CashuPaymentRequestRoute.AcquireThenPay(
+                mintUrls = listOf(first, second),
+                targetMintUrl = second,
+                amountSats = 25,
+                addsNewMint = true,
+            ),
+            selected,
+        )
+    }
+
+    @Test
+    fun routeUsesLightningFallbackBeforeExternalTopUp() {
         val route = routeForCashuPaymentRequest(
             rawRequest = "bitcoin:bc1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9e75rs?lightning=lnbc10u1ptest&creq=creqa-test",
             request = request(mints = listOf("https://target.example.com")).copy(amount = 25),

--- a/android/app/src/test/java/com/cashu/me/Core/WalletCashuRequestPaymentTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletCashuRequestPaymentTest.kt
@@ -31,36 +31,6 @@ class WalletCashuRequestPaymentTest {
     }
 
     @Test
-    fun addMintAndPayUsesTrackedMintUrlBeforeRefreshing() = runBlocking {
-        val events = mutableListOf<String>()
-
-        addMintAndPayCashuPaymentRequestAndRefresh(
-            encoded = "creq1payment",
-            customAmountSats = null,
-            mintUrl = "https://mint.example/",
-            ensureMintTracked = { mintUrl ->
-                events += "ensure:$mintUrl"
-                "https://mint.example"
-            },
-            payCashuPaymentRequest = { encoded, amount, mintUrl ->
-                events += "pay:$encoded:$amount:$mintUrl"
-            },
-            refreshBalance = { events += "refreshBalance" },
-            loadTransactions = { events += "loadTransactions" },
-        )
-
-        assertEquals(
-            listOf(
-                "ensure:https://mint.example/",
-                "pay:creq1payment:null:https://mint.example",
-                "refreshBalance",
-                "loadTransactions",
-            ),
-            events,
-        )
-    }
-
-    @Test
     fun paymentFailureDoesNotRefreshBalanceOrTransactions() {
         val events = mutableListOf<String>()
 

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendCashuRequestTopUpTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendCashuRequestTopUpTest.kt
@@ -1,36 +1,104 @@
 package com.cashu.me.ui.send
 
-import kotlinx.coroutines.runBlocking
-import com.cashu.me.Models.MintQuoteInfo
-import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Core.CashuPaymentRequestRoute
+import com.cashu.me.Core.cashuRequestTopUpAmount
+import com.cashu.me.Core.selectCashuRequestFundingSource
+import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.PaymentMethodKind
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SendCashuRequestTopUpTest {
     @Test
-    fun externalTopUpCreatesBolt11SatMintQuoteForTargetMint() = runBlocking {
-        val quote = MintQuoteInfo(
-            id = "quote-id",
-            request = "lnbc1invoice",
-            amount = 42,
-            paymentMethod = PaymentMethodKind.Bolt11,
-            state = MintQuoteState.Unpaid,
-            expiryEpochSeconds = 123,
-            mintUrl = "https://mint.example",
+    fun acquireThenPayAndLightningFallbackRemainPayable() {
+        assertTrue(
+            isCashuRequestPayEnabled(
+                CashuPaymentRequestRoute.AcquireThenPay(
+                    mintUrls = listOf("https://mint.example"),
+                    targetMintUrl = "https://mint.example",
+                    amountSats = 42,
+                    addsNewMint = true,
+                ),
+            ),
         )
-        val calls = mutableListOf<String>()
-
-        val created = createExternalTopUpQuote(
-            mintUrl = "https://mint.example",
-            requestedAmountSats = 42,
-        ) { mintUrl, amount, method, unit ->
-            calls += "$mintUrl:$amount:${method.rawValue}:$unit"
-            quote
-        }
-
-        assertSame(quote, created)
-        assertEquals(listOf("https://mint.example:42:bolt11:sat"), calls)
+        assertTrue(
+            isCashuRequestPayEnabled(
+                CashuPaymentRequestRoute.PayBolt11Fallback("lnbc1fallback"),
+            ),
+        )
     }
+
+    @Test
+    fun acquireThenPayRequiresAtLeastOneRequestedMint() {
+        assertFalse(
+            isCashuRequestPayEnabled(
+                CashuPaymentRequestRoute.AcquireThenPay(
+                    mintUrls = emptyList(),
+                    targetMintUrl = null,
+                    amountSats = 42,
+                    addsNewMint = false,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun topUpAmountReservesTargetMintInputFees() {
+        assertEquals(42, cashuRequestTopUpAmount(42, inputFeePpk = 0))
+        assertEquals(43, cashuRequestTopUpAmount(42, inputFeePpk = 1))
+        assertEquals(74, cashuRequestTopUpAmount(42, inputFeePpk = 1_000))
+    }
+
+    @Test
+    fun fundingSourceExcludesTargetAndUnsupportedOrUnderfundedMints() {
+        val target = mint("https://target.example", balance = 500)
+        val unsupported = mint(
+            "https://unsupported.example",
+            balance = 400,
+            meltMethods = emptyList(),
+        )
+        val underfunded = mint("https://small.example", balance = 49)
+        val sufficient = mint("https://source.example", balance = 100)
+
+        assertEquals(
+            sufficient,
+            selectCashuRequestFundingSource(
+                mints = listOf(target, unsupported, underfunded, sufficient),
+                targetMintUrl = "${target.url}/",
+                requiredAmountSats = 50,
+            ),
+        )
+    }
+
+    @Test
+    fun payButtonExplainsWhetherMintWillBeAddedOrFunded() {
+        val add = CashuPaymentRequestRoute.AcquireThenPay(
+            mintUrls = listOf("https://target.example"),
+            targetMintUrl = "https://target.example",
+            amountSats = 42,
+            addsNewMint = true,
+        )
+        val fund = add.copy(addsNewMint = false)
+        val choose = add.copy(
+            mintUrls = listOf("https://one.example", "https://two.example"),
+            targetMintUrl = null,
+        )
+
+        assertEquals("Add target.example & pay", cashuRequestPayButtonText(add, "Pay"))
+        assertEquals("Fund target.example & pay", cashuRequestPayButtonText(fund, "Pay"))
+        assertEquals("Add a mint & pay", cashuRequestPayButtonText(choose, "Pay"))
+    }
+
+    private fun mint(
+        url: String,
+        balance: Long,
+        meltMethods: List<PaymentMethodKind>? = null,
+    ) = MintInfo(
+        url = url,
+        name = url.substringAfter("//").substringBefore('.'),
+        balance = balance,
+        supportedMeltMethods = meltMethods,
+    )
 }

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendPaymentDetailsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendPaymentDetailsTest.kt
@@ -210,12 +210,14 @@ class SendPaymentDetailsTest {
     }
 
     @Test
-    fun cashuAddMintRouteUsesRequestedMintIdentityWithoutClaimingAnUnknownName() {
+    fun cashuTopUpRouteUsesRequestedMintIdentityWithoutClaimingAnUnknownName() {
         val details = buildSendPaymentDetails(
             rail = cashuRail(),
-            cashuRoute = CashuPaymentRequestRoute.AddMintToPay(
+            cashuRoute = CashuPaymentRequestRoute.AcquireThenPay(
                 mintUrls = listOf("https://requested.example/path"),
+                targetMintUrl = "https://requested.example/path",
                 amountSats = 21,
+                addsNewMint = true,
             ),
             amountSats = 21,
             mint = Mint,
@@ -229,6 +231,10 @@ class SendPaymentDetailsTest {
         assertEquals(
             SendPaymentDetailValue.Text("Add requested mint"),
             details.value(SendPaymentDetailKey.Route),
+        )
+        assertEquals(
+            SendPaymentDetailValue.Pending,
+            details.value(SendPaymentDetailKey.NetworkFee),
         )
     }
 


### PR DESCRIPTION
## Summary

- Add or fund a requested target mint before paying a Cashu Request when compatible ecash is unavailable.
- Fund the target over BOLT11 from another eligible held mint when possible, with an external Lightning top-up fallback.
- Reserve the target mint input fee so fee-charging mints can still send the exact requested amount.
- Preserve all requested mint choices, restrict held-mint selection to compatible mints, and automatically complete the request after an external top-up settles.
- Match the existing iOS acquire-then-pay behavior using native Android UI.

## Why

The earlier Android change only produced an exact-amount external top-up invoice. It did not implement the iOS cross-mint funding path, did not automatically finish the pending request, lost multi-mint choice, and could remain underfunded on mints that charge input fees.

With these changes this is a genuine Android enhancement and closes the relevant iOS and Android parity gap.

## Testing

- Focused Cashu Request routing, top-up, fee, and payment-detail tests
- Full Android debug unit test suite
- Debug APK assembly
- Android lint