### PR TITLE
Fix transaction history currency conversion

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
@@ -344,7 +344,11 @@ fun AmountFormatter.displayText(
     }
 }
 
-/** Format an amount in its native mint unit; BTC-price conversion only applies to sats. */
+/**
+ * Format an amount in its native mint unit; BTC-price conversion only applies
+ * to sats. Positive sub-cent Bitcoin amounts use a "less than one cent" label
+ * so a fiat preference never silently flips an individual transaction to sats.
+ */
 fun AmountFormatter.displayMintUnitAmount(
     amount: Long,
     unit: String,
@@ -355,7 +359,7 @@ fun AmountFormatter.displayMintUnitAmount(
     useBitcoinSymbol: Boolean,
 ): AmountDisplayText {
     if (CurrencyRegistry.isSatoshiUnit(unit)) {
-        return displayText(
+        val display = displayText(
             amountSats = amount,
             preferredPrimary = preferredPrimary,
             showFiat = showFiat,
@@ -363,6 +367,41 @@ fun AmountFormatter.displayMintUnitAmount(
             currencyCode = currencyCode,
             useBitcoinSymbol = useBitcoinSymbol,
         )
+        val price = btcPrice?.takeIf { it.isFinite() && it > 0 }
+        val fiatValue = price?.let { amount.toDouble() / 100_000_000.0 * it }
+        if (!showFiat || amount <= 0 || fiatValue == null || fiatValue >= 0.01) {
+            return display
+        }
+
+        val thresholdParts = when (val affix = currencyAffix(currencyCode)) {
+            is AmountParts.Affix.Prefix -> AmountParts(
+                value = "0.01",
+                affix = AmountParts.Affix.Prefix("<${affix.symbol}"),
+            )
+            is AmountParts.Affix.Suffix -> AmountParts(
+                value = "<0.01",
+                affix = affix,
+            )
+            AmountParts.Affix.None -> AmountParts(
+                value = "<0.01",
+                affix = AmountParts.Affix.None,
+            )
+        }
+        val satsParts = satsParts(amount, useBitcoinSymbol)
+        return when (AmountDisplayPrimary.fromRaw(preferredPrimary)) {
+            AmountDisplayPrimary.Fiat -> AmountDisplayText(
+                primary = thresholdParts.joined,
+                secondary = satsParts.joined,
+                effectivePrimary = AmountDisplayPrimary.Fiat,
+                primaryParts = thresholdParts,
+            )
+            AmountDisplayPrimary.Sats -> AmountDisplayText(
+                primary = satsParts.joined,
+                secondary = thresholdParts.joined,
+                effectivePrimary = AmountDisplayPrimary.Sats,
+                primaryParts = satsParts,
+            )
+        }
     }
     return AmountDisplayText(
         primary = CurrencyAmount(amount, CurrencyRegistry.currencyForMintUnit(unit)).formatted(),

--- a/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AmountFormatter.kt
@@ -354,7 +354,7 @@ fun AmountFormatter.displayMintUnitAmount(
     currencyCode: String,
     useBitcoinSymbol: Boolean,
 ): AmountDisplayText {
-    if (unit.equals("sat", ignoreCase = true)) {
+    if (CurrencyRegistry.isSatoshiUnit(unit)) {
         return displayText(
             amountSats = amount,
             preferredPrimary = preferredPrimary,

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/CurrencyProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/CurrencyProtocol.kt
@@ -84,6 +84,10 @@ data class CurrencyAmount(
 }
 
 object CurrencyRegistry {
+    private val satoshiUnitNames = setOf("sat", "sats", "satoshi", "satoshis")
+    private val usdUnitNames = setOf("usd", "dollar", "dollars")
+    private val eurUnitNames = setOf("eur", "euro", "euros")
+
     val supportedCurrencies: List<WalletCurrency> = listOf(
         WalletCurrencies.Satoshi,
         WalletCurrencies.Usd,
@@ -96,18 +100,28 @@ object CurrencyRegistry {
     }
 
     /**
+     * Whether a mint unit represents Bitcoin's satoshi account. History can
+     * receive legacy aliases from persisted requests and tokens, so display
+     * conversion must use the same classification as the currency registry.
+     */
+    fun isSatoshiUnit(unit: String): Boolean = normalizedMintUnit(unit) in satoshiUnitNames
+
+    /**
      * Never null: unknown mint units resolve to a generic code-after currency
      * (0 decimals, uppercase code as the unit label), mirroring iOS
      * GenericCurrency so custom-unit mints always format.
      */
     fun currencyForMintUnit(unit: String): WalletCurrency {
-        return when (unit.trim().lowercase()) {
-            "sat", "sats", "satoshi", "satoshis" -> WalletCurrencies.Satoshi
-            "usd", "dollar", "dollars" -> WalletCurrencies.Usd
-            "eur", "euro", "euros" -> WalletCurrencies.Eur
+        val normalized = normalizedMintUnit(unit)
+        return when {
+            normalized in satoshiUnitNames -> WalletCurrencies.Satoshi
+            normalized in usdUnitNames -> WalletCurrencies.Usd
+            normalized in eurUnitNames -> WalletCurrencies.Eur
             else -> genericCurrency(unit)
         }
     }
+
+    private fun normalizedMintUnit(unit: String): String = unit.trim().lowercase()
 
     private fun genericCurrency(unit: String): WalletCurrency {
         val code = unit.trim().uppercase().ifEmpty { "SAT" }

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -126,7 +126,7 @@ object TransactionDisplay {
         if (value.length > 16) "${value.take(8)}…${value.takeLast(6)}" else value
 
     private fun formatNativeAmount(amount: Long, unit: String): String =
-        if (unit.equals("sat", ignoreCase = true)) {
+        if (CurrencyRegistry.isSatoshiUnit(unit)) {
             "$amount sat"
         } else {
             CurrencyAmount(amount, CurrencyRegistry.currencyForMintUnit(unit)).formatted()

--- a/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/CashuRequestRow.kt
@@ -13,10 +13,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
-import com.cashu.me.Core.AmountDisplayPrimary
 import com.cashu.me.Core.AmountDisplayText
 import com.cashu.me.Core.AmountFormatter
-import com.cashu.me.Core.displayText
+import com.cashu.me.Core.displayMintUnitAmount
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Models.CashuRequest
@@ -38,7 +37,7 @@ fun requestRowAmount(
         request.amount != null && request.amount > 0L -> request.amount
         else -> return null
     }
-    return if (request.unit.equals("sat", ignoreCase = true)) {
+    return if (CurrencyRegistry.isSatoshiUnit(request.unit)) {
         formatter.formatWalletSats(amount, useBitcoinSymbol)
     } else {
         CurrencyAmount(amount, CurrencyRegistry.currencyForMintUnit(request.unit)).formatted()
@@ -59,15 +58,9 @@ fun requestRowDisplay(
         request.amount != null && request.amount > 0L -> request.amount
         else -> return null
     }
-    if (!request.unit.equals("sat", ignoreCase = true)) {
-        return AmountDisplayText(
-            primary = CurrencyAmount(amount, CurrencyRegistry.currencyForMintUnit(request.unit)).formatted(),
-            secondary = null,
-            effectivePrimary = AmountDisplayPrimary.Sats,
-        )
-    }
-    return formatter.displayText(
-        amountSats = amount,
+    return formatter.displayMintUnitAmount(
+        amount = amount,
+        unit = request.unit,
         preferredPrimary = preferredPrimary,
         showFiat = showFiat,
         btcPrice = btcPrice,

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -366,7 +366,7 @@ private fun HeroAmount(
     currencyCode: String,
     compact: Boolean,
 ) {
-    if (!transaction.unit.equals("sat", ignoreCase = true)) {
+    if (!CurrencyRegistry.isSatoshiUnit(transaction.unit)) {
         val formatted = CurrencyAmount(
             transaction.amount,
             CurrencyRegistry.currencyForMintUnit(transaction.unit),

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -44,10 +44,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.AmountDisplayText
 import com.cashu.me.Core.PendingTokenClaimCheckResult
 import com.cashu.me.Core.PriceService
-import com.cashu.me.Core.Protocols.CurrencyAmount
-import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.OnchainExplorer
 import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.runPendingTokenClaimCheck
@@ -55,6 +54,7 @@ import com.cashu.me.Core.SettingsManager
 import com.cashu.me.Core.shouldOfferManualClaimCheck
 import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.displayMintUnitAmount
 import com.cashu.me.Models.TransactionKind
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
@@ -215,6 +215,7 @@ fun TransactionReceiptSheet(
                         HeroAmount(
                             transaction = current,
                             formatter = formatter,
+                            preferredPrimary = settings.homeBalancePrimary,
                             useBitcoinSymbol = settings.useBitcoinSymbol,
                             showFiat = settings.showFiatBalance,
                             btcPrice = priceState.btcPrice,
@@ -360,49 +361,34 @@ private fun copyConfirmationMessage(label: String): String = when (label) {
 private fun HeroAmount(
     transaction: WalletTransaction,
     formatter: AmountFormatter,
+    preferredPrimary: String,
     useBitcoinSymbol: Boolean,
     showFiat: Boolean,
     btcPrice: Double,
     currencyCode: String,
     compact: Boolean,
 ) {
-    if (!CurrencyRegistry.isSatoshiUnit(transaction.unit)) {
-        val formatted = CurrencyAmount(
-            transaction.amount,
-            CurrencyRegistry.currencyForMintUnit(transaction.unit),
-        ).formatted()
-        AmountText(
-            text = formatted,
-            style = (if (compact) MaterialTheme.typography.headlineLarge else MaterialTheme.typography.displayMedium)
-                .copy(fontWeight = FontWeight.Bold)
-                .withMonoDigits(),
-            color = MaterialTheme.colorScheme.onSurface,
-            modifier = Modifier.padding(vertical = 5.dp),
-        )
-        return
-    }
-
-    val fiatParts = if (showFiat) {
-        formatter.fiatParts(
-            amountSats = transaction.amount,
-            btcPrice = btcPrice.takeIf { it > 0 },
-            currencyCode = currencyCode,
-        )
-    } else {
-        null
-    }
+    val display = transactionReceiptAmountDisplay(
+        transaction = transaction,
+        formatter = formatter,
+        preferredPrimary = preferredPrimary,
+        showFiat = showFiat,
+        btcPrice = btcPrice,
+        currencyCode = currencyCode,
+        useBitcoinSymbol = useBitcoinSymbol,
+    )
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         AmountHero(
-            parts = formatter.satsParts(transaction.amount, useBitcoinSymbol),
+            parts = display.primaryParts,
             scale = if (compact) AmountScale.Compact else AmountScale.Confirm,
             accessibilityPrefix = "Amount",
         )
-        fiatParts?.let { parts ->
+        display.secondary?.let { secondary ->
             AmountText(
-                text = parts.joined,
+                text = secondary,
                 style = MaterialTheme.typography.bodyLarge
                     .atSize(18.sp, leading = LeadingLabel)
                     .copy(fontWeight = FontWeight.Medium)
@@ -413,6 +399,24 @@ private fun HeroAmount(
         }
     }
 }
+
+internal fun transactionReceiptAmountDisplay(
+    transaction: WalletTransaction,
+    formatter: AmountFormatter,
+    preferredPrimary: String,
+    showFiat: Boolean,
+    btcPrice: Double?,
+    currencyCode: String,
+    useBitcoinSymbol: Boolean,
+): AmountDisplayText = formatter.displayMintUnitAmount(
+    amount = transaction.amount,
+    unit = transaction.unit,
+    preferredPrimary = preferredPrimary,
+    showFiat = showFiat,
+    btcPrice = btcPrice,
+    currencyCode = currencyCode,
+    useBitcoinSymbol = useBitcoinSymbol,
+)
 
 private fun WalletTransaction.explorerUrl(): String? {
     if (kind != TransactionKind.Onchain) return null

--- a/android/app/src/test/java/com/cashu/me/Core/CurrencyProtocolTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CurrencyProtocolTest.kt
@@ -50,14 +50,33 @@ class CurrencyProtocolTest {
         val display = AmountFormatter().displayMintUnitAmount(
             amount = 500,
             unit = "usd",
-            preferredPrimary = "sats",
+            preferredPrimary = "fiat",
             showFiat = true,
-            btcPrice = 100_000.0,
-            currencyCode = "USD",
+            btcPrice = 20_000.0,
+            currencyCode = "EUR",
             useBitcoinSymbol = false,
         )
 
         assertEquals("\$5.00", display.primary)
         assertNull(display.secondary)
+    }
+
+    @Test
+    fun historyAmountsConvertEverySatoshiUnitAlias() {
+        listOf("sat", "SAT", " sats ", "satoshi", "satoshis").forEach { unit ->
+            val display = AmountFormatter().displayMintUnitAmount(
+                amount = 300_000,
+                unit = unit,
+                preferredPrimary = "fiat",
+                showFiat = true,
+                btcPrice = 20_000.0,
+                currencyCode = "USD",
+                useBitcoinSymbol = false,
+            )
+
+            assertEquals("Failed for unit: $unit", "\$60.00", display.primary)
+            assertEquals("Failed for unit: $unit", "300,000 sat", display.secondary)
+            assertEquals("Failed for unit: $unit", AmountDisplayPrimary.Fiat, display.effectivePrimary)
+        }
     }
 }

--- a/android/app/src/test/java/com/cashu/me/ui/history/TransactionReceiptAmountTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/history/TransactionReceiptAmountTest.kt
@@ -1,0 +1,38 @@
+package com.cashu.me.ui.history
+
+import com.cashu.me.Core.AmountDisplayPrimary
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TransactionReceiptAmountTest {
+    @Test
+    fun lightningReceiptUsesHomeFiatPreference() {
+        val transaction = WalletTransaction(
+            id = "lightning-receive",
+            amount = 1,
+            type = TransactionType.Incoming,
+            kind = TransactionKind.Lightning,
+            dateEpochMillis = 0,
+            status = TransactionStatus.Completed,
+        )
+
+        val display = transactionReceiptAmountDisplay(
+            transaction = transaction,
+            formatter = AmountFormatter(),
+            preferredPrimary = "fiat",
+            showFiat = true,
+            btcPrice = 20_000.0,
+            currencyCode = "USD",
+            useBitcoinSymbol = false,
+        )
+
+        assertEquals("<$0.01", display.primary)
+        assertEquals("1 sat", display.secondary)
+        assertEquals(AmountDisplayPrimary.Fiat, display.effectivePrimary)
+    }
+}

--- a/ios/CashuWallet/Core/AmountFormatter.swift
+++ b/ios/CashuWallet/Core/AmountFormatter.swift
@@ -190,6 +190,40 @@ enum AmountFormatter {
         }
     }
 
+    /// Formats an amount in its native mint unit. Bitcoin-denominated aliases
+    /// share the Home balance's sats/fiat ordering; fiat and custom mint units
+    /// remain in their native denomination because a BTC spot price cannot
+    /// convert them correctly.
+    static func displayMintUnitAmount(
+        amount: UInt64,
+        unit: String,
+        preferredPrimary: AmountDisplayPrimary,
+        showFiat: Bool,
+        btcPrice: Double?,
+        currencyCode: String,
+        useBitcoinSymbol: Bool
+    ) -> AmountDisplayText {
+        guard CurrencyRegistry.isSatoshiUnit(unit) else {
+            return AmountDisplayText(
+                primary: CurrencyAmount(
+                    value: amount,
+                    currency: CurrencyRegistry.currency(forMintUnit: unit)
+                ).formatted(),
+                secondary: nil,
+                effectivePrimary: .sats
+            )
+        }
+
+        return displayText(
+            amountSats: amount,
+            preferredPrimary: preferredPrimary,
+            showFiat: showFiat,
+            btcPrice: btcPrice,
+            currencyCode: currencyCode,
+            useBitcoinSymbol: useBitcoinSymbol
+        )
+    }
+
     // MARK: - Live amount entry (sats or fiat)
     //
     // The keypad writes a single `amountString` that types left-to-right like a

--- a/ios/CashuWallet/Core/AmountFormatter.swift
+++ b/ios/CashuWallet/Core/AmountFormatter.swift
@@ -193,7 +193,9 @@ enum AmountFormatter {
     /// Formats an amount in its native mint unit. Bitcoin-denominated aliases
     /// share the Home balance's sats/fiat ordering; fiat and custom mint units
     /// remain in their native denomination because a BTC spot price cannot
-    /// convert them correctly.
+    /// convert them correctly. A positive sub-cent Bitcoin amount uses a
+    /// "less than one cent" label so a fiat preference never silently flips
+    /// an individual transaction back to sats.
     static func displayMintUnitAmount(
         amount: UInt64,
         unit: String,
@@ -214,7 +216,7 @@ enum AmountFormatter {
             )
         }
 
-        return displayText(
+        let display = displayText(
             amountSats: amount,
             preferredPrimary: preferredPrimary,
             showFiat: showFiat,
@@ -222,6 +224,32 @@ enum AmountFormatter {
             currencyCode: currencyCode,
             useBitcoinSymbol: useBitcoinSymbol
         )
+
+        guard showFiat,
+              amount > 0,
+              let btcPrice,
+              btcPrice.isFinite,
+              btcPrice > 0,
+              Double(amount) / 100_000_000.0 * btcPrice < 0.01 else {
+            return display
+        }
+
+        let fiatThreshold = "<\(fiat(0.01, currencyCode: currencyCode))"
+        let satsText = sats(amount, useBitcoinSymbol: useBitcoinSymbol)
+        switch preferredPrimary {
+        case .fiat:
+            return AmountDisplayText(
+                primary: fiatThreshold,
+                secondary: satsText,
+                effectivePrimary: .fiat
+            )
+        case .sats:
+            return AmountDisplayText(
+                primary: satsText,
+                secondary: fiatThreshold,
+                effectivePrimary: .sats
+            )
+        }
     }
 
     // MARK: - Live amount entry (sats or fiat)

--- a/ios/CashuWallet/Core/Protocols/CurrencyProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/CurrencyProtocol.swift
@@ -183,6 +183,10 @@ enum HomeBalance {
 
 /// Registry for looking up currencies by code
 enum CurrencyRegistry {
+    private static let satoshiUnitNames: Set<String> = [
+        "sat", "sats", "satoshi", "satoshis"
+    ]
+
     /// All supported currencies
     static let supportedCurrencies: [any Currency] = [
         SatoshiCurrency(),
@@ -194,21 +198,35 @@ enum CurrencyRegistry {
     static func currency(forCode code: String) -> (any Currency)? {
         supportedCurrencies.first { $0.code.uppercased() == code.uppercased() }
     }
+
+    /// Whether a mint unit represents Bitcoin's satoshi account. History can
+    /// receive legacy aliases from persisted requests and tokens, so display
+    /// conversion must use the same classification as the currency registry.
+    static func isSatoshiUnit(_ unit: String) -> Bool {
+        satoshiUnitNames.contains(normalizedMintUnit(unit))
+    }
     
     /// Map a mint unit string to a currency for entry precision + display.
     /// Known units resolve to their built-in currency; any other (custom) unit
     /// falls back to a `GenericCurrency` so the result is never nil and
     /// arbitrary mint units are supported.
     static func currency(forMintUnit unit: String) -> any Currency {
-        switch unit.lowercased() {
-        case "sat", "sats", "satoshi", "satoshis":
+        let normalized = normalizedMintUnit(unit)
+        if satoshiUnitNames.contains(normalized) {
             return SatoshiCurrency()
+        }
+
+        switch normalized {
         case "usd", "dollar", "dollars":
             return USDCurrency()
         case "eur", "euro", "euros":
             return EURCurrency()
         default:
-            return GenericCurrency(unit: unit)
+            return GenericCurrency(unit: unit.trimmingCharacters(in: .whitespacesAndNewlines))
         }
+    }
+
+    private static func normalizedMintUnit(_ unit: String) -> String {
+        unit.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 }

--- a/ios/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
+++ b/ios/CashuWallet/Views/Components/CashuRequestAmountColumn.swift
@@ -29,21 +29,10 @@ struct CashuRequestAmountColumn: View {
         // "any amount" + waiting: no trailing element.
     }
 
-    private var isSatRequest: Bool { request.unit.lowercased() == "sat" }
-
     private func amountDisplay(_ amount: UInt64) -> AmountDisplayText {
-        guard isSatRequest else {
-            return AmountDisplayText(
-                primary: CurrencyAmount(
-                    value: amount,
-                    currency: CurrencyRegistry.currency(forMintUnit: request.unit)
-                ).formatted(),
-                secondary: nil,
-                effectivePrimary: .sats
-            )
-        }
-        return AmountFormatter.displayText(
-            amountSats: amount,
+        AmountFormatter.displayMintUnitAmount(
+            amount: amount,
+            unit: request.unit,
             preferredPrimary: settings.homeBalancePrimary,
             showFiat: settings.showFiatBalance,
             btcPrice: priceService.btcPriceUSD,

--- a/ios/CashuWallet/Views/Components/TransactionAmountColumn.swift
+++ b/ios/CashuWallet/Views/Components/TransactionAmountColumn.swift
@@ -50,32 +50,19 @@ struct TransactionAmountColumn: View {
     // Only a settled receipt gets a sign. Sent, pending, and expired rows stay
     // unsigned; direction remains explicit in the title and arrow.
     private var formattedAmount: String {
-        let value = nativeAmount
+        let value = amountDisplay.primary
         guard !transaction.isUnsettled, transaction.type == .incoming else { return value }
         return "+\(value)"
     }
 
-    private var isSatUnit: Bool {
-        transaction.unit.lowercased() == "sat"
-    }
-
-    private var nativeAmount: String {
-        if isSatUnit {
-            return satDisplay.primary
-        }
-        return CurrencyAmount(
-            value: transaction.amount,
-            currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
-        ).formatted()
-    }
-
     private var secondaryAmount: String? {
-        isSatUnit ? satDisplay.secondary : nil
+        amountDisplay.secondary
     }
 
-    private var satDisplay: AmountDisplayText {
-        AmountFormatter.displayText(
-            amountSats: transaction.amount,
+    private var amountDisplay: AmountDisplayText {
+        AmountFormatter.displayMintUnitAmount(
+            amount: transaction.amount,
+            unit: transaction.unit,
             preferredPrimary: settings.homeBalancePrimary,
             showFiat: settings.showFiatBalance,
             btcPrice: priceService.btcPriceUSD,

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -554,9 +554,10 @@ struct HistoryView: View {
         let amountPart: String
         if amount == 0 {
             amountPart = "any amount"
-        } else if request.unit.lowercased() == "sat" {
-            let display = AmountFormatter.displayText(
-                amountSats: amount,
+        } else {
+            let display = AmountFormatter.displayMintUnitAmount(
+                amount: amount,
+                unit: request.unit,
                 preferredPrimary: settings.homeBalancePrimary,
                 showFiat: settings.showFiatBalance,
                 btcPrice: priceService.btcPriceUSD,
@@ -566,11 +567,6 @@ struct HistoryView: View {
             amountPart = [display.primary, display.secondary]
                 .compactMap { $0 }
                 .joined(separator: ", ")
-        } else {
-            amountPart = CurrencyAmount(
-                value: amount,
-                currency: CurrencyRegistry.currency(forMintUnit: request.unit)
-            ).formatted()
         }
         return "\(request.displayTitle), \(amountPart), \(received ? "received" : "waiting for payment"), \(formatRelativeDate(request.createdAt))"
     }
@@ -648,22 +644,15 @@ struct HistoryView: View {
     // pending row reads as a bare amount in VoiceOver too (status is announced
     // separately).
     private func formatAmount(_ transaction: WalletTransaction) -> String {
-        let value: String
-        if transaction.unit.lowercased() == "sat" {
-            value = AmountFormatter.displayText(
-                amountSats: transaction.amount,
-                preferredPrimary: settings.homeBalancePrimary,
-                showFiat: settings.showFiatBalance,
-                btcPrice: priceService.btcPriceUSD,
-                currencyCode: settings.bitcoinPriceCurrency,
-                useBitcoinSymbol: settings.useBitcoinSymbol
-            ).primary
-        } else {
-            value = CurrencyAmount(
-                value: transaction.amount,
-                currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
-            ).formatted()
-        }
+        let value = AmountFormatter.displayMintUnitAmount(
+            amount: transaction.amount,
+            unit: transaction.unit,
+            preferredPrimary: settings.homeBalancePrimary,
+            showFiat: settings.showFiatBalance,
+            btcPrice: priceService.btcPriceUSD,
+            currencyCode: settings.bitcoinPriceCurrency,
+            useBitcoinSymbol: settings.useBitcoinSymbol
+        ).primary
         guard !transaction.isUnsettled else { return value }
         return transaction.type == .incoming ? "+\(value)" : value
     }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -128,36 +128,17 @@ struct TransactionDetailView: View {
                         // nothing while a no-QR transaction is still pending.
                         heroSlot
 
-                        // Amount hero — always crisp `.primary`; the glyph above
-                        // carries the state colour.
-                        Group {
-                            if !isSatUnit {
-                                AmountLockup(
-                                    parts: AmountParts.parse(formattedNativeAmount),
-                                    role: showsQR ? .amountCompact : .amountConfirm,
-                                    value: Double(transaction.amount),
-                                    accessibilityPrefix: "Amount"
-                                )
-                            } else if transaction.kind == .onchain {
-                                AmountLockup(
-                                    parts: AmountFormatter.satsParts(
-                                        transaction.amount, useBitcoinSymbol: settings.useBitcoinSymbol
-                                    ),
-                                    role: showsQR ? .amountCompact : .amountConfirm,
-                                    value: Double(transaction.amount),
-                                    accessibilityPrefix: "Amount"
-                                )
-                            } else {
-                                TransactionReceiptAmountPair(
-                                    sats: transaction.amount,
-                                    role: showsQR ? .amountCompact : .amountConfirm,
-                                    showFiat: settings.showFiatBalance,
-                                    btcPrice: priceService.btcPriceUSD,
-                                    currencyCode: priceService.currencyCode,
-                                    useBitcoinSymbol: settings.useBitcoinSymbol
-                                )
-                            }
-                        }
+                        // Receipt amounts use the same primary/secondary ordering
+                        // as Home and History. The glyph above carries state colour.
+                        TransactionReceiptAmountPair(
+                            transaction: transaction,
+                            role: showsQR ? .amountCompact : .amountConfirm,
+                            preferredPrimary: settings.homeBalancePrimary,
+                            showFiat: settings.showFiatBalance,
+                            btcPrice: priceService.btcPriceUSD,
+                            currencyCode: settings.bitcoinPriceCurrency,
+                            useBitcoinSymbol: settings.useBitcoinSymbol
+                        )
                         .padding(.top, heroSlotIsEmpty ? 32 : 0)
 
                         // Detail rows on canvas, led by Status + Date. Type is
@@ -378,13 +359,6 @@ struct TransactionDetailView: View {
         CurrencyRegistry.isSatoshiUnit(transaction.unit)
     }
 
-    private var formattedNativeAmount: String {
-        CurrencyAmount(
-            value: transaction.amount,
-            currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
-        ).formatted()
-    }
-
     private var formattedNativeFee: String {
         if isSatUnit { return "\(transaction.fee) sat" }
         return CurrencyAmount(
@@ -543,41 +517,62 @@ struct TransactionDetailView: View {
     }
 }
 
-/// A receipt is a settled sat amount with an optional live fiat reference — not
-/// an entry control. Keeping the pair static prevents a historical transaction
-/// from changing hierarchy with the home or keypad display preferences.
-private struct TransactionReceiptAmountPair: View {
-    let sats: UInt64
+/// A receipt follows the same amount hierarchy selected from the Home balance.
+/// It remains a static display rather than an independent entry-mode control.
+struct TransactionReceiptAmountPair: View {
+    let transaction: WalletTransaction
     let role: CashuTextRole
+    let preferredPrimary: AmountDisplayPrimary
     let showFiat: Bool
-    let btcPrice: Double
+    let btcPrice: Double?
     let currencyCode: String
     let useBitcoinSymbol: Bool
 
-    private var fiatText: String? {
-        guard showFiat else { return nil }
-        return AmountFormatter.fiat(
-            sats: sats,
+    static func display(
+        transaction: WalletTransaction,
+        preferredPrimary: AmountDisplayPrimary,
+        showFiat: Bool,
+        btcPrice: Double?,
+        currencyCode: String,
+        useBitcoinSymbol: Bool
+    ) -> AmountDisplayText {
+        AmountFormatter.displayMintUnitAmount(
+            amount: transaction.amount,
+            unit: transaction.unit,
+            preferredPrimary: preferredPrimary,
+            showFiat: showFiat,
             btcPrice: btcPrice,
-            currencyCode: currencyCode
+            currencyCode: currencyCode,
+            useBitcoinSymbol: useBitcoinSymbol
+        )
+    }
+
+    private var amountDisplay: AmountDisplayText {
+        Self.display(
+            transaction: transaction,
+            preferredPrimary: preferredPrimary,
+            showFiat: showFiat,
+            btcPrice: btcPrice,
+            currencyCode: currencyCode,
+            useBitcoinSymbol: useBitcoinSymbol
         )
     }
 
     var body: some View {
         VStack(spacing: AmountPairMetrics.spacing) {
             AmountLockup(
-                parts: AmountFormatter.satsParts(sats, useBitcoinSymbol: useBitcoinSymbol),
+                parts: amountDisplay.primaryParts,
                 role: role,
-                value: Double(sats),
+                value: Double(transaction.amount),
                 accessibilityPrefix: "Amount"
             )
 
-            if let fiatText {
-                Text(fiatText)
+            if let secondary = amountDisplay.secondary {
+                Text(secondary)
                     .cashuText(.bodyEmphasis)
                     .monospacedDigit()
                     .foregroundStyle(.secondary)
-                    .accessibilityLabel("Fiat equivalent: \(fiatText)")
+                    .accessibilityLabel("Alternate amount: \(secondary)")
             }
         }
     }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -375,7 +375,7 @@ struct TransactionDetailView: View {
     }
 
     private var isSatUnit: Bool {
-        transaction.unit.caseInsensitiveCompare("sat") == .orderedSame
+        CurrencyRegistry.isSatoshiUnit(transaction.unit)
     }
 
     private var formattedNativeAmount: String {

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -588,15 +588,15 @@ struct MainWalletView: View {
     }
 
     private func formatAmount(_ transaction: WalletTransaction) -> String {
-        let value: String
-        if transaction.unit.lowercased() == "sat" {
-            value = balanceDisplay(transaction.amount).primary
-        } else {
-            value = CurrencyAmount(
-                value: transaction.amount,
-                currency: CurrencyRegistry.currency(forMintUnit: transaction.unit)
-            ).formatted()
-        }
+        let value = AmountFormatter.displayMintUnitAmount(
+            amount: transaction.amount,
+            unit: transaction.unit,
+            preferredPrimary: settings.homeBalancePrimary,
+            showFiat: settings.showFiatBalance,
+            btcPrice: priceService.btcPriceUSD,
+            currencyCode: settings.bitcoinPriceCurrency,
+            useBitcoinSymbol: settings.useBitcoinSymbol
+        ).primary
         guard !transaction.isUnsettled else { return value }
         return transaction.type == .incoming ? "+\(value)" : value
     }

--- a/ios/CashuWalletTests/MintServiceTests.swift
+++ b/ios/CashuWalletTests/MintServiceTests.swift
@@ -786,6 +786,31 @@ final class MultiUnitSupportTests: XCTestCase {
         XCTAssertNil(display.secondary)
     }
 
+    func testLightningReceiptUsesHomeFiatPreference() {
+        let transaction = WalletTransaction(
+            id: "lightning-receive",
+            amount: 1,
+            type: .incoming,
+            kind: .lightning,
+            date: Date(),
+            memo: nil,
+            status: .completed
+        )
+
+        let display = TransactionReceiptAmountPair.display(
+            transaction: transaction,
+            preferredPrimary: .fiat,
+            showFiat: true,
+            btcPrice: 20_000,
+            currencyCode: "USD",
+            useBitcoinSymbol: false
+        )
+
+        XCTAssertEqual(display.primary, "<$0.01")
+        XCTAssertEqual(display.secondary, "1 sat")
+        XCTAssertEqual(display.effectivePrimary, .fiat)
+    }
+
     func testHomeBalancePrimaryDefaultsToSatsAndPersistsIndependently() {
         let store = SettingsStore(storage: InMemoryStorage())
 

--- a/ios/CashuWalletTests/MintServiceTests.swift
+++ b/ios/CashuWalletTests/MintServiceTests.swift
@@ -753,6 +753,39 @@ final class MultiUnitSupportTests: XCTestCase {
         XCTAssertEqual(display.effectivePrimary, .sats)
     }
 
+    func testHistoryAmountConvertsEverySatoshiUnitAlias() {
+        for unit in ["sat", "SAT", " sats ", "satoshi", "satoshis"] {
+            let display = AmountFormatter.displayMintUnitAmount(
+                amount: 300_000,
+                unit: unit,
+                preferredPrimary: .fiat,
+                showFiat: true,
+                btcPrice: 20_000,
+                currencyCode: "USD",
+                useBitcoinSymbol: false
+            )
+
+            XCTAssertEqual(display.primary, "$60.00", "Failed for unit: \(unit)")
+            XCTAssertEqual(display.secondary, "300,000 sat", "Failed for unit: \(unit)")
+            XCTAssertEqual(display.effectivePrimary, .fiat, "Failed for unit: \(unit)")
+        }
+    }
+
+    func testHistoryAmountKeepsNonBitcoinMintUnitNative() {
+        let display = AmountFormatter.displayMintUnitAmount(
+            amount: 500,
+            unit: "usd",
+            preferredPrimary: .fiat,
+            showFiat: true,
+            btcPrice: 20_000,
+            currencyCode: "EUR",
+            useBitcoinSymbol: false
+        )
+
+        XCTAssertEqual(display.primary, "$5.00")
+        XCTAssertNil(display.secondary)
+    }
+
     func testHomeBalancePrimaryDefaultsToSatsAndPersistsIndependently() {
         let store = SettingsStore(storage: InMemoryStorage())
 


### PR DESCRIPTION
## Summary
- normalize all supported satoshi unit aliases before applying the Home balance currency preference
- use the shared mint-unit formatter for transaction and Cashu Request history rows, accessibility text, and transaction receipt amounts on iOS and Android
- make transaction receipts follow the primary currency selected from the Home balance, including Lightning receives and on-chain transactions
- show positive sub-cent Bitcoin conversions as `<0.01` in the selected fiat currency instead of silently reverting that transaction to sats
- keep USD, EUR, and custom mint units in their native denomination instead of applying a Bitcoin spot-price conversion
- add cross-platform regression coverage for satoshi aliases, native non-Bitcoin units, and incoming Lightning receipts

## Testing
- `./gradlew --no-daemon :app:testDebugUnitTest :app:lintDebug --stacktrace`
- iOS `CashuWalletTests` target, excluding the external-service `CDKIntegrationTests` and `NutshellIntegrationTests` suites
- focused iOS `MultiUnitSupportTests`