### PR TITLE
fix: fit transaction receipts and refine spacing

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -4,9 +4,8 @@ import android.content.ClipData
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -182,158 +181,179 @@ fun TransactionReceiptSheet(
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = CashuTheme.spacing.comfortable),
+                            .padding(horizontal = CashuTheme.spacing.comfortable)
+                            .padding(bottom = CashuTheme.spacing.comfortable),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                        verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.section),
                     ) {
-                        // Hero state slot: live request → QR; completed → 64dp green
-                        // check; failed → 64dp red X; pending with no QR → no glyph.
-                        // State detail lives in the monochrome Status row below.
-                        when {
-                            showsQr && qrContent != null -> QrCard(
-                                content = qrContent,
-                                staticOnly = current.kind != TransactionKind.Ecash,
-                                shareSubject = title,
-                                confirmationMessage =
-                                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                        ) {
+                            // Hero state slot: live request → QR; completed → 64dp green
+                            // check; failed → 64dp red X; pending with no QR → no glyph.
+                            // State detail lives in the monochrome Status row below.
+                            when {
+                                showsQr && qrContent != null -> QrCard(
+                                    content = qrContent,
+                                    staticOnly = current.kind != TransactionKind.Ecash,
+                                    shareSubject = title,
+                                    confirmationMessage =
+                                        "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                )
+                                current.status == TransactionStatus.Completed -> Icon(
+                                    imageVector = Icons.Filled.CheckCircle,
+                                    contentDescription = "Completed",
+                                    tint = CashuTheme.colors.onReceivedContainer,
+                                    modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
+                                )
+                                current.status == TransactionStatus.Failed -> Icon(
+                                    imageVector = Icons.Filled.Cancel,
+                                    contentDescription = "Failed",
+                                    tint = MaterialTheme.colorScheme.error,
+                                    modifier = Modifier.size(FAILED_GLYPH_SIZE),
+                                )
+                                else -> Unit
+                            }
+
+                            HeroAmount(
+                                transaction = current,
+                                formatter = formatter,
+                                preferredPrimary = settings.homeBalancePrimary,
+                                useBitcoinSymbol = settings.useBitcoinSymbol,
+                                showFiat = settings.showFiatBalance,
+                                btcPrice = priceState.btcPrice,
+                                currencyCode = priceState.currencyCode,
+                                compact = showsQr,
                             )
-                            current.status == TransactionStatus.Completed -> Icon(
-                                imageVector = Icons.Filled.CheckCircle,
-                                contentDescription = "Completed",
-                                tint = CashuTheme.colors.onReceivedContainer,
-                                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
-                            )
-                            current.status == TransactionStatus.Failed -> Icon(
-                                imageVector = Icons.Filled.Cancel,
-                                contentDescription = "Failed",
-                                tint = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.size(FAILED_GLYPH_SIZE),
-                            )
-                            else -> Unit
                         }
 
-                        HeroAmount(
-                            transaction = current,
-                            formatter = formatter,
-                            preferredPrimary = settings.homeBalancePrimary,
-                            useBitcoinSymbol = settings.useBitcoinSymbol,
-                            showFiat = settings.showFiatBalance,
-                            btcPrice = priceState.btcPrice,
-                            currencyCode = priceState.currencyCode,
-                            compact = showsQr,
-                        )
-
-                        Column(modifier = Modifier.fillMaxWidth()) {
-                            fields.forEach { field ->
-                                InspectorRow(
-                                    label = field.label,
-                                    value = field.value,
-                                    valueMonospaced = field.value.length > 24 ||
-                                        field.label in MonospacedLabels,
-                                    onClick = field.copyValue?.let { full ->
-                                        {
-                                            scope.launch {
-                                                clipboard.setClipEntry(
-                                                    ClipEntry(ClipData.newPlainText(field.label, full)),
-                                                )
-                                                confirmationToastController?.show(
-                                                    copyConfirmationMessage(field.label),
-                                                )
-                                            }
-                                        }
-                                    },
-                                    trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
-                                )
-                            }
-                            // Explorer link joins the detail rows (iOS parity) —
-                            // it's reference material, not an action.
-                            if (explorerUrl != null) {
-                                ExplorerLinkRow(onClick = { context.openInBrowser(explorerUrl) })
-                            }
-                        }
-
-                        if (offersManualClaimCheck) {
-                            when (val outcome = manualCheckResult) {
-                                PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
-                                    text = "Status checked",
-                                    detail = "This token has not been claimed yet.",
-                                    severity = NoticeSeverity.Info,
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                )
-                                is PendingTokenClaimCheckResult.Failed -> InlineNotice(
-                                    text = "Couldn't check status",
-                                    detail = outcome.message.text,
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                    severity = NoticeSeverity.Caution,
-                                )
-                                PendingTokenClaimCheckResult.Claimed, null -> Unit
-                            }
-                        }
-
-                        if (pendingReceiveToken != null && onClaimReceiveToken != null) {
-                            Spacer(Modifier.height(CashuTheme.spacing.snug))
-                            PrimaryButton(
-                                text = "Receive",
-                                onClick = { onClaimReceiveToken(pendingReceiveToken) },
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        } else {
-                            if (copyableContent != null) {
-                                Spacer(Modifier.height(CashuTheme.spacing.snug))
-                                SecondaryButton(
-                                    text = "Copy",
-                                    onClick = {
-                                        scope.launch {
-                                            clipboard.setClipEntry(
-                                                ClipEntry(ClipData.newPlainText(title, copyableContent)),
-                                            )
-                                            confirmationToastController?.show(
-                                                "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-                                            )
-                                        }
-                                    },
-                                    modifier = Modifier.semantics {
-                                        liveRegion = LiveRegionMode.Polite
-                                    },
-                                )
-                            }
-                            if (offersManualClaimCheck) {
-                                PrimaryButton(
-                                    text = if (checkingClaim) "Checking…" else "Check Status",
-                                    onClick = {
-                                        checkingClaim = true
-                                        manualCheckResult = null
-                                        scope.launch {
-                                            try {
-                                                manualCheckResult = runPendingTokenClaimCheck {
-                                                    walletManager.checkPendingTokenStatus(current)
+                        // The last row's 12dp inset + this gap leaves 24dp before actions.
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+                        ) {
+                            Column(modifier = Modifier.fillMaxWidth()) {
+                                fields.forEach { field ->
+                                    InspectorRow(
+                                        label = field.label,
+                                        modifier = Modifier.heightIn(min = 48.dp),
+                                        value = field.value,
+                                        valueMonospaced = field.value.length > 24 ||
+                                            field.label in MonospacedLabels,
+                                        onClick = field.copyValue?.let { full ->
+                                            {
+                                                scope.launch {
+                                                    clipboard.setClipEntry(
+                                                        ClipEntry(ClipData.newPlainText(field.label, full)),
+                                                    )
+                                                    confirmationToastController?.show(
+                                                        copyConfirmationMessage(field.label),
+                                                    )
                                                 }
-                                            } finally {
-                                                checkingClaim = false
                                             }
-                                        }
-                                    },
-                                    loading = checkingClaim,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .testTag(UiTestTags.HistoryCheckTokenStatus)
-                                        .semantics {
-                                            contentDescription = if (checkingClaim) {
-                                                "Checking claim status"
-                                            } else {
-                                                "Check Status"
-                                            }
+                                        },
+                                        trailingIcon = field.copyValue?.let { Icons.Outlined.ContentCopy },
+                                    )
+                                }
+                                // Explorer link joins the detail rows (iOS parity) —
+                                // it's reference material, not an action.
+                                if (explorerUrl != null) {
+                                    ExplorerLinkRow(
+                                        onClick = { context.openInBrowser(explorerUrl) },
+                                        modifier = Modifier.heightIn(min = 48.dp),
+                                    )
+                                }
+                            }
+
+                            if (offersManualClaimCheck) {
+                                when (val outcome = manualCheckResult) {
+                                    PendingTokenClaimCheckResult.NotClaimed -> InlineNotice(
+                                        text = "Status checked",
+                                        detail = "This token has not been claimed yet.",
+                                        severity = NoticeSeverity.Info,
+                                        modifier = Modifier.semantics {
                                             liveRegion = LiveRegionMode.Polite
                                         },
-                                )
+                                    )
+                                    is PendingTokenClaimCheckResult.Failed -> InlineNotice(
+                                        text = "Couldn't check status",
+                                        detail = outcome.message.text,
+                                        modifier = Modifier.semantics {
+                                            liveRegion = LiveRegionMode.Polite
+                                        },
+                                        severity = NoticeSeverity.Caution,
+                                    )
+                                    PendingTokenClaimCheckResult.Claimed, null -> Unit
+                                }
+                            }
+
+                            if ((pendingReceiveToken != null && onClaimReceiveToken != null) ||
+                                copyableContent != null || offersManualClaimCheck
+                            ) {
+                                Column(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+                                ) {
+                                    if (pendingReceiveToken != null && onClaimReceiveToken != null) {
+                                        PrimaryButton(
+                                            text = "Receive",
+                                            onClick = { onClaimReceiveToken(pendingReceiveToken) },
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    } else {
+                                        if (copyableContent != null) {
+                                            SecondaryButton(
+                                                text = "Copy",
+                                                onClick = {
+                                                    scope.launch {
+                                                        clipboard.setClipEntry(
+                                                            ClipEntry(ClipData.newPlainText(title, copyableContent)),
+                                                        )
+                                                        confirmationToastController?.show(
+                                                            "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+                                                        )
+                                                    }
+                                                },
+                                                modifier = Modifier.semantics {
+                                                    liveRegion = LiveRegionMode.Polite
+                                                },
+                                            )
+                                        }
+                                        if (offersManualClaimCheck) {
+                                            PrimaryButton(
+                                                text = if (checkingClaim) "Checking…" else "Check Status",
+                                                onClick = {
+                                                    checkingClaim = true
+                                                    manualCheckResult = null
+                                                    scope.launch {
+                                                        try {
+                                                            manualCheckResult = runPendingTokenClaimCheck {
+                                                                walletManager.checkPendingTokenStatus(current)
+                                                            }
+                                                        } finally {
+                                                            checkingClaim = false
+                                                        }
+                                                    }
+                                                },
+                                                loading = checkingClaim,
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .testTag(UiTestTags.HistoryCheckTokenStatus)
+                                                    .semantics {
+                                                        contentDescription = if (checkingClaim) {
+                                                            "Checking claim status"
+                                                        } else {
+                                                            "Check Status"
+                                                        }
+                                                        liveRegion = LiveRegionMode.Polite
+                                                    },
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
-
-                        Spacer(Modifier.height(CashuTheme.spacing.comfortable))
                     }
                 }
             }

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -1155,6 +1155,14 @@ chevron on a switchable mint. Method/action rows (the Send and Receive entry
 sheets, Settings navigation rows) are a different vocabulary and keep their
 leading icons — there the glyph identifies a destination, not a field.
 
+Transaction receipts group the status hero and amount with a 16pt/dp gap,
+then separate that group from the detail rows by 24pt/dp. Detail rows use
+12pt/dp vertical padding and retain native minimum touch heights (44pt on iOS,
+48dp on Android). A 12pt/dp gap after the rows combines with the last row's
+bottom padding to leave 24pt/dp before the actions. Stacked actions use a
+12pt/dp gap, and the content ends with 16pt/dp padding above the native bottom
+inset. The QR's size and white border stay unchanged.
+
 **The Confirmation Toast Rule.** Completed utility actions such as Copy use a
 single top-center capsule with a short semantic message (for example, “Copied
 Bitcoin address”). It enters with a restrained upward spring/slide and opacity,

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -114,88 +114,93 @@ struct TransactionDetailView: View {
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
-                // Hero: an actionable QR (unclaimed token / pending or
-                // reusable invoice), else a state glyph that bounces in on
-                // open — green check when completed, red X when failed;
-                // nothing while a no-QR transaction is still pending.
-                heroSlot
+                // Group the state and amount more closely than the receipt facts.
+                VStack(spacing: 16) {
+                    // Hero: an actionable QR (unclaimed token / pending or
+                    // reusable invoice), else a state glyph that bounces in on
+                    // open — green check when completed, red X when failed;
+                    // nothing while a no-QR transaction is still pending.
+                    heroSlot
 
-                // Receipt amounts use the same primary/secondary ordering
-                // as Home and History. The glyph above carries state colour.
-                TransactionReceiptAmountPair(
-                    transaction: transaction,
-                    role: showsQR ? .amountCompact : .amountConfirm,
-                    preferredPrimary: settings.homeBalancePrimary,
-                    showFiat: settings.showFiatBalance,
-                    btcPrice: priceService.btcPriceUSD,
-                    currencyCode: settings.bitcoinPriceCurrency,
-                    useBitcoinSymbol: settings.useBitcoinSymbol
-                )
-                .padding(.top, heroSlotIsEmpty ? 32 : 0)
-
-                // Detail rows on canvas, led by Status + Date. Type is
-                // omitted — the nav title names it.
-                VStack(spacing: 0) {
-                    ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
-                        if let copyValue = row.copyValue {
-                            copyableRow(label: row.label, value: row.value, copyValue: copyValue)
-                        } else {
-                            detailRow(label: row.label, value: row.value)
-                        }
-                    }
-                    if let explorerURL = onchainExplorerURL {
-                        explorerLinkRow(label: "View in block explorer", url: explorerURL)
-                    }
-                }
-                .padding(.top, 8)
-                .padding(.horizontal, 4)
-
-                if offersManualClaimCheck {
-                    switch manualClaimCheckResult {
-                    case .notClaimed:
-                        InlineNotice(
-                            message: "This token has not been claimed yet.",
-                            title: "Status checked",
-                            severity: .info
-                        )
-                    case .failed(let message):
-                        InlineNotice(
-                            message: message.text,
-                            title: "Couldn't check status",
-                            severity: message.severity
-                        )
-                    case .claimed, nil:
-                        EmptyView()
-                    }
+                    // Receipt amounts use the same primary/secondary ordering
+                    // as Home and History. The glyph above carries state colour.
+                    TransactionReceiptAmountPair(
+                        transaction: transaction,
+                        role: showsQR ? .amountCompact : .amountConfirm,
+                        preferredPrimary: settings.homeBalancePrimary,
+                        showFiat: settings.showFiatBalance,
+                        btcPrice: priceService.btcPriceUSD,
+                        currencyCode: settings.bitcoinPriceCurrency,
+                        useBitcoinSymbol: settings.useBitcoinSymbol
+                    )
+                    .padding(.top, heroSlotIsEmpty ? 16 : 0)
                 }
 
-                // Pending outgoing ecash gains the same one-off status action as
-                // the generated-token screen when automatic checks are disabled.
-                // Keep it after Copy so the two surfaces share the same action order.
-                if offersManualClaimCheck || copyableContent != nil {
-                    VStack(spacing: 12) {
-                        if let content = copyableContent {
-                            Button(action: { copyContent(content) }) {
-                                Text("Copy")
+                // Row bottom padding + this gap leaves 24pt before the actions.
+                VStack(spacing: 12) {
+                    // Detail rows on canvas, led by Status + Date. Type is
+                    // omitted — the nav title names it.
+                    VStack(spacing: 0) {
+                        ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
+                            if let copyValue = row.copyValue {
+                                copyableRow(label: row.label, value: row.value, copyValue: copyValue)
+                            } else {
+                                detailRow(label: row.label, value: row.value)
                             }
-                            .flatSheetSecondaryButton()
-                            .accessibilityLabel("Copy \(qrContentTypeLabel)")
-                            .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                         }
+                        if let explorerURL = onchainExplorerURL {
+                            explorerLinkRow(label: "View in block explorer", url: explorerURL)
+                        }
+                    }
+                    .padding(.horizontal, 4)
 
-                        if offersManualClaimCheck {
-                            Button(action: { startManualClaimCheck() }) {
-                                if isCheckingClaim {
-                                    ProgressView()
-                                } else {
-                                    Text("Check Status")
+                    if offersManualClaimCheck {
+                        switch manualClaimCheckResult {
+                        case .notClaimed:
+                            InlineNotice(
+                                message: "This token has not been claimed yet.",
+                                title: "Status checked",
+                                severity: .info
+                            )
+                        case .failed(let message):
+                            InlineNotice(
+                                message: message.text,
+                                title: "Couldn't check status",
+                                severity: message.severity
+                            )
+                        case .claimed, nil:
+                            EmptyView()
+                        }
+                    }
+
+                    // Pending outgoing ecash gains the same one-off status action as
+                    // the generated-token screen when automatic checks are disabled.
+                    // Keep it after Copy so the two surfaces share the same action order.
+                    if offersManualClaimCheck || copyableContent != nil {
+                        VStack(spacing: 12) {
+                            if let content = copyableContent {
+                                Button(action: { copyContent(content) }) {
+                                    Text("Copy")
                                 }
+                                .flatSheetSecondaryButton()
+                                .accessibilityLabel("Copy \(qrContentTypeLabel)")
+                                .accessibilityHint("Copies the \(qrContentAccessibilityLabel) to clipboard")
                             }
-                            .glassButton()
-                            .disabled(isCheckingClaim)
-                            .accessibilityIdentifier("cashu.history.check-token-status")
-                            .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
-                            .accessibilityInputLabels(["Check Status"])
+
+                            if offersManualClaimCheck {
+                                Button(action: { startManualClaimCheck() }) {
+                                    if isCheckingClaim {
+                                        ProgressView()
+                                    } else {
+                                        Text("Check Status")
+                                    }
+                                }
+                                .glassButton()
+                                .disabled(isCheckingClaim)
+                                .accessibilityIdentifier("cashu.history.check-token-status")
+                                .accessibilityLabel(isCheckingClaim ? "Checking claim status" : "Check Status")
+                                .accessibilityInputLabels(["Check Status"])
+                            }
                         }
                     }
                 }
@@ -275,13 +280,13 @@ struct TransactionDetailView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.success.foreground)
-                .padding(.top, 24)
+                .padding(.top, 16)
                 .accessibilityLabel("Completed")
         } else if transaction.status == .failed {
             Image(systemName: "xmark.circle.fill")
                 .font(.statusGlyph)
                 .foregroundStyle(ErrorSeverity.error.foreground)
-                .padding(.top, 24)
+                .padding(.top, 16)
                 .accessibilityLabel("Failed")
         }
     }
@@ -370,7 +375,8 @@ struct TransactionDetailView: View {
         }
         .font(.subheadline)
         .padding(.horizontal, 4)
-        .padding(.vertical, 14)
+        .padding(.vertical, 12)
+        .frame(minHeight: 44)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(label)
         .accessibilityValue(value)
@@ -401,7 +407,8 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -425,7 +432,8 @@ struct TransactionDetailView: View {
             }
             .font(.subheadline)
             .padding(.horizontal, 4)
-            .padding(.vertical, 14)
+            .padding(.vertical, 12)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -13,6 +13,7 @@ struct TransactionDetailView: View {
     @State private var isCheckingClaim = false
     @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
     @State private var manualClaimCheckTask: Task<Void, Never>?
+    @State private var contentHeight: CGFloat = 0
 
     init(transaction: WalletTransaction) {
         self.seed = transaction
@@ -104,81 +105,68 @@ struct TransactionDetailView: View {
     }
 
     /// Every transaction detail opens as a member of the same receipt-sheet
-    /// family; only the height varies with content. A QR hero needs most of the
-    /// screen, an onchain receipt carries an extra explorer row, and everything
-    /// else fits the standard receipt detent. `.large` stays reachable by drag.
-    /// The QR fraction is sized so the scroll content — including its 24pt
-    /// bottom padding, the row-to-CTA gap every receipt shows — fits without
-    /// clipping; any tighter and that gap is the first thing cut.
-    private var presentationDetents: Set<PresentationDetent> {
-        if showsQR { return [.fraction(0.94), .large] }
-        return transaction.kind == .onchain
-            ? [.fraction(0.78), .large]
-            : [.fraction(0.68), .large]
-    }
-
+    /// family. The sheet hugs its measured content (capped at 90% of the
+    /// screen, scrolling past that) instead of guessing a screen fraction:
+    /// fixed fractions clipped the rows behind the bottom actions on smaller
+    /// devices whenever the receipt grew — a Fee row, the fiat conversion
+    /// line, a second CTA — while fitting content on larger ones. Same
+    /// contract as `QRCodeDetailSheet` and the other content-fit receipts.
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                ScrollView {
-                    VStack(spacing: 24) {
-                        // Hero: an actionable QR (unclaimed token / pending or
-                        // reusable invoice), else a state glyph that bounces in on
-                        // open — green check when completed, red X when failed;
-                        // nothing while a no-QR transaction is still pending.
-                        heroSlot
+            VStack(spacing: 24) {
+                // Hero: an actionable QR (unclaimed token / pending or
+                // reusable invoice), else a state glyph that bounces in on
+                // open — green check when completed, red X when failed;
+                // nothing while a no-QR transaction is still pending.
+                heroSlot
 
-                        // Receipt amounts use the same primary/secondary ordering
-                        // as Home and History. The glyph above carries state colour.
-                        TransactionReceiptAmountPair(
-                            transaction: transaction,
-                            role: showsQR ? .amountCompact : .amountConfirm,
-                            preferredPrimary: settings.homeBalancePrimary,
-                            showFiat: settings.showFiatBalance,
-                            btcPrice: priceService.btcPriceUSD,
-                            currencyCode: settings.bitcoinPriceCurrency,
-                            useBitcoinSymbol: settings.useBitcoinSymbol
-                        )
-                        .padding(.top, heroSlotIsEmpty ? 32 : 0)
+                // Receipt amounts use the same primary/secondary ordering
+                // as Home and History. The glyph above carries state colour.
+                TransactionReceiptAmountPair(
+                    transaction: transaction,
+                    role: showsQR ? .amountCompact : .amountConfirm,
+                    preferredPrimary: settings.homeBalancePrimary,
+                    showFiat: settings.showFiatBalance,
+                    btcPrice: priceService.btcPriceUSD,
+                    currencyCode: settings.bitcoinPriceCurrency,
+                    useBitcoinSymbol: settings.useBitcoinSymbol
+                )
+                .padding(.top, heroSlotIsEmpty ? 32 : 0)
 
-                        // Detail rows on canvas, led by Status + Date. Type is
-                        // omitted — the nav title names it.
-                        VStack(spacing: 0) {
-                            ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
-                                if let copyValue = row.copyValue {
-                                    copyableRow(label: row.label, value: row.value, copyValue: copyValue)
-                                } else {
-                                    detailRow(label: row.label, value: row.value)
-                                }
-                            }
-                            if let explorerURL = onchainExplorerURL {
-                                explorerLinkRow(label: "View in block explorer", url: explorerURL)
-                            }
-                        }
-                        .padding(.top, 8)
-                        .padding(.horizontal, 4)
-
-                        if offersManualClaimCheck {
-                            switch manualClaimCheckResult {
-                            case .notClaimed:
-                                InlineNotice(
-                                    message: "This token has not been claimed yet.",
-                                    title: "Status checked",
-                                    severity: .info
-                                )
-                            case .failed(let message):
-                                InlineNotice(
-                                    message: message.text,
-                                    title: "Couldn't check status",
-                                    severity: message.severity
-                                )
-                            case .claimed, nil:
-                                EmptyView()
-                            }
+                // Detail rows on canvas, led by Status + Date. Type is
+                // omitted — the nav title names it.
+                VStack(spacing: 0) {
+                    ForEach(Array(detailRows.enumerated()), id: \.offset) { _, row in
+                        if let copyValue = row.copyValue {
+                            copyableRow(label: row.label, value: row.value, copyValue: copyValue)
+                        } else {
+                            detailRow(label: row.label, value: row.value)
                         }
                     }
-                    .padding(.horizontal)
-                    .padding(.bottom, copyableContent == nil ? 0 : 24)
+                    if let explorerURL = onchainExplorerURL {
+                        explorerLinkRow(label: "View in block explorer", url: explorerURL)
+                    }
+                }
+                .padding(.top, 8)
+                .padding(.horizontal, 4)
+
+                if offersManualClaimCheck {
+                    switch manualClaimCheckResult {
+                    case .notClaimed:
+                        InlineNotice(
+                            message: "This token has not been claimed yet.",
+                            title: "Status checked",
+                            severity: .info
+                        )
+                    case .failed(let message):
+                        InlineNotice(
+                            message: message.text,
+                            title: "Couldn't check status",
+                            severity: message.severity
+                        )
+                    case .claimed, nil:
+                        EmptyView()
+                    }
                 }
 
                 // Pending outgoing ecash gains the same one-off status action as
@@ -210,10 +198,11 @@ struct TransactionDetailView: View {
                             .accessibilityInputLabels(["Check Status"])
                         }
                     }
-                    .padding(.horizontal)
-                    .padding(.bottom, 16)
                 }
             }
+            .padding(.horizontal)
+            .padding(.bottom, 16)
+            .contentFitMeasured { contentHeight = $0 }
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
@@ -243,7 +232,7 @@ struct TransactionDetailView: View {
             }
         }
         .compactBottomSheetSurface()
-        .presentationDetents(presentationDetents)
+        .contentFitDetent(contentHeight, estimate: 500, navigationBar: true)
         .presentationDragIndicator(.visible)
     }
 


### PR DESCRIPTION
## Problem and result

Transaction receipts on iOS used fixed-height sheets that could hide lower rows behind pinned actions when a receipt included a fee, fiat conversion or a second button. The sheet now fits its measured content and scrolls when the content exceeds the existing 90% helper cap. Copy and Check Status are part of that measured content, so the lower rows and actions stay reachable.

Both native apps also use clearer spacing between receipt groups: 16pt/dp between hero and amount, 24pt/dp before details, 12pt/dp around stacked actions, and 16pt/dp bottom padding above native insets. iOS reduces excessive hero and row padding. Android removes accumulated spacer/column gaps around actions. Detail rows retain native minimum heights of 44pt on iOS and 48dp on Android. QR dimensions and the white border, transaction data and action logic are unchanged. The spacing contract is documented in DESIGN.md.

The iOS sheet uses a single measured detent and no longer drag-expands to `.large`, consistent with the existing content-fit helper. Android retains its native bottom-sheet behavior.

## Validation

- Original content-fit behavior was reviewed against main; screenshots and findings are in the first visual-review comment.
- The spacing follow-up was compared with previously reviewed head `0aca0e0` using fresh isolated builds: 42 before/after pairs, 84 validated and visually inspected screenshots.
- iOS builds and six focused capture-test method runs passed on iPhone 17e and iPhone 17 Pro Max, including the largest accessibility text size on the compact phone. Copy and pending Check Status remain hittable after scrolling.
- Android debug/instrumentation builds and six capture cases per revision passed on Pixel 8, Android 17 / API 37.
- iOS uses the approved 26.5 (23F77) fallback because newer stable simulator downloads were unavailable. This focused run does not replace the full test suites.

Remaining limits: existing iOS largest-text date/status truncation and label wrapping; no live payment/status-result, screen-reader announcement, Android large-text, dark-mode or physical-device coverage. The fixtures contain synthetic data only and are not included in the source changes.
