### PR TITLE
Fix Cashu request payment sheet parity

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/send/CashuRequestFeeEstimate.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/CashuRequestFeeEstimate.kt
@@ -57,6 +57,21 @@ internal fun CashuRequestFeeEstimate.presentation(
         is CashuRequestFeeEstimate.Unavailable -> CashuRequestFeePresentation(value = "Unavailable")
     }
 
+/**
+ * Compact amount-entry presentation. Before an amount exists the row reserves
+ * its slot with a dash; an acquire-and-pay route reports the honest network-fee
+ * category because its Lightning reserve is not known until the quote exists.
+ */
+internal fun CashuRequestFeeEstimate.amountEntryPresentation(
+    usesNetworkRoute: Boolean,
+    formatAmount: (Long) -> String,
+): CashuRequestFeePresentation =
+    when {
+        usesNetworkRoute -> CashuRequestFeePresentation(value = "Network fee")
+        this is CashuRequestFeeEstimate.Unrequested -> CashuRequestFeePresentation(value = "—")
+        else -> presentation(formatAmount)
+    }
+
 internal suspend fun resolveCashuRequestFeeEstimate(
     key: CashuRequestFeeEstimateKey,
     estimate: suspend (amountSats: Long, mintUrl: String) -> Long,

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -114,6 +114,7 @@ import com.cashu.me.ui.components.PaymentStatusScreen
 import com.cashu.me.ui.components.PrimaryButton
 import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SheetHeader
+import com.cashu.me.ui.components.SkeletonValue
 import com.cashu.me.ui.components.SpinnerRing
 import com.cashu.me.ui.components.TwoFaceScreen
 import com.cashu.me.ui.mints.ConnectMintContext
@@ -127,6 +128,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 private const val TYPE_DEBOUNCE_MS = 400L
+private const val CASHU_FEE_DEBOUNCE_MS = 250L
 
 // PaymentStatusScreen's scaffold metrics, mirrored so the confirm face's hero
 // band (amount / quote spinner / caution face) lands at the same Y as the
@@ -542,11 +544,26 @@ fun UnifiedSendScreen(
     // work automatically, and reject a stale completion as a final backstop.
     LaunchedEffect(step, cashuRequestFeeKey) {
         val key = cashuRequestFeeKey
-        if (step != SendStep.Confirm || key == null) {
+        val showsFeePreview = step == SendStep.Amount || step == SendStep.Confirm
+        if (!showsFeePreview || key == null) {
             cashuRequestFeeEstimate = CashuRequestFeeEstimate.Unrequested
             return@LaunchedEffect
         }
+
+        // Preserve a completed amount-entry estimate when Continue opens the
+        // confirmation face. Failed estimates intentionally retry there.
+        val current = cashuRequestFeeEstimate
+        if (current.key == key &&
+            (current is CashuRequestFeeEstimate.NoFee || current is CashuRequestFeeEstimate.Amount)
+        ) {
+            return@LaunchedEffect
+        }
+
         cashuRequestFeeEstimate = CashuRequestFeeEstimate.Loading(key)
+        if (step == SendStep.Amount) {
+            // Match iOS: do not ask CDK to reselect proofs on every keypress.
+            delay(CASHU_FEE_DEBOUNCE_MS)
+        }
         val result = resolveCashuRequestFeeEstimate(key) { amountSats, mintUrl ->
             walletManager.estimateCashuPaymentRequestFee(amountSats, mintUrl)
         }
@@ -742,6 +759,13 @@ fun UnifiedSendScreen(
                                 fiatCurrencyCode = priceState.currencyCode,
                                 useBitcoinSymbol = settings.useBitcoinSymbol,
                                 formatter = formatter,
+                                cashuRequestFeePresentation = (locked as? LockedRail.Creq)?.let {
+                                    displayedCashuRequestFeeEstimate.amountEntryPresentation(
+                                        usesNetworkRoute = cashuRoute is CashuPaymentRequestRoute.AcquireThenPay,
+                                    ) { fee ->
+                                        formatter.formatWalletSats(fee, settings.useBitcoinSymbol)
+                                    }
+                                },
                                 onContinue = {
                                     cameFromAmount = true
                                     step = SendStep.Confirm
@@ -1081,6 +1105,46 @@ private fun ToRow(destination: String, modifier: Modifier = Modifier) {
 }
 
 @Composable
+private fun EstimatedCashuRequestFeeRow(
+    presentation: CashuRequestFeePresentation,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 32.dp)
+            .semantics(mergeDescendants = true) {
+                stateDescription = if (presentation.loading) {
+                    "Calculating"
+                } else {
+                    presentation.value
+                }
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = "Estimated fee",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.weight(1f))
+        SkeletonValue(loading = presentation.loading) {
+            Text(
+                text = presentation.value,
+                style = if (presentation.valueMonospaced) {
+                    MaterialTheme.typography.bodyMedium.withMonoDigits()
+                } else {
+                    MaterialTheme.typography.bodyMedium
+                },
+                fontWeight = FontWeight.Medium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+@Composable
 private fun AmountFace(
     amount: String,
     onAmountChange: (String) -> Unit,
@@ -1095,6 +1159,7 @@ private fun AmountFace(
     fiatCurrencyCode: String,
     useBitcoinSymbol: Boolean,
     formatter: AmountFormatter,
+    cashuRequestFeePresentation: CashuRequestFeePresentation?,
     onContinue: () -> Unit,
 ) {
     val mintBalance = mint?.balance ?: 0L
@@ -1156,6 +1221,10 @@ private fun AmountFace(
                     )
                 }
             }
+        }
+        if (cashuRequestFeePresentation != null) {
+            EstimatedCashuRequestFeeRow(cashuRequestFeePresentation)
+            Spacer(Modifier.height(CashuTheme.spacing.snug))
         }
         // Under the amount, over the keypad (Send Ecash / Receive parity).
         if (mint != null) {

--- a/android/app/src/test/java/com/cashu/me/ui/send/CashuRequestFeeEstimateTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/CashuRequestFeeEstimateTest.kt
@@ -27,6 +27,28 @@ class CashuRequestFeeEstimateTest {
     }
 
     @Test
+    fun amountEntryReservesTheFeeRowBeforeAnAmountExists() {
+        assertEquals(
+            CashuRequestFeePresentation(value = "—"),
+            CashuRequestFeeEstimate.Unrequested.amountEntryPresentation(
+                usesNetworkRoute = false,
+                formatAmount = { "$it sat" },
+            ),
+        )
+    }
+
+    @Test
+    fun amountEntryDescribesAcquireAndPayAsANetworkFee() {
+        assertEquals(
+            CashuRequestFeePresentation(value = "Network fee"),
+            CashuRequestFeeEstimate.Amount(key, sats = 3L).amountEntryPresentation(
+                usesNetworkRoute = true,
+                formatAmount = { "$it sat" },
+            ),
+        )
+    }
+
+    @Test
     fun zeroFeeIsPresentedAsNoFee() = runBlocking {
         val result = resolveCashuRequestFeeEstimate(key) { _, _ -> 0L }
 

--- a/ios/CashuWallet/App/ContentView.swift
+++ b/ios/CashuWallet/App/ContentView.swift
@@ -48,7 +48,7 @@ struct ContentView: View {
             value: walletManager.needsOnboarding
         )
         // The one full-screen flow-page slot: token claims (scan, deep link,
-        // paste-into-flow), scan-routed pay screens, held NUT-18 approvals.
+        // paste-into-flow), scan-routed melts, held NUT-18 approvals.
         // `onDismiss` promotes any surface parked by `NavigationManager.present`.
         .fullScreenCover(
             item: $navigationManager.activeFlowCover,
@@ -102,13 +102,6 @@ struct ContentView: View {
                 initialMode: mode,
                 autoQuoteOnAppear: autoQuote,
                 routeExplanation: explanation,
-                onComplete: { navigationManager.activeFlowCover = nil }
-            )
-            .environmentObject(walletManager)
-            .canvasSheetBackground()
-        case .cashuRequestPay(let summary):
-            CashuPaymentRequestPayView(
-                request: summary,
                 onComplete: { navigationManager.activeFlowCover = nil }
             )
             .environmentObject(walletManager)

--- a/ios/CashuWallet/Core/Navigation/NavigationManager.swift
+++ b/ios/CashuWallet/Core/Navigation/NavigationManager.swift
@@ -12,6 +12,7 @@ enum WalletSheet: Identifiable {
     case send(prefill: String?)
     case sendEdit(prefill: String)
     case sendAmount(SendAmountDestination)
+    case cashuRequestPay(CashuPaymentRequestSummary)
     case scanner
     case sendEcash
     case receiveLightning
@@ -28,6 +29,7 @@ enum WalletSheet: Identifiable {
         case .send: return "send"
         case .sendEdit: return "sendEdit"
         case .sendAmount: return "sendAmount"
+        case .cashuRequestPay(let summary): return "creq-\(summary.encoded.prefix(64))"
         case .scanner: return "scanner"
         case .sendEcash: return "sendEcash"
         case .receiveLightning: return "receiveLightning"
@@ -40,7 +42,7 @@ enum WalletSheet: Identifiable {
 
 /// The full-screen flow-page slot, bound by `ContentView`'s single
 /// `.fullScreenCover(item:)`: payment pages that read as a brand-new screen
-/// with nothing visible beneath (token claim, scan-routed pay, held approval).
+/// with nothing visible beneath (token claim, scan-routed melts, held approval).
 enum FlowCover: Identifiable {
     case receiveToken(String)
     case heldApproval(PendingReceiveToken)
@@ -50,14 +52,12 @@ enum FlowCover: Identifiable {
         autoQuote: Bool,
         explanation: CashuRequestRouteExplanation?
     )
-    case cashuRequestPay(CashuPaymentRequestSummary)
 
     var id: String {
         switch self {
         case .receiveToken(let token): return "token-\(token.prefix(48))"
         case .heldApproval(let pending): return "held-\(pending.tokenId)"
         case .melt(let request, _, _, _): return "melt-\(request.prefix(64))"
-        case .cashuRequestPay(let summary): return "creq-\(summary.encoded.prefix(64))"
         }
     }
 }
@@ -216,7 +216,7 @@ final class NavigationManager: ObservableObject {
         case .receiveToken(let token):
             present(.cover(.receiveToken(token)))
         case .cashuRequestPay(let summary):
-            present(.cover(.cashuRequestPay(summary)))
+            present(.sheet(.cashuRequestPay(summary)))
         case .melt(let request, let mode, let autoQuote, let explanation):
             present(.cover(.melt(
                 request: request,

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -479,18 +479,22 @@ struct CashuPaymentRequestPayView: View {
                 statusView(paymentPhase)
                     .transition(.opacity)
               } else {
-                // Family-style confirm layout. Any/multi-mint requests get a top mint
-                // pill (matching Pay Lightning) and just the amount hero; a request
-                // pinned to one required mint keeps the centered mint-identity header
-                // above the amount. Read-only request facts (Memo / Fees) sit beneath.
-                // Shared Pay-flow scaffold (see `PayFlowScaffold`) so the request
-                // facts sit at the same Y here as on the processing / success
-                // screens. Any/multi-mint requests show the switchable mint pill as
-                // the top accessory; a required mint keeps its centered identity
-                // header inside the hero band, above the amount.
-                PayFlowScaffold {
+                // Family-style confirm layout. Fixed-amount any/multi-mint requests
+                // get a top mint pill (matching Pay Lightning); amountless requests
+                // keep their fee preview and source mint beside the amount controls,
+                // directly above the number pad (matching Android and the unified
+                // Send amount screen). A fixed-amount request pinned to one required
+                // mint keeps the centered mint-identity header above the amount.
+                // Read-only request facts sit beneath.
+                // Fixed-amount requests use the shared Pay-flow anchor so their facts
+                // remain aligned with processing / success. Amount entry instead
+                // centers the complete amount lockup in the non-scrolling space above
+                // the fixed fee, mint, and number-pad controls.
+                PayFlowScaffold(
+                    contentLayout: request.amount == nil ? .centered : .anchoredScrollable
+                ) {
                     VStack(spacing: 12) {
-                        if request.isSatUnit, pickerSelectedMint == nil {
+                        if showsMintIdentityHeader {
                             mintHeader
                                 .padding(.horizontal)
                         }
@@ -518,8 +522,18 @@ struct CashuPaymentRequestPayView: View {
                 } footer: {
                     VStack(spacing: 16) {
                         if request.amount == nil {
-                            NumberPadAmountInput(amountString: $customAmountString, unit: entryUnit)
-                                .padding(.horizontal, NumberPadMetrics.gutter)
+                            VStack(spacing: 8) {
+                                if request.isSatUnit {
+                                    amountEntryFeeRow
+
+                                    if let selected = selectedPaymentMint {
+                                        paymentMintSelector(selected, isAmountEntry: true)
+                                    }
+                                }
+
+                                NumberPadAmountInput(amountString: $customAmountString, unit: entryUnit)
+                            }
+                            .padding(.horizontal, NumberPadMetrics.gutter)
                         }
 
                         Button(action: payRequest) {
@@ -542,22 +556,12 @@ struct CashuPaymentRequestPayView: View {
                         }
                     }
                 } topAccessory: {
-                    if request.isSatUnit, let selected = pickerSelectedMint {
-                        MintSelectorRow(
-                            direction: .source,
-                            mint: selected,
-                            balanceText: AmountFormatter.sats(
-                                selected.balance,
-                                useBitcoinSymbol: settings.useBitcoinSymbol
-                            ),
-                            onChooseMint: candidateMints.count > 1 ? {
-                                HapticFeedback.selection()
-                                showingMintPicker = true
-                            } : nil
-                        )
-                        // Aligned to the number pad below, not the CTA.
-                        .padding(.horizontal, NumberPadMetrics.gutter)
-                        .padding(.top, 8)
+                    if request.amount != nil,
+                       request.isSatUnit,
+                       let selected = pickerSelectedMint {
+                        paymentMintSelector(selected)
+                            .padding(.horizontal, NumberPadMetrics.gutter)
+                            .padding(.top, 8)
                     }
                 }
               }
@@ -618,6 +622,47 @@ struct CashuPaymentRequestPayView: View {
                 feeTask?.cancel()
             }
         }
+        // Preserve native swipe-to-dismiss everywhere except the brief interval
+        // where proofs are being reserved or delivered.
+        .interactiveDismissDisabled(isPaying)
+    }
+
+    private var showsMintIdentityHeader: Bool {
+        guard request.isSatUnit else { return false }
+        if request.amount == nil {
+            return selectedPaymentMint == nil
+        }
+        return pickerSelectedMint == nil
+    }
+
+    private func paymentMintSelector(_ mint: MintInfo, isAmountEntry: Bool = false) -> some View {
+        let onUseMax: (() -> Void)? = isAmountEntry && mint.balance > 0 ? {
+            useMaximumAmount(from: mint)
+        } : nil
+
+        return MintSelectorRow(
+            direction: .source,
+            mint: mint,
+            balanceText: AmountFormatter.sats(
+                mint.balance,
+                useBitcoinSymbol: settings.useBitcoinSymbol
+            ),
+            showsBalance: isAmountEntry,
+            onUseMax: onUseMax,
+            onChooseMint: candidateMints.count > 1 ? {
+                HapticFeedback.selection()
+                showingMintPicker = true
+            } : nil
+        )
+    }
+
+    private func useMaximumAmount(from mint: MintInfo) {
+        HapticFeedback.selection()
+        customAmountString = AmountFormatter.entryConverted(
+            raw: String(mint.balance),
+            from: .sats,
+            to: entryUnit
+        )
     }
 
     @ViewBuilder
@@ -735,9 +780,9 @@ struct CashuPaymentRequestPayView: View {
         return nil
     }
 
-    /// Family-style detail rows beneath the amount: the requester's memo and the
-    /// fee. Only shown for sat requests; non-sat requests surface their own
-    /// "unsupported" warning. (Mint selection lives in the top pill / header.)
+    /// Family-style detail rows beneath the amount. Amountless requests keep the
+    /// live fee beside the keypad so it cannot disappear behind the fixed input;
+    /// fixed-amount requests keep it here because they have no number pad.
     @ViewBuilder
     private var requestDetailsSection: some View {
         if request.isSatUnit {
@@ -750,7 +795,9 @@ struct CashuPaymentRequestPayView: View {
                 if let memo {
                     detailRow(label: "Memo", value: memo)
                 }
-                feesRow
+                if request.amount != nil {
+                    feesRow
+                }
             }
             .padding(.top, 16)
             .padding(.horizontal)
@@ -813,7 +860,26 @@ struct CashuPaymentRequestPayView: View {
         .font(.subheadline)
         .padding(.horizontal, 4)
         .padding(.vertical, 14)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Fees")
+        .accessibilityValue(feeAccessibilityValue)
+    }
+
+    /// Compact, non-scrolling amount-entry metadata. It reserves its place while
+    /// the debounced estimate is loading, so neither the mint row nor keypad jumps.
+    private var amountEntryFeeRow: some View {
+        HStack {
+            Text("Estimated fee")
+                .foregroundStyle(.secondary)
+            Spacer()
+            feeValueText
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 4)
+        .padding(.vertical, FlowRowMetrics.verticalPadding)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Estimated fee")
+        .accessibilityValue(feeAccessibilityValue)
     }
 
     @ViewBuilder
@@ -831,9 +897,23 @@ struct CashuPaymentRequestPayView: View {
             case .amount(let fee):
                 Text(AmountFormatter.sats(fee, useBitcoinSymbol: settings.useBitcoinSymbol))
                     .fontWeight(.medium)
-            case .idle, .unavailable:
+            case .idle:
                 Text("—").foregroundStyle(.secondary)
+            case .unavailable:
+                Text("Unavailable").foregroundStyle(.secondary)
             }
+        }
+    }
+
+    private var feeAccessibilityValue: String {
+        if needsAcquire { return "Network fee" }
+        switch feeState {
+        case .idle: return "Not yet calculated"
+        case .loading: return "Calculating"
+        case .free: return "No fee"
+        case .amount(let fee):
+            return AmountFormatter.sats(fee, useBitcoinSymbol: settings.useBitcoinSymbol)
+        case .unavailable: return "Unavailable"
         }
     }
 
@@ -1077,8 +1157,8 @@ struct CashuPaymentRequestPayView: View {
                     customAmountSats: request.amount == nil ? paymentAmount : nil,
                     preferredMintURL: mint.url
                 )
-                // The consistency fix: every creq payment now lands on the shared
-                // full-screen success screen, same as Lightning/on-chain.
+                // Every creq payment lands on the shared success face, matching
+                // the Lightning/on-chain payment vocabulary.
                 withAnimation(.smooth(duration: 0.3)) { paymentPhase = .success }
             } catch {
                 let walletMessage = error.walletMessage
@@ -1148,7 +1228,7 @@ struct CashuPaymentRequestPayView: View {
         }
     }
 
-    /// Full-screen processing → success → failure status. Preserves the payment
+    /// Full-height processing → success → failure status. Preserves the payment
     /// facts (amount / mint / fee / memo) as rows. onDone completes like the old
     /// overlay's onDismiss did; onRetry returns to the confirm screen.
     private func statusView(_ phase: PaymentStatusView.Phase) -> some View {
@@ -1214,8 +1294,10 @@ struct CashuPaymentRequestPayView: View {
                 label: "Fees",
                 value: AmountFormatter.sats(fee, useBitcoinSymbol: settings.useBitcoinSymbol)
             )
-        case .idle, .unavailable:
+        case .idle:
             return .init(label: "Fees", value: "—")
+        case .unavailable:
+            return .init(label: "Fees", value: "Unavailable")
         }
     }
 }

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -703,6 +703,15 @@ struct MainWalletView: View {
                     )
                 }
             )
+        case .cashuRequestPay(let summary):
+            CashuPaymentRequestPayView(
+                request: summary,
+                onComplete: { navigationManager.activeWalletSheet = nil }
+            )
+            .environmentObject(walletManager)
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+            .flatBottomSheetSurface()
         case .scanner:
             // The scanner self-dismisses on a successful read and hands the
             // payload back; the routed surface presents only after this sheet

--- a/ios/CashuWallet/Views/Send/Components/AuthorizingOverlay.swift
+++ b/ios/CashuWallet/Views/Send/Components/AuthorizingOverlay.swift
@@ -366,8 +366,13 @@ struct SpinnerRing: View {
     }
 }
 
-/// Shared vertical scaffold for every Pay flow's confirm + status screens, so the
-/// payment-details block sits at the **same** vertical position across confirm →
+enum PayFlowContentLayout {
+    case anchoredScrollable
+    case centered
+}
+
+/// Shared vertical scaffold for Pay flow screens. Its default anchored layout keeps the
+/// payment-details block at the **same** vertical position across confirm →
 /// processing → success (no jump as the state changes). Layout contract:
 ///
 ///     [ topAccessory ]   ← overlaid at the top (e.g. mint chip); does NOT shift the anchor
@@ -380,7 +385,8 @@ struct SpinnerRing: View {
 /// The hero band is a fixed height, so both the hero **and** the details-block top
 /// stay stationary regardless of how many detail rows a given phase shows. Content
 /// scrolls if it exceeds the viewport (small devices / large Dynamic Type) rather
-/// than clipping. The caller still owns the toolbar header.
+/// than clipping. Amount entry can instead center its content in the space above a
+/// fixed keypad by selecting `.centered`. The caller still owns the toolbar header.
 struct PayFlowScaffold<TopAccessory: View, Hero: View, Details: View, Footer: View>: View {
     /// Fraction of the available height reserved above the hero band (upper-middle anchor).
     private static var topFraction: CGFloat { 0.16 }
@@ -393,13 +399,16 @@ struct PayFlowScaffold<TopAccessory: View, Hero: View, Details: View, Footer: Vi
     private let hero: Hero
     private let details: Details
     private let footer: Footer
+    private let contentLayout: PayFlowContentLayout
 
     init(
+        contentLayout: PayFlowContentLayout = .anchoredScrollable,
         @ViewBuilder hero: () -> Hero,
         @ViewBuilder details: () -> Details,
         @ViewBuilder footer: () -> Footer,
         @ViewBuilder topAccessory: () -> TopAccessory = { EmptyView() }
     ) {
+        self.contentLayout = contentLayout
         self.hero = hero()
         self.details = details()
         self.footer = footer()
@@ -409,24 +418,38 @@ struct PayFlowScaffold<TopAccessory: View, Hero: View, Details: View, Footer: Vi
     var body: some View {
         GeometryReader { geo in
             VStack(spacing: 0) {
-                ScrollView(.vertical, showsIndicators: false) {
+                if contentLayout == .anchoredScrollable {
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(spacing: 0) {
+                            Color.clear
+                                .frame(height: geo.size.height * Self.topFraction)
+                            hero
+                                .frame(maxWidth: .infinity)
+                                .frame(minHeight: Self.heroBandHeight)
+                            details
+                                .padding(.top, Self.heroDetailsGap)
+                        }
+                        .frame(maxWidth: .infinity)
+                        // Resolve the anchored column's geometry as one rigid unit before it
+                        // combines with the parent. Without this, when the GeometryReader's
+                        // size goes 0 → real on first layout, the hero/details interpolate
+                        // from the (0,0) origin under any live ancestor .animation scope
+                        // (this screen's value: phase, or PaymentStatusView's value: phaseKey)
+                        // — sliding the amount hero in from the top-left. Isolating geometry
+                        // leaves opacity/scale transitions (the spinner→check morph) untouched.
+                        .geometryGroup()
+                    }
+                } else {
                     VStack(spacing: 0) {
-                        Color.clear
-                            .frame(height: geo.size.height * Self.topFraction)
+                        Spacer(minLength: 0)
                         hero
                             .frame(maxWidth: .infinity)
-                            .frame(minHeight: Self.heroBandHeight)
+                            .layoutPriority(1)
                         details
                             .padding(.top, Self.heroDetailsGap)
+                        Spacer(minLength: 0)
                     }
-                    .frame(maxWidth: .infinity)
-                    // Resolve the anchored column's geometry as one rigid unit before it
-                    // combines with the parent. Without this, when the GeometryReader's
-                    // size goes 0 → real on first layout, the hero/details interpolate
-                    // from the (0,0) origin under any live ancestor .animation scope
-                    // (this screen's value: phase, or PaymentStatusView's value: phaseKey)
-                    // — sliding the amount hero in from the top-left. Isolating geometry
-                    // leaves opacity/scale transitions (the spinner→check morph) untouched.
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .geometryGroup()
                 }
                 footer

--- a/ios/CashuWalletTests/WalletSurfaceCoordinatorTests.swift
+++ b/ios/CashuWalletTests/WalletSurfaceCoordinatorTests.swift
@@ -104,6 +104,28 @@ final class WalletSurfaceCoordinatorTests: XCTestCase {
         XCTAssertEqual(nav.activeWalletSheet?.id, "sendAmount")
     }
 
+    func testCashuRequestPayWaitsForScannerThenOpensAsSheet() {
+        let nav = NavigationManager()
+        let request = CashuPaymentRequestSummary(
+            encoded: "creqAtest",
+            amount: nil,
+            unit: "sat",
+            description: nil,
+            mints: []
+        )
+        nav.activeWalletSheet = .scanner
+
+        nav.present(.sheet(.cashuRequestPay(request)))
+
+        XCTAssertNil(nav.activeWalletSheet)
+        XCTAssertTrue(nav.isFlowSurfaceOpen, "the scanner sheet is still dismissing")
+
+        nav.sheetDidDismiss()
+
+        XCTAssertEqual(nav.activeWalletSheet?.id, "creq-creqAtest")
+        XCTAssertNil(nav.activeFlowCover)
+    }
+
     func testDeepLinkTokensQueueAndConsumeInOrder() {
         let nav = NavigationManager()
 


### PR DESCRIPTION
## Summary

- Present scanned Cashu requests as a native, swipe-dismissable iOS bottom sheet.
- Keep the iOS estimated fee, mint selector, balance, and Send Max action directly above the number pad.
- Center the non-scrollable iOS amount lockup so both entered and converted amounts remain visible.
- Add a debounced estimated-fee row to the Android Cashu request amount and confirmation flow.
- Add focused Android fee-estimate tests and iOS wallet-sheet routing coverage.

## Testing

- iOS simulator build
- iOS WalletSurfaceCoordinatorTests
- Android debug build and unit tests
- Diff whitespace validation