### PR TITLE
Fix reusable amountless BOLT12 receives

### DIFF
--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -160,7 +160,6 @@ jobs:
         ./CI/setup-nutshell.sh
 
     - name: Setup local CDK mint
-      if: env.UI_TIER == 'full'
       working-directory: .
       run: |
         chmod +x CI/setup-cdk.sh
@@ -171,9 +170,7 @@ jobs:
       run: |
         chmod +x CI/start-nutshell.sh CI/start-cdk.sh
         ./CI/start-nutshell.sh 3338
-        if [ "$UI_TIER" = "full" ]; then
-          ./CI/start-cdk.sh
-        fi
+        ./CI/start-cdk.sh
 
     - name: Run required Android UI suite
       if: env.UI_TIER != 'full'
@@ -186,7 +183,9 @@ jobs:
           -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.cashu.me.test.FullOnly \
           -Pandroid.testInstrumentationRunnerArguments.timeout_msec=600000 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.liveUiLocalMintEnabled=true \
-          -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338
+          -Pandroid.testInstrumentationRunnerArguments.cashu.nativeWalletLocalMintIntegration=true \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338 \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.cdkMintUrl=http://10.0.2.2:3339
 
     - name: Run full Android UI and native suite
       if: env.UI_TIER == 'full'

--- a/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
+++ b/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
@@ -401,6 +401,11 @@ class MintIntegrationTestSuite: IntegrationTestBase {
 
         // Open a fresh repository over the same durable store at the exact
         // failure boundary: payment is recorded, but no ecash was issued.
+        // This deliberately proves process/database-handle recovery, not a
+        // seed-only restore into an empty database. NUT-09 cannot discover a
+        // mint-generated quote id, and a BOLT12 quote additionally needs its
+        // stored NUT-20 signing key association. A true database-loss test
+        // requires an upstream/exported quote-backup format first.
         // Keep the first FFI handle alive because explicitly destroying a CDK
         // Tokio runtime inside an async XCTest context can itself panic.
         let reopenedRepository = try WalletRepository(

--- a/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
+++ b/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
@@ -335,20 +335,105 @@ class MintIntegrationTestSuite: IntegrationTestBase {
     func waitForQuotePayment(
         quoteId: String,
         method: PaymentMethod,
+        wallet targetWallet: Wallet? = nil,
         timeout: TimeInterval = 15.0
     ) async throws -> MintQuote {
+        let target = targetWallet ?? wallet!
         let start = Date()
-        var updated = try await wallet.fetchMintQuote(quoteId: quoteId, paymentMethod: method)
+        var updated = try await target.fetchMintQuote(quoteId: quoteId, paymentMethod: method)
         while updated.amountPaid.value <= updated.amountIssued.value,
               Date().timeIntervalSince(start) < timeout {
             try await Task.sleep(nanoseconds: 200_000_000)  // 200 ms
-            updated = try await wallet.fetchMintQuote(quoteId: quoteId, paymentMethod: method)
+            updated = try await target.fetchMintQuote(quoteId: quoteId, paymentMethod: method)
         }
         XCTAssertGreaterThan(
             updated.amountPaid.value, updated.amountIssued.value,
             "\(method) quote was not auto-paid by the FakeWallet within \(timeout)s"
         )
         return updated
+    }
+
+    func runBolt12SweepRecoversEveryQuoteAfterRestart() async throws {
+        let dbPath = NSTemporaryDirectory()
+            .appending("bolt12_recovery_\(UUID().uuidString).sqlite")
+        let mnemonic = try generateMnemonic()
+        let mintURL = MintUrl(url: mintUrlStr)
+
+        let firstRepository = try WalletRepository(
+            mnemonic: mnemonic,
+            store: .sqlite(path: dbPath)
+        )
+        try await firstRepository.createWallet(
+            mintUrl: mintURL,
+            unit: .sat,
+            targetProofCount: nil
+        )
+        let firstWallet = try await firstRepository.getWallet(
+            mintUrl: mintURL,
+            unit: .sat
+        )
+
+        let firstQuote = try await firstWallet.mintQuote(
+            paymentMethod: .bolt12,
+            amount: nil,
+            description: nil,
+            extra: nil
+        )
+        let secondQuote = try await firstWallet.mintQuote(
+            paymentMethod: .bolt12,
+            amount: nil,
+            description: nil,
+            extra: nil
+        )
+        let quotes = [firstQuote, secondQuote]
+        var expectedOutstanding: UInt64 = 0
+        for quote in quotes {
+            let paid = try await waitForQuotePayment(
+                quoteId: quote.id,
+                method: .bolt12,
+                wallet: firstWallet
+            )
+            expectedOutstanding += paid.amountPaid.value - paid.amountIssued.value
+        }
+        XCTAssertGreaterThan(expectedOutstanding, 0)
+        let balanceBeforeRestart = try await firstWallet.totalBalance()
+        XCTAssertEqual(balanceBeforeRestart.value, 0)
+
+        // Open a fresh repository over the same durable store at the exact
+        // failure boundary: payment is recorded, but no ecash was issued.
+        // Keep the first FFI handle alive because explicitly destroying a CDK
+        // Tokio runtime inside an async XCTest context can itself panic.
+        let reopenedRepository = try WalletRepository(
+            mnemonic: mnemonic,
+            store: .sqlite(path: dbPath)
+        )
+        try await reopenedRepository.createWallet(
+            mintUrl: mintURL,
+            unit: .sat,
+            targetProofCount: nil
+        )
+        let reopenedWallet = try await reopenedRepository.getWallet(
+            mintUrl: mintURL,
+            unit: .sat
+        )
+
+        let recovered = try await reopenedWallet.mintUnissuedQuotes()
+        XCTAssertEqual(recovered.value, expectedOutstanding)
+        let balanceAfterRecovery = try await reopenedWallet.totalBalance()
+        XCTAssertEqual(balanceAfterRecovery.value, expectedOutstanding)
+
+        for quote in quotes {
+            let verified = try await reopenedWallet.checkMintQuote(quoteId: quote.id)
+            XCTAssertEqual(verified.amountIssued.value, verified.amountPaid.value)
+        }
+        let secondSweep = try await reopenedWallet.mintUnissuedQuotes()
+        XCTAssertEqual(secondSweep.value, 0)
+
+        withExtendedLifetime((firstRepository, firstWallet)) {}
+
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(atPath: dbPath + suffix)
+        }
     }
 
     func runBolt12MintFlow() async throws {
@@ -381,10 +466,9 @@ class MintIntegrationTestSuite: IntegrationTestBase {
     }
 
     func runBolt12MeltFlow() async throws {
-        _ = try await mintSats(100)
-
-        // Any offer works as the payee for the FakeWallet; reuse one handed out
-        // by the mint's own fake node via a throwaway bolt12 mint quote.
+        // Keep payer and receiver state separate: the receiver publishes one
+        // reusable offer while the payer requests a fresh invoice for each
+        // entered amount.
         let offerQuote = try await wallet.mintQuote(
             paymentMethod: .bolt12,
             amount: nil,
@@ -393,24 +477,115 @@ class MintIntegrationTestSuite: IntegrationTestBase {
         )
         let offer = offerQuote.request
 
-        // The offer is amountless, so the melt amount comes from MeltOptions.
-        let meltQuote = try await wallet.meltQuote(
+        // FakeWallet seeds a newly checked amountless offer with one synthetic
+        // payment. Settle that fixture credit first so the assertions below
+        // measure only the two payer-generated invoice flows.
+        let fixturePaid = try await waitForQuotePayment(
+            quoteId: offerQuote.id,
+            method: .bolt12
+        )
+        let fixtureOutstanding = fixturePaid.amountPaid.value - fixturePaid.amountIssued.value
+        XCTAssertGreaterThan(fixtureOutstanding, 0)
+        let fixtureProofs = try await wallet.mintUnified(
+            quoteId: offerQuote.id,
+            amountSplitTarget: .none,
+            spendingConditions: nil
+        )
+        XCTAssertEqual(
+            fixtureProofs.reduce(0) { $0 + $1.amount.value },
+            fixtureOutstanding
+        )
+        let receiverBalanceBeforePayments = try await wallet.totalBalance()
+
+        let payerDbPath = NSTemporaryDirectory()
+            .appending("bolt12_payer_\(UUID().uuidString).sqlite")
+        let payerRepository = try WalletRepository(
+            mnemonic: try generateMnemonic(),
+            store: .sqlite(path: payerDbPath)
+        )
+        let mintURL = MintUrl(url: mintUrlStr)
+        try await payerRepository.createWallet(
+            mintUrl: mintURL,
+            unit: .sat,
+            targetProofCount: nil
+        )
+        let payerWallet = try await payerRepository.getWallet(
+            mintUrl: mintURL,
+            unit: .sat
+        )
+        _ = try await mintSats(100, wallet: payerWallet)
+
+        // First amount: CDK sends an invoice_request carrying 21, receives a
+        // unique BOLT12 invoice, and pays it.
+        let firstMeltQuote = try await payerWallet.meltQuote(
             method: .bolt12,
             request: offer,
             options: .amountless(amountMsat: Amount(value: 21_000)),
             extra: nil
         )
-        XCTAssertEqual(meltQuote.amount.value, 21, "Melt quote should be for 21 sats")
+        XCTAssertEqual(firstMeltQuote.amount.value, 21, "First melt quote should be for 21 sats")
+        let firstPrepared = try await payerWallet.prepareMelt(quoteId: firstMeltQuote.id)
+        let firstFinalized = try await firstPrepared.confirm()
+        XCTAssertEqual(firstFinalized.state, .paid, "First BOLT12 payment should settle")
 
-        let prepared = try await wallet.prepareMelt(quoteId: meltQuote.id)
-        let finalized = try await prepared.confirm()
-        XCTAssertEqual(finalized.state, .paid, "BOLT12 melt should settle against the FakeWallet")
-
-        let balance = try await wallet.totalBalance()
-        XCTAssertEqual(
-            balance.value, 100 - 21 - finalized.feePaid.value,
-            "Balance should drop by melt amount plus fee"
+        let firstPaid = try await waitForQuotePayment(
+            quoteId: offerQuote.id,
+            method: .bolt12
         )
+        let firstOutstanding = firstPaid.amountPaid.value - firstPaid.amountIssued.value
+        XCTAssertEqual(firstOutstanding, 21)
+        let firstProofs = try await wallet.mintUnified(
+            quoteId: offerQuote.id,
+            amountSplitTarget: .none,
+            spendingConditions: nil
+        )
+        XCTAssertEqual(firstProofs.reduce(0) { $0 + $1.amount.value }, 21)
+
+        // Second amount against the same parent offer must create another
+        // payment quote/invoice and expose only the new 13-sat issuance delta.
+        let secondMeltQuote = try await payerWallet.meltQuote(
+            method: .bolt12,
+            request: offer,
+            options: .amountless(amountMsat: Amount(value: 13_000)),
+            extra: nil
+        )
+        XCTAssertEqual(secondMeltQuote.amount.value, 13, "Second melt quote should be for 13 sats")
+        XCTAssertNotEqual(firstMeltQuote.id, secondMeltQuote.id)
+        let secondPrepared = try await payerWallet.prepareMelt(quoteId: secondMeltQuote.id)
+        let secondFinalized = try await secondPrepared.confirm()
+        XCTAssertEqual(secondFinalized.state, .paid, "Second BOLT12 payment should settle")
+
+        let secondPaid = try await waitForQuotePayment(
+            quoteId: offerQuote.id,
+            method: .bolt12
+        )
+        let secondOutstanding = secondPaid.amountPaid.value - secondPaid.amountIssued.value
+        XCTAssertEqual(secondOutstanding, 13)
+        let secondProofs = try await wallet.mintUnified(
+            quoteId: offerQuote.id,
+            amountSplitTarget: .none,
+            spendingConditions: nil
+        )
+        XCTAssertEqual(secondProofs.reduce(0) { $0 + $1.amount.value }, 13)
+
+        let receiverBalance = try await wallet.totalBalance()
+        XCTAssertEqual(
+            receiverBalance.value,
+            receiverBalanceBeforePayments.value + 34,
+            "Reusable offer should issue both payer-generated deltas exactly once"
+        )
+
+        let payerBalance = try await payerWallet.totalBalance()
+        XCTAssertEqual(
+            payerBalance.value,
+            100 - 34 - firstFinalized.feePaid.value - secondFinalized.feePaid.value,
+            "Payer balance should drop by both amounts plus their fees"
+        )
+
+        withExtendedLifetime((payerRepository, payerWallet)) {}
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(atPath: payerDbPath + suffix)
+        }
     }
 
     func runOnchainMintFlow() async throws {
@@ -531,6 +706,9 @@ final class CDKIntegrationTests: MintIntegrationTestSuite {
 
     // BOLT12 & on-chain run only against CDK — Nutshell's FakeWallet is bolt11-only.
     func testBolt12MintFlow() async throws { try await runBolt12MintFlow() }
+    func testBolt12SweepRecoversEveryQuoteAfterRestart() async throws {
+        try await runBolt12SweepRecoversEveryQuoteAfterRestart()
+    }
     func testBolt12MeltFlow() async throws { try await runBolt12MeltFlow() }
     func testOnchainMintFlow() async throws { try await runOnchainMintFlow() }
     func testOnchainMeltFlow() async throws { try await runOnchainMeltFlow() }

--- a/CI/IntegrationTests/Tests/PaymentRequestDecoderTests.swift
+++ b/CI/IntegrationTests/Tests/PaymentRequestDecoderTests.swift
@@ -1,7 +1,11 @@
 import XCTest
+import Cdk
 @testable import CashuWallet
 
 final class PaymentRequestDecoderTests: XCTestCase {
+
+    private let amountlessBolt12Offer =
+        "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"
 
     // MARK: - iconName
 
@@ -169,6 +173,67 @@ final class PaymentRequestDecoderTests: XCTestCase {
     func testDecodeLightningAddressWithSubdomain() {
         let result = PaymentRequestDecoder.decode("alice@wallet.example.com")
         XCTAssertEqual(result, .lightningAddress("alice@wallet.example.com"))
+    }
+
+    func testDecodeRealAmountlessBolt12Offer() {
+        guard case .bolt12(let amountSats, _) = PaymentRequestDecoder.decode(amountlessBolt12Offer) else {
+            return XCTFail("Expected a real amountless BOLT12 offer to be recognized")
+        }
+
+        XCTAssertNil(amountSats)
+        XCTAssertEqual(
+            PaymentRequestDecoder.encodedLightningRequest(from: "lightning:\(amountlessBolt12Offer)"),
+            amountlessBolt12Offer
+        )
+    }
+
+    func testBolt12TextEnvelopeNormalizesUppercaseAndContinuation() {
+        let split = amountlessBolt12Offer.index(amountlessBolt12Offer.startIndex, offsetBy: 32)
+        let continued = "\(amountlessBolt12Offer[..<split])+\n \(amountlessBolt12Offer[split...])"
+        let compactContinuation = "\(amountlessBolt12Offer[..<split])+\(amountlessBolt12Offer[split...])"
+
+        XCTAssertEqual(
+            PaymentRequestDecoder.encodedLightningRequest(from: amountlessBolt12Offer.uppercased()),
+            amountlessBolt12Offer
+        )
+        XCTAssertEqual(
+            PaymentRequestDecoder.encodedLightningRequest(from: continued),
+            amountlessBolt12Offer
+        )
+        XCTAssertEqual(
+            PaymentRequestDecoder.encodedLightningRequest(from: compactContinuation),
+            amountlessBolt12Offer
+        )
+        XCTAssertNil(
+            PaymentRequestDecoder.encodedLightningRequest(
+                from: "L\(amountlessBolt12Offer.dropFirst())"
+            )
+        )
+    }
+
+    func testAmountlessBolt12DestinationRequiresAmountEntry() {
+        let destination = SendAmountDestination.melt(
+            request: amountlessBolt12Offer,
+            mode: .lightning,
+            decoded: .bolt12(amountSats: nil, description: nil)
+        )
+
+        XCTAssertFalse(destination.carriesAmount)
+    }
+
+    func testAmountlessMeltOptionsCarryEnteredAmountInMillisatoshis() throws {
+        guard case .amountless(let amountMsat) = try meltOptionsForLightningRequest(
+            requestAmountMsat: nil,
+            amountSats: 21
+        ) else {
+            return XCTFail("Expected amountless melt options")
+        }
+
+        XCTAssertEqual(amountMsat.value, 21_000)
+        XCTAssertNil(
+            try meltOptionsForLightningRequest(requestAmountMsat: 5_000, amountSats: 21),
+            "A request carrying its own amount must not be overridden"
+        )
     }
 
     // MARK: - decode — onchain

--- a/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
@@ -6,12 +6,14 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.util.UUID
 import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import com.cashu.me.Core.Platform.AndroidSecureStorage
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Models.CashuRequest
 import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.MintQuoteScheduleRecord
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -30,6 +32,13 @@ class StorageDataStoreInstrumentedTest {
     fun walletStoreMigratesSharedPreferencesAndClearsWalletBoundary() {
         val storeName = uniqueStoreName("wallet_store")
         val mint = MintInfo(url = "https://mint.example.com", name = "Example", balance = 21)
+        val schedule = MintQuoteScheduleRecord(
+            firstObservedAtEpochMillis = 1_000,
+            nextAttemptAtEpochMillis = 2_000,
+            consecutiveFailures = 2,
+            hadOutstandingPayment = true,
+            isReusable = true,
+        )
         context.seedSharedPreferences(storeName) {
             putString(
                 StorageKeys.walletMints,
@@ -37,6 +46,13 @@ class StorageDataStoreInstrumentedTest {
             )
             putString(StorageKeys.walletActiveMintUrl, mint.url)
             putString(StorageKeys.walletProcessedNPCQuotes, json.encodeToString(ListSerializer(String.serializer()), listOf("quote-1")))
+            putString(
+                StorageKeys.walletMintQuoteSchedules,
+                json.encodeToString(
+                    MapSerializer(String.serializer(), MintQuoteScheduleRecord.serializer()),
+                    mapOf("quote-1" to schedule),
+                ),
+            )
             putString(
                 StorageKeys.cashuRequests,
                 json.encodeToString(ListSerializer(CashuRequest.serializer()), listOf(CashuRequest(id = "req-1", encoded = "creqA-test"))),
@@ -49,6 +65,7 @@ class StorageDataStoreInstrumentedTest {
         assertEquals(mint.url, store.activeMintURL)
         assertEquals(listOf(mint), store.loadMints())
         assertEquals(listOf("quote-1"), store.loadProcessedNPCQuotes())
+        assertEquals(mapOf("quote-1" to schedule), store.loadMintQuoteSchedules())
         assertEquals("req-1", store.loadCashuRequests().first().id)
         assertEquals("req-1", store.currentCashuRequestId)
 
@@ -57,6 +74,7 @@ class StorageDataStoreInstrumentedTest {
         assertNull(store.activeMintURL)
         assertEquals(emptyList<MintInfo>(), store.loadMints())
         assertEquals(emptyList<String>(), store.loadProcessedNPCQuotes())
+        assertEquals(emptyMap<String, MintQuoteScheduleRecord>(), store.loadMintQuoteSchedules())
         assertEquals(emptyList<CashuRequest>(), store.loadCashuRequests())
         assertNull(store.currentCashuRequestId)
     }

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -173,6 +173,32 @@ class NativeWalletLocalMintInstrumentedTest {
             )
             assertEquals(PaymentMethodKind.Bolt12, LightningRequestParser.parse(bolt12.request).method)
 
+            step = "CDK BOLT12 paid-but-unissued restart recovery"
+            val paidBolt12 = bolt12.awaitPaid(payer.gateway)
+            val outstandingBolt12 = paidBolt12.amountPaid - paidBolt12.amountIssued
+            assertTrue(outstandingBolt12 > 0)
+            val balanceBeforeRecovery = payer.gateway.totalBalance(cdkMintUrl)
+
+            // Reopen the same native database before issuing. This is the app
+            // process-death boundary that previously left a paid quote behind.
+            val payerMnemonic = payer.mnemonic
+            payer.close()
+            payer.open(payerMnemonic)
+            assertTrue(
+                payer.gateway.listUnissuedMintQuotes().any { it.id == paidBolt12.id },
+            )
+            assertEquals(
+                outstandingBolt12,
+                payer.gateway.mintUnissuedQuotes(cdkMintUrl, "sat"),
+            )
+            val verifiedBolt12 = payer.gateway.checkMintQuote(paidBolt12.id)
+            assertEquals(verifiedBolt12.amountPaid, verifiedBolt12.amountIssued)
+            assertEquals(
+                balanceBeforeRecovery + outstandingBolt12,
+                payer.gateway.totalBalance(cdkMintUrl),
+            )
+            assertEquals(0L, payer.gateway.mintUnissuedQuotes(cdkMintUrl, "sat"))
+
             step = "CDK on-chain quote"
             val onchain = payer.gateway.createMintQuote(
                 amount = 5,

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -41,6 +41,56 @@ class NativeWalletLocalMintInstrumentedTest {
     }
 
     @Test
+    fun bolt12PaidButUnissuedQuoteRecoversAfterDatabaseReopen() = runBlocking {
+        assumeNativeMatrixEnabled()
+        assertMintEndpointReady(cdkMintUrl)
+        workDir.deleteRecursively()
+        workDir.mkdirs()
+
+        val payer = TestWallet("bolt12-recovery")
+        try {
+            payer.open()
+            payer.gateway.ensureWallet(cdkMintUrl)
+            val quote = payer.gateway.createMintQuote(
+                amount = null,
+                method = PaymentMethodKind.Bolt12,
+                mintUrl = cdkMintUrl,
+                unit = "sat",
+            )
+            assertEquals(PaymentMethodKind.Bolt12, LightningRequestParser.parse(quote.request).method)
+
+            val paid = quote.awaitPaid(payer.gateway)
+            val outstanding = paid.amountPaid - paid.amountIssued
+            assertTrue(outstanding > 0)
+            val balanceBeforeRecovery = payer.gateway.totalBalance(cdkMintUrl)
+
+            val payerMnemonic = payer.mnemonic
+            payer.close()
+            payer.open(payerMnemonic)
+
+            assertTrue(payer.gateway.listUnissuedMintQuotes().any { it.id == paid.id })
+            assertEquals(
+                outstanding,
+                payer.gateway.mintUnissuedQuotes(cdkMintUrl, "sat"),
+            )
+            val verified = payer.gateway.checkMintQuote(paid.id)
+            assertEquals(verified.amountPaid, verified.amountIssued)
+            assertEquals(
+                balanceBeforeRecovery + outstanding,
+                payer.gateway.totalBalance(cdkMintUrl),
+            )
+            assertEquals(0L, payer.gateway.mintUnissuedQuotes(cdkMintUrl, "sat"))
+
+            // This is deliberately the process-death boundary over the same
+            // durable database. A seed-only restore cannot discover a
+            // mint-generated quote id or its NUT-20 signing-key association;
+            // that requires an upstream/exported quote-backup format.
+        } finally {
+            payer.close()
+        }
+    }
+
+    @Test
     fun nativeCdkWalletMatrixAgainstLocalMints() = runBlocking {
         assumeNativeMatrixEnabled()
         assertMintEndpointReady(nutshellMintUrl)
@@ -181,6 +231,10 @@ class NativeWalletLocalMintInstrumentedTest {
 
             // Reopen the same native database before issuing. This is the app
             // process-death boundary that previously left a paid quote behind.
+            // It is not a seed-only restore into an empty database: NUT-09
+            // cannot discover the mint-generated quote id, and BOLT12 issuance
+            // also needs the stored NUT-20 signing-key association. That needs
+            // a CDK/exported quote-backup format before it can be tested here.
             val payerMnemonic = payer.mnemonic
             payer.close()
             payer.open(payerMnemonic)

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -26,7 +26,6 @@ import org.junit.Assume.assumeTrue
 import org.junit.Test
 import com.cashu.me.test.FullOnly
 
-@FullOnly
 class NativeWalletLocalMintInstrumentedTest {
     private val args = InstrumentationRegistry.getArguments()
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
@@ -90,6 +89,7 @@ class NativeWalletLocalMintInstrumentedTest {
         }
     }
 
+    @FullOnly
     @Test
     fun nativeCdkWalletMatrixAgainstLocalMints() = runBlocking {
         assumeNativeMatrixEnabled()

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -26,6 +26,7 @@ import com.cashu.me.Models.WalletTransaction
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
 
 /**
  * Stateful deterministic native-wallet replacement used only by app-level
@@ -177,8 +178,9 @@ class FakeWalletGateway(
     override suspend fun checkMintQuote(quoteId: String): MintQuoteInfo =
         checkNotNull(mintQuotes[quoteId]) { "Unknown fake quote $quoteId" }.value
 
-    override fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> =
+    override fun subscribeToMintQuote(quoteId: String, mayRefresh: () -> Boolean): Flow<MintQuoteInfo> =
         checkNotNull(mintQuotes[quoteId]) { "Unknown fake quote $quoteId" }
+            .filter { mayRefresh() }
 
     override suspend fun listUnissuedMintQuotes(): List<MintQuoteInfo> =
         mintQuotes.values.map { it.value }.filter { it.state != MintQuoteState.Issued }

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -53,6 +53,10 @@ interface CdkWalletGateway {
     suspend fun unitBalanceIfExists(mintUrl: String, unit: String): Long?
     suspend fun createMintQuote(amount: Long?, method: PaymentMethodKind, mintUrl: String, unit: String = "sat"): MintQuoteInfo
     suspend fun checkMintQuote(quoteId: String): MintQuoteInfo
+
+    /** Last durable local quote snapshot, without contacting the mint. */
+    suspend fun storedMintQuote(quoteId: String): MintQuoteInfo? = null
+
     fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo>
     suspend fun listUnissuedMintQuotes(): List<MintQuoteInfo>
     suspend fun mintTokens(quoteId: String): Long

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -57,7 +57,9 @@ interface CdkWalletGateway {
     /** Last durable local quote snapshot, without contacting the mint. */
     suspend fun storedMintQuote(quoteId: String): MintQuoteInfo? = null
 
-    fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo>
+    /** Push updates may trigger CDK saga recovery, so callers can defer the
+     * network refresh while their persisted retry deadline is in the future. */
+    fun subscribeToMintQuote(quoteId: String, mayRefresh: () -> Boolean = { true }): Flow<MintQuoteInfo>
     suspend fun listUnissuedMintQuotes(): List<MintQuoteInfo>
     suspend fun mintTokens(quoteId: String): Long
     suspend fun mintNPCQuote(quote: NPCQuote, p2pkPubkey: String?): Long

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -42,6 +42,7 @@ import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
 import org.cashudevkit.FinalizedMelt as CdkFinalizedMelt
 import org.cashudevkit.KeysetLoadPolicy as CdkKeysetLoadPolicy
 import org.cashudevkit.MeltConfirmOutcome as CdkMeltConfirmOutcome
+import org.cashudevkit.MeltOptions as CdkMeltOptions
 import org.cashudevkit.MeltQuote as CdkMeltQuote
 import org.cashudevkit.MintInfo as CdkMintInfo
 import org.cashudevkit.MintQuote as CdkMintQuote
@@ -108,6 +109,30 @@ internal suspend fun awaitLightningSettlementOrNull(
     } catch (_: Exception) {
         null
     }
+}
+
+/** Builds CDK's explicit amount override for amountless Lightning requests. */
+internal fun meltOptionsForLightningRequest(
+    decoded: PaymentRequestDecodeResult,
+    amountSats: Long?,
+): CdkMeltOptions? {
+    val requestAmountSats = when (decoded) {
+        is PaymentRequestDecodeResult.Bolt11 -> decoded.amountSats
+        is PaymentRequestDecodeResult.Bolt12 -> decoded.amountSats
+        else -> return null
+    }
+    if (requestAmountSats != null && requestAmountSats > 0L) return null
+
+    val amount = amountSats?.takeIf { it > 0L }
+        ?: throw CdkGatewayUnavailable(
+            "This Lightning request doesn't include an amount. Enter an amount before requesting a quote.",
+        )
+    val amountMsat = try {
+        Math.multiplyExact(amount, 1_000L)
+    } catch (_: ArithmeticException) {
+        throw CdkGatewayUnavailable("Amount is too large.")
+    }
+    return CdkMeltOptions.Amountless(CdkAmount(amountMsat.toULong()))
 }
 
 class CdkWalletGatewayImpl : WalletGateway {
@@ -360,7 +385,17 @@ class CdkWalletGatewayImpl : WalletGateway {
                     "(amount_paid=${normalizedQuote.amountPaid.value}, amount_issued=${normalizedQuote.amountIssued.value}).",
             )
         }
-        normalizedQuote.usedByOperation?.let { releaseMintQuoteReservation(it, quoteId) }
+        if (normalizedQuote.usedByOperation != null) {
+            // The live CDK saga owns the deterministic secrets required to
+            // replay or restore an ambiguous mint response. Deleting it and
+            // issuing fresh outputs can strand a payment the mint already
+            // marked issued. Quote checks resume sagas; leave this one intact
+            // for the next reconciliation pass when recovery is unavailable.
+            throw CdkGatewayUnavailable(
+                "A previous mint attempt is still being recovered. " +
+                    "The wallet will retry automatically.",
+            )
+        }
         val proofs = walletFor(normalizedQuote.mintUrl.url, normalizedQuote.unit).mintUnified(
             quoteId = quoteId,
             amountSplitTarget = CdkSplitTarget.None,
@@ -384,7 +419,8 @@ class CdkWalletGatewayImpl : WalletGateway {
 
     override suspend fun createMeltQuote(request: String, amountSats: Long?, preferredMintURL: String?): MeltQuoteInfo = cdkCall {
         val wallet = preferredMintURL?.let { walletFor(it) } ?: firstWallet()
-        when (val decoded = PaymentRequestDecoder.decode(request)) {
+        val decoded = PaymentRequestDecoder.decode(request)
+        when (decoded) {
             is PaymentRequestDecodeResult.LightningAddress -> {
                 val amount = requirePositiveAmount(amountSats, "Lightning address payments require an amount.")
                 val amountMsat = try {
@@ -435,10 +471,11 @@ class CdkWalletGatewayImpl : WalletGateway {
         }
         val method = PaymentRequestParser.paymentMethod(request) ?: PaymentMethodKind.Bolt11
         val normalized = PaymentRequestDecoder.encodedLightningRequest(request) ?: request.trim()
+        val options = meltOptionsForLightningRequest(decoded, amountSats)
         val quote = wallet.meltQuote(
             method = cdkPaymentMethod(method),
             request = normalized,
-            options = null,
+            options = options,
             extra = null,
         )
         quote.toDomain(fallbackMethod = method)
@@ -971,17 +1008,6 @@ class CdkWalletGatewayImpl : WalletGateway {
         val saga = runCatching { database?.getSaga(operationId) }.getOrNull()
         if (saga != null) return this
         return clearingReservation()
-    }
-
-    private suspend fun releaseMintQuoteReservation(operationId: String, quoteId: String) {
-        runCatching {
-            database?.releaseMintQuote(operationId)
-            runCatching { database?.deleteSaga(operationId) }
-            val refreshed = database?.getMintQuote(quoteId)
-            if (refreshed?.usedByOperation != null) {
-                replaceStoredMintQuote(refreshed.clearingReservation())
-            }
-        }
     }
 
     private suspend fun replaceStoredMintQuote(quote: CdkMintQuote) {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -335,7 +335,7 @@ class CdkWalletGatewayImpl : WalletGateway {
         }
     }
 
-    override fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> = flow {
+    override fun subscribeToMintQuote(quoteId: String, mayRefresh: () -> Boolean): Flow<MintQuoteInfo> = flow {
         val subscription = cdkCall {
             val quote = database?.getMintQuote(quoteId)
                 ?: throw CdkGatewayUnavailable("No stored mint quote for $quoteId.")
@@ -347,6 +347,7 @@ class CdkWalletGatewayImpl : WalletGateway {
             while (true) {
                 val payload = withContext(Dispatchers.IO) { subscription.recv() }
                 if (!payload.referencesMintQuote(quoteId)) continue
+                if (!mayRefresh()) continue
                 val refreshed = checkMintQuote(quoteId)
                 emit(refreshed)
                 // An amountless BOLT12 offer remains open after each mint. Keep

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -325,6 +325,16 @@ class CdkWalletGatewayImpl : WalletGateway {
         )
     }
 
+    override suspend fun storedMintQuote(quoteId: String): MintQuoteInfo? = cdkCall {
+        database?.getMintQuote(quoteId)?.let { quote ->
+            val method = quote.paymentMethod.toDomain()
+            quote.withLocalMintQuoteMetadata(method).toDomain(
+                fallbackAmount = quote.amount?.value?.toLong(),
+                fallbackMethod = method,
+            )
+        }
+    }
+
     override fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> = flow {
         val subscription = cdkCall {
             val quote = database?.getMintQuote(quoteId)

--- a/android/app/src/main/java/com/cashu/me/Core/LightningRequestParser.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/LightningRequestParser.kt
@@ -1,6 +1,8 @@
 package com.cashu.me.Core
 
 import com.cashu.me.Models.PaymentMethodKind
+import java.nio.ByteBuffer
+import java.nio.charset.CodingErrorAction
 
 data class ParsedLightningRequest(
     val request: String,
@@ -11,12 +13,15 @@ data class ParsedLightningRequest(
 
 object LightningRequestParser {
     private val bolt11Prefixes = listOf("lnbc", "lntb", "lnbcrt", "lnsb")
-    private val bolt12Prefixes = listOf("lno", "lni")
+    private const val bolt12Alphabet = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+    private val bolt12Values = bolt12Alphabet.withIndex().associate { (index, character) -> character to index }
+    private val knownOfferTypes = setOf(2uL, 4uL, 6uL, 8uL, 10uL, 12uL, 14uL, 16uL, 18uL, 20uL, 22uL)
+    private const val maximumBitcoinAmountMsat = 2_100_000_000_000_000_000uL
 
     fun parse(raw: String): ParsedLightningRequest {
         val request = PaymentRequestParser.normalizeLightningRequest(raw)
+        parseBolt12Offer(request)?.let { return it }
         return when {
-            isBolt12(request) -> ParsedLightningRequest(request, PaymentMethodKind.Bolt12)
             isBolt11(request) -> ParsedLightningRequest(
                 request = request,
                 method = PaymentMethodKind.Bolt11,
@@ -33,10 +38,180 @@ object LightningRequestParser {
         return bolt11Prefixes.any { lower.startsWith(it) }
     }
 
-    fun isBolt12(raw: String): Boolean {
-        val lower = PaymentRequestParser.normalizeLightningRequest(raw).lowercase()
-        return bolt12Prefixes.any { lower.startsWith(it) }
+    fun isBolt12(raw: String): Boolean = parseBolt12Offer(raw) != null
+
+    /**
+     * Parses the BOLT12 text envelope and the offer TLVs needed by Send. CDK's
+     * decoder currently rejects valid amountless offers whose description is
+     * empty, even though BOLT12 permits them. CDK still performs the final
+     * protocol validation when the wallet requests a quote.
+     */
+    fun parseBolt12Offer(raw: String): ParsedLightningRequest? {
+        val request = normalizeBolt12Offer(raw) ?: return null
+        if (!request.startsWith("lno1")) return null
+        val encoded = request.drop(4)
+        if (encoded.isEmpty()) return null
+        val values = encoded.map { bolt12Values[it] ?: return null }
+        val bytes = convertBolt12Bits(values) ?: return null
+
+        var cursor = 0
+        var previousType: ULong? = null
+        var amountMsat: ULong? = null
+        var sawAmount = false
+        var sawDescription = false
+        var sawCurrency = false
+        var description: String? = null
+        var hasPaths = false
+        var hasIssuerId = false
+
+        while (cursor < bytes.size) {
+            val (type, afterType) = readBigSize(bytes, cursor) ?: return null
+            val (length, afterLength) = readBigSize(bytes, afterType) ?: return null
+            if (previousType != null && type <= previousType) return null
+            previousType = type
+            if (type !in 1uL..79uL && type !in 1_000_000_000uL..1_999_999_999uL) return null
+            // Unknown odd records are optional extensions; unknown even
+            // records are mandatory and make the offer unreadable.
+            if (type % 2uL == 0uL && type !in knownOfferTypes) return null
+            if (length > (bytes.size - afterLength).toULong()) return null
+
+            val fieldEnd = afterLength + length.toInt()
+            val field = bytes.copyOfRange(afterLength, fieldEnd)
+            cursor = fieldEnd
+
+            when (type) {
+                2uL -> if (field.isEmpty() || field.size % 32 != 0) return null
+                6uL -> {
+                    if (field.size != 3 || field.any { (it.toInt() and 0xff) !in 65..90 }) return null
+                    sawCurrency = true
+                }
+                8uL -> {
+                    val value = decodeTruncatedULong(field) ?: return null
+                    if (value == 0uL || value > maximumBitcoinAmountMsat) return null
+                    sawAmount = true
+                    amountMsat = value
+                }
+                10uL -> {
+                    val value = decodeUtf8(field) ?: return null
+                    sawDescription = true
+                    description = value.ifEmpty { null }
+                }
+                14uL, 20uL -> decodeTruncatedULong(field) ?: return null
+                16uL -> hasPaths = field.isNotEmpty()
+                18uL -> decodeUtf8(field) ?: return null
+                22uL -> {
+                    val prefix = field.firstOrNull()?.toInt()?.and(0xff)
+                    if (field.size != 33 || prefix !in setOf(0x02, 0x03)) return null
+                    hasIssuerId = true
+                }
+            }
+        }
+
+        if ((!hasPaths && !hasIssuerId) || (sawAmount && !sawDescription) || (sawCurrency && !sawAmount)) {
+            return null
+        }
+        // Currency-denominated offer amounts are not millisatoshis. Leave
+        // those to CDK rather than treating them as amountless.
+        if (sawCurrency) return null
+
+        val amountSats = amountMsat?.let { millisatoshis ->
+            val sats = millisatoshis / 1_000uL + if (millisatoshis % 1_000uL == 0uL) 0uL else 1uL
+            if (sats > Long.MAX_VALUE.toULong()) return null
+            sats.toLong()
+        }
+        return ParsedLightningRequest(
+            request = request,
+            method = PaymentMethodKind.Bolt12,
+            amountSats = amountSats,
+            description = description,
+        )
     }
+
+    private fun normalizeBolt12Offer(raw: String): String? {
+        val input = PaymentRequestParser.normalizeLightningRequest(raw).trim()
+        if (input.isEmpty()) return null
+
+        val compact = StringBuilder(input.length)
+        var index = 0
+        while (index < input.length) {
+            val character = input[index]
+            if (character == '+') {
+                if (compact.isEmpty() || !isBolt12DataCharacter(compact.last())) return null
+                index += 1
+                while (index < input.length && input[index].isWhitespace()) index += 1
+                if (index >= input.length || !isBolt12DataCharacter(input[index])) {
+                    return null
+                }
+                continue
+            }
+            if (character.isWhitespace()) return null
+            compact.append(character)
+            index += 1
+        }
+
+        val text = compact.toString()
+        if (text.any(Char::isLowerCase) && text.any(Char::isUpperCase)) return null
+        return text.lowercase()
+    }
+
+    private fun isBolt12DataCharacter(character: Char): Boolean =
+        character.lowercaseChar() in bolt12Alphabet
+
+    private fun convertBolt12Bits(values: List<Int>): ByteArray? {
+        var accumulator = 0
+        var bitCount = 0
+        val output = ArrayList<Byte>()
+        values.forEach { value ->
+            if (value !in 0..31) return null
+            accumulator = ((accumulator shl 5) or value) and 0x0fff
+            bitCount += 5
+            while (bitCount >= 8) {
+                bitCount -= 8
+                output += ((accumulator shr bitCount) and 0xff).toByte()
+            }
+        }
+        if (bitCount >= 5 || ((accumulator shl (8 - bitCount)) and 0xff) != 0) return null
+        return output.toByteArray()
+    }
+
+    private fun readBigSize(bytes: ByteArray, start: Int): Pair<ULong, Int>? {
+        if (start !in bytes.indices) return null
+        val marker = bytes[start].toInt() and 0xff
+        if (marker < 0xfd) return marker.toULong() to start + 1
+
+        val byteCount = when (marker) {
+            0xfd -> 2
+            0xfe -> 4
+            else -> 8
+        }
+        val end = start + 1 + byteCount
+        if (end > bytes.size) return null
+        var value = 0uL
+        for (index in start + 1 until end) {
+            value = (value shl 8) or (bytes[index].toInt() and 0xff).toULong()
+        }
+        val minimum = when (marker) {
+            0xfd -> 0xfduL
+            0xfe -> 0x1_0000uL
+            else -> 0x1_0000_0000uL
+        }
+        return if (value >= minimum) value to end else null
+    }
+
+    private fun decodeTruncatedULong(bytes: ByteArray): ULong? {
+        if (bytes.size > 8 || (bytes.isNotEmpty() && bytes.first() == 0.toByte())) return null
+        return bytes.fold(0uL) { value, byte ->
+            (value shl 8) or (byte.toInt() and 0xff).toULong()
+        }
+    }
+
+    private fun decodeUtf8(bytes: ByteArray): String? = runCatching {
+        Charsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(bytes))
+            .toString()
+    }.getOrNull()
 
     private fun parseBolt11AmountSats(invoice: String): Long? {
         val lower = invoice.lowercase()

--- a/android/app/src/main/java/com/cashu/me/Core/MintQuoteSchedulePolicy.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintQuoteSchedulePolicy.kt
@@ -37,6 +37,7 @@ internal object MintQuoteSchedulePolicy {
         existing: Map<String, MintQuoteScheduleRecord>,
         nowEpochMillis: Long,
         force: Boolean,
+        unsettledOnchainQuoteIds: Set<String> = emptySet(),
     ): Selection {
         val uniqueIds = quoteIds.asSequence().filter(String::isNotBlank).toSet()
         val records = existing
@@ -48,6 +49,13 @@ internal object MintQuoteSchedulePolicy {
                 quoteId,
                 MintQuoteScheduleRecord(firstObservedAtEpochMillis = nowEpochMillis),
             )
+        }
+        // Reopen schedules created by the old expiry policy while a deposit
+        // was still waiting for confirmations. CDK remains the source of truth.
+        unsettledOnchainQuoteIds.forEach { quoteId ->
+            records[quoteId]?.takeIf { it.isComplete }?.let { record ->
+                records[quoteId] = record.copy(isComplete = false, nextAttemptAtEpochMillis = 0)
+            }
         }
 
         val limit = if (force) FORCED_BATCH_LIMIT else PASSIVE_BATCH_LIMIT
@@ -68,9 +76,14 @@ internal object MintQuoteSchedulePolicy {
         // cancelled halfway through, the same first row cannot starve all
         // later rows on the next foreground tick.
         selected.forEach { quoteId ->
-            records[quoteId] = checkNotNull(records[quoteId]).copy(
+            val record = checkNotNull(records[quoteId])
+            records[quoteId] = record.copy(
                 lastAttemptAtEpochMillis = nowEpochMillis,
-                nextAttemptAtEpochMillis = nowEpochMillis + FAILURE_DELAYS_MS.first(),
+                nextAttemptAtEpochMillis = if (record.consecutiveFailures == 0) {
+                    nowEpochMillis + FAILURE_DELAYS_MS.first()
+                } else {
+                    record.nextAttemptAtEpochMillis
+                },
             )
         }
         return Selection(selected, records)
@@ -89,8 +102,10 @@ internal object MintQuoteSchedulePolicy {
             ?.takeIf { it > 0 }
             ?.let { nowEpochMillis / 1_000 >= it }
             ?: false
+        // Deposits seen before an on-chain quote expires can confirm later.
+        val expiredInvoice = quote.paymentMethod == PaymentMethodKind.Bolt11 && expired
         val complete = !reusable && (
-            expired || quote.state == MintQuoteState.Issued || quote.hasSettledPayment
+            expiredInvoice || quote.state == MintQuoteState.Issued || quote.hasSettledPayment
         )
         val age = (nowEpochMillis - record.firstObservedAtEpochMillis).coerceAtLeast(0)
         val nextInterval = if (age < RECENT_QUOTE_WINDOW_MS) {
@@ -132,6 +147,10 @@ internal object MintQuoteSchedulePolicy {
             isComplete = false,
         )
     }
+
+    fun shouldAttempt(record: MintQuoteScheduleRecord?, nowEpochMillis: Long, force: Boolean): Boolean =
+        force || record == null || record.consecutiveFailures == 0 ||
+            record.nextAttemptAtEpochMillis <= nowEpochMillis
 
     fun retryStatus(record: MintQuoteScheduleRecord): MintQuoteRetryStatus {
         if (!record.hadOutstandingPayment || record.consecutiveFailures == 0) {

--- a/android/app/src/main/java/com/cashu/me/Core/MintQuoteSchedulePolicy.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/MintQuoteSchedulePolicy.kt
@@ -1,0 +1,150 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteRetryState
+import com.cashu.me.Models.MintQuoteRetryStatus
+import com.cashu.me.Models.MintQuoteScheduleRecord
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+
+/**
+ * Pure policy for the app-wide mint-quote sweeper. It deliberately separates
+ * scheduling from CDK's quote ledger: losing or corrupting this metadata may
+ * cause an early check, but can never change how much ecash may be issued.
+ */
+internal object MintQuoteSchedulePolicy {
+    const val PASSIVE_BATCH_LIMIT = 2
+    const val FORCED_BATCH_LIMIT = 20
+    private const val RECENT_QUOTE_WINDOW_MS = 2 * 60_000L
+    private const val RECENT_QUOTE_INTERVAL_MS = 10_000L
+    private const val IDLE_QUOTE_INTERVAL_MS = 60_000L
+    private const val NEEDS_ATTENTION_FAILURE_COUNT = 4
+    private val FAILURE_DELAYS_MS = longArrayOf(
+        5_000L,
+        15_000L,
+        30_000L,
+        60_000L,
+        5 * 60_000L,
+    )
+
+    data class Selection(
+        val quoteIds: List<String>,
+        val records: Map<String, MintQuoteScheduleRecord>,
+    )
+
+    fun select(
+        quoteIds: Collection<String>,
+        existing: Map<String, MintQuoteScheduleRecord>,
+        nowEpochMillis: Long,
+        force: Boolean,
+    ): Selection {
+        val uniqueIds = quoteIds.asSequence().filter(String::isNotBlank).toSet()
+        val records = existing
+            .filterKeys { it in uniqueIds }
+            .toMutableMap()
+
+        uniqueIds.forEach { quoteId ->
+            records.putIfAbsent(
+                quoteId,
+                MintQuoteScheduleRecord(firstObservedAtEpochMillis = nowEpochMillis),
+            )
+        }
+
+        val limit = if (force) FORCED_BATCH_LIMIT else PASSIVE_BATCH_LIMIT
+        val selected = uniqueIds.asSequence()
+            .filter { quoteId ->
+                val record = checkNotNull(records[quoteId])
+                !record.isComplete && (force || record.nextAttemptAtEpochMillis <= nowEpochMillis)
+            }
+            .sortedWith(
+                compareBy<String> { records[it]?.lastAttemptAtEpochMillis ?: Long.MIN_VALUE }
+                    .thenBy { records[it]?.nextAttemptAtEpochMillis ?: Long.MIN_VALUE }
+                    .thenBy { it },
+            )
+            .take(limit)
+            .toList()
+
+        // Reserve the selected slice before network work. If the coroutine is
+        // cancelled halfway through, the same first row cannot starve all
+        // later rows on the next foreground tick.
+        selected.forEach { quoteId ->
+            records[quoteId] = checkNotNull(records[quoteId]).copy(
+                lastAttemptAtEpochMillis = nowEpochMillis,
+                nextAttemptAtEpochMillis = nowEpochMillis + FAILURE_DELAYS_MS.first(),
+            )
+        }
+        return Selection(selected, records)
+    }
+
+    fun observed(
+        previous: MintQuoteScheduleRecord?,
+        quote: MintQuoteInfo,
+        nowEpochMillis: Long,
+    ): MintQuoteScheduleRecord {
+        val record = previous ?: MintQuoteScheduleRecord(
+            firstObservedAtEpochMillis = nowEpochMillis,
+        )
+        val reusable = quote.paymentMethod == PaymentMethodKind.Bolt12
+        val expired = quote.expiryEpochSeconds
+            ?.takeIf { it > 0 }
+            ?.let { nowEpochMillis / 1_000 >= it }
+            ?: false
+        val complete = !reusable && (
+            expired || quote.state == MintQuoteState.Issued || quote.hasSettledPayment
+        )
+        val age = (nowEpochMillis - record.firstObservedAtEpochMillis).coerceAtLeast(0)
+        val nextInterval = if (age < RECENT_QUOTE_WINDOW_MS) {
+            RECENT_QUOTE_INTERVAL_MS
+        } else {
+            IDLE_QUOTE_INTERVAL_MS
+        }
+        return record.copy(
+            lastAttemptAtEpochMillis = nowEpochMillis,
+            nextAttemptAtEpochMillis = if (complete) Long.MAX_VALUE else nowEpochMillis + nextInterval,
+            consecutiveFailures = 0,
+            hadOutstandingPayment = false,
+            isReusable = reusable,
+            isComplete = complete,
+        )
+    }
+
+    fun failed(
+        previous: MintQuoteScheduleRecord?,
+        nowEpochMillis: Long,
+        hadOutstandingPayment: Boolean,
+        isReusable: Boolean,
+    ): MintQuoteScheduleRecord {
+        val record = previous ?: MintQuoteScheduleRecord(
+            firstObservedAtEpochMillis = nowEpochMillis,
+        )
+        val failures = if (record.consecutiveFailures == Int.MAX_VALUE) {
+            Int.MAX_VALUE
+        } else {
+            record.consecutiveFailures + 1
+        }
+        val delay = FAILURE_DELAYS_MS[(failures - 1).coerceAtMost(FAILURE_DELAYS_MS.lastIndex)]
+        return record.copy(
+            lastAttemptAtEpochMillis = nowEpochMillis,
+            nextAttemptAtEpochMillis = nowEpochMillis + delay,
+            consecutiveFailures = failures,
+            hadOutstandingPayment = hadOutstandingPayment || record.hadOutstandingPayment,
+            isReusable = isReusable || record.isReusable,
+            isComplete = false,
+        )
+    }
+
+    fun retryStatus(record: MintQuoteScheduleRecord): MintQuoteRetryStatus {
+        if (!record.hadOutstandingPayment || record.consecutiveFailures == 0) {
+            return MintQuoteRetryStatus()
+        }
+        return MintQuoteRetryStatus(
+            state = if (record.consecutiveFailures >= NEEDS_ATTENTION_FAILURE_COUNT) {
+                MintQuoteRetryState.NeedsAttention
+            } else {
+                MintQuoteRetryState.RetryScheduled
+            },
+            nextRetryAtEpochMillis = record.nextAttemptAtEpochMillis,
+            failureCount = record.consecutiveFailures,
+        )
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/PaymentRequestDecoder.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PaymentRequestDecoder.kt
@@ -68,6 +68,9 @@ object PaymentRequestParser {
                 CdkPaymentType.BOLT12 -> PaymentMethodKind.Bolt12
             }
         }
+        if (LightningRequestParser.parseBolt12Offer(normalized) != null) {
+            return PaymentMethodKind.Bolt12
+        }
         if (isBitcoinAddress(request)) return PaymentMethodKind.Onchain
         return null
     }
@@ -108,8 +111,12 @@ object PaymentRequestDecoder {
     fun encodedLightningRequest(raw: String): String? {
         val trimmed = raw.trim()
         if (trimmed.isEmpty()) return null
-        bitcoinPaymentURI(trimmed)?.lightning?.let { return PaymentRequestParser.normalizeLightningRequest(it) }
+        bitcoinPaymentURI(trimmed)?.lightning?.let { embedded ->
+            val normalized = PaymentRequestParser.normalizeLightningRequest(embedded)
+            return LightningRequestParser.parseBolt12Offer(normalized)?.request ?: normalized
+        }
         val normalized = PaymentRequestParser.normalizeLightningRequest(trimmed)
+        LightningRequestParser.parseBolt12Offer(normalized)?.let { return it.request }
         return if (runCatching { decodeInvoice(normalized) }.isSuccess) normalized else null
     }
 
@@ -150,12 +157,15 @@ object PaymentRequestDecoder {
 
     private fun decodedLightningRequest(raw: String): PaymentRequestDecodeResult? {
         val normalized = encodedLightningRequest(raw) ?: return null
-        val decoded = runCatching { decodeInvoice(normalized) }.getOrNull() ?: return null
-        val amountSats = decoded.amountMsat?.let { (it.toLong() + 999) / 1000 }
-        return when (decoded.paymentType) {
-            CdkPaymentType.BOLT11 -> PaymentRequestDecodeResult.Bolt11(amountSats, decoded.description)
-            CdkPaymentType.BOLT12 -> PaymentRequestDecodeResult.Bolt12(amountSats, decoded.description)
+        runCatching { decodeInvoice(normalized) }.getOrNull()?.let { decoded ->
+            val amountSats = decoded.amountMsat?.let { (it.toLong() + 999) / 1000 }
+            return when (decoded.paymentType) {
+                CdkPaymentType.BOLT11 -> PaymentRequestDecodeResult.Bolt11(amountSats, decoded.description)
+                CdkPaymentType.BOLT12 -> PaymentRequestDecodeResult.Bolt12(amountSats, decoded.description)
+            }
         }
+        val offer = LightningRequestParser.parseBolt12Offer(normalized) ?: return null
+        return PaymentRequestDecodeResult.Bolt12(offer.amountSats, offer.description)
     }
 
     fun amountLocked(result: PaymentRequestDecodeResult): Boolean = when (result) {

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -53,6 +53,7 @@ object StorageKeys {
     const val walletSavedTokens = "wallet.savedTokens"
     const val walletPaymentPreimages = "wallet.paymentPreimages"
     const val walletMintQuoteTimestamps = "wallet.mintQuoteTimestamps"
+    const val walletMintQuoteSchedules = "wallet.mintQuoteSchedules.v1"
     const val walletProcessedNPCQuotes = "wallet.processedNPCQuotes"
     const val walletProcessedCashuRequests = "wallet.processedCashuRequests"
     const val walletProcessedNip17GiftWraps = "wallet.processedNip17GiftWraps"
@@ -144,6 +145,7 @@ object StorageKeys {
         walletSavedTokens,
         walletPaymentPreimages,
         walletMintQuoteTimestamps,
+        walletMintQuoteSchedules,
         walletProcessedNPCQuotes,
         walletProcessedCashuRequests,
         walletProcessedNip17GiftWraps,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -600,7 +600,8 @@ class WalletManager(
             mintQuoteSyncService.rememberMintQuoteTimestamp(it.id)
         }
 
-    fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> = gateway.subscribeToMintQuote(quoteId)
+    fun subscribeToMintQuote(quoteId: String): Flow<MintQuoteInfo> =
+        gateway.subscribeToMintQuote(quoteId) { mintQuoteSyncService.shouldAttempt(quoteId) }
 
     override suspend fun mintTokens(quoteId: String): Long =
         mintTokens(
@@ -632,9 +633,12 @@ class WalletManager(
     internal suspend fun refreshPendingMintQuote(
         quoteId: String,
         confirmationOwner: ReceiveConfirmationOwner,
+        force: Boolean = false,
     ): MintQuoteSyncResult {
-        val result = mintQuoteSyncService.syncPendingMintQuote(quoteId)
-        if (result.minted) refreshBalance()
+        val result = mintQuoteSyncService.syncPendingMintQuote(quoteId, force)
+        // A prior status poll or websocket check may already have recovered
+        // the issue saga. Re-read balances for an already-settled receive too.
+        if (result.minted || result.hasSettledPayment) refreshBalance()
         loadTransactions()
         result.receivedAmount?.let { amount ->
             publishReceivedPayment(amount, result.unit, confirmationOwner)
@@ -645,6 +649,9 @@ class WalletManager(
     /** Advisory UI state only; NUT-25 paid/issued counters remain authoritative. */
     internal fun mintQuoteRetryStatus(quoteId: String) =
         mintQuoteSyncService.retryStatus(quoteId)
+
+    internal fun shouldAttemptMintQuote(quoteId: String): Boolean =
+        mintQuoteSyncService.shouldAttempt(quoteId)
 
     /**
      * Cooldown-gated sync for passive triggers (app start, resume, History
@@ -683,20 +690,26 @@ class WalletManager(
         }
         lastMintQuoteSyncAtMs.set(System.currentTimeMillis())
         try {
-            val databaseQuoteIds = runCatching { gateway.listUnissuedMintQuotes().map { it.id } }
+            val databaseQuotes = runCatching { gateway.listUnissuedMintQuotes() }
                 .onFailure { AppLogger.wallet.error("Mint quote ledger scan failed", it) }
                 .getOrDefault(emptyList())
             // App intents are a second durable index. Usually these IDs are
             // already in CDK's list; the union also surfaces a missing local
             // quote instead of silently dropping an older/migrated offer.
             val intentQuoteIds = cashuRequestStore.state.value.requests.mapNotNull { it.quoteId }
-            val quoteIds = (databaseQuoteIds + intentQuoteIds).distinct().sorted()
-            val selectedQuoteIds = mintQuoteSyncService.selectQuoteIdsForSync(quoteIds, force)
+            val quoteIds = (databaseQuotes.map { it.id } + intentQuoteIds).distinct().sorted()
+            val selectedQuoteIds = mintQuoteSyncService.selectQuoteIdsForSync(
+                quoteIds,
+                force,
+                unsettledOnchainQuoteIds = databaseQuotes.filter {
+                    it.paymentMethod == PaymentMethodKind.Onchain && it.amountIssued == 0L
+                }.map { it.id }.toSet(),
+            )
             if (selectedQuoteIds.isEmpty()) return 0
 
             var mintedQuotes = 0
             selectedQuoteIds.forEach { quoteId ->
-                val result = mintQuoteSyncService.syncPendingMintQuote(quoteId)
+                val result = mintQuoteSyncService.syncPendingMintQuote(quoteId, force)
                 result.receivedAmount?.let { amount ->
                     mintedQuotes += 1
                     publishReceivedPayment(

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -3,7 +3,6 @@ package com.cashu.me.Core
 import java.net.URL
 import java.text.Normalizer
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -25,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 import org.cashudevkit.PendingMelt
 import org.cashudevkit.QuoteState as CdkQuoteState
 import org.cashudevkit.npubcashDeriveSecretKeyFromSeed
@@ -103,7 +103,7 @@ class WalletManager(
     // calls [syncPendingMintQuotes] directly to bypass the cooldown.
     // Atomic: startup maintenance runs on Dispatchers.IO while the foreground
     // poll runs on the main-scoped job.
-    private val isSyncingMintQuotes = AtomicBoolean(false)
+    private val mintQuoteSweepMutex = Mutex()
     // 0 = never synced. Written/read across the IO + Main poll jobs.
     private val lastMintQuoteSyncAtMs = AtomicLong(0L)
 
@@ -642,6 +642,10 @@ class WalletManager(
         return result
     }
 
+    /** Advisory UI state only; NUT-25 paid/issued counters remain authoritative. */
+    internal fun mintQuoteRetryStatus(quoteId: String) =
+        mintQuoteSyncService.retryStatus(quoteId)
+
     /**
      * Cooldown-gated sync for passive triggers (app start, resume, History
      * open, the foreground poll). Skips when a sync ran within
@@ -668,8 +672,15 @@ class WalletManager(
      *   it preempts cooldown gating (explicit user intent).
      */
     suspend fun syncPendingMintQuotes(force: Boolean = false): Int {
-        // Coarse in-flight guard: collapse overlapping triggers into one pass.
-        if (!isSyncingMintQuotes.compareAndSet(false, true)) return 0
+        // Passive triggers collapse while an existing pass is active. An
+        // explicit user refresh waits its turn instead of being silently
+        // discarded — this makes `force` real rather than a documentation-only
+        // parameter and matches iOS's coordinated forced lane.
+        if (force) {
+            mintQuoteSweepMutex.lock()
+        } else if (!mintQuoteSweepMutex.tryLock()) {
+            return 0
+        }
         lastMintQuoteSyncAtMs.set(System.currentTimeMillis())
         try {
             val databaseQuoteIds = runCatching { gateway.listUnissuedMintQuotes().map { it.id } }
@@ -680,9 +691,11 @@ class WalletManager(
             // quote instead of silently dropping an older/migrated offer.
             val intentQuoteIds = cashuRequestStore.state.value.requests.mapNotNull { it.quoteId }
             val quoteIds = (databaseQuoteIds + intentQuoteIds).distinct().sorted()
+            val selectedQuoteIds = mintQuoteSyncService.selectQuoteIdsForSync(quoteIds, force)
+            if (selectedQuoteIds.isEmpty()) return 0
 
             var mintedQuotes = 0
-            quoteIds.forEach { quoteId ->
+            selectedQuoteIds.forEach { quoteId ->
                 val result = mintQuoteSyncService.syncPendingMintQuote(quoteId)
                 result.receivedAmount?.let { amount ->
                     mintedQuotes += 1
@@ -692,12 +705,16 @@ class WalletManager(
                         confirmationOwner = ReceiveConfirmationOwner.Home,
                     )
                 }
+                // Each gateway call releases its native mutex. Yield between
+                // rows so foreground user work can acquire it before the next
+                // maintenance quote; the passive batch itself is capped at two.
+                if (!force) yield()
             }
             if (mintedQuotes > 0) refreshBalance()
             loadTransactions()
             return mintedQuotes
         } finally {
-            isSyncingMintQuotes.set(false)
+            mintQuoteSweepMutex.unlock()
         }
     }
 
@@ -1596,11 +1613,11 @@ class WalletManager(
         // Minimum gap between passive mint-quote sync passes. Equal to the
         // foreground poll interval so the poll drives one pass per interval
         // (iOS `mintQuoteSyncCooldown` parity).
-        const val MINT_QUOTE_SYNC_COOLDOWN_MS = 5_000L
+        const val MINT_QUOTE_SYNC_COOLDOWN_MS = 10_000L
 
         // How often the foreground poll re-checks pending quotes while the
         // app is active (iOS `pendingQuotePollInterval` parity).
-        const val PENDING_QUOTE_POLL_INTERVAL_MS = 5_000L
+        const val PENDING_QUOTE_POLL_INTERVAL_MS = 10_000L
     }
 }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -629,17 +629,17 @@ class WalletManager(
      * poll) and transaction detail open — must not flip the global loading
      * flag (passive UX).
      */
-    suspend fun refreshPendingMintQuote(
+    internal suspend fun refreshPendingMintQuote(
         quoteId: String,
         confirmationOwner: ReceiveConfirmationOwner,
-    ): Boolean {
+    ): MintQuoteSyncResult {
         val result = mintQuoteSyncService.syncPendingMintQuote(quoteId)
         if (result.minted) refreshBalance()
         loadTransactions()
         result.receivedAmount?.let { amount ->
             publishReceivedPayment(amount, result.unit, confirmationOwner)
         }
-        return result.minted
+        return result
     }
 
     /**
@@ -656,10 +656,11 @@ class WalletManager(
     }
 
     /**
-     * Check every tracked wallet for paid-but-unissued mint quotes and mint
-     * them (CDK 0.18 `mintUnissuedQuotes`): each quote's NUT-04 counters are
-     * refreshed with the mint and only the outstanding delta is minted, which
-     * covers reusable BOLT12 offers without any local heuristics.
+     * Reconcile every persisted mint quote individually. CDK's unissued list
+     * deliberately retains all BOLT12 quotes forever, so a reusable offer is
+     * checked after dismissal, suspension, and relaunch as well as while its QR
+     * is visible. Every path uses [WalletMintQuoteSyncService]'s single lane and
+     * verifies `amountPaid` against `amountIssued` before reporting success.
      * Silent by design (iOS parity): must never flip the global loading flag.
      *
      * @param force when false (poll / startup / History open), the pass only
@@ -671,27 +672,30 @@ class WalletManager(
         if (!isSyncingMintQuotes.compareAndSet(false, true)) return 0
         lastMintQuoteSyncAtMs.set(System.currentTimeMillis())
         try {
-            var mintedWallets = 0
-            transactionUnitsByMint(mutableState.value.mints).forEach { (mintUrl, units) ->
-                units.forEach { unit ->
-                    val minted = runCatching { gateway.mintUnissuedQuotes(mintUrl, unit) }
-                        .onFailure { AppLogger.wallet.error("Unissued quote sweep failed for $mintUrl ($unit)", it) }
-                        .getOrDefault(0L)
-                    if (minted > 0) {
-                        mintedWallets += 1
-                        // Home receive beat for a background-settled payment
-                        // (e.g. a BOLT12 offer paid from another wallet).
-                        publishReceivedPayment(
-                            amount = minted,
-                            unit = unit,
-                            confirmationOwner = ReceiveConfirmationOwner.Home,
-                        )
-                    }
+            val databaseQuoteIds = runCatching { gateway.listUnissuedMintQuotes().map { it.id } }
+                .onFailure { AppLogger.wallet.error("Mint quote ledger scan failed", it) }
+                .getOrDefault(emptyList())
+            // App intents are a second durable index. Usually these IDs are
+            // already in CDK's list; the union also surfaces a missing local
+            // quote instead of silently dropping an older/migrated offer.
+            val intentQuoteIds = cashuRequestStore.state.value.requests.mapNotNull { it.quoteId }
+            val quoteIds = (databaseQuoteIds + intentQuoteIds).distinct().sorted()
+
+            var mintedQuotes = 0
+            quoteIds.forEach { quoteId ->
+                val result = mintQuoteSyncService.syncPendingMintQuote(quoteId)
+                result.receivedAmount?.let { amount ->
+                    mintedQuotes += 1
+                    publishReceivedPayment(
+                        amount = amount,
+                        unit = result.unit,
+                        confirmationOwner = ReceiveConfirmationOwner.Home,
+                    )
                 }
             }
-            if (mintedWallets > 0) refreshBalance()
+            if (mintedQuotes > 0) refreshBalance()
             loadTransactions()
-            return mintedWallets
+            return mintedQuotes
         } finally {
             isSyncingMintQuotes.set(false)
         }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
@@ -2,6 +2,9 @@ package com.cashu.me.Core
 
 import com.cashu.me.Core.CDK.CdkWalletGateway
 import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteRetryStatus
+import com.cashu.me.Models.MintQuoteScheduleRecord
+import com.cashu.me.Models.PaymentMethodKind
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -10,6 +13,7 @@ internal data class MintQuoteSyncResult(
     val quote: MintQuoteInfo? = null,
     val newlyIssued: Long = 0,
     val hadOutstandingPayment: Boolean = false,
+    val retryStatus: MintQuoteRetryStatus = MintQuoteRetryStatus(),
 ) {
     val minted: Boolean get() = newlyIssued > 0
     val receivedAmount: Long? get() = newlyIssued.takeIf { it > 0 }
@@ -53,8 +57,12 @@ internal fun reconciledMintQuoteResult(
 
 internal class WalletMintQuoteSyncService private constructor(
     private val checkQuote: suspend (String) -> MintQuoteInfo,
+    private val storedQuote: suspend (String) -> MintQuoteInfo?,
     private val mintQuote: suspend (String) -> Long,
     private val quoteObserved: (String) -> Unit,
+    private val loadSchedules: () -> Map<String, MintQuoteScheduleRecord>,
+    private val saveSchedules: (Map<String, MintQuoteScheduleRecord>) -> Unit,
+    private val nowEpochMillis: () -> Long,
     private val logFailure: (String, Throwable) -> Unit,
 ) {
     /**
@@ -63,12 +71,14 @@ internal class WalletMintQuoteSyncService private constructor(
      * duplicate issuance attempts and duplicate receipt events.
      */
     private val reconciliationMutex = Mutex()
+    private val scheduleMonitor = Any()
 
     constructor(
         gateway: CdkWalletGateway,
         walletStore: WalletStore,
     ) : this(
         checkQuote = gateway::checkMintQuote,
+        storedQuote = gateway::storedMintQuote,
         mintQuote = gateway::mintTokens,
         quoteObserved = { quoteId ->
             val current = walletStore.loadMintQuoteTimestamps()
@@ -76,6 +86,9 @@ internal class WalletMintQuoteSyncService private constructor(
                 walletStore.saveMintQuoteTimestamps(current + (quoteId to System.currentTimeMillis()))
             }
         },
+        loadSchedules = walletStore::loadMintQuoteSchedules,
+        saveSchedules = walletStore::saveMintQuoteSchedules,
+        nowEpochMillis = System::currentTimeMillis,
         logFailure = { message, error -> AppLogger.wallet.error(message, error) },
     )
 
@@ -83,7 +96,44 @@ internal class WalletMintQuoteSyncService private constructor(
     internal constructor(
         checkQuote: suspend (String) -> MintQuoteInfo,
         mintQuote: suspend (String) -> Long,
-    ) : this(checkQuote, mintQuote, {}, { _, _ -> })
+        storedQuote: suspend (String) -> MintQuoteInfo? = { null },
+        loadSchedules: () -> Map<String, MintQuoteScheduleRecord> = { emptyMap() },
+        saveSchedules: (Map<String, MintQuoteScheduleRecord>) -> Unit = {},
+        nowEpochMillis: () -> Long = System::currentTimeMillis,
+    ) : this(
+        checkQuote = checkQuote,
+        storedQuote = storedQuote,
+        mintQuote = mintQuote,
+        quoteObserved = {},
+        loadSchedules = loadSchedules,
+        saveSchedules = saveSchedules,
+        nowEpochMillis = nowEpochMillis,
+        logFailure = { _, _ -> },
+    )
+
+    /**
+     * Select a fair, bounded slice for one sweep and reserve it before any
+     * network suspension. Explicit refresh bypasses due times but remains
+     * bounded so a large historical ledger cannot monopolize the wallet.
+     */
+    fun selectQuoteIdsForSync(quoteIds: Collection<String>, force: Boolean): List<String> =
+        synchronized(scheduleMonitor) {
+            val selection = MintQuoteSchedulePolicy.select(
+                quoteIds = quoteIds,
+                existing = schedulesLocked(),
+                nowEpochMillis = nowEpochMillis(),
+                force = force,
+            )
+            persistSchedulesLocked(selection.records)
+            selection.quoteIds
+        }
+
+    /** Rehydrate a paid-but-unissued status when its receive screen reopens. */
+    fun retryStatus(quoteId: String): MintQuoteRetryStatus = synchronized(scheduleMonitor) {
+        schedulesLocked()[quoteId]
+            ?.let(MintQuoteSchedulePolicy::retryStatus)
+            ?: MintQuoteRetryStatus()
+    }
 
     /**
      * Check -> mint -> verify one persisted quote. The quote stays unresolved
@@ -100,10 +150,17 @@ internal class WalletMintQuoteSyncService private constructor(
                 if (!isMissingQuoteError(error)) {
                     logFailure("Failed to refresh pending quote $quoteId", error)
                 }
-                return@withLock MintQuoteSyncResult()
+                val local = runCatching { storedQuote(quoteId) }.getOrNull()
+                val retryStatus = recordFailure(quoteId, local)
+                return@withLock MintQuoteSyncResult(
+                    quote = local,
+                    hadOutstandingPayment = local?.mintableAmount?.let { it > 0 } == true,
+                    retryStatus = retryStatus,
+                )
             }
 
             if (observed.mintableAmount == 0L) {
+                recordObservation(observed)
                 return@withLock reconciledMintQuoteResult(observed)
             }
 
@@ -128,18 +185,65 @@ internal class WalletMintQuoteSyncService private constructor(
             }
             val result = reconciledMintQuoteResult(observed, mintedAmount, verified)
 
-            if (result.remainingAmount > 0L && mintError != null) {
-                logFailure(
-                    "Paid mint quote remains unissued: $quoteId " +
-                        "remaining=${result.remainingAmount}",
-                    mintError,
+            if (result.remainingAmount > 0L) {
+                val failure = mintError ?: IllegalStateException(
+                    "Mint quote made no verified issuance progress.",
                 )
+                logFailure(
+                    "Paid mint quote remains unissued: $quoteId remaining=${result.remainingAmount}",
+                    failure,
+                )
+                return@withLock result.copy(retryStatus = recordFailure(quoteId, result.quote))
             }
+            recordObservation(checkNotNull(result.quote))
             result
         }
 
     fun rememberMintQuoteTimestamp(quoteId: String) {
         quoteObserved(quoteId)
+        synchronized(scheduleMonitor) {
+            val schedules = schedulesLocked().toMutableMap()
+            schedules.putIfAbsent(
+                quoteId,
+                MintQuoteScheduleRecord(firstObservedAtEpochMillis = nowEpochMillis()),
+            )
+            persistSchedulesLocked(schedules)
+        }
+    }
+
+    private fun recordObservation(quote: MintQuoteInfo) {
+        synchronized(scheduleMonitor) {
+            val schedules = schedulesLocked().toMutableMap()
+            schedules[quote.id] = MintQuoteSchedulePolicy.observed(
+                previous = schedules[quote.id],
+                quote = quote,
+                nowEpochMillis = nowEpochMillis(),
+            )
+            persistSchedulesLocked(schedules)
+        }
+    }
+
+    private fun recordFailure(quoteId: String, quote: MintQuoteInfo?): MintQuoteRetryStatus =
+        synchronized(scheduleMonitor) {
+            val schedules = schedulesLocked().toMutableMap()
+            val record = MintQuoteSchedulePolicy.failed(
+                previous = schedules[quoteId],
+                nowEpochMillis = nowEpochMillis(),
+                hadOutstandingPayment = quote?.mintableAmount?.let { it > 0 } == true,
+                isReusable = quote?.paymentMethod == PaymentMethodKind.Bolt12,
+            )
+            schedules[quoteId] = record
+            persistSchedulesLocked(schedules)
+            MintQuoteSchedulePolicy.retryStatus(record)
+        }
+
+    // Always reload at the wallet boundary. Wallet replacement clears or
+    // restores this store while the manager remains alive; retaining a process
+    // cache here could otherwise resurrect retry metadata from the old wallet.
+    private fun schedulesLocked(): Map<String, MintQuoteScheduleRecord> = loadSchedules()
+
+    private fun persistSchedulesLocked(schedules: Map<String, MintQuoteScheduleRecord>) {
+        saveSchedules(schedules)
     }
 
     fun isAlreadyIssuedMintError(error: Throwable): Boolean {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
@@ -1,77 +1,149 @@
 package com.cashu.me.Core
 
 import com.cashu.me.Core.CDK.CdkWalletGateway
+import com.cashu.me.Models.MintQuoteInfo
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 internal data class MintQuoteSyncResult(
-    val minted: Boolean,
-    val receivedAmount: Long? = null,
-    val unit: String = "sat",
-)
-
-internal class WalletMintQuoteSyncService(
-    private val gateway: CdkWalletGateway,
-    private val walletStore: WalletStore,
+    val quote: MintQuoteInfo? = null,
+    val newlyIssued: Long = 0,
+    val hadOutstandingPayment: Boolean = false,
 ) {
-    private val mintQuoteSyncsInFlight = mutableSetOf<String>()
+    val minted: Boolean get() = newlyIssued > 0
+    val receivedAmount: Long? get() = newlyIssued.takeIf { it > 0 }
+    val unit: String get() = quote?.unit ?: "sat"
+    val remainingAmount: Long get() = quote?.mintableAmount ?: 0
+    val hasSettledPayment: Boolean get() = quote?.hasSettledPayment == true
+}
+
+/**
+ * Merge a mint response and its verification check without ever moving either
+ * NUT-25 counter backwards. A successful mint response is enough to infer a
+ * local advance when the follow-up GET is temporarily unavailable; conversely,
+ * a verified counter advance resolves a lost/ambiguous mint response.
+ */
+internal fun reconciledMintQuoteResult(
+    observed: MintQuoteInfo,
+    mintedAmount: Long = 0,
+    verified: MintQuoteInfo? = null,
+): MintQuoteSyncResult {
+    val nonNegativeMinted = mintedAmount.coerceAtLeast(0)
+    val inferredIssued = if (nonNegativeMinted > Long.MAX_VALUE - observed.amountIssued) {
+        Long.MAX_VALUE
+    } else {
+        observed.amountIssued + nonNegativeMinted
+    }
+    val base = verified ?: observed
+    val paid = maxOf(base.amountPaid, observed.amountPaid)
+    val issued = maxOf(base.amountIssued, inferredIssued)
+    val quote = base.copy(
+        amountPaid = paid,
+        amountIssued = issued,
+        state = mintQuoteStateForDomain(base.paymentMethod, base.state, paid, issued),
+    )
+    val verifiedAdvance = (issued - observed.amountIssued).coerceAtLeast(0)
+    return MintQuoteSyncResult(
+        quote = quote,
+        newlyIssued = maxOf(nonNegativeMinted, verifiedAdvance),
+        hadOutstandingPayment = observed.amountPaid > observed.amountIssued,
+    )
+}
+
+internal class WalletMintQuoteSyncService private constructor(
+    private val checkQuote: suspend (String) -> MintQuoteInfo,
+    private val mintQuote: suspend (String) -> Long,
+    private val quoteObserved: (String) -> Unit,
+    private val logFailure: (String, Throwable) -> Unit,
+) {
+    /**
+     * One reconciliation lane covers foreground polling, receive screens, and
+     * History refresh. Keeping check → mint → verify atomic at this layer avoids
+     * duplicate issuance attempts and duplicate receipt events.
+     */
+    private val reconciliationMutex = Mutex()
+
+    constructor(
+        gateway: CdkWalletGateway,
+        walletStore: WalletStore,
+    ) : this(
+        checkQuote = gateway::checkMintQuote,
+        mintQuote = gateway::mintTokens,
+        quoteObserved = { quoteId ->
+            val current = walletStore.loadMintQuoteTimestamps()
+            if (quoteId !in current) {
+                walletStore.saveMintQuoteTimestamps(current + (quoteId to System.currentTimeMillis()))
+            }
+        },
+        logFailure = { message, error -> AppLogger.wallet.error(message, error) },
+    )
+
+    /** Test seam for the counter state machine; production uses CDK above. */
+    internal constructor(
+        checkQuote: suspend (String) -> MintQuoteInfo,
+        mintQuote: suspend (String) -> Long,
+    ) : this(checkQuote, mintQuote, {}, { _, _ -> })
 
     /**
-     * Check one quote with its mint and mint it when a paid amount is still
-     * outstanding. CDK's NUT-04 `amountPaid`/`amountIssued` counters make
-     * this correct for reusable BOLT12 offers too: fully-issued offers mint 0.
+     * Check -> mint -> verify one persisted quote. The quote stays unresolved
+     * when any paid amount remains, so the next foreground/startup pass retries
+     * it. Reusable BOLT12 quotes can run through this method indefinitely.
      */
-    suspend fun syncPendingMintQuote(quoteId: String): MintQuoteSyncResult {
-        if (!mintQuoteSyncsInFlight.add(quoteId)) return MintQuoteSyncResult(minted = false)
-        return try {
-            val updatedQuote = try {
-                gateway.checkMintQuote(quoteId).also { rememberMintQuoteTimestamp(it.id) }
+    suspend fun syncPendingMintQuote(quoteId: String): MintQuoteSyncResult =
+        reconciliationMutex.withLock {
+            val observed = try {
+                checkQuote(quoteId).also { rememberMintQuoteTimestamp(it.id) }
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
                 if (!isMissingQuoteError(error)) {
-                    AppLogger.wallet.error("Failed to refresh pending quote $quoteId", error)
+                    logFailure("Failed to refresh pending quote $quoteId", error)
                 }
-                return MintQuoteSyncResult(minted = false)
+                return@withLock MintQuoteSyncResult()
             }
 
-            if (updatedQuote.amountPaid <= updatedQuote.amountIssued) {
-                return MintQuoteSyncResult(minted = false)
+            if (observed.mintableAmount == 0L) {
+                return@withLock reconciledMintQuoteResult(observed)
             }
 
-            val minted = try {
-                gateway.mintTokens(quoteId)
-                true
+            var mintedAmount = 0L
+            var mintError: Throwable? = null
+            try {
+                mintedAmount = mintQuote(quoteId)
             } catch (error: CancellationException) {
                 throw error
             } catch (error: Throwable) {
-                when {
-                    isAlreadyIssuedMintError(error) -> true
-                    else -> {
-                        AppLogger.wallet.error("Failed to mint pending quote $quoteId", error)
-                        false
-                    }
-                }
+                mintError = error
             }
 
-            MintQuoteSyncResult(
-                minted = minted,
-                receivedAmount = (updatedQuote.amountPaid - updatedQuote.amountIssued).takeIf { minted && it > 0 },
-                unit = updatedQuote.unit,
-            )
-        } finally {
-            mintQuoteSyncsInFlight.remove(quoteId)
+            // Always ask again. If POST /mint succeeded but its response was
+            // lost, amount_issued is the durable proof that issuance happened.
+            val verified = try {
+                checkQuote(quoteId).also { rememberMintQuoteTimestamp(it.id) }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Throwable) {
+                null
+            }
+            val result = reconciledMintQuoteResult(observed, mintedAmount, verified)
+
+            if (result.remainingAmount > 0L && mintError != null) {
+                logFailure(
+                    "Paid mint quote remains unissued: $quoteId " +
+                        "remaining=${result.remainingAmount}",
+                    mintError,
+                )
+            }
+            result
         }
-    }
 
     fun rememberMintQuoteTimestamp(quoteId: String) {
-        val current = walletStore.loadMintQuoteTimestamps()
-        if (quoteId !in current) {
-            walletStore.saveMintQuoteTimestamps(current + (quoteId to System.currentTimeMillis()))
-        }
+        quoteObserved(quoteId)
     }
 
     fun isAlreadyIssuedMintError(error: Throwable): Boolean {
-        val message = "${error.message.orEmpty()} ${error}".lowercase()
+        val message = "${error.message.orEmpty()} $error".lowercase()
         if (
             message.contains("already being minted") ||
             message.contains("not issued") ||
@@ -88,7 +160,7 @@ internal class WalletMintQuoteSyncService(
     }
 
     private fun isMissingQuoteError(error: Throwable): Boolean {
-        val message = "${error.message.orEmpty()} ${error}".lowercase()
+        val message = "${error.message.orEmpty()} $error".lowercase()
         return message.contains("not found") ||
             message.contains("no stored mint quote") ||
             message.contains("missing quote")

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMintQuoteSyncService.kt
@@ -32,6 +32,7 @@ internal fun reconciledMintQuoteResult(
     observed: MintQuoteInfo,
     mintedAmount: Long = 0,
     verified: MintQuoteInfo? = null,
+    issuedBeforeCheck: Long? = null,
 ): MintQuoteSyncResult {
     val nonNegativeMinted = mintedAmount.coerceAtLeast(0)
     val inferredIssued = if (nonNegativeMinted > Long.MAX_VALUE - observed.amountIssued) {
@@ -47,7 +48,7 @@ internal fun reconciledMintQuoteResult(
         amountIssued = issued,
         state = mintQuoteStateForDomain(base.paymentMethod, base.state, paid, issued),
     )
-    val verifiedAdvance = (issued - observed.amountIssued).coerceAtLeast(0)
+    val verifiedAdvance = (issued - (issuedBeforeCheck ?: observed.amountIssued)).coerceAtLeast(0)
     return MintQuoteSyncResult(
         quote = quote,
         newlyIssued = maxOf(nonNegativeMinted, verifiedAdvance),
@@ -116,13 +117,18 @@ internal class WalletMintQuoteSyncService private constructor(
      * network suspension. Explicit refresh bypasses due times but remains
      * bounded so a large historical ledger cannot monopolize the wallet.
      */
-    fun selectQuoteIdsForSync(quoteIds: Collection<String>, force: Boolean): List<String> =
+    fun selectQuoteIdsForSync(
+        quoteIds: Collection<String>,
+        force: Boolean,
+        unsettledOnchainQuoteIds: Set<String> = emptySet(),
+    ): List<String> =
         synchronized(scheduleMonitor) {
             val selection = MintQuoteSchedulePolicy.select(
                 quoteIds = quoteIds,
                 existing = schedulesLocked(),
                 nowEpochMillis = nowEpochMillis(),
                 force = force,
+                unsettledOnchainQuoteIds = unsettledOnchainQuoteIds,
             )
             persistSchedulesLocked(selection.records)
             selection.quoteIds
@@ -135,13 +141,21 @@ internal class WalletMintQuoteSyncService private constructor(
             ?: MintQuoteRetryStatus()
     }
 
+    fun shouldAttempt(quoteId: String, force: Boolean = false): Boolean = synchronized(scheduleMonitor) {
+        MintQuoteSchedulePolicy.shouldAttempt(schedulesLocked()[quoteId], nowEpochMillis(), force)
+    }
+
     /**
      * Check -> mint -> verify one persisted quote. The quote stays unresolved
      * when any paid amount remains, so the next foreground/startup pass retries
      * it. Reusable BOLT12 quotes can run through this method indefinitely.
      */
-    suspend fun syncPendingMintQuote(quoteId: String): MintQuoteSyncResult =
+    suspend fun syncPendingMintQuote(quoteId: String, force: Boolean = false): MintQuoteSyncResult =
         reconciliationMutex.withLock {
+            val cached = storedQuoteOrNull(quoteId)
+            if (!shouldAttempt(quoteId, force)) {
+                return@withLock MintQuoteSyncResult(quote = cached, retryStatus = retryStatus(quoteId))
+            }
             val observed = try {
                 checkQuote(quoteId).also { rememberMintQuoteTimestamp(it.id) }
             } catch (error: CancellationException) {
@@ -150,7 +164,7 @@ internal class WalletMintQuoteSyncService private constructor(
                 if (!isMissingQuoteError(error)) {
                     logFailure("Failed to refresh pending quote $quoteId", error)
                 }
-                val local = runCatching { storedQuote(quoteId) }.getOrNull()
+                val local = storedQuoteOrNull(quoteId) ?: cached
                 val retryStatus = recordFailure(quoteId, local)
                 return@withLock MintQuoteSyncResult(
                     quote = local,
@@ -161,7 +175,7 @@ internal class WalletMintQuoteSyncService private constructor(
 
             if (observed.mintableAmount == 0L) {
                 recordObservation(observed)
-                return@withLock reconciledMintQuoteResult(observed)
+                return@withLock reconciledMintQuoteResult(observed, issuedBeforeCheck = cached?.amountIssued)
             }
 
             var mintedAmount = 0L
@@ -183,7 +197,7 @@ internal class WalletMintQuoteSyncService private constructor(
             } catch (_: Throwable) {
                 null
             }
-            val result = reconciledMintQuoteResult(observed, mintedAmount, verified)
+            val result = reconciledMintQuoteResult(observed, mintedAmount, verified, cached?.amountIssued)
 
             if (result.remainingAmount > 0L) {
                 val failure = mintError ?: IllegalStateException(
@@ -198,6 +212,14 @@ internal class WalletMintQuoteSyncService private constructor(
             recordObservation(checkNotNull(result.quote))
             result
         }
+
+    private suspend fun storedQuoteOrNull(quoteId: String): MintQuoteInfo? = try {
+        storedQuote(quoteId)
+    } catch (error: CancellationException) {
+        throw error
+    } catch (_: Throwable) {
+        null
+    }
 
     fun rememberMintQuoteTimestamp(quoteId: String) {
         quoteObserved(quoteId)

--- a/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.Json
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Models.CashuRequest
 import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.MintQuoteScheduleRecord
 import com.cashu.me.Models.PendingReceiveToken
 import com.cashu.me.Models.WalletTransaction
 
@@ -54,6 +55,11 @@ class WalletStore(
         loadMap(StorageKeys.walletMintQuoteTimestamps, Long.serializer())
     fun saveMintQuoteTimestamps(timestamps: Map<String, Long>) =
         saveMap(StorageKeys.walletMintQuoteTimestamps, Long.serializer(), timestamps)
+
+    fun loadMintQuoteSchedules(): Map<String, MintQuoteScheduleRecord> =
+        loadMap(StorageKeys.walletMintQuoteSchedules, MintQuoteScheduleRecord.serializer())
+    fun saveMintQuoteSchedules(schedules: Map<String, MintQuoteScheduleRecord>) =
+        saveMap(StorageKeys.walletMintQuoteSchedules, MintQuoteScheduleRecord.serializer(), schedules)
 
     fun loadProcessedNPCQuotes(): List<String> = loadList(StorageKeys.walletProcessedNPCQuotes, String.serializer())
     fun saveProcessedNPCQuotes(quotes: List<String>) =

--- a/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
@@ -36,6 +36,14 @@ data class MintQuoteInfo(
         get() = expiryEpochSeconds != null &&
             expiryEpochSeconds > 0 &&
             System.currentTimeMillis() / 1000 > expiryEpochSeconds
+
+    /** NUT-25's authoritative amount still available for issuance. */
+    val mintableAmount: Long
+        get() = (amountPaid - amountIssued).coerceAtLeast(0)
+
+    /** A payment is complete only after ecash issuance catches up. */
+    val hasSettledPayment: Boolean
+        get() = amountPaid > 0 && amountIssued >= amountPaid
 }
 
 @Serializable

--- a/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Quotes/QuoteModels.kt
@@ -12,6 +12,36 @@ enum class MintQuoteState {
     Unknown,
 }
 
+/** What the wallet can honestly promise after a paid quote fails to issue. */
+@Serializable
+enum class MintQuoteRetryState {
+    None,
+    RetryScheduled,
+    NeedsAttention,
+}
+
+/**
+ * Durable maintenance metadata kept outside CDK's money ledger. CDK remains
+ * authoritative for paid/issued counters; this record only bounds when the app
+ * asks again and preserves retry truth across process restarts.
+ */
+@Serializable
+data class MintQuoteScheduleRecord(
+    val firstObservedAtEpochMillis: Long,
+    val lastAttemptAtEpochMillis: Long? = null,
+    val nextAttemptAtEpochMillis: Long = 0,
+    val consecutiveFailures: Int = 0,
+    val hadOutstandingPayment: Boolean = false,
+    val isReusable: Boolean = false,
+    val isComplete: Boolean = false,
+)
+
+data class MintQuoteRetryStatus(
+    val state: MintQuoteRetryState = MintQuoteRetryState.None,
+    val nextRetryAtEpochMillis: Long? = null,
+    val failureCount: Int = 0,
+)
+
 @Serializable
 data class MintQuoteInfo(
     val id: String,

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -331,7 +331,7 @@ fun ReceiveLightningScreen(
     fun createNewOnchainAddress() {
         val quote = (face as? ReceiveLnFace.Display)?.quote
         if (quote != null && quote.paymentMethod == PaymentMethodKind.Onchain &&
-            quote.state != MintQuoteState.Issued && !quote.isExpired
+            quote.state != MintQuoteState.Issued
         ) {
             abandonedOnchainQuoteIds = abandonedOnchainQuoteIds + quote.id
         }
@@ -413,28 +413,12 @@ fun ReceiveLightningScreen(
     // The header chevron owns the internal Display → Input step-back.
     // Failure terminal uses the header close affordance (and Try Again).
 
-    // Abandoned-quote watcher: every quote-keyed monitor re-keys to the
-    // replacement after "Use new address", so this screen-scoped loop is what
-    // keeps checking the old address(es). refreshPendingMintQuote returns
-    // whether tokens were actually minted — on-chain quotes can sit Pending
-    // until a mint attempt succeeds, so the Boolean (not the quote state) is
-    // the reliable signal. Keyed on isNotEmpty so the first pass runs
-    // immediately after the first tap (a quote already paid at tap time mints
-    // on the first tick). Dies with the sheet; the global pending-quote sweep
-    // remains the fallback after that.
+    // Keep outgoing addresses in the shared reconciliation lane, including
+    // expired quotes whose deposits may still be waiting for confirmations.
+    // The global pending-quote sweep remains the fallback after dismissal.
     LaunchedEffect(abandonedOnchainQuoteIds.isNotEmpty()) {
         while (abandonedOnchainQuoteIds.isNotEmpty() && successInfo == null) {
             for (quoteId in abandonedOnchainQuoteIds) {
-                val info = runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull()
-                // Drop quotes that expired before the mint saw any deposit; a
-                // funded-but-expired quote keeps being checked.
-                if (info != null && info.isExpired &&
-                    info.state == MintQuoteState.Unpaid &&
-                    (info.amount ?: 0L) == 0L && info.amountPaid == 0L
-                ) {
-                    abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
-                    continue
-                }
                 val reconciliation = runCatching {
                     walletManager.refreshPendingMintQuote(
                         quoteId,
@@ -446,8 +430,6 @@ fun ReceiveLightningScreen(
                 abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
                 // Refetch for the credited amount (on-chain always mints sat).
                 val refreshed = reconciliation.quote
-                    ?: runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull()
-                    ?: info
                 val paidAmount = reconciliation.newlyIssued.takeIf { it > 0 }
                     ?: refreshed?.amount
                     ?: refreshed?.amountIssued?.takeIf { it > 0 }
@@ -706,6 +688,7 @@ fun ReceiveLightningScreen(
                         var intervalMs = initialMs
                         while (true) {
                             delay(intervalMs)
+                            if (!walletManager.shouldAttemptMintQuote(current.quote.id)) continue
                             val refreshed = runCatching { walletManager.pollMintQuote(current.quote.id) }
                                 .getOrNull()
                                 ?: continue // transient failure — keep monitoring
@@ -715,6 +698,7 @@ fun ReceiveLightningScreen(
                             // payment (the mint never marks them terminally
                             // paid), so keep polling for the next one.
                             val keepPolling = refreshed.paymentMethod == PaymentMethodKind.Bolt12 ||
+                                (refreshed.paymentMethod == PaymentMethodKind.Onchain && !refreshed.hasSettledPayment) ||
                                 shouldPollMintQuote(
                                     state = refreshed.state,
                                     expiryEpochSeconds = refreshed.expiryEpochSeconds,
@@ -795,7 +779,7 @@ fun ReceiveLightningScreen(
                     // issuance. The local flag describes only a real
                     // check/issue operation; durable retry truth comes from the
                     // scheduler record returned with the result.
-                    fun reconcileDisplayedQuote() {
+                    fun reconcileDisplayedQuote(force: Boolean = false) {
                         if (isReconcilingQuote) return
                         val quoteId = liveQuote.id
                         val paymentMethod = liveQuote.paymentMethod
@@ -803,13 +787,14 @@ fun ReceiveLightningScreen(
                         // A caught-up reusable quote is merely being checked;
                         // don't claim ecash issuance until its counters already
                         // prove that a paid delta exists.
-                        isIssuingEcash = liveQuote.mintableAmount > 0 ||
-                            liveQuote.state == MintQuoteState.Paid
+                        isIssuingEcash = (force || walletManager.shouldAttemptMintQuote(quoteId)) &&
+                            (liveQuote.mintableAmount > 0 || liveQuote.state == MintQuoteState.Paid)
                         walletManager.launch {
                             try {
                                 val result = walletManager.refreshPendingMintQuote(
                                     quoteId,
                                     confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                    force = force,
                                 )
                                 result.quote?.let { liveQuote = it }
                                 mintRetryStatus = result.retryStatus
@@ -923,7 +908,7 @@ fun ReceiveLightningScreen(
                             "View transaction in block explorer"
                         },
                         onCopy = { clipboard.setText(AnnotatedString(liveQuote.request)) },
-                        onRetryPendingMint = ::reconcileDisplayedQuote,
+                        onRetryPendingMint = { reconcileDisplayedQuote(force = true) },
                         onEditReusableAmount = if (
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12
                         ) {

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -36,7 +36,9 @@ import androidx.compose.material.icons.outlined.CurrencyBitcoin
 import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material.icons.outlined.Refresh
 import androidx.compose.material.icons.outlined.Repeat
+import androidx.compose.material.icons.outlined.Schedule
 import androidx.compose.material.icons.outlined.Timer
+import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.CircularProgressIndicator
@@ -62,6 +64,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -88,6 +93,7 @@ import com.cashu.me.Core.quoteExpiryText
 import com.cashu.me.Core.shouldPollMintQuote
 import com.cashu.me.Models.MintInfo
 import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteRetryState
 import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.ui.components.AmountEntryHero
@@ -138,9 +144,12 @@ private sealed interface ReceiveLnFace {
     )
 }
 
-private enum class ReusableOfferSettlementState {
+private enum class MintQuoteSettlementState {
     Waiting,
-    Minting,
+    PaymentDetected,
+    Issuing,
+    RetryScheduled,
+    NeedsAttention,
     Ready,
 }
 
@@ -666,6 +675,11 @@ fun ReceiveLightningScreen(
 
                 is ReceiveLnFace.Display -> {
                     var liveQuote by remember(current.quote.id) { mutableStateOf(current.quote) }
+                    var mintRetryStatus by remember(current.quote.id) {
+                        mutableStateOf(walletManager.mintQuoteRetryStatus(current.quote.id))
+                    }
+                    var isReconcilingQuote by remember(current.quote.id) { mutableStateOf(false) }
+                    var isIssuingEcash by remember(current.quote.id) { mutableStateOf(false) }
                     LaunchedEffect(current.quote.id) {
                         persistReusableOffer(current.quote)
                     }
@@ -696,6 +710,7 @@ fun ReceiveLightningScreen(
                                 .getOrNull()
                                 ?: continue // transient failure — keep monitoring
                             liveQuote = refreshed
+                            mintRetryStatus = walletManager.mintQuoteRetryStatus(refreshed.id)
                             // Reusable BOLT12 offers stay open after each
                             // payment (the mint never marks them terminally
                             // paid), so keep polling for the next one.
@@ -774,6 +789,46 @@ fun ReceiveLightningScreen(
                                 ).formatted()
                             }
                         }
+
+                    // Runs on WalletManager's app-lifetime scope so dismissing
+                    // the sheet cannot cancel a paid quote midway through
+                    // issuance. The local flag describes only a real
+                    // check/issue operation; durable retry truth comes from the
+                    // scheduler record returned with the result.
+                    fun reconcileDisplayedQuote() {
+                        if (isReconcilingQuote) return
+                        val quoteId = liveQuote.id
+                        val paymentMethod = liveQuote.paymentMethod
+                        isReconcilingQuote = true
+                        // A caught-up reusable quote is merely being checked;
+                        // don't claim ecash issuance until its counters already
+                        // prove that a paid delta exists.
+                        isIssuingEcash = liveQuote.mintableAmount > 0 ||
+                            liveQuote.state == MintQuoteState.Paid
+                        walletManager.launch {
+                            try {
+                                val result = walletManager.refreshPendingMintQuote(
+                                    quoteId,
+                                    confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                )
+                                result.quote?.let { liveQuote = it }
+                                mintRetryStatus = result.retryStatus
+                                if (paymentMethod != PaymentMethodKind.Bolt12 &&
+                                    result.hasSettledPayment
+                                ) {
+                                    successInfo = ReceiveSuccessInfo(
+                                        amountLabel = amountLabel,
+                                        mintName = activeMint?.name,
+                                        method = paymentMethod,
+                                    )
+                                }
+                            } finally {
+                                isIssuingEcash = false
+                                isReconcilingQuote = false
+                            }
+                        }
+                    }
+
                     LaunchedEffect(
                         liveQuote.id,
                         liveQuote.state,
@@ -790,14 +845,7 @@ fun ReceiveLightningScreen(
                                 liveQuote.state == MintQuoteState.Paid ||
                                 liveQuote.state == MintQuoteState.Issued
                             ) {
-                                walletManager.launch {
-                                    runCatching {
-                                        walletManager.refreshPendingMintQuote(
-                                            liveQuote.id,
-                                            confirmationOwner = ReceiveConfirmationOwner.InFlow,
-                                        )
-                                    }.getOrNull()?.quote?.let { liveQuote = it }
-                                }
+                                reconcileDisplayedQuote()
                             }
                             return@LaunchedEffect
                         }
@@ -807,22 +855,7 @@ fun ReceiveLightningScreen(
                             // Keep the request visible until reconciliation
                             // verifies amount_issued. A paid invoice is not yet
                             // a successful ecash receive.
-                            walletManager.launch {
-                                val result = runCatching {
-                                    walletManager.refreshPendingMintQuote(
-                                        liveQuote.id,
-                                        confirmationOwner = ReceiveConfirmationOwner.InFlow,
-                                    )
-                                }.getOrNull() ?: return@launch
-                                result.quote?.let { liveQuote = it }
-                                if (result.hasSettledPayment) {
-                                    successInfo = ReceiveSuccessInfo(
-                                        amountLabel = amountLabel,
-                                        mintName = activeMint?.name,
-                                        method = liveQuote.paymentMethod,
-                                    )
-                                }
-                            }
+                            reconcileDisplayedQuote()
                         }
                     }
                     val isOnchain = liveQuote.paymentMethod == PaymentMethodKind.Onchain
@@ -848,11 +881,20 @@ fun ReceiveLightningScreen(
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12 && liveQuote.isAmountless
                         },
                         receivedAmountLabel = receivedAmountLabel,
-                        reusableSettlementState = when {
-                            liveQuote.paymentMethod != PaymentMethodKind.Bolt12 -> null
-                            liveQuote.mintableAmount > 0 -> ReusableOfferSettlementState.Minting
-                            liveQuote.amountIssued > 0 -> ReusableOfferSettlementState.Ready
-                            else -> ReusableOfferSettlementState.Waiting
+                        settlementState = when {
+                            isIssuingEcash -> MintQuoteSettlementState.Issuing
+                            liveQuote.mintableAmount > 0 &&
+                                mintRetryStatus.state == MintQuoteRetryState.NeedsAttention ->
+                                MintQuoteSettlementState.NeedsAttention
+                            liveQuote.mintableAmount > 0 &&
+                                mintRetryStatus.state == MintQuoteRetryState.RetryScheduled ->
+                                MintQuoteSettlementState.RetryScheduled
+                            liveQuote.mintableAmount > 0 -> MintQuoteSettlementState.PaymentDetected
+                            liveQuote.paymentMethod == PaymentMethodKind.Bolt12 &&
+                                liveQuote.amountIssued > 0 -> MintQuoteSettlementState.Ready
+                            liveQuote.paymentMethod == PaymentMethodKind.Bolt12 ->
+                                MintQuoteSettlementState.Waiting
+                            else -> null
                         },
                         mintName = activeMint?.name,
                         createdAtEpochMillis = cashuRequestState.requests
@@ -881,6 +923,7 @@ fun ReceiveLightningScreen(
                             "View transaction in block explorer"
                         },
                         onCopy = { clipboard.setText(AnnotatedString(liveQuote.request)) },
+                        onRetryPendingMint = ::reconcileDisplayedQuote,
                         onEditReusableAmount = if (
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12
                         ) {
@@ -1134,7 +1177,7 @@ private fun DisplayFace(
     quote: MintQuoteInfo,
     amountLabel: String?,
     receivedAmountLabel: String?,
-    reusableSettlementState: ReusableOfferSettlementState?,
+    settlementState: MintQuoteSettlementState?,
     mintName: String?,
     createdAtEpochMillis: Long?,
     errorText: String?,
@@ -1146,6 +1189,7 @@ private fun DisplayFace(
     pendingStatusText: String,
     explorerLabel: String,
     onCopy: () -> Unit,
+    onRetryPendingMint: () -> Unit,
     onEditReusableAmount: (() -> Unit)?,
     onOpenExplorer: (() -> Unit)?,
 ) {
@@ -1186,9 +1230,10 @@ private fun DisplayFace(
                     useBitcoinSymbol = useBitcoinSymbol,
                 )
             }
-            if (isReusable) {
-                ReusableOfferStatus(
-                    state = reusableSettlementState ?: ReusableOfferSettlementState.Waiting,
+            if (settlementState != null) {
+                MintQuoteSettlementStatus(
+                    state = settlementState,
+                    onRetry = onRetryPendingMint,
                 )
             } else {
                 WaitingForPaymentRow(text = pendingStatusText)
@@ -1312,15 +1357,17 @@ internal fun GeneratedInvoiceAmount(
 }
 
 /**
- * Status line for a reusable BOLT12 offer. Mirrors the Cashu Request status
- * block: quiet waiting, an explicit paid-but-unissued minting state, then a
- * ready-again state only after the ecash issuance counter catches up.
+ * Honest mint settlement status shared by one-shot and reusable receives.
+ * A spinner means an operation is active, while scheduled/attention states
+ * come from durable retry metadata and always retain an explicit manual retry.
  */
 @Composable
-private fun ReusableOfferStatus(
-    state: ReusableOfferSettlementState,
+private fun MintQuoteSettlementStatus(
+    state: MintQuoteSettlementState,
+    onRetry: () -> Unit,
 ) {
     AnimatedContent(
+        modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
         targetState = state,
         transitionSpec = {
             (
@@ -1333,11 +1380,27 @@ private fun ReusableOfferStatus(
                 )
                 ) togetherWith fadeOut(tween(150))
         },
-        label = "reusable-offer-status",
+        label = "mint-quote-settlement-status",
     ) { current ->
         when (current) {
-            ReusableOfferSettlementState.Waiting -> WaitingForPaymentRow()
-            ReusableOfferSettlementState.Minting -> Row(
+            MintQuoteSettlementState.Waiting -> WaitingForPaymentRow()
+            MintQuoteSettlementState.PaymentDetected -> Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Schedule,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(CashuTheme.spacing.loose),
+                )
+                Text(
+                    text = "Payment received. Ecash issuance is pending.",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            MintQuoteSettlementState.Issuing -> Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
             ) {
@@ -1346,12 +1409,60 @@ private fun ReusableOfferStatus(
                     strokeWidth = 2.dp,
                 )
                 Text(
-                    text = "Payment found. Minting ecash…",
+                    text = "Payment received. Issuing ecash…",
                     style = MaterialTheme.typography.titleMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            ReusableOfferSettlementState.Ready -> Row(
+            MintQuoteSettlementState.RetryScheduled,
+            MintQuoteSettlementState.NeedsAttention -> {
+                val needsAttention = current == MintQuoteSettlementState.NeedsAttention
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.tight),
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+                    ) {
+                        Icon(
+                            imageVector = if (needsAttention) {
+                                Icons.Outlined.WarningAmber
+                            } else {
+                                Icons.Outlined.Schedule
+                            },
+                            contentDescription = null,
+                            tint = if (needsAttention) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                            modifier = Modifier.size(CashuTheme.spacing.loose),
+                        )
+                        Text(
+                            text = if (needsAttention) {
+                                "Payment received. Ecash is still pending."
+                            } else {
+                                "Payment received. Retrying ecash automatically."
+                            },
+                            style = MaterialTheme.typography.titleMedium,
+                            color = if (needsAttention) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                    }
+                    androidx.compose.material3.TextButton(onClick = onRetry) {
+                        Icon(
+                            imageVector = Icons.Outlined.Refresh,
+                            contentDescription = null,
+                        )
+                        Text("Retry now")
+                    }
+                }
+            }
+            MintQuoteSettlementState.Ready -> Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
             ) {

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.outlined.Repeat
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
@@ -135,6 +136,12 @@ private sealed interface ReceiveLnFace {
         val forceNewReusableOffer: Boolean,
         val amountOverride: Long?,
     )
+}
+
+private enum class ReusableOfferSettlementState {
+    Waiting,
+    Minting,
+    Ready,
 }
 
 private fun receiveRequestHeaderTitle(method: PaymentMethodKind): String = when (method) {
@@ -419,20 +426,22 @@ fun ReceiveLightningScreen(
                     abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
                     continue
                 }
-                val minted = runCatching {
+                val reconciliation = runCatching {
                     walletManager.refreshPendingMintQuote(
                         quoteId,
                         confirmationOwner = ReceiveConfirmationOwner.InFlow,
                     )
                 }
-                    .getOrDefault(false)
-                if (!minted) continue
+                    .getOrNull()
+                if (reconciliation?.hasSettledPayment != true) continue
                 abandonedOnchainQuoteIds = abandonedOnchainQuoteIds - quoteId
                 // Refetch for the credited amount (on-chain always mints sat).
-                val refreshed = runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull() ?: info
-                val paidAmount = refreshed?.amount
+                val refreshed = reconciliation.quote
+                    ?: runCatching { walletManager.pollMintQuote(quoteId) }.getOrNull()
+                    ?: info
+                val paidAmount = reconciliation.newlyIssued.takeIf { it > 0 }
+                    ?: refreshed?.amount
                     ?: refreshed?.amountIssued?.takeIf { it > 0 }
-                    ?: refreshed?.amountPaid?.takeIf { it > 0 }
                 successInfo = ReceiveSuccessInfo(
                     amountLabel = paidAmount?.let {
                         formatter.formatWalletSats(it, settings.useBitcoinSymbol)
@@ -674,10 +683,10 @@ fun ReceiveLightningScreen(
                         // iOS pollMintQuote parity: linear backoff (+1s per
                         // iteration up to the max), terminal-state/expiry aware
                         // via shouldPollMintQuote. Per-rail intervals:
-                        // BOLT11 5s→15s, BOLT12 10s→30s, on-chain flat 30s.
+                        // BOLT11/BOLT12 5s→15s, on-chain flat 30s.
                         val (initialMs, maxMs) = when (current.quote.paymentMethod) {
                             PaymentMethodKind.Bolt11 -> 5_000L to 15_000L
-                            PaymentMethodKind.Bolt12 -> 10_000L to 30_000L
+                            PaymentMethodKind.Bolt12 -> 5_000L to 15_000L
                             PaymentMethodKind.Onchain -> 30_000L to 30_000L
                         }
                         var intervalMs = initialMs
@@ -751,14 +760,16 @@ fun ReceiveLightningScreen(
                             ).formatted()
                         }
                     }
-                    val receivedAmountLabel = liveQuote.amountPaid
+                    // Green/received state is based on issued ecash, never on
+                    // a Lightning payment that is still waiting to be minted.
+                    val receivedAmountLabel = liveQuote.amountIssued
                         .takeIf { it > 0 }
-                        ?.let { paid ->
+                        ?.let { issued ->
                             if (liveQuote.unit.equals("sat", ignoreCase = true)) {
-                                formatter.formatWalletSats(paid, settings.useBitcoinSymbol)
+                                formatter.formatWalletSats(issued, settings.useBitcoinSymbol)
                             } else {
                                 CurrencyAmount(
-                                    paid,
+                                    issued,
                                     CurrencyRegistry.currencyForMintUnit(liveQuote.unit),
                                 ).formatted()
                             }
@@ -785,7 +796,7 @@ fun ReceiveLightningScreen(
                                             liveQuote.id,
                                             confirmationOwner = ReceiveConfirmationOwner.InFlow,
                                         )
-                                    }
+                                    }.getOrNull()?.quote?.let { liveQuote = it }
                                 }
                             }
                             return@LaunchedEffect
@@ -793,23 +804,25 @@ fun ReceiveLightningScreen(
                         if (liveQuote.state == MintQuoteState.Paid ||
                             liveQuote.state == MintQuoteState.Issued
                         ) {
-                            // Finish the UX immediately and mint on the wallet's
-                            // app-lifetime scope so the dismiss never cancels it
-                            // (iOS: unstructured task that outlives the sheet).
+                            // Keep the request visible until reconciliation
+                            // verifies amount_issued. A paid invoice is not yet
+                            // a successful ecash receive.
                             walletManager.launch {
-                                runCatching {
-                                    walletManager.mintTokens(
-                                        quoteId = liveQuote.id,
-                                        unit = liveQuote.unit,
+                                val result = runCatching {
+                                    walletManager.refreshPendingMintQuote(
+                                        liveQuote.id,
                                         confirmationOwner = ReceiveConfirmationOwner.InFlow,
+                                    )
+                                }.getOrNull() ?: return@launch
+                                result.quote?.let { liveQuote = it }
+                                if (result.hasSettledPayment) {
+                                    successInfo = ReceiveSuccessInfo(
+                                        amountLabel = amountLabel,
+                                        mintName = activeMint?.name,
+                                        method = liveQuote.paymentMethod,
                                     )
                                 }
                             }
-                            successInfo = ReceiveSuccessInfo(
-                                amountLabel = amountLabel,
-                                mintName = activeMint?.name,
-                                method = liveQuote.paymentMethod,
-                            )
                         }
                     }
                     val isOnchain = liveQuote.paymentMethod == PaymentMethodKind.Onchain
@@ -835,6 +848,12 @@ fun ReceiveLightningScreen(
                             liveQuote.paymentMethod == PaymentMethodKind.Bolt12 && liveQuote.isAmountless
                         },
                         receivedAmountLabel = receivedAmountLabel,
+                        reusableSettlementState = when {
+                            liveQuote.paymentMethod != PaymentMethodKind.Bolt12 -> null
+                            liveQuote.mintableAmount > 0 -> ReusableOfferSettlementState.Minting
+                            liveQuote.amountIssued > 0 -> ReusableOfferSettlementState.Ready
+                            else -> ReusableOfferSettlementState.Waiting
+                        },
                         mintName = activeMint?.name,
                         createdAtEpochMillis = cashuRequestState.requests
                             .firstOrNull { it.quoteId == liveQuote.id }
@@ -1115,6 +1134,7 @@ private fun DisplayFace(
     quote: MintQuoteInfo,
     amountLabel: String?,
     receivedAmountLabel: String?,
+    reusableSettlementState: ReusableOfferSettlementState?,
     mintName: String?,
     createdAtEpochMillis: Long?,
     errorText: String?,
@@ -1168,8 +1188,7 @@ private fun DisplayFace(
             }
             if (isReusable) {
                 ReusableOfferStatus(
-                    received = receivedAmountLabel != null,
-                    receivedAmountLabel = receivedAmountLabel,
+                    state = reusableSettlementState ?: ReusableOfferSettlementState.Waiting,
                 )
             } else {
                 WaitingForPaymentRow(text = pendingStatusText)
@@ -1294,15 +1313,15 @@ internal fun GeneratedInvoiceAmount(
 
 /**
  * Status line for a reusable BOLT12 offer. Mirrors the Cashu Request status
- * block: quiet waiting pulse, then a green "Payment received!" once funds land
- * — without the old multi-line explainer that crowded the QR.
+ * block: quiet waiting, an explicit paid-but-unissued minting state, then a
+ * ready-again state only after the ecash issuance counter catches up.
  */
 @Composable
-private fun ReusableOfferStatus(received: Boolean, receivedAmountLabel: String?) {
-    // Waiting → received swaps with the same fade + scale-in the terminal
-    // glyph uses, so an arriving payment reads as a morph, not a pop.
+private fun ReusableOfferStatus(
+    state: ReusableOfferSettlementState,
+) {
     AnimatedContent(
-        targetState = received,
+        targetState = state,
         transitionSpec = {
             (
                 fadeIn(tween(200)) + scaleIn(
@@ -1315,9 +1334,24 @@ private fun ReusableOfferStatus(received: Boolean, receivedAmountLabel: String?)
                 ) togetherWith fadeOut(tween(150))
         },
         label = "reusable-offer-status",
-    ) { isReceived ->
-        if (isReceived) {
-            Row(
+    ) { current ->
+        when (current) {
+            ReusableOfferSettlementState.Waiting -> WaitingForPaymentRow()
+            ReusableOfferSettlementState.Minting -> Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(CashuTheme.spacing.loose),
+                    strokeWidth = 2.dp,
+                )
+                Text(
+                    text = "Payment found. Minting ecash…",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            ReusableOfferSettlementState.Ready -> Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.snug),
             ) {
@@ -1328,13 +1362,11 @@ private fun ReusableOfferStatus(received: Boolean, receivedAmountLabel: String?)
                     modifier = Modifier.size(CashuTheme.spacing.loose),
                 )
                 Text(
-                    text = receivedAmountLabel?.let { "Received $it" } ?: "Payment received!",
+                    text = "Ready for another payment",
                     style = MaterialTheme.typography.titleMedium,
                     color = CashuTheme.colors.onReceivedContainer,
                 )
             }
-        } else {
-            WaitingForPaymentRow()
         }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendDestinationResolver.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendDestinationResolver.kt
@@ -10,8 +10,6 @@ import com.cashu.me.Models.PaymentMethodKind
 
 internal const val AmountlessBolt11Hint =
     "This BOLT11 invoice doesn't include an amount. Ask for an amount-specific invoice before paying."
-internal const val AmountlessBolt12Hint =
-    "This BOLT12 offer doesn't include an amount. Amountless offers are not payable here yet."
 
 internal sealed interface SendDestinationResolution {
     data class Hint(val message: String) : SendDestinationResolution
@@ -58,16 +56,22 @@ internal fun resolveSendDestination(
             if (known == null || known <= 0L) {
                 SendDestinationResolution.Hint(AmountlessBolt11Hint)
             } else {
-                SendDestinationResolution.Melt(request, decoded, known, requiresAmountEntry = false)
+                SendDestinationResolution.Melt(
+                    PaymentRequestDecoder.encodedLightningRequest(request) ?: request,
+                    decoded,
+                    known,
+                    requiresAmountEntry = false,
+                )
             }
         }
         is PaymentRequestDecodeResult.Bolt12 -> {
-            val known = decoded.amountSats
-            if (known == null || known <= 0L) {
-                SendDestinationResolution.Hint(AmountlessBolt12Hint)
-            } else {
-                SendDestinationResolution.Melt(request, decoded, known, requiresAmountEntry = false)
-            }
+            val known = decoded.amountSats?.takeIf { it > 0L }
+            SendDestinationResolution.Melt(
+                request = PaymentRequestDecoder.encodedLightningRequest(request) ?: request,
+                decoded = decoded,
+                knownAmount = known,
+                requiresAmountEntry = known == null,
+            )
         }
         is PaymentRequestDecodeResult.LightningAddress,
         is PaymentRequestDecodeResult.Onchain -> SendDestinationResolution.Melt(

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/CdkMintMethodMappingTest.kt
@@ -1,7 +1,9 @@
 package com.cashu.me.Core.CDK
 
+import com.cashu.me.Core.PaymentRequestDecodeResult
 import com.cashu.me.Models.PaymentMethodKind
 import org.cashudevkit.CurrencyUnit as CdkCurrencyUnit
+import org.cashudevkit.MeltOptions as CdkMeltOptions
 import org.cashudevkit.MeltMethodSettings as CdkMeltMethodSettings
 import org.cashudevkit.MintMethodSettings as CdkMintMethodSettings
 import org.cashudevkit.Nut04Settings as CdkNut04Settings
@@ -19,6 +21,27 @@ import org.junit.Test
  * rails are dropped, matching iOS `supportedMintPaymentMethods` / `…Melt…`.
  */
 class CdkMintMethodMappingTest {
+
+    @Test
+    fun amountlessBolt12MeltUsesEnteredAmountInMillisatoshis() {
+        val options = meltOptionsForLightningRequest(
+            decoded = PaymentRequestDecodeResult.Bolt12(amountSats = null, description = null),
+            amountSats = 21L,
+        )
+
+        assertTrue(options is CdkMeltOptions.Amountless)
+        assertEquals(21_000uL, (options as CdkMeltOptions.Amountless).amountMsat.value)
+    }
+
+    @Test
+    fun amountCarryingBolt12DoesNotOverrideRequestAmount() {
+        val options = meltOptionsForLightningRequest(
+            decoded = PaymentRequestDecodeResult.Bolt12(amountSats = 21L, description = null),
+            amountSats = 42L,
+        )
+
+        assertEquals(null, options)
+    }
 
     @Test
     fun emptyNut04MethodListStaysReportedEmpty() {

--- a/android/app/src/test/java/com/cashu/me/Core/MintQuoteSchedulePolicyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintQuoteSchedulePolicyTest.kt
@@ -12,6 +12,39 @@ import org.junit.Test
 
 class MintQuoteSchedulePolicyTest {
     @Test
+    fun `onchain deposits remain eligible after expiry and old schedules reopen`() {
+        val pending = quote(PaymentMethodKind.Onchain, MintQuoteState.Pending, 0, 0)
+            .copy(expiryEpochSeconds = 100)
+        val record = MintQuoteSchedulePolicy.observed(null, pending, 101_000)
+        assertFalse(record.isComplete)
+        for (force in listOf(false, true)) {
+            val selected = MintQuoteSchedulePolicy.select(
+                listOf(pending.id), mapOf(pending.id to record), 700_000, force,
+            )
+            assertEquals(listOf(pending.id), selected.quoteIds)
+        }
+
+        val oldRecord = record.copy(isComplete = true, nextAttemptAtEpochMillis = Long.MAX_VALUE)
+        val restored = MintQuoteSchedulePolicy.select(
+            listOf(pending.id), mapOf(pending.id to oldRecord), 700_000, false,
+            unsettledOnchainQuoteIds = setOf(pending.id),
+        )
+        assertEquals(listOf(pending.id), restored.quoteIds)
+    }
+
+    @Test
+    fun `selecting a due failed quote does not postpone its retry`() {
+        val record = MintQuoteSchedulePolicy.failed(null, 10_000, true, true)
+        val selected = MintQuoteSchedulePolicy.select(
+            listOf("quote"), mapOf("quote" to record), record.nextAttemptAtEpochMillis, false,
+        )
+        assertEquals(listOf("quote"), selected.quoteIds)
+        assertTrue(MintQuoteSchedulePolicy.shouldAttempt(
+            selected.records["quote"], record.nextAttemptAtEpochMillis, false,
+        ))
+    }
+
+    @Test
     fun `passive sweeps are bounded and rotate fairly`() {
         val ids = (1..5).map { "quote-$it" }
         val first = MintQuoteSchedulePolicy.select(ids, emptyMap(), nowEpochMillis = 1_000, force = false)

--- a/android/app/src/test/java/com/cashu/me/Core/MintQuoteSchedulePolicyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintQuoteSchedulePolicyTest.kt
@@ -1,0 +1,165 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteRetryState
+import com.cashu.me.Models.MintQuoteScheduleRecord
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MintQuoteSchedulePolicyTest {
+    @Test
+    fun `passive sweeps are bounded and rotate fairly`() {
+        val ids = (1..5).map { "quote-$it" }
+        val first = MintQuoteSchedulePolicy.select(ids, emptyMap(), nowEpochMillis = 1_000, force = false)
+
+        assertEquals(MintQuoteSchedulePolicy.PASSIVE_BATCH_LIMIT, first.quoteIds.size)
+
+        val second = MintQuoteSchedulePolicy.select(ids, first.records, nowEpochMillis = 1_000, force = false)
+        assertEquals(MintQuoteSchedulePolicy.PASSIVE_BATCH_LIMIT, second.quoteIds.size)
+        assertTrue(first.quoteIds.intersect(second.quoteIds.toSet()).isEmpty())
+    }
+
+    @Test
+    fun `forced sweep bypasses due time but stays bounded`() {
+        val ids = (1..30).map { "quote-$it" }
+        val future = ids.associateWith {
+            MintQuoteScheduleRecord(
+                firstObservedAtEpochMillis = 1,
+                nextAttemptAtEpochMillis = Long.MAX_VALUE - 1,
+            )
+        }
+
+        assertTrue(
+            MintQuoteSchedulePolicy.select(ids, future, 2_000, force = false).quoteIds.isEmpty(),
+        )
+        assertEquals(
+            MintQuoteSchedulePolicy.FORCED_BATCH_LIMIT,
+            MintQuoteSchedulePolicy.select(ids, future, 2_000, force = true).quoteIds.size,
+        )
+    }
+
+    @Test
+    fun `paid issuance failures become truthful needs-attention state`() {
+        var record: MintQuoteScheduleRecord? = null
+        repeat(3) {
+            record = MintQuoteSchedulePolicy.failed(
+                previous = record,
+                nowEpochMillis = it * 10_000L,
+                hadOutstandingPayment = true,
+                isReusable = true,
+            )
+        }
+        assertEquals(
+            MintQuoteRetryState.RetryScheduled,
+            MintQuoteSchedulePolicy.retryStatus(checkNotNull(record)).state,
+        )
+
+        record = MintQuoteSchedulePolicy.failed(
+            previous = record,
+            nowEpochMillis = 40_000,
+            hadOutstandingPayment = true,
+            isReusable = true,
+        )
+        assertEquals(
+            MintQuoteRetryState.NeedsAttention,
+            MintQuoteSchedulePolicy.retryStatus(checkNotNull(record)).state,
+        )
+        assertEquals(4, record!!.consecutiveFailures)
+    }
+
+    @Test
+    fun `waiting failures back off without claiming a payment needs attention`() {
+        val record = MintQuoteSchedulePolicy.failed(
+            previous = null,
+            nowEpochMillis = 10_000,
+            hadOutstandingPayment = false,
+            isReusable = true,
+        )
+
+        assertEquals(MintQuoteRetryState.None, MintQuoteSchedulePolicy.retryStatus(record).state)
+        assertTrue(record.nextAttemptAtEpochMillis > 10_000)
+    }
+
+    @Test
+    fun `failure counter saturates without overflowing`() {
+        val saturated = MintQuoteSchedulePolicy.failed(
+            previous = MintQuoteScheduleRecord(
+                firstObservedAtEpochMillis = 1,
+                consecutiveFailures = Int.MAX_VALUE,
+                hadOutstandingPayment = true,
+            ),
+            nowEpochMillis = 10_000,
+            hadOutstandingPayment = true,
+            isReusable = true,
+        )
+
+        assertEquals(Int.MAX_VALUE, saturated.consecutiveFailures)
+        assertEquals(
+            MintQuoteRetryState.NeedsAttention,
+            MintQuoteSchedulePolicy.retryStatus(saturated).state,
+        )
+    }
+
+    @Test
+    fun `reusable quote remains scheduled after issuance catches up`() {
+        val record = MintQuoteSchedulePolicy.observed(
+            previous = null,
+            quote = quote(
+                method = PaymentMethodKind.Bolt12,
+                state = MintQuoteState.Issued,
+                paid = 21,
+                issued = 21,
+            ),
+            nowEpochMillis = 1_000,
+        )
+
+        assertTrue(record.isReusable)
+        assertFalse(record.isComplete)
+        assertTrue(record.nextAttemptAtEpochMillis > 1_000)
+    }
+
+    @Test
+    fun `settled one-shot quote leaves the scheduler`() {
+        val record = MintQuoteSchedulePolicy.observed(
+            previous = null,
+            quote = quote(
+                method = PaymentMethodKind.Bolt11,
+                state = MintQuoteState.Issued,
+                paid = 21,
+                issued = 21,
+            ),
+            nowEpochMillis = 1_000,
+        )
+
+        assertTrue(record.isComplete)
+        assertEquals(
+            emptyList<String>(),
+            MintQuoteSchedulePolicy.select(
+                quoteIds = listOf("quote"),
+                existing = mapOf("quote" to record),
+                nowEpochMillis = Long.MAX_VALUE,
+                force = true,
+            ).quoteIds,
+        )
+    }
+
+    private fun quote(
+        method: PaymentMethodKind,
+        state: MintQuoteState,
+        paid: Long,
+        issued: Long,
+    ) = MintQuoteInfo(
+        id = "quote",
+        request = "request",
+        amount = paid,
+        paymentMethod = method,
+        state = state,
+        expiryEpochSeconds = null,
+        amountPaid = paid,
+        amountIssued = issued,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/Core/PaymentRequestDecoderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PaymentRequestDecoderTest.kt
@@ -38,11 +38,11 @@ class PaymentRequestDecoderTest {
 
     @Test
     fun rawAndSchemedBolt12PrefixesAreRecognizedByLightningParser() {
-        assertTrue(LightningRequestParser.isBolt12("lno1ptest"))
-        assertTrue(LightningRequestParser.isBolt12("lightning://lno1ptest"))
+        assertTrue(LightningRequestParser.isBolt12(AmountlessBolt12Offer))
+        assertTrue(LightningRequestParser.isBolt12("lightning://$AmountlessBolt12Offer"))
         assertEquals(
             PaymentMethodKind.Bolt12,
-            LightningRequestParser.parse("lightning:lno1ptest").method,
+            LightningRequestParser.parse("lightning:$AmountlessBolt12Offer").method,
         )
     }
 
@@ -114,6 +114,42 @@ class PaymentRequestDecoderTest {
     }
 
     @Test
+    fun decodeRecognizesRealAmountlessBolt12Offer() {
+        val decoded = PaymentRequestDecoder.decode(AmountlessBolt12Offer)
+
+        assertTrue(decoded is PaymentRequestDecodeResult.Bolt12)
+        assertEquals(null, (decoded as PaymentRequestDecodeResult.Bolt12).amountSats)
+        assertEquals(
+            AmountlessBolt12Offer,
+            PaymentRequestDecoder.encodedLightningRequest("lightning:$AmountlessBolt12Offer"),
+        )
+    }
+
+    @Test
+    fun bolt12TextEnvelopeNormalizesUppercaseAndContinuation() {
+        val continued = AmountlessBolt12Offer.take(32) + "+\n " + AmountlessBolt12Offer.drop(32)
+        val compactContinuation = AmountlessBolt12Offer.take(32) + "+" + AmountlessBolt12Offer.drop(32)
+
+        assertEquals(
+            AmountlessBolt12Offer,
+            PaymentRequestDecoder.encodedLightningRequest(AmountlessBolt12Offer.uppercase()),
+        )
+        assertEquals(
+            AmountlessBolt12Offer,
+            PaymentRequestDecoder.encodedLightningRequest(continued),
+        )
+        assertEquals(
+            AmountlessBolt12Offer,
+            PaymentRequestDecoder.encodedLightningRequest(compactContinuation),
+        )
+        assertEquals(
+            null,
+            PaymentRequestDecoder.encodedLightningRequest("L${AmountlessBolt12Offer.drop(1)}"),
+        )
+        assertTrue(!LightningRequestParser.isBolt12("lno1ptest"))
+    }
+
+    @Test
     fun decodeRecognizesPlainBitcoinAddress() {
         val decoded = PaymentRequestDecoder.decode("1BoatSLRHtKNngkdXEeobR76b53LETtpyT")
         assertEquals(PaymentRequestDecodeResult.Onchain("1BoatSLRHtKNngkdXEeobR76b53LETtpyT"), decoded)
@@ -122,5 +158,10 @@ class PaymentRequestDecoderTest {
     @Test
     fun lightningAddressIsNotBitcoinAddress() {
         assertTrue(!PaymentRequestParser.isBitcoinAddress("user@example.com"))
+    }
+
+    private companion object {
+        const val AmountlessBolt12Offer =
+            "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/Services/NFCPaymentInputDecoderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/Services/NFCPaymentInputDecoderTest.kt
@@ -42,10 +42,11 @@ class NFCPaymentInputDecoderTest {
 
     @Test
     fun routesBolt12LightningSchemeToLightningRequest() {
-        val decoded = NFCPaymentInputDecoder.decode("lightning:lno1ptest")
+        val offer = "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"
+        val decoded = NFCPaymentInputDecoder.decode("lightning:$offer")
 
         assertTrue(decoded is NFCPaymentInput.LightningRequest)
-        assertEquals("lno1ptest", (decoded as NFCPaymentInput.LightningRequest).request)
+        assertEquals(offer, (decoded as NFCPaymentInput.LightningRequest).request)
     }
 
     @Test

--- a/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
@@ -16,6 +16,74 @@ import org.junit.Test
 
 class WalletMintQuoteSyncServiceTest {
     @Test
+    fun `recovery during the first check reports the issuance delta once`() = runBlocking {
+        val ledger = QuoteLedger(paid = 21, issued = 0).apply { recoverOnNextCheck = 21 }
+        val service = ledger.service()
+
+        val recovered = service.syncPendingMintQuote(ledger.quote.id)
+        val duplicate = service.syncPendingMintQuote(ledger.quote.id)
+
+        assertEquals(21L, recovered.newlyIssued)
+        assertTrue(recovered.minted)
+        assertEquals(0L, duplicate.newlyIssued)
+        assertEquals(0, ledger.mintCalls)
+    }
+
+    @Test
+    fun `first check recovery and a later payment report the combined delta`() = runBlocking {
+        val ledger = QuoteLedger(paid = 34, issued = 0).apply { recoverOnNextCheck = 21 }
+        val result = ledger.service().syncPendingMintQuote(ledger.quote.id)
+
+        assertEquals(34L, result.newlyIssued)
+        assertEquals(1, ledger.mintCalls)
+        assertTrue(result.hasSettledPayment)
+    }
+
+    @Test
+    fun `automatic retries respect persisted deadlines and manual retries bypass them`() = runBlocking {
+        val ledger = QuoteLedger(paid = 8, issued = 0).apply { failuresBeforeIssuance = 5 }
+        val first = ledger.service().syncPendingMintQuote(ledger.quote.id)
+        val checkCalls = ledger.checkCalls
+        val record = ledger.schedules[ledger.quote.id]
+
+        // Recreate the service over the same durable state, as on relaunch.
+        val reopened = ledger.service()
+        val deferred = reopened.syncPendingMintQuote(ledger.quote.id)
+        assertEquals(first.retryStatus, deferred.retryStatus)
+        assertEquals(checkCalls, ledger.checkCalls)
+        assertEquals(1, ledger.mintCalls)
+        assertEquals(record, ledger.schedules[ledger.quote.id])
+
+        ledger.now = checkNotNull(first.retryStatus.nextRetryAtEpochMillis)
+        reopened.syncPendingMintQuote(ledger.quote.id)
+        assertEquals(2, ledger.mintCalls)
+
+        ledger.failuresBeforeIssuance = 0
+        val manual = reopened.syncPendingMintQuote(ledger.quote.id, force = true)
+        assertEquals(8L, manual.newlyIssued)
+        assertEquals(3, ledger.mintCalls)
+        assertEquals(MintQuoteRetryState.None, manual.retryStatus.state)
+    }
+
+    @Test
+    fun `onchain payment confirmed after expiry is issued on the next sweep`() = runBlocking {
+        val ledger = QuoteLedger(paid = 0, issued = 0).apply {
+            quote = quote.copy(paymentMethod = PaymentMethodKind.Onchain, expiryEpochSeconds = 1)
+        }
+        val service = ledger.service()
+        service.syncPendingMintQuote(ledger.quote.id)
+        assertFalse(checkNotNull(ledger.schedules[ledger.quote.id]).isComplete)
+
+        ledger.addPayment(21)
+        ledger.now += 60_000
+        val selected = service.selectQuoteIdsForSync(listOf(ledger.quote.id), force = false)
+        assertEquals(listOf(ledger.quote.id), selected)
+        val result = service.syncPendingMintQuote(selected.single())
+        assertEquals(21L, result.newlyIssued)
+        assertTrue(result.hasSettledPayment)
+    }
+
+    @Test
     fun `paid quote is only complete after issued counter catches up`() = runBlocking {
         val ledger = QuoteLedger(paid = 21, issued = 0)
         val result = ledger.service().syncPendingMintQuote(ledger.quote.id)
@@ -66,7 +134,7 @@ class WalletMintQuoteSyncServiceTest {
         val service = ledger.service()
 
         val failed = service.syncPendingMintQuote(ledger.quote.id)
-        val recovered = service.syncPendingMintQuote(ledger.quote.id)
+        val recovered = service.syncPendingMintQuote(ledger.quote.id, force = true)
 
         assertFalse(failed.hasSettledPayment)
         assertEquals(8L, failed.remainingAmount)
@@ -158,18 +226,33 @@ class WalletMintQuoteSyncServiceTest {
             amount = null,
             isAmountless = true,
             paymentMethod = PaymentMethodKind.Bolt12,
-            state = if (paid > issued) MintQuoteState.Paid else MintQuoteState.Issued,
+            state = if (paid > issued) MintQuoteState.Paid else if (paid > 0) MintQuoteState.Issued else MintQuoteState.Pending,
             expiryEpochSeconds = null,
             mintUrl = "https://mint.example",
             amountPaid = paid,
             amountIssued = issued,
         )
         var mintCalls = 0
+        var checkCalls = 0
+        var now = 10_000L
+        var schedules: Map<String, MintQuoteScheduleRecord> = emptyMap()
+        var recoverOnNextCheck = 0L
         var failuresBeforeIssuance = 0
         var throwAfterNextIssuance = false
 
         fun service() = WalletMintQuoteSyncService(
-            checkQuote = { quote },
+            storedQuote = { quote },
+            checkQuote = {
+                checkCalls += 1
+                if (recoverOnNextCheck > 0) {
+                    quote = quote.copy(amountIssued = quote.amountIssued + recoverOnNextCheck)
+                    recoverOnNextCheck = 0
+                }
+                quote
+            },
+            loadSchedules = { schedules },
+            saveSchedules = { schedules = it },
+            nowEpochMillis = { now },
             mintQuote = {
                 mintCalls += 1
                 if (failuresBeforeIssuance > 0) {

--- a/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
@@ -1,6 +1,8 @@
 package com.cashu.me.Core
 
 import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteRetryState
+import com.cashu.me.Models.MintQuoteScheduleRecord
 import com.cashu.me.Models.MintQuoteState
 import com.cashu.me.Models.PaymentMethodKind
 import kotlinx.coroutines.Dispatchers
@@ -68,9 +70,70 @@ class WalletMintQuoteSyncServiceTest {
 
         assertFalse(failed.hasSettledPayment)
         assertEquals(8L, failed.remainingAmount)
+        assertEquals(MintQuoteRetryState.RetryScheduled, failed.retryStatus.state)
         assertEquals(8L, recovered.newlyIssued)
         assertTrue(recovered.hasSettledPayment)
+        assertEquals(MintQuoteRetryState.None, recovered.retryStatus.state)
         assertEquals(2, ledger.mintCalls)
+    }
+
+    @Test
+    fun `check failure uses durable paid snapshot and reports a scheduled retry`() = runBlocking {
+        val cached = MintQuoteInfo(
+            id = "reusable-quote",
+            request = "lno1test",
+            amount = null,
+            isAmountless = true,
+            paymentMethod = PaymentMethodKind.Bolt12,
+            state = MintQuoteState.Paid,
+            expiryEpochSeconds = null,
+            mintUrl = "https://mint.example",
+            amountPaid = 5,
+            amountIssued = 0,
+        )
+        val service = WalletMintQuoteSyncService(
+            checkQuote = { error("mint temporarily unavailable") },
+            storedQuote = { cached },
+            mintQuote = { error("must not mint without a status check") },
+            nowEpochMillis = { 10_000 },
+        )
+
+        val result = service.syncPendingMintQuote(cached.id)
+
+        assertEquals(cached, result.quote)
+        assertEquals(5L, result.remainingAmount)
+        assertEquals(MintQuoteRetryState.RetryScheduled, result.retryStatus.state)
+        assertEquals(15_000L, result.retryStatus.nextRetryAtEpochMillis)
+    }
+
+    @Test
+    fun `wallet boundary storage reset clears retry state immediately`() {
+        var schedules = mapOf(
+            "old-quote" to MintQuoteScheduleRecord(
+                firstObservedAtEpochMillis = 1_000,
+                consecutiveFailures = 4,
+                hadOutstandingPayment = true,
+                isReusable = true,
+            ),
+        )
+        val service = WalletMintQuoteSyncService(
+            checkQuote = { error("unused") },
+            mintQuote = { error("unused") },
+            loadSchedules = { schedules },
+            saveSchedules = { schedules = it },
+        )
+
+        assertEquals(
+            MintQuoteRetryState.NeedsAttention,
+            service.retryStatus("old-quote").state,
+        )
+
+        // WalletStore.removeAllWalletData() changes the durable source while
+        // WalletManager remains alive. The service must not retain the old
+        // wallet's retry metadata in memory.
+        schedules = emptyMap()
+
+        assertEquals(MintQuoteRetryState.None, service.retryStatus("old-quote").state)
     }
 
     @Test

--- a/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
@@ -1,0 +1,136 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WalletMintQuoteSyncServiceTest {
+    @Test
+    fun `paid quote is only complete after issued counter catches up`() = runBlocking {
+        val ledger = QuoteLedger(paid = 21, issued = 0)
+        val result = ledger.service().syncPendingMintQuote(ledger.quote.id)
+
+        assertEquals(21L, result.newlyIssued)
+        assertEquals(21L, result.quote?.amountIssued)
+        assertEquals(0L, result.remainingAmount)
+        assertTrue(result.hasSettledPayment)
+        assertEquals(1, ledger.mintCalls)
+    }
+
+    @Test
+    fun `same reusable offer settles every later payment exactly once`() = runBlocking {
+        val ledger = QuoteLedger(paid = 10, issued = 0)
+        val service = ledger.service()
+
+        val first = service.syncPendingMintQuote(ledger.quote.id)
+        ledger.addPayment(11)
+        val second = service.syncPendingMintQuote(ledger.quote.id)
+        val duplicateCheck = service.syncPendingMintQuote(ledger.quote.id)
+
+        assertEquals(10L, first.newlyIssued)
+        assertEquals(11L, second.newlyIssued)
+        assertEquals(0L, duplicateCheck.newlyIssued)
+        assertEquals(21L, duplicateCheck.quote?.amountPaid)
+        assertEquals(21L, duplicateCheck.quote?.amountIssued)
+        assertEquals(2, ledger.mintCalls)
+    }
+
+    @Test
+    fun `ambiguous mint response is resolved by verified issued counter`() = runBlocking {
+        val ledger = QuoteLedger(paid = 13, issued = 0).apply {
+            throwAfterNextIssuance = true
+        }
+
+        val result = ledger.service().syncPendingMintQuote(ledger.quote.id)
+
+        assertEquals(13L, result.newlyIssued)
+        assertTrue(result.hasSettledPayment)
+        assertEquals(13L, result.quote?.amountIssued)
+    }
+
+    @Test
+    fun `failed issuance remains tracked and succeeds on a later pass`() = runBlocking {
+        val ledger = QuoteLedger(paid = 8, issued = 0).apply {
+            failuresBeforeIssuance = 1
+        }
+        val service = ledger.service()
+
+        val failed = service.syncPendingMintQuote(ledger.quote.id)
+        val recovered = service.syncPendingMintQuote(ledger.quote.id)
+
+        assertFalse(failed.hasSettledPayment)
+        assertEquals(8L, failed.remainingAmount)
+        assertEquals(8L, recovered.newlyIssued)
+        assertTrue(recovered.hasSettledPayment)
+        assertEquals(2, ledger.mintCalls)
+    }
+
+    @Test
+    fun `concurrent triggers share one check mint verify lane`() = runBlocking {
+        val ledger = QuoteLedger(paid = 31, issued = 0)
+        val service = ledger.service()
+
+        val results = listOf(
+            async(Dispatchers.Default) { service.syncPendingMintQuote(ledger.quote.id) },
+            async(Dispatchers.Default) { service.syncPendingMintQuote(ledger.quote.id) },
+        ).awaitAll()
+
+        assertEquals(1, ledger.mintCalls)
+        assertEquals(31L, results.sumOf { it.newlyIssued })
+        assertTrue(results.all { it.hasSettledPayment })
+    }
+
+    private class QuoteLedger(paid: Long, issued: Long) {
+        var quote = MintQuoteInfo(
+            id = "reusable-quote",
+            request = "lno1test",
+            amount = null,
+            isAmountless = true,
+            paymentMethod = PaymentMethodKind.Bolt12,
+            state = if (paid > issued) MintQuoteState.Paid else MintQuoteState.Issued,
+            expiryEpochSeconds = null,
+            mintUrl = "https://mint.example",
+            amountPaid = paid,
+            amountIssued = issued,
+        )
+        var mintCalls = 0
+        var failuresBeforeIssuance = 0
+        var throwAfterNextIssuance = false
+
+        fun service() = WalletMintQuoteSyncService(
+            checkQuote = { quote },
+            mintQuote = {
+                mintCalls += 1
+                if (failuresBeforeIssuance > 0) {
+                    failuresBeforeIssuance -= 1
+                    error("temporary mint failure")
+                }
+                val issuedNow = quote.mintableAmount
+                quote = quote.copy(
+                    amountIssued = quote.amountPaid,
+                    state = MintQuoteState.Issued,
+                )
+                if (throwAfterNextIssuance) {
+                    throwAfterNextIssuance = false
+                    error("response lost after issuance")
+                }
+                issuedNow
+            },
+        )
+
+        fun addPayment(amount: Long) {
+            quote = quote.copy(
+                amountPaid = quote.amountPaid + amount,
+                state = MintQuoteState.Paid,
+            )
+        }
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/ui/send/SendDestinationResolverTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/send/SendDestinationResolverTest.kt
@@ -18,13 +18,15 @@ class SendDestinationResolverTest {
     }
 
     @Test
-    fun amountlessBolt12OfferShowsHintInsteadOfAdvancing() {
-        val resolution = resolveSendDestination("lightning:lno1ptest", walletMints = emptyList())
+    fun amountlessBolt12OfferRoutesToAmountEntry() {
+        val resolution = resolveSendDestination("lightning:$AmountlessBolt12Offer", walletMints = emptyList())
 
-        assertEquals(
-            SendDestinationResolution.Hint(AmountlessBolt12Hint),
-            resolution,
-        )
+        assertTrue(resolution is SendDestinationResolution.Melt)
+        val melt = resolution as SendDestinationResolution.Melt
+        assertEquals(AmountlessBolt12Offer, melt.request)
+        assertEquals(null, melt.knownAmount)
+        assertTrue(melt.requiresAmountEntry)
+        assertTrue(melt.decoded is PaymentRequestDecodeResult.Bolt12)
     }
 
     @Test
@@ -58,6 +60,9 @@ class SendDestinationResolverTest {
     }
 
     private companion object {
+        private const val AmountlessBolt12Offer =
+            "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"
+
         // BOLT #11 example: donation invoice with no amount in the HRP.
         private const val Bolt11AmountlessDonationInvoice =
             "lnbc1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq9qrsgq357wnc5r2ueh7ck6q93dj32dlqnls087fxdwk8qakdyafkq3yap9us6v52vjjsrvywa6rt52cm9r9zqt8r2t7mlcwspyetp5h2tztugp9lfyql"

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		A09100000000000000000001 /* MintQuoteRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000002 /* MintQuoteRecovery.swift */; };
 		CD9100000000000000000001 /* MintDetailInfoLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000002 /* MintDetailInfoLoader.swift */; };
 		CD9100000000000000000003 /* MintDetailInfoLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */; };
+		C33400000000000000000001 /* MintQuoteReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33400000000000000000002 /* MintQuoteReconciler.swift */; };
 		323A00000000000000000001 /* PriceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A00000000000000000002 /* PriceServiceTests.swift */; };
 		1100000000000001 /* CashuWalletApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000001 /* CashuWalletApp.swift */; };
 		1100000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000002 /* ContentView.swift */; };
@@ -200,6 +201,7 @@
 		A09100000000000000000002 /* MintQuoteRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintQuoteRecovery.swift; sourceTree = "<group>"; };
 		CD9100000000000000000002 /* MintDetailInfoLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintDetailInfoLoader.swift; sourceTree = "<group>"; };
 		CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MintDetailInfoLoaderTests.swift; path = CashuWalletTests/MintDetailInfoLoaderTests.swift; sourceTree = "<group>"; };
+		C33400000000000000000002 /* MintQuoteReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintQuoteReconciler.swift; sourceTree = "<group>"; };
 		323A00000000000000000002 /* PriceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriceServiceTests.swift; path = CashuWalletTests/PriceServiceTests.swift; sourceTree = "<group>"; };
 		0100000000000001 /* CashuWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CashuWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2100000000000001 /* CashuWalletApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletApp.swift; sourceTree = "<group>"; };
@@ -711,6 +713,7 @@
 				BB00000000000013 /* TokenService.swift */,
 				BB00000000000014 /* LightningService.swift */,
 				A09100000000000000000002 /* MintQuoteRecovery.swift */,
+				C33400000000000000000002 /* MintQuoteReconciler.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1098,6 +1101,7 @@
 				BB00000000000003 /* TokenService.swift in Sources */,
 				BB00000000000004 /* LightningService.swift in Sources */,
 				A09100000000000000000001 /* MintQuoteRecovery.swift in Sources */,
+				C33400000000000000000001 /* MintQuoteReconciler.swift in Sources */,
 				CC00000000000001 /* ThemeSettingsSection.swift in Sources */,
 				CC00000000000002 /* BackupSettingsSection.swift in Sources */,
 				CC00000000000004 /* P2PKSettingsSection.swift in Sources */,

--- a/ios/CashuWallet/Core/LightningRequestParser.swift
+++ b/ios/CashuWallet/Core/LightningRequestParser.swift
@@ -20,16 +20,21 @@ enum LightningRequestParser {
 
     static func parse(_ request: String) throws -> ParsedRequest {
         let normalizedRequest = normalize(request)
-        let decodedRequest = try decodeInvoice(invoiceStr: normalizedRequest)
-
-        let method: PaymentMethod
-        switch decodedRequest.paymentType {
-        case .bolt11:
-            method = .bolt11
-        case .bolt12:
-            method = .bolt12
+        do {
+            let decodedRequest = try decodeInvoice(invoiceStr: normalizedRequest)
+            let method: PaymentMethod
+            switch decodedRequest.paymentType {
+            case .bolt11:
+                method = .bolt11
+            case .bolt12:
+                method = .bolt12
+            }
+            return ParsedRequest(request: normalizedRequest, method: method)
+        } catch {
+            if let offer = PaymentRequestParser.bolt12OfferMetadata(from: normalizedRequest) {
+                return ParsedRequest(request: offer.normalizedRequest, method: .bolt12)
+            }
+            throw error
         }
-
-        return ParsedRequest(request: normalizedRequest, method: method)
     }
 }

--- a/ios/CashuWallet/Core/Navigation/NavigationManager.swift
+++ b/ios/CashuWallet/Core/Navigation/NavigationManager.swift
@@ -288,7 +288,12 @@ enum ScanRouter {
         case .bolt11, .bolt12:
             let request = PaymentRequestDecoder.encodedLightningRequest(from: trimmed)
                 ?? PaymentRequestParser.normalizeLightningRequest(trimmed)
-            return .melt(request: request, mode: .lightning, autoQuote: true, explanation: nil)
+            return .melt(
+                request: request,
+                mode: .lightning,
+                autoQuote: PaymentRequestDecoder.amountLocked(decoded),
+                explanation: nil
+            )
         case .onchain:
             return .melt(
                 request: PaymentRequestParser.normalizeBitcoinRequest(trimmed),

--- a/ios/CashuWallet/Core/PaymentRequestDecoder.swift
+++ b/ios/CashuWallet/Core/PaymentRequestDecoder.swift
@@ -60,24 +60,32 @@ actor CdkRuntime {
         let normalized = PaymentRequestDecoder.encodedLightningRequest(from: raw)
             ?? PaymentRequestParser.normalizeLightningRequest(raw)
 
-        guard !normalized.isEmpty,
-              let decoded = try? decodeInvoice(invoiceStr: normalized) else {
-            return nil
+        guard !normalized.isEmpty else { return nil }
+
+        if let decoded = try? decodeInvoice(invoiceStr: normalized) {
+            let paymentMethod: PaymentMethodKind
+            switch decoded.paymentType {
+            case .bolt11:
+                paymentMethod = .bolt11
+            case .bolt12:
+                paymentMethod = .bolt12
+            }
+
+            return LightningRequestMetadata(
+                normalizedRequest: normalized,
+                paymentMethod: paymentMethod,
+                amountSats: decoded.amountMsat.map(PaymentRequestDecoder.satsCeiling(from:)),
+                amountMsat: decoded.amountMsat
+            )
         }
 
-        let paymentMethod: PaymentMethodKind
-        switch decoded.paymentType {
-        case .bolt11:
-            paymentMethod = .bolt11
-        case .bolt12:
-            paymentMethod = .bolt12
-        }
+        guard let offer = PaymentRequestParser.bolt12OfferMetadata(from: normalized) else { return nil }
 
         return LightningRequestMetadata(
-            normalizedRequest: normalized,
-            paymentMethod: paymentMethod,
-            amountSats: decoded.amountMsat.map(PaymentRequestDecoder.satsCeiling(from:)),
-            amountMsat: decoded.amountMsat
+            normalizedRequest: offer.normalizedRequest,
+            paymentMethod: .bolt12,
+            amountSats: offer.amountMsat.map(PaymentRequestDecoder.satsCeiling(from:)),
+            amountMsat: offer.amountMsat
         )
     }
 
@@ -102,16 +110,13 @@ enum PaymentRequestDecodeResult: Equatable, Sendable {
 }
 
 extension PaymentRequestDecodeResult {
-    /// Clean caution copy when this is a Lightning request that carries no amount,
-    /// so every melt entry point surfaces identical, plain-language wording instead
-    /// of a failing quote round-trip that leaks raw CDK codes. Nil for anything that
-    /// isn't an amountless BOLT11 invoice or BOLT12 offer.
+    /// Clean caution copy for amountless request types this wallet still cannot
+    /// pay. BOLT12 offers are intentionally excluded: Send collects an amount
+    /// and passes it through CDK's amountless melt option.
     var amountlessMeltCaution: String? {
         switch self {
         case .bolt11(let amountSats, _) where amountSats == nil:
             return "This invoice doesn't set an amount. Ask the sender for one with the amount set."
-        case .bolt12(let amountSats, _) where amountSats == nil:
-            return "This offer doesn't set an amount. Ask the sender for one with the amount set."
         default:
             return nil
         }
@@ -124,8 +129,10 @@ enum PaymentRequestMode: String, Equatable, Sendable {
 }
 
 /// Centralized payment-request decoder. Wraps `PaymentRequestParser` +
-/// CashuDevKit's `decodeInvoice` so the chip preview, recents tap, scan
-/// callback, and live decode feedback all share a single classification path.
+/// CashuDevKit's `decodeInvoice`, with a BOLT12 envelope/TLV fallback for
+/// valid amountless offers that CDK's stricter decoder rejects. The chip
+/// preview, recents tap, scan callback, and live decode feedback all share this
+/// single classification path.
 enum PaymentRequestDecoder {
     static func decode(
         _ raw: String,
@@ -165,12 +172,18 @@ enum PaymentRequestDecoder {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
 
+        let normalized: String
         if let bitcoinURI = bitcoinPaymentURI(from: trimmed),
            let lightning = bitcoinURI.lightning {
-            return PaymentRequestParser.normalizeLightningRequest(lightning)
+            normalized = PaymentRequestParser.normalizeLightningRequest(lightning)
+        } else {
+            normalized = PaymentRequestParser.normalizeLightningRequest(trimmed)
         }
 
-        let normalized = PaymentRequestParser.normalizeLightningRequest(trimmed)
+        if let offer = PaymentRequestParser.bolt12OfferMetadata(from: normalized) {
+            return offer.normalizedRequest
+        }
+
         guard (try? decodeInvoice(invoiceStr: normalized)) != nil else {
             return nil
         }
@@ -220,18 +233,23 @@ enum PaymentRequestDecoder {
     }
 
     private static func decodedLightningRequest(from raw: String) -> PaymentRequestDecodeResult? {
-        guard let normalized = encodedLightningRequest(from: raw),
-              let decoded = try? decodeInvoice(invoiceStr: normalized) else {
-            return nil
+        guard let normalized = encodedLightningRequest(from: raw) else { return nil }
+
+        if let decoded = try? decodeInvoice(invoiceStr: normalized) {
+            let amountSats: UInt64? = decoded.amountMsat.map(satsCeiling(from:))
+            switch decoded.paymentType {
+            case .bolt11:
+                return .bolt11(amountSats: amountSats, description: decoded.description)
+            case .bolt12:
+                return .bolt12(amountSats: amountSats, description: decoded.description)
+            }
         }
 
-        let amountSats: UInt64? = decoded.amountMsat.map(satsCeiling(from:))
-        switch decoded.paymentType {
-        case .bolt11:
-            return .bolt11(amountSats: amountSats, description: decoded.description)
-        case .bolt12:
-            return .bolt12(amountSats: amountSats, description: decoded.description)
-        }
+        guard let offer = PaymentRequestParser.bolt12OfferMetadata(from: normalized) else { return nil }
+        return .bolt12(
+            amountSats: offer.amountMsat.map(satsCeiling(from:)),
+            description: offer.description
+        )
     }
 
     fileprivate static func satsCeiling(from amountMsat: UInt64) -> UInt64 {

--- a/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -93,6 +93,7 @@ enum StorageKeys {
     static let savedTokens = "wallet.savedTokens"
     static let paymentPreimages = "wallet.paymentPreimages"
     static let mintQuoteTimestamps = "wallet.mintQuoteTimestamps"
+    static let mintQuoteSchedules = "wallet.mintQuoteSchedules.v1"
     static let mintKeysetRefreshTimestamps = "wallet.mintKeysetRefreshTimestamps"
     static let processedNPCQuotes = "wallet.processedNPCQuotes"
     static let nostrMintBackupLastBackupDate = "wallet.nostrMintBackup.lastBackupDate"
@@ -225,6 +226,7 @@ enum StorageKeys {
         savedTokens,
         paymentPreimages,
         mintQuoteTimestamps,
+        mintQuoteSchedules,
         mintKeysetRefreshTimestamps,
         processedNPCQuotes,
         nostrMintBackupLastBackupDate,

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -239,6 +239,29 @@ class LightningService: ObservableObject {
             "The mint context for this receive request is unavailable. Create a new request and try again."
         )
     }
+
+    /// Last durable local quote snapshot without contacting the mint. Recovery
+    /// uses this only to tell the truth after a status request fails: a cached
+    /// paid/issued delta is enough to say that ecash is still pending, but never
+    /// enough to claim success.
+    func storedMintQuote(quoteId: String) async -> MintQuoteInfo? {
+        guard let database = walletDatabase() else { return nil }
+        let quote: MintQuote
+        do {
+            guard let stored = try await database.getMintQuote(quoteId: quoteId) else {
+                return nil
+            }
+            quote = stored
+        } catch {
+            return nil
+        }
+        let method = PaymentMethodKind.from(quote.paymentMethod) ?? .bolt11
+        return mintQuoteInfo(
+            from: quote,
+            fallbackAmount: quote.amount?.value,
+            paymentMethod: method
+        )
+    }
     
     /// Mint tokens after invoice is paid
     /// - Parameter quoteId: The quote ID to mint

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -29,6 +29,25 @@ enum MintQuoteContextPolicy {
     }
 }
 
+/// Builds CDK's explicit amount override for a request that does not carry one.
+/// Keeping this small conversion outside the service makes the protocol boundary
+/// directly testable without a live wallet repository.
+func meltOptionsForLightningRequest(
+    requestAmountMsat: UInt64?,
+    amountSats: UInt64?
+) throws -> MeltOptions? {
+    guard requestAmountMsat == nil else { return nil }
+    guard let amountSats, amountSats > 0 else {
+        throw WalletError.networkError(
+            "This Lightning request doesn't include an amount. Enter an amount before requesting a quote."
+        )
+    }
+    guard amountSats <= UInt64.max / 1_000 else {
+        throw WalletError.networkError("Amount is too large.")
+    }
+    return .amountless(amountMsat: Amount(value: amountSats * 1_000))
+}
+
 // MARK: - Lightning Service
 
 /// Service responsible for Lightning Network operations (NUT-04/NUT-05).
@@ -316,6 +335,7 @@ class LightningService: ObservableObject {
     /// - Returns: Melt quote with fee information
     func createMeltQuote(
         request: String,
+        amount: UInt64? = nil,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
         guard let repo = walletRepository() else {
@@ -335,6 +355,10 @@ class LightningService: ObservableObject {
         let normalizedRequest = metadata.normalizedRequest
         let paymentMethod = metadata.paymentMethod
         let invoiceAmountSats = metadata.amountSats
+        let meltOptions = try meltOptionsForLightningRequest(
+            requestAmountMsat: metadata.amountMsat,
+            amountSats: amount
+        )
 
         if PaymentRequestParser.isBitcoinAddress(normalizedRequest) {
             throw WalletError.networkError("On-chain payments require an amount before requesting a quote.")
@@ -342,7 +366,7 @@ class LightningService: ObservableObject {
 
         let candidates = meltQuoteCandidateMints(
             paymentMethod: paymentMethod,
-            minimumAmount: invoiceAmountSats,
+            minimumAmount: invoiceAmountSats ?? amount,
             preferredMintURL: preferredMintURL
         )
 
@@ -361,7 +385,7 @@ class LightningService: ObservableObject {
                 let quote = try await wallet.meltQuote(
                     method: paymentMethod.cdkMethod,
                     request: normalizedRequest,
-                    options: nil,
+                    options: meltOptions,
                     extra: nil
                 )
 
@@ -391,7 +415,7 @@ class LightningService: ObservableObject {
         invoice: String,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
-        try await createMeltQuote(request: invoice, preferredMintURL: preferredMintURL)
+        try await createMeltQuote(request: invoice, amount: nil, preferredMintURL: preferredMintURL)
     }
     
     /// Create a melt quote for paying a human-readable address.
@@ -1136,12 +1160,15 @@ class LightningService: ObservableObject {
             id: quote.id,
             request: quote.request,
             amount: resolvedAmount,
+            isAmountless: quote.amount == nil,
             paymentMethod: paymentMethod,
             state: mintQuoteState(from: quote, paymentMethod: paymentMethod),
             expiry: displayExpiry(quote.expiry),
             createdAt: createdAt,
             unit: PaymentRequestDecoder.unitDescription(quote.unit),
-            mintURL: quote.mintUrl.url
+            mintURL: quote.mintUrl.url,
+            amountPaid: quote.amountPaid.value,
+            amountIssued: quote.amountIssued.value
         )
     }
 

--- a/ios/CashuWallet/Core/Services/MintQuoteReconciler.swift
+++ b/ios/CashuWallet/Core/Services/MintQuoteReconciler.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Runs under WalletManager's repository lease. Keeping network checks inside
+/// this operation makes recovery, retry deadlines, and issuance one workflow.
+@MainActor
+struct MintQuoteReconciler {
+    private enum ReconciliationError: Error { case noIssuanceProgress }
+
+    var storedQuote: (String) async -> MintQuoteInfo?
+    var checkQuote: (String) async throws -> MintQuoteInfo
+    var mintQuote: (String) async throws -> UInt64
+    var schedule: (String) -> MintQuoteScheduleRecord?
+    var observed: (MintQuoteInfo) -> Void
+    var failed: (String, MintQuoteInfo?) -> MintQuoteRetryStatus
+    var logFailure: (String, Error) -> Void
+    var now: () -> Date = Date.init
+
+    func reconcile(quoteID: String, force: Bool = false) async -> MintQuoteReconciliationResult? {
+        let cached = await storedQuote(quoteID)
+        guard !Task.isCancelled else { return nil }
+        let record = schedule(quoteID)
+        guard MintQuoteSchedulePolicy.shouldAttempt(record: record, now: now(), force: force) else {
+            return cached.map {
+                MintQuoteReconciliationResult(
+                    observed: $0,
+                    retryStatus: record.map(MintQuoteSchedulePolicy.retryStatus) ?? MintQuoteRetryStatus()
+                )
+            }
+        }
+
+        let checked: MintQuoteInfo
+        do {
+            checked = try await checkQuote(quoteID)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            logFailure(quoteID, error)
+            let local = await storedQuote(quoteID) ?? cached
+            let retryStatus = failed(quoteID, local)
+            return local.map { MintQuoteReconciliationResult(observed: $0, retryStatus: retryStatus) }
+        }
+
+        guard checked.mintableAmount > 0 else {
+            observed(checked)
+            return MintQuoteReconciliationResult(
+                observed: checked,
+                issuedBeforeCheck: cached?.amountIssued
+            )
+        }
+
+        var mintedAmount: UInt64 = 0
+        var mintError: Error?
+        do {
+            mintedAmount = try await mintQuote(quoteID)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            mintError = error
+        }
+
+        let verified: MintQuoteInfo?
+        do {
+            verified = try await checkQuote(quoteID)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            verified = nil
+        }
+
+        let result = MintQuoteReconciliationResult(
+            observed: checked,
+            mintedAmount: mintedAmount,
+            verified: verified,
+            issuedBeforeCheck: cached?.amountIssued
+        )
+        if result.remainingAmount > 0 {
+            logFailure(quoteID, mintError ?? ReconciliationError.noIssuanceProgress)
+            return MintQuoteReconciliationResult(
+                observed: checked,
+                mintedAmount: mintedAmount,
+                verified: verified,
+                issuedBeforeCheck: cached?.amountIssued,
+                retryStatus: failed(quoteID, result.quote)
+            )
+        }
+
+        observed(result.quote)
+        return result
+    }
+}

--- a/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+CashuPaymentRequests.swift
@@ -449,7 +449,8 @@ extension WalletManager {
 
     /// Mint proofs for a paid quote, retrying so a slow/settling mint doesn't fail
     /// the whole flow. Returns false if all attempts are exhausted (the pending
-    /// quote is minted later by `claimPaidMintQuote`/History refresh).
+    /// quote stays in the durable reconciliation ledger and is minted by the
+    /// foreground/startup sweep or an explicit History refresh).
     private func mintWithRetries(quoteId: String) async -> Bool {
         for attempt in 0..<8 {
             guard !Task.isCancelled else { return false }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
@@ -20,6 +20,7 @@ extension WalletManager {
                 targetMintURL: targetMintURL,
                 unit: PaymentRequestDecoder.currencyUnit(from: unit)
             )
+            self.rememberMintQuoteForScheduling(quote)
             await self.loadTransactionsAssumingWalletOperationLease()
             return quote
         }
@@ -30,16 +31,20 @@ extension WalletManager {
         unit: String
     ) async throws -> MintQuoteInfo? {
         try await operationCoordinator.perform(kind: .mintQuote, resourceID: mintURL) {
-            try await self.lightningService.existingAmountlessOffer(
+            let quote = try await self.lightningService.existingAmountlessOffer(
                 mintURL: mintURL,
                 unit: PaymentRequestDecoder.currencyUnit(from: unit)
             )
+            if let quote { self.rememberMintQuoteForScheduling(quote) }
+            return quote
         }
     }
 
     func existingOnchainMintQuote(mintURL: String? = nil) async throws -> MintQuoteInfo? {
         try await operationCoordinator.perform(kind: .mintQuote) {
-            try await self.lightningService.existingOnchainMintQuote(mintURL: mintURL)
+            let quote = try await self.lightningService.existingOnchainMintQuote(mintURL: mintURL)
+            if let quote { self.rememberMintQuoteForScheduling(quote) }
+            return quote
         }
     }
 
@@ -48,7 +53,9 @@ extension WalletManager {
             kind: .mintQuote,
             resourceID: quoteId
         ) {
-            try await self.lightningService.checkMintQuote(quoteId: quoteId)
+            let quote = try await self.lightningService.checkMintQuote(quoteId: quoteId)
+            self.rememberMintQuoteForScheduling(quote)
+            return quote
         }
     }
 

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lightning.swift
@@ -78,30 +78,9 @@ extension WalletManager {
         return amount
     }
 
-    /// Fire-and-forget: keep trying to mint a paid quote so a slow/transiently
-    /// failing mint never blocks the receive sheet. `mintTokens` already
-    /// refreshes balance + history on success, so the wallet credits the moment
-    /// it lands; `syncPendingMintQuotes()` (History pull-to-refresh) is the
-    /// ultimate backstop if all attempts here fail.
-    func claimPaidMintQuote(quoteId: String) async {
-        for _ in 0..<8 {
-            guard !Task.isCancelled else { return }
-            do {
-                _ = try await mintTokens(quoteId: quoteId)
-                return
-            } catch {
-                do { try await Task.sleep(for: .milliseconds(2500)) }
-                catch { return }
-            }
-        }
-        AppLogger.wallet.error(
-            "claimPaidMintQuote: gave up minting resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public)"
-        )
-        SentryService.breadcrumb("Lightning mint claim gave up after retries", category: "wallet.lightning")
-    }
-
     func createMeltQuote(
         request: String,
+        amount: UInt64? = nil,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
         try await operationCoordinator.perform(
@@ -110,6 +89,7 @@ extension WalletManager {
         ) {
             try await self.lightningService.createMeltQuote(
                 request: request,
+                amount: amount,
                 preferredMintURL: preferredMintURL
             )
         }
@@ -119,7 +99,7 @@ extension WalletManager {
         invoice: String,
         preferredMintURL: String? = nil
     ) async throws -> MeltQuoteInfo {
-        return try await createMeltQuote(request: invoice, preferredMintURL: preferredMintURL)
+        return try await createMeltQuote(request: invoice, amount: nil, preferredMintURL: preferredMintURL)
     }
 
     func createHumanReadableMeltQuote(

--- a/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
@@ -16,25 +16,29 @@ extension WalletManager {
         await syncPendingMintQuotes(force: false)
     }
 
-    /// Silent single-quote check + mint if paid. Used when opening a pending
-    /// Lightning / on-chain receive in transaction detail (Android
-    /// `refreshPendingMintQuote` parity). Does not touch the global loading flag.
+    /// Reconcile one persisted quote against its mint. The returned counters
+    /// distinguish "the Lightning payment arrived" from "the ecash was
+    /// actually issued"; callers must never present success from the former.
+    /// Does not touch the global loading flag.
     @discardableResult
-    func refreshPendingMintQuote(quoteId: String) async -> Bool {
+    func refreshPendingMintQuote(quoteId: String) async -> MintQuoteReconciliationResult? {
         do {
             return try await operationCoordinator.perform(
                 kind: .mintQuote,
                 resourceID: quoteId
             ) {
-                let minted = await self.mintQuoteIfPaid(quoteId: quoteId)
-                if minted {
+                guard let result = await self.reconcileMintQuote(quoteId: quoteId) else {
+                    await self.loadTransactionsAssumingWalletOperationLease()
+                    return nil
+                }
+                if result.newlyIssued > 0 {
                     await self.refreshBalanceAssumingWalletOperationLease()
                 }
                 await self.loadTransactionsAssumingWalletOperationLease()
-                return minted
+                return result
             }
         } catch {
-            return false
+            return nil
         }
     }
 
@@ -66,10 +70,10 @@ extension WalletManager {
         pendingQuotePollTask = nil
     }
 
-    /// Check every tracked wallet for paid-but-unissued mint quotes and mint
-    /// them. CDK 0.18's `mintUnissuedQuotes()` refreshes each quote's NUT-04
-    /// counters with the mint and mints only the outstanding delta, which
-    /// covers reusable BOLT12 offers without any local heuristics.
+    /// Check every persisted, reconcilable quote and mint its outstanding
+    /// counter delta. CDK keeps every BOLT12 quote in this list permanently,
+    /// including fully-issued reusable offers, so later payments are still
+    /// found after dismissal, app suspension, or relaunch.
     /// - Parameter force: `false` (poll / startup / History open) only runs
     ///   when the repository lane is idle; `true` (pull-to-refresh) preempts.
     func syncPendingMintQuotes(force: Bool = false) async {
@@ -94,20 +98,33 @@ extension WalletManager {
     }
 
     private func mintUnissuedQuotesAcrossWallets() async {
-        guard walletRepository != nil else { return }
         lastMintQuoteSyncAt = Date()
 
-        var mintedAny = false
-        for wallet in await trackedWalletsAssumingWalletOperationLease() {
-            guard !Task.isCancelled else { break }
+        // The CDK database is the durable ledger. Union it with app-level
+        // receive intents so an older/migrated BOLT12 row is still explicitly
+        // checked and produces a useful missing-quote diagnostic instead of
+        // silently disappearing from maintenance.
+        var quoteIDs = Set(CashuRequestStore.shared.requests.compactMap(\.quoteId))
+        if let db {
             do {
-                let minted = try await wallet.mintUnissuedQuotes()
-                mintedAny = mintedAny || minted.value > 0
-            } catch is CancellationError {
-                break
+                quoteIDs.formUnion(try await db.getUnissuedMintQuotes().map(\.id))
             } catch {
                 AppLogger.wallet.error(
-                    "unissued quote sweep failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                    "mint quote ledger scan failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
+            }
+        }
+
+        var mintedAny = false
+        for quoteID in quoteIDs.sorted() {
+            guard !Task.isCancelled else { return }
+            guard let result = await reconcileMintQuote(quoteId: quoteID) else { continue }
+            if result.newlyIssued > 0 {
+                mintedAny = true
+                postReceivedMintNotification(
+                    amount: result.newlyIssued,
+                    unit: result.quote.unit,
+                    homeHaptic: true
                 )
             }
             if await operationCoordinator.hasWaitingUserOperation() { break }
@@ -120,43 +137,64 @@ extension WalletManager {
         await loadTransactionsAssumingWalletOperationLease()
     }
 
-    /// Check one quote with its mint and mint it when an unpaid amount is
-    /// outstanding. The NUT-04 `amountPaid`/`amountIssued` counters make this
-    /// correct for reusable BOLT12 offers too: fully-issued offers mint 0.
-    @discardableResult
-    private func mintQuoteIfPaid(quoteId: String) async -> Bool {
+    /// Check → mint → verify one quote while the wallet operation lane is held.
+    /// A follow-up check also resolves the important ambiguous case where the
+    /// mint issued ecash but the client lost the response. If another payment
+    /// arrives during the attempt, `remainingAmount` stays positive and the
+    /// next foreground tick mints that new delta.
+    private func reconcileMintQuote(quoteId: String) async -> MintQuoteReconciliationResult? {
+        let observed: MintQuoteInfo
         do {
-            _ = try await lightningService.checkMintQuote(quoteId: quoteId)
+            observed = try await lightningService.checkMintQuote(quoteId: quoteId)
         } catch {
             AppLogger.wallet.error(
                 "pending quote refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
-            return false
+            return nil
         }
 
-        let storedQuote: MintQuote??
-        do {
-            storedQuote = try await db?.getMintQuote(quoteId: quoteId)
-        } catch {
-            storedQuote = nil
-        }
-        guard let quote = storedQuote ?? nil,
-              quote.amountPaid.value > quote.amountIssued.value else {
-            return false
+        guard observed.mintableAmount > 0 else {
+            return MintQuoteReconciliationResult(observed: observed)
         }
 
+        var mintedAmount: UInt64 = 0
+        var mintError: Error?
         do {
-            _ = try await lightningService.mintTokens(quoteId: quoteId)
-            return true
+            mintedAmount = try await lightningService.mintTokens(quoteId: quoteId)
         } catch {
-            if isAlreadyIssuedMintError(error) {
-                return true
-            }
+            mintError = error
+        }
+
+        // Always verify counters after the attempt. This turns a response-loss
+        // failure into success when the mint did issue, without relying on
+        // fragile error-message matching.
+        let verified = try? await lightningService.checkMintQuote(quoteId: quoteId)
+        let result = MintQuoteReconciliationResult(
+            observed: observed,
+            mintedAmount: mintedAmount,
+            verified: verified
+        )
+
+        if result.remainingAmount > 0, let mintError {
             AppLogger.wallet.error(
-                "pending quote mint failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                "pending quote mint remains unissued resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) remaining=\(result.remainingAmount, privacy: .public) error_type=\(String(reflecting: type(of: mintError)), privacy: .public)"
             )
-            return false
         }
+
+        return result
+    }
+
+    func postReceivedMintNotification(amount: UInt64, unit: String, homeHaptic: Bool) {
+        guard amount > 0 else { return }
+        NotificationCenter.default.post(
+            name: .cashuTokenReceived,
+            object: nil,
+            userInfo: [
+                "amount": amount,
+                "unit": unit,
+                "homeHaptic": homeHaptic
+            ]
+        )
     }
 
     // MARK: - Transaction History

--- a/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
@@ -21,17 +21,19 @@ extension WalletManager {
     /// actually issued"; callers must never present success from the former.
     /// Does not touch the global loading flag.
     @discardableResult
-    func refreshPendingMintQuote(quoteId: String) async -> MintQuoteReconciliationResult? {
+    func refreshPendingMintQuote(quoteId: String, force: Bool = false) async -> MintQuoteReconciliationResult? {
         do {
             return try await operationCoordinator.perform(
                 kind: .mintQuote,
                 resourceID: quoteId
             ) {
-                guard let result = await self.reconcileMintQuote(quoteId: quoteId) else {
+                guard let result = await self.reconcileMintQuote(quoteId: quoteId, force: force) else {
                     await self.loadTransactionsAssumingWalletOperationLease()
                     return nil
                 }
-                if result.newlyIssued > 0 {
+                // A previous status observer may already have recovered the
+                // saga. Settled receives still need their visible balance read.
+                if result.newlyIssued > 0 || result.hasSettledPayment {
                     await self.refreshBalanceAssumingWalletOperationLease()
                 }
                 await self.loadTransactionsAssumingWalletOperationLease()
@@ -51,6 +53,12 @@ extension WalletManager {
             return MintQuoteRetryStatus()
         }
         return MintQuoteSchedulePolicy.retryStatus(for: record)
+    }
+
+    func shouldAttemptMintQuote(quoteID: String) -> Bool {
+        MintQuoteSchedulePolicy.shouldAttempt(
+            record: walletStore.loadMintQuoteSchedules()[quoteID], now: Date(), force: false
+        )
     }
 
     // MARK: - Foreground polling
@@ -109,6 +117,7 @@ extension WalletManager {
     }
 
     private func mintUnissuedQuotesAcrossWallets(force: Bool) async {
+        guard walletRepository != nil else { return }
         lastMintQuoteSyncAt = Date()
 
         // The CDK database is the durable ledger. Union it with app-level
@@ -116,9 +125,14 @@ extension WalletManager {
         // checked and produces a useful missing-quote diagnostic instead of
         // silently disappearing from maintenance.
         var quoteIDs = Set(CashuRequestStore.shared.requests.compactMap(\.quoteId))
+        var unsettledOnchainQuoteIDs = Set<String>()
         if let db {
             do {
-                quoteIDs.formUnion(try await db.getUnissuedMintQuotes().map(\.id))
+                let quotes = try await db.getUnissuedMintQuotes()
+                quoteIDs.formUnion(quotes.map(\.id))
+                unsettledOnchainQuoteIDs.formUnion(quotes.filter {
+                    PaymentMethodKind.from($0.paymentMethod) == .onchain && $0.amountIssued.value == 0
+                }.map(\.id))
             } catch {
                 AppLogger.wallet.error(
                     "mint quote ledger scan failed error_type=\(String(reflecting: type(of: error)), privacy: .public)"
@@ -130,15 +144,16 @@ extension WalletManager {
             quoteIDs: quoteIDs,
             existing: walletStore.loadMintQuoteSchedules(),
             now: Date(),
-            force: force
+            force: force,
+            unsettledOnchainQuoteIDs: unsettledOnchainQuoteIDs
         )
         walletStore.saveMintQuoteSchedules(selection.records)
         guard !selection.quoteIDs.isEmpty else { return }
 
         var mintedAny = false
         for quoteID in selection.quoteIDs {
-            guard !Task.isCancelled else { return }
-            guard let result = await reconcileMintQuote(quoteId: quoteID) else { continue }
+            guard !Task.isCancelled else { break }
+            guard let result = await reconcileMintQuote(quoteId: quoteID, force: force) else { continue }
             if result.newlyIssued > 0 {
                 mintedAny = true
                 postReceivedMintNotification(
@@ -162,71 +177,21 @@ extension WalletManager {
     /// mint issued ecash but the client lost the response. If another payment
     /// arrives during the attempt, `remainingAmount` stays positive and the
     /// next foreground tick mints that new delta.
-    private func reconcileMintQuote(quoteId: String) async -> MintQuoteReconciliationResult? {
-        let observed: MintQuoteInfo
-        do {
-            observed = try await lightningService.checkMintQuote(quoteId: quoteId)
-        } catch {
-            if error is CancellationError { return nil }
-            AppLogger.wallet.error(
-                "pending quote refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
-            )
-            guard let cached = await lightningService.storedMintQuote(quoteId: quoteId) else {
-                _ = recordMintQuoteFailure(quoteID: quoteId, quote: nil)
-                return nil
+    private func reconcileMintQuote(quoteId: String, force: Bool) async -> MintQuoteReconciliationResult? {
+        let reconciler = MintQuoteReconciler(
+            storedQuote: lightningService.storedMintQuote,
+            checkQuote: lightningService.checkMintQuote,
+            mintQuote: lightningService.mintTokens,
+            schedule: { self.walletStore.loadMintQuoteSchedules()[$0] },
+            observed: recordMintQuoteObservation,
+            failed: recordMintQuoteFailure,
+            logFailure: { quoteID, error in
+                AppLogger.wallet.error(
+                    "mint quote reconciliation failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteID), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
+                )
             }
-            return MintQuoteReconciliationResult(
-                observed: cached,
-                retryStatus: recordMintQuoteFailure(quoteID: quoteId, quote: cached)
-            )
-        }
-
-        guard observed.mintableAmount > 0 else {
-            recordMintQuoteObservation(observed)
-            return MintQuoteReconciliationResult(observed: observed)
-        }
-
-        var mintedAmount: UInt64 = 0
-        var mintError: Error?
-        do {
-            mintedAmount = try await lightningService.mintTokens(quoteId: quoteId)
-        } catch is CancellationError {
-            return nil
-        } catch {
-            mintError = error
-        }
-
-        // Always verify counters after the attempt. This turns a response-loss
-        // failure into success when the mint did issue, without relying on
-        // fragile error-message matching.
-        let verified: MintQuoteInfo?
-        do {
-            verified = try await lightningService.checkMintQuote(quoteId: quoteId)
-        } catch is CancellationError {
-            return nil
-        } catch {
-            verified = nil
-        }
-        let result = MintQuoteReconciliationResult(
-            observed: observed,
-            mintedAmount: mintedAmount,
-            verified: verified
         )
-
-        if result.remainingAmount > 0 {
-            AppLogger.wallet.error(
-                "pending quote mint remains unissued resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) remaining=\(result.remainingAmount, privacy: .public) error_type=\(String(reflecting: type(of: mintError ?? WalletError.networkError("Mint quote made no verified issuance progress."))), privacy: .public)"
-            )
-            return MintQuoteReconciliationResult(
-                observed: observed,
-                mintedAmount: mintedAmount,
-                verified: verified,
-                retryStatus: recordMintQuoteFailure(quoteID: quoteId, quote: result.quote)
-            )
-        }
-
-        recordMintQuoteObservation(result.quote)
-        return result
+        return await reconciler.reconcile(quoteID: quoteId, force: force)
     }
 
     /// Register a newly-created/discovered quote without postponing an already

--- a/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
@@ -42,6 +42,17 @@ extension WalletManager {
         }
     }
 
+    /// Restore the last honest paid-but-unissued state when a receive screen is
+    /// reopened. The schedule metadata is advisory only; quote counters remain
+    /// authoritative and callers must ignore this status once no amount is
+    /// outstanding.
+    func mintQuoteRetryStatus(quoteID: String) -> MintQuoteRetryStatus {
+        guard let record = walletStore.loadMintQuoteSchedules()[quoteID] else {
+            return MintQuoteRetryStatus()
+        }
+        return MintQuoteSchedulePolicy.retryStatus(for: record)
+    }
+
     // MARK: - Foreground polling
 
     /// While the app is active, re-check pending quotes every
@@ -80,7 +91,7 @@ extension WalletManager {
         if force {
             do {
                 try await operationCoordinator.perform(kind: .quotePoll) {
-                    await self.mintUnissuedQuotesAcrossWallets()
+                    await self.mintUnissuedQuotesAcrossWallets(force: true)
                 }
             } catch {
                 // Explicit refresh cancellation is expected when its view exits.
@@ -90,14 +101,14 @@ extension WalletManager {
 
         do {
             try await operationCoordinator.performIfIdle(kind: .quotePoll) {
-                await self.mintUnissuedQuotesAcrossWallets()
+                await self.mintUnissuedQuotesAcrossWallets(force: false)
             }
         } catch {
             // Passive maintenance is best effort and will run again next tick.
         }
     }
 
-    private func mintUnissuedQuotesAcrossWallets() async {
+    private func mintUnissuedQuotesAcrossWallets(force: Bool) async {
         lastMintQuoteSyncAt = Date()
 
         // The CDK database is the durable ledger. Union it with app-level
@@ -115,8 +126,17 @@ extension WalletManager {
             }
         }
 
+        let selection = MintQuoteSchedulePolicy.select(
+            quoteIDs: quoteIDs,
+            existing: walletStore.loadMintQuoteSchedules(),
+            now: Date(),
+            force: force
+        )
+        walletStore.saveMintQuoteSchedules(selection.records)
+        guard !selection.quoteIDs.isEmpty else { return }
+
         var mintedAny = false
-        for quoteID in quoteIDs.sorted() {
+        for quoteID in selection.quoteIDs {
             guard !Task.isCancelled else { return }
             guard let result = await reconcileMintQuote(quoteId: quoteID) else { continue }
             if result.newlyIssued > 0 {
@@ -147,13 +167,22 @@ extension WalletManager {
         do {
             observed = try await lightningService.checkMintQuote(quoteId: quoteId)
         } catch {
+            if error is CancellationError { return nil }
             AppLogger.wallet.error(
                 "pending quote refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
             )
-            return nil
+            guard let cached = await lightningService.storedMintQuote(quoteId: quoteId) else {
+                _ = recordMintQuoteFailure(quoteID: quoteId, quote: nil)
+                return nil
+            }
+            return MintQuoteReconciliationResult(
+                observed: cached,
+                retryStatus: recordMintQuoteFailure(quoteID: quoteId, quote: cached)
+            )
         }
 
         guard observed.mintableAmount > 0 else {
+            recordMintQuoteObservation(observed)
             return MintQuoteReconciliationResult(observed: observed)
         }
 
@@ -161,6 +190,8 @@ extension WalletManager {
         var mintError: Error?
         do {
             mintedAmount = try await lightningService.mintTokens(quoteId: quoteId)
+        } catch is CancellationError {
+            return nil
         } catch {
             mintError = error
         }
@@ -168,20 +199,73 @@ extension WalletManager {
         // Always verify counters after the attempt. This turns a response-loss
         // failure into success when the mint did issue, without relying on
         // fragile error-message matching.
-        let verified = try? await lightningService.checkMintQuote(quoteId: quoteId)
+        let verified: MintQuoteInfo?
+        do {
+            verified = try await lightningService.checkMintQuote(quoteId: quoteId)
+        } catch is CancellationError {
+            return nil
+        } catch {
+            verified = nil
+        }
         let result = MintQuoteReconciliationResult(
             observed: observed,
             mintedAmount: mintedAmount,
             verified: verified
         )
 
-        if result.remainingAmount > 0, let mintError {
+        if result.remainingAmount > 0 {
             AppLogger.wallet.error(
-                "pending quote mint remains unissued resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) remaining=\(result.remainingAmount, privacy: .public) error_type=\(String(reflecting: type(of: mintError)), privacy: .public)"
+                "pending quote mint remains unissued resource=\(WalletOperationCoordinator.privacySafeIdentifier(quoteId), privacy: .public) remaining=\(result.remainingAmount, privacy: .public) error_type=\(String(reflecting: type(of: mintError ?? WalletError.networkError("Mint quote made no verified issuance progress."))), privacy: .public)"
+            )
+            return MintQuoteReconciliationResult(
+                observed: observed,
+                mintedAmount: mintedAmount,
+                verified: verified,
+                retryStatus: recordMintQuoteFailure(quoteID: quoteId, quote: result.quote)
             )
         }
 
+        recordMintQuoteObservation(result.quote)
         return result
+    }
+
+    /// Register a newly-created/discovered quote without postponing an already
+    /// due reconciliation. The first sweep sees it immediately.
+    func rememberMintQuoteForScheduling(_ quote: MintQuoteInfo) {
+        var schedules = walletStore.loadMintQuoteSchedules()
+        guard schedules[quote.id] == nil else { return }
+        schedules[quote.id] = MintQuoteScheduleRecord(
+            firstObservedAt: Date().timeIntervalSince1970,
+            isReusable: quote.paymentMethod == .bolt12
+        )
+        walletStore.saveMintQuoteSchedules(schedules)
+    }
+
+    private func recordMintQuoteObservation(_ quote: MintQuoteInfo) {
+        var schedules = walletStore.loadMintQuoteSchedules()
+        schedules[quote.id] = MintQuoteSchedulePolicy.observed(
+            previous: schedules[quote.id],
+            quote: quote,
+            now: Date()
+        )
+        walletStore.saveMintQuoteSchedules(schedules)
+    }
+
+    @discardableResult
+    private func recordMintQuoteFailure(
+        quoteID: String,
+        quote: MintQuoteInfo?
+    ) -> MintQuoteRetryStatus {
+        var schedules = walletStore.loadMintQuoteSchedules()
+        let record = MintQuoteSchedulePolicy.failed(
+            previous: schedules[quoteID],
+            now: Date(),
+            hadOutstandingPayment: (quote?.mintableAmount ?? 0) > 0,
+            isReusable: quote?.paymentMethod == .bolt12
+        )
+        schedules[quoteID] = record
+        walletStore.saveMintQuoteSchedules(schedules)
+        return MintQuoteSchedulePolicy.retryStatus(for: record)
     }
 
     func postReceivedMintNotification(amount: UInt64, unit: String, homeHaptic: Bool) {

--- a/ios/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager.swift
@@ -59,13 +59,13 @@ class WalletManager: ObservableObject {
     /// don't hammer it. Kept equal to `pendingQuotePollInterval` (Android
     /// parity) so the poll drives one sync pass per interval.
     var lastMintQuoteSyncAt: Date?
-    let mintQuoteSyncCooldown: TimeInterval = 5
+    let mintQuoteSyncCooldown: TimeInterval = 10
 
     /// Foreground quote poll (started/stopped on scenePhase changes). Re-checks
     /// pending mint + melt quotes while the app is active so a payment lands
     /// without pull-to-refresh (Android parity).
     var pendingQuotePollTask: Task<Void, Never>?
-    let pendingQuotePollInterval: TimeInterval = 5
+    let pendingQuotePollInterval: TimeInterval = 10
 
     // MARK: - Services
 

--- a/ios/CashuWallet/Core/WalletStore.swift
+++ b/ios/CashuWallet/Core/WalletStore.swift
@@ -69,6 +69,14 @@ final class WalletStore {
         set(timestamps, forKey: StorageKeys.mintQuoteTimestamps)
     }
 
+    func loadMintQuoteSchedules() -> [String: MintQuoteScheduleRecord] {
+        value(forKey: StorageKeys.mintQuoteSchedules) ?? [:]
+    }
+
+    func saveMintQuoteSchedules(_ schedules: [String: MintQuoteScheduleRecord]) {
+        set(schedules, forKey: StorageKeys.mintQuoteSchedules)
+    }
+
     /// Last successful online keyset refresh per mint. Startup uses this to
     /// avoid contacting every configured mint on every app launch.
     func loadMintKeysetRefreshTimestamps() -> [String: TimeInterval] {

--- a/ios/CashuWallet/Models/Payments/PaymentRequestParser.swift
+++ b/ios/CashuWallet/Models/Payments/PaymentRequestParser.swift
@@ -3,6 +3,19 @@ import Cdk
 import CryptoKit
 
 enum PaymentRequestParser {
+    struct Bolt12OfferMetadata: Equatable, Sendable {
+        let normalizedRequest: String
+        let amountMsat: UInt64?
+        let description: String?
+    }
+
+    private static let bolt12Alphabet = Array("qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+    private static let bolt12Values = Dictionary(
+        uniqueKeysWithValues: bolt12Alphabet.enumerated().map { ($0.element, $0.offset) }
+    )
+    private static let knownOfferTypes: Set<UInt64> = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22]
+    private static let maximumBitcoinAmountMsat: UInt64 = 2_100_000_000_000_000_000
+
     static func normalizeLightningRequest(_ request: String) -> String {
         let trimmedRequest = request.trimmingCharacters(in: .whitespacesAndNewlines)
         let lightningPrefixes = ["lightning://", "lightning:"]
@@ -60,11 +73,218 @@ enum PaymentRequestParser {
             }
         }
 
+        if bolt12OfferMetadata(from: normalizedRequest) != nil {
+            return .bolt12
+        }
+
         if isBitcoinAddress(request) {
             return .onchain
         }
 
         return nil
+    }
+
+    /// Parses the BOLT12 text envelope and the small subset of offer TLVs the
+    /// send flow needs. CDK currently rejects valid amountless offers with an
+    /// empty description, even though BOLT12 permits them, so this standards-
+    /// envelope/TLV fallback keeps recognition independent from that stricter
+    /// decoder; CDK still performs the final protocol validation when quoting.
+    static func bolt12OfferMetadata(from request: String) -> Bolt12OfferMetadata? {
+        guard let normalized = normalizeBolt12Offer(request),
+              normalized.hasPrefix("lno1") else {
+            return nil
+        }
+
+        let encoded = normalized.dropFirst(4)
+        guard !encoded.isEmpty else { return nil }
+        let values = encoded.compactMap { bolt12Values[$0] }
+        guard values.count == encoded.count,
+              let bytes = convertBolt12Bits(values) else {
+            return nil
+        }
+
+        var cursor = 0
+        var previousType: UInt64?
+        var amountMsat: UInt64?
+        var sawAmount = false
+        var sawDescription = false
+        var sawCurrency = false
+        var description: String?
+        var hasPaths = false
+        var hasIssuerID = false
+
+        while cursor < bytes.count {
+            guard let type = readBigSize(bytes, cursor: &cursor),
+                  let length = readBigSize(bytes, cursor: &cursor),
+                  length <= UInt64(bytes.count - cursor) else {
+                return nil
+            }
+            if let previousType, type <= previousType { return nil }
+            previousType = type
+
+            guard (1...79).contains(type) || (1_000_000_000...1_999_999_999).contains(type) else {
+                return nil
+            }
+            // Unknown odd records are optional extensions; unknown even
+            // records are mandatory and make the offer unreadable.
+            guard type % 2 != 0 || knownOfferTypes.contains(type) else { return nil }
+
+            let fieldEnd = cursor + Int(length)
+            let field = Array(bytes[cursor..<fieldEnd])
+            cursor = fieldEnd
+
+            switch type {
+            case 2:
+                guard !field.isEmpty, field.count.isMultiple(of: 32) else { return nil }
+            case 6:
+                guard field.count == 3, field.allSatisfy({ (65...90).contains($0) }) else { return nil }
+                sawCurrency = true
+            case 8:
+                guard let value = decodeTruncatedUInt64(field),
+                      value > 0,
+                      value <= maximumBitcoinAmountMsat else {
+                    return nil
+                }
+                sawAmount = true
+                amountMsat = value
+            case 10:
+                guard let value = String(bytes: field, encoding: .utf8) else { return nil }
+                sawDescription = true
+                description = value.isEmpty ? nil : value
+            case 14, 20:
+                guard decodeTruncatedUInt64(field) != nil else { return nil }
+            case 16:
+                hasPaths = !field.isEmpty
+            case 18:
+                guard String(bytes: field, encoding: .utf8) != nil else { return nil }
+            case 22:
+                guard field.count == 33,
+                      (field.first == 0x02 || field.first == 0x03) else {
+                    return nil
+                }
+                hasIssuerID = true
+            default:
+                break
+            }
+        }
+
+        guard hasPaths || hasIssuerID,
+              !sawAmount || sawDescription,
+              !sawCurrency || sawAmount else {
+            return nil
+        }
+
+        // A currency-denominated offer's amount is not millisatoshis. Leave
+        // those to CDK rather than misrouting them as an amountless offer.
+        guard !sawCurrency else { return nil }
+
+        return Bolt12OfferMetadata(
+            normalizedRequest: normalized,
+            amountMsat: amountMsat,
+            description: description
+        )
+    }
+
+    /// BOLT12 uses bech32-style data without a checksum. It also explicitly
+    /// permits `+` followed by optional whitespace as a continuation marker.
+    private static func normalizeBolt12Offer(_ request: String) -> String? {
+        let raw = normalizeLightningRequest(request)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
+
+        var compact = ""
+        var index = raw.startIndex
+        while index < raw.endIndex {
+            let character = raw[index]
+            if character == "+" {
+                guard let previous = compact.last, isBolt12Character(previous) else { return nil }
+                index = raw.index(after: index)
+                while index < raw.endIndex, raw[index].isWhitespace {
+                    index = raw.index(after: index)
+                }
+                guard index < raw.endIndex,
+                      isBolt12Character(raw[index]) else {
+                    return nil
+                }
+                continue
+            }
+            guard !character.isWhitespace else { return nil }
+            compact.append(character)
+            index = raw.index(after: index)
+        }
+
+        let hasLowercase = compact.contains { $0.isLowercase }
+        let hasUppercase = compact.contains { $0.isUppercase }
+        guard !(hasLowercase && hasUppercase) else { return nil }
+        return compact.lowercased()
+    }
+
+    private static func isBolt12Character(_ character: Character) -> Bool {
+        let lowercased = Character(String(character).lowercased())
+        return bolt12Values[lowercased] != nil
+    }
+
+    private static func convertBolt12Bits(_ values: [Int]) -> [UInt8]? {
+        var accumulator = 0
+        var bitCount = 0
+        var bytes: [UInt8] = []
+
+        for value in values {
+            guard (0..<32).contains(value) else { return nil }
+            accumulator = ((accumulator << 5) | value) & 0x0fff
+            bitCount += 5
+            while bitCount >= 8 {
+                bitCount -= 8
+                bytes.append(UInt8((accumulator >> bitCount) & 0xff))
+            }
+        }
+
+        // At most four zero bits may remain after conversion.
+        guard bitCount < 5,
+              ((accumulator << (8 - bitCount)) & 0xff) == 0 else {
+            return nil
+        }
+        return bytes
+    }
+
+    private static func readBigSize(_ bytes: [UInt8], cursor: inout Int) -> UInt64? {
+        guard cursor < bytes.count else { return nil }
+        let marker = bytes[cursor]
+        cursor += 1
+
+        let byteCount: Int
+        let minimum: UInt64
+        switch marker {
+        case 0x00...0xfc:
+            return UInt64(marker)
+        case 0xfd:
+            byteCount = 2
+            minimum = 0xfd
+        case 0xfe:
+            byteCount = 4
+            minimum = 0x1_0000
+        case 0xff:
+            byteCount = 8
+            minimum = 0x1_0000_0000
+        default:
+            return nil
+        }
+
+        guard cursor + byteCount <= bytes.count else { return nil }
+        var value: UInt64 = 0
+        for byte in bytes[cursor..<cursor + byteCount] {
+            value = (value << 8) | UInt64(byte)
+        }
+        cursor += byteCount
+        return value >= minimum ? value : nil
+    }
+
+    private static func decodeTruncatedUInt64(_ bytes: [UInt8]) -> UInt64? {
+        guard bytes.count <= 8,
+              bytes.isEmpty || bytes.first != 0 else {
+            return nil
+        }
+        return bytes.reduce(0) { ($0 << 8) | UInt64($1) }
     }
 }
 

--- a/ios/CashuWallet/Models/Quotes/QuoteModels.swift
+++ b/ios/CashuWallet/Models/Quotes/QuoteModels.swift
@@ -51,6 +51,7 @@ struct MintQuoteReconciliationResult {
     let quote: MintQuoteInfo
     let newlyIssued: UInt64
     let hadOutstandingPayment: Bool
+    let retryStatus: MintQuoteRetryStatus
 
     var remainingAmount: UInt64 { quote.mintableAmount }
     var hasSettledPayment: Bool { quote.hasSettledPayment }
@@ -58,7 +59,8 @@ struct MintQuoteReconciliationResult {
     init(
         observed: MintQuoteInfo,
         mintedAmount: UInt64 = 0,
-        verified: MintQuoteInfo? = nil
+        verified: MintQuoteInfo? = nil,
+        retryStatus: MintQuoteRetryStatus = MintQuoteRetryStatus()
     ) {
         var reconciled = verified ?? observed
         reconciled.amountPaid = max(reconciled.amountPaid, observed.amountPaid)
@@ -81,6 +83,146 @@ struct MintQuoteReconciliationResult {
         quote = reconciled
         newlyIssued = max(mintedAmount, verifiedAdvance)
         hadOutstandingPayment = observed.amountPaid > observed.amountIssued
+        self.retryStatus = retryStatus
+    }
+}
+
+/// What the wallet can honestly promise after a paid quote fails to issue.
+enum MintQuoteRetryState: String, Codable, Equatable {
+    case none
+    case retryScheduled
+    case needsAttention
+}
+
+struct MintQuoteRetryStatus: Equatable {
+    var state: MintQuoteRetryState = .none
+    var nextRetryAt: Date?
+    var failureCount = 0
+}
+
+/// Durable maintenance metadata. CDK's paid/issued counters remain the money
+/// ledger; this record only bounds when the app checks again and preserves the
+/// truthful retry state across process restarts.
+struct MintQuoteScheduleRecord: Codable, Equatable {
+    var firstObservedAt: TimeInterval
+    var lastAttemptAt: TimeInterval?
+    var nextAttemptAt: TimeInterval = 0
+    var consecutiveFailures = 0
+    var hadOutstandingPayment = false
+    var isReusable = false
+    var isComplete = false
+}
+
+enum MintQuoteSchedulePolicy {
+    static let passiveBatchLimit = 2
+    static let forcedBatchLimit = 20
+    private static let recentQuoteWindow: TimeInterval = 2 * 60
+    private static let recentQuoteInterval: TimeInterval = 10
+    private static let idleQuoteInterval: TimeInterval = 60
+    private static let needsAttentionFailureCount = 4
+    private static let failureDelays: [TimeInterval] = [5, 15, 30, 60, 5 * 60]
+
+    struct Selection {
+        let quoteIDs: [String]
+        let records: [String: MintQuoteScheduleRecord]
+    }
+
+    static func select(
+        quoteIDs: Set<String>,
+        existing: [String: MintQuoteScheduleRecord],
+        now: Date,
+        force: Bool
+    ) -> Selection {
+        let nowValue = now.timeIntervalSince1970
+        var records = existing.filter { quoteIDs.contains($0.key) }
+        for quoteID in quoteIDs where !quoteID.isEmpty && records[quoteID] == nil {
+            records[quoteID] = MintQuoteScheduleRecord(firstObservedAt: nowValue)
+        }
+
+        let limit = force ? forcedBatchLimit : passiveBatchLimit
+        let selected = quoteIDs
+            .filter { quoteID in
+                guard let record = records[quoteID] else { return false }
+                return !record.isComplete && (force || record.nextAttemptAt <= nowValue)
+            }
+            .sorted { lhs, rhs in
+                guard let left = records[lhs], let right = records[rhs] else {
+                    return lhs < rhs
+                }
+                let leftAttempt = left.lastAttemptAt ?? -TimeInterval.greatestFiniteMagnitude
+                let rightAttempt = right.lastAttemptAt ?? -TimeInterval.greatestFiniteMagnitude
+                if leftAttempt != rightAttempt { return leftAttempt < rightAttempt }
+                if left.nextAttemptAt != right.nextAttemptAt {
+                    return left.nextAttemptAt < right.nextAttemptAt
+                }
+                return lhs < rhs
+            }
+            .prefix(limit)
+
+        for quoteID in selected {
+            guard var record = records[quoteID] else { continue }
+            record.lastAttemptAt = nowValue
+            record.nextAttemptAt = nowValue + (failureDelays.first ?? 5)
+            records[quoteID] = record
+        }
+        return Selection(quoteIDs: Array(selected), records: records)
+    }
+
+    static func observed(
+        previous: MintQuoteScheduleRecord?,
+        quote: MintQuoteInfo,
+        now: Date
+    ) -> MintQuoteScheduleRecord {
+        let nowValue = now.timeIntervalSince1970
+        var record = previous ?? MintQuoteScheduleRecord(firstObservedAt: nowValue)
+        let reusable = quote.paymentMethod == .bolt12
+        let expired = quote.expiry.map { $0 > 0 && UInt64(nowValue) >= $0 } ?? false
+        let complete = !reusable && (expired || quote.state == .issued || quote.hasSettledPayment)
+        let age = max(0, nowValue - record.firstObservedAt)
+        let interval = age < recentQuoteWindow ? recentQuoteInterval : idleQuoteInterval
+
+        record.lastAttemptAt = nowValue
+        record.nextAttemptAt = complete ? .greatestFiniteMagnitude : nowValue + interval
+        record.consecutiveFailures = 0
+        record.hadOutstandingPayment = false
+        record.isReusable = reusable
+        record.isComplete = complete
+        return record
+    }
+
+    static func failed(
+        previous: MintQuoteScheduleRecord?,
+        now: Date,
+        hadOutstandingPayment: Bool,
+        isReusable: Bool
+    ) -> MintQuoteScheduleRecord {
+        let nowValue = now.timeIntervalSince1970
+        var record = previous ?? MintQuoteScheduleRecord(firstObservedAt: nowValue)
+        let failures = record.consecutiveFailures == Int.max
+            ? Int.max
+            : record.consecutiveFailures + 1
+        let delayIndex = min(max(0, failures - 1), failureDelays.count - 1)
+
+        record.lastAttemptAt = nowValue
+        record.nextAttemptAt = nowValue + failureDelays[delayIndex]
+        record.consecutiveFailures = failures
+        record.hadOutstandingPayment = hadOutstandingPayment || record.hadOutstandingPayment
+        record.isReusable = isReusable || record.isReusable
+        record.isComplete = false
+        return record
+    }
+
+    static func retryStatus(for record: MintQuoteScheduleRecord) -> MintQuoteRetryStatus {
+        guard record.hadOutstandingPayment, record.consecutiveFailures > 0 else {
+            return MintQuoteRetryStatus()
+        }
+        return MintQuoteRetryStatus(
+            state: record.consecutiveFailures >= needsAttentionFailureCount
+                ? .needsAttention
+                : .retryScheduled,
+            nextRetryAt: Date(timeIntervalSince1970: record.nextAttemptAt),
+            failureCount: record.consecutiveFailures
+        )
     }
 }
 

--- a/ios/CashuWallet/Models/Quotes/QuoteModels.swift
+++ b/ios/CashuWallet/Models/Quotes/QuoteModels.swift
@@ -4,6 +4,10 @@ struct MintQuoteInfo: Identifiable {
     let id: String
     let request: String  // Payment request (BOLT11 invoice, BOLT12 offer, or on-chain address)
     let amount: UInt64?
+    /// Whether the quote was created without an amount. This cannot be derived
+    /// from `amount`: NUT-25 reports the cumulative paid amount after the first
+    /// payment, but the underlying BOLT12 offer remains amountless and reusable.
+    let isAmountless: Bool
     let paymentMethod: PaymentMethodKind
     var state: MintQuoteState
     let expiry: UInt64?
@@ -20,9 +24,63 @@ struct MintQuoteInfo: Identifiable {
     /// instead of mutable active-mint state.
     var mintURL: String? = nil
 
+    /// NUT-25's durable settlement ledger. A reusable offer is fully caught up
+    /// when these values are equal; their difference is the only amount the
+    /// wallet is allowed to mint.
+    var amountPaid: UInt64 = 0
+    var amountIssued: UInt64 = 0
+
+    var mintableAmount: UInt64 {
+        amountPaid > amountIssued ? amountPaid - amountIssued : 0
+    }
+
+    var hasSettledPayment: Bool {
+        amountPaid > 0 && amountIssued >= amountPaid
+    }
+
     var isExpired: Bool {
         guard let expiry = expiry, expiry > 0 else { return false }
         return Date().timeIntervalSince1970 > Double(expiry)
+    }
+}
+
+/// Counter-verified result of reconciling one persisted mint quote. A
+/// successful mint response is combined with a follow-up quote check so an
+/// ambiguous network failure cannot lose a payment or mint it twice.
+struct MintQuoteReconciliationResult {
+    let quote: MintQuoteInfo
+    let newlyIssued: UInt64
+    let hadOutstandingPayment: Bool
+
+    var remainingAmount: UInt64 { quote.mintableAmount }
+    var hasSettledPayment: Bool { quote.hasSettledPayment }
+
+    init(
+        observed: MintQuoteInfo,
+        mintedAmount: UInt64 = 0,
+        verified: MintQuoteInfo? = nil
+    ) {
+        var reconciled = verified ?? observed
+        reconciled.amountPaid = max(reconciled.amountPaid, observed.amountPaid)
+
+        let inferredIssued: UInt64
+        let (sum, overflow) = observed.amountIssued.addingReportingOverflow(mintedAmount)
+        inferredIssued = overflow ? UInt64.max : sum
+        reconciled.amountIssued = max(reconciled.amountIssued, inferredIssued)
+
+        if reconciled.amountPaid > 0,
+           reconciled.amountIssued >= reconciled.amountPaid {
+            reconciled.state = .issued
+        } else if reconciled.amountPaid > reconciled.amountIssued {
+            reconciled.state = .paid
+        }
+
+        let verifiedAdvance = reconciled.amountIssued > observed.amountIssued
+            ? reconciled.amountIssued - observed.amountIssued
+            : 0
+        quote = reconciled
+        newlyIssued = max(mintedAmount, verifiedAdvance)
+        hadOutstandingPayment = observed.amountPaid > observed.amountIssued
     }
 }
 

--- a/ios/CashuWallet/Models/Quotes/QuoteModels.swift
+++ b/ios/CashuWallet/Models/Quotes/QuoteModels.swift
@@ -60,6 +60,7 @@ struct MintQuoteReconciliationResult {
         observed: MintQuoteInfo,
         mintedAmount: UInt64 = 0,
         verified: MintQuoteInfo? = nil,
+        issuedBeforeCheck: UInt64? = nil,
         retryStatus: MintQuoteRetryStatus = MintQuoteRetryStatus()
     ) {
         var reconciled = verified ?? observed
@@ -77,8 +78,10 @@ struct MintQuoteReconciliationResult {
             reconciled.state = .paid
         }
 
-        let verifiedAdvance = reconciled.amountIssued > observed.amountIssued
-            ? reconciled.amountIssued - observed.amountIssued
+        // A quote status check may itself finish CDK's interrupted issue saga.
+        let baseline = issuedBeforeCheck ?? observed.amountIssued
+        let verifiedAdvance = reconciled.amountIssued > baseline
+            ? reconciled.amountIssued - baseline
             : 0
         quote = reconciled
         newlyIssued = max(mintedAmount, verifiedAdvance)
@@ -131,12 +134,19 @@ enum MintQuoteSchedulePolicy {
         quoteIDs: Set<String>,
         existing: [String: MintQuoteScheduleRecord],
         now: Date,
-        force: Bool
+        force: Bool,
+        unsettledOnchainQuoteIDs: Set<String> = []
     ) -> Selection {
         let nowValue = now.timeIntervalSince1970
         var records = existing.filter { quoteIDs.contains($0.key) }
         for quoteID in quoteIDs where !quoteID.isEmpty && records[quoteID] == nil {
             records[quoteID] = MintQuoteScheduleRecord(firstObservedAt: nowValue)
+        }
+        // Older schedules treated expiry as terminal even while an on-chain
+        // deposit was waiting for confirmations. The durable quote reopens it.
+        for quoteID in unsettledOnchainQuoteIDs where records[quoteID]?.isComplete == true {
+            records[quoteID]?.isComplete = false
+            records[quoteID]?.nextAttemptAt = 0
         }
 
         let limit = force ? forcedBatchLimit : passiveBatchLimit
@@ -162,7 +172,9 @@ enum MintQuoteSchedulePolicy {
         for quoteID in selected {
             guard var record = records[quoteID] else { continue }
             record.lastAttemptAt = nowValue
-            record.nextAttemptAt = nowValue + (failureDelays.first ?? 5)
+            if record.consecutiveFailures == 0 {
+                record.nextAttemptAt = nowValue + (failureDelays.first ?? 5)
+            }
             records[quoteID] = record
         }
         return Selection(quoteIDs: Array(selected), records: records)
@@ -177,7 +189,10 @@ enum MintQuoteSchedulePolicy {
         var record = previous ?? MintQuoteScheduleRecord(firstObservedAt: nowValue)
         let reusable = quote.paymentMethod == .bolt12
         let expired = quote.expiry.map { $0 > 0 && UInt64(nowValue) >= $0 } ?? false
-        let complete = !reusable && (expired || quote.state == .issued || quote.hasSettledPayment)
+        // On-chain expiry stops new deposits, not confirmation of deposits
+        // already seen by the mint. Zero paid counters cannot prove completion.
+        let expiredInvoice = quote.paymentMethod == .bolt11 && expired
+        let complete = !reusable && (expiredInvoice || quote.state == .issued || quote.hasSettledPayment)
         let age = max(0, nowValue - record.firstObservedAt)
         let interval = age < recentQuoteWindow ? recentQuoteInterval : idleQuoteInterval
 
@@ -210,6 +225,17 @@ enum MintQuoteSchedulePolicy {
         record.isReusable = isReusable || record.isReusable
         record.isComplete = false
         return record
+    }
+
+    /// Receive polling can run more often than maintenance, but shares its
+    /// failure backoff. Explicit retry and refresh actions bypass the deadline.
+    static func shouldAttempt(
+        record: MintQuoteScheduleRecord?,
+        now: Date,
+        force: Bool
+    ) -> Bool {
+        guard !force, let record, record.consecutiveFailures > 0 else { return true }
+        return record.nextAttemptAt <= now.timeIntervalSince1970
     }
 
     static func retryStatus(for record: MintQuoteScheduleRecord) -> MintQuoteRetryStatus {

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -263,8 +263,7 @@ struct ReceiveLightningView: View {
         return orderedMethods.isEmpty ? [.bolt11] : orderedMethods
     }
 
-    /// Picker rows: BOLT12 fans out into fixed + any-amount, so a BOLT12-only
-    /// mint still yields two options (and therefore a visible picker).
+    /// Picker rows are derived from the mint's supported payment methods.
     private var availableMethodOptions: [ReceiveMethodOption] {
         ReceiveMethodOption.options(for: availableMintMethods)
     }
@@ -276,8 +275,7 @@ struct ReceiveLightningView: View {
     }
 
     private var shouldShowMethodPicker: Bool {
-        // Count options, not methods: a BOLT12-only mint is one method but two
-        // options, and the in-screen toggle that used to disambiguate is gone.
+        // Count user-facing options rather than raw mint capabilities.
         availableMethodOptions.count > 1
     }
 
@@ -572,7 +570,7 @@ struct ReceiveLightningView: View {
                             ShareSheet(items: [qrShareText])
                         }
 
-                    if let amount = quote.amount, amount > 0 {
+                    if !quote.isAmountless, let amount = quote.amount, amount > 0 {
                         if quote.unit.lowercased() == "sat" {
                             CurrencyAmountDisplay(
                                 sats: amount,
@@ -599,9 +597,17 @@ struct ReceiveLightningView: View {
                         )
                         editableRow(
                             label: "Amount",
-                            value: quote.amount.flatMap { $0 > 0 ? formatQuoteAmount($0, unit: quote.unit) : nil } ?? "Any",
+                            value: quote.isAmountless
+                                ? "Any"
+                                : quote.amount.flatMap { $0 > 0 ? formatQuoteAmount($0, unit: quote.unit) : nil } ?? "Any",
                             action: { showReusableAmountPicker = true }
                         )
+                        if quote.amountIssued > 0 {
+                            detailRow(
+                                label: "Total received",
+                                value: formatQuoteAmount(quote.amountIssued, unit: quote.unit)
+                            )
+                        }
                         if let created = quote.createdAt {
                             detailRow(
                                 label: "Created",
@@ -624,7 +630,7 @@ struct ReceiveLightningView: View {
         }
         .sheet(isPresented: $showReusableAmountPicker) {
             CashuRequestAmountPickerSheet(
-                currentAmount: quote.amount,
+                currentAmount: quote.isAmountless ? nil : quote.amount,
                 unit: quote.unit,
                 onSelect: {
                     setReusableOfferAmount($0, mintURL: quote.mintURL, unit: quote.unit)
@@ -646,7 +652,8 @@ struct ReceiveLightningView: View {
     /// Full-screen success shown once ecash is issued — the exact same
     /// `PaymentStatusView` the pay/send flows use, so a received payment reads
     /// identically to a sent one (checkmark → title → detail block → Done).
-    /// Stays until the user taps Done.
+    /// Stays until the user taps Done. This view is reached only after the
+    /// reconciliation path has verified that ecash was issued.
     private func receiveSuccessView(quote: MintQuoteInfo) -> some View {
         PaymentStatusView(
             details: receiveSuccessRows(quote: quote),
@@ -869,10 +876,6 @@ struct ReceiveLightningView: View {
 
     @ViewBuilder
     private var statusBadge: some View {
-        // No `isPaid` branch: the body swaps to the full-screen success
-        // terminal the instant `isPaid` flips, so an inline received badge
-        // here could never render — the celebration lives in
-        // `PaymentStatusView`'s staged entrance.
         Group {
             if isCheckingPayment || isMinting {
                 HStack(spacing: 6) {
@@ -894,6 +897,19 @@ struct ReceiveLightningView: View {
                 // Same severity token as the countdown above it, which already
                 // moved off Color.red — the two states of one clock.
                 .foregroundStyle(ErrorSeverity.error.foreground)
+                .transition(.opacity)
+            } else if let quote = mintQuote,
+                      quote.paymentMethod == .bolt12,
+                      quote.amountIssued > 0,
+                      quote.mintableAmount == 0 {
+                HStack(spacing: 6) {
+                    Image(systemName: "checkmark.seal.fill")
+                        .symbolEffect(.bounce, value: reduceMotion ? nil : quote.amountIssued)
+                        .accessibilityHidden(true)
+                    Text("Ready for another payment")
+                }
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
                 .transition(.opacity)
             } else if mintQuote?.state == .paid || mintQuote?.state == .issued {
                 HStack(spacing: 6) {
@@ -1065,7 +1081,7 @@ struct ReceiveLightningView: View {
             amountString = ""
             loadOrCreateAmountlessOffer()
         } else {
-            // Lightning / fixed reusable: land on the amount screen.
+            // Amount-requiring rails: land on the amount screen.
             selectedMethod = option.method
             isAmountless = false
         }
@@ -1097,7 +1113,9 @@ struct ReceiveLightningView: View {
             rail: rail,
             quoteId: quote.id,
             encoded: quote.request,
-            amount: quote.amount,
+            // A paid amountless offer reports a cumulative amount, but its QR
+            // is still amountless. Preserve the original offer shape.
+            amount: quote.isAmountless ? nil : quote.amount,
             unit: quote.unit,
             mints: mintURLs,
             reusable: reusable,
@@ -1389,14 +1407,17 @@ struct ReceiveLightningView: View {
                 id: refreshed.id,
                 request: refreshed.request,
                 amount: mintedAmount,
+                isAmountless: false,
                 paymentMethod: .onchain,
                 state: .issued,
                 expiry: refreshed.expiry,
                 createdAt: refreshed.createdAt,
                 unit: refreshed.unit,
-                mintURL: refreshed.mintURL
+                mintURL: refreshed.mintURL,
+                amountPaid: mintedAmount ?? refreshed.amountPaid,
+                amountIssued: mintedAmount ?? refreshed.amountIssued
             )
-            await completeReceivedQuote()
+            await completeReceivedQuote(receivedAmount: mintedAmount)
             return
         }
     }
@@ -1411,7 +1432,11 @@ struct ReceiveLightningView: View {
             case .bolt11:
                 await pollMintQuote(quoteId: quote.id, initialInterval: 5, maxInterval: 15)
             case .bolt12:
-                await monitorMintQuoteViaSubscription(quoteId: quote.id, paymentMethod: .bolt12)
+                // A reusable offer must keep making progress even when a
+                // websocket stays connected but stops delivering updates.
+                // Polling also reconciles every paid/issued counter delta, so
+                // no individual payment can leave the quote stranded.
+                await pollMintQuote(quoteId: quote.id, initialInterval: 5, maxInterval: 15)
             case .onchain:
                 await refreshMintQuoteStatus()
                 await monitorMintQuoteViaSubscription(quoteId: quote.id, paymentMethod: .onchain)
@@ -1495,17 +1520,23 @@ struct ReceiveLightningView: View {
                 onchainObservation = nil
             }
 
+            if updatedQuote.paymentMethod == .bolt12 {
+                // A BOLT12 offer is never terminal. Reconcile its cumulative
+                // paid/issued counters and leave the same QR active for the
+                // next payer-generated invoice.
+                await reconcileReusableOffer(updatedQuote)
+                return
+            }
+
             switch updatedQuote.state {
             case .pending:
                 return
             case .paid:
-                // A paid invoice is not spendable ecash until minting succeeds.
-                // Keep monitoring through transient failures; show a receipt only
-                // after CDK has persisted the issued proofs.
+                // "Paid" is not success yet: keep the request visible until
+                // the quote counters prove ecash issuance completed.
                 await mintQuoteIfReady(updatedQuote)
             case .issued:
-                // Mint already issued the ecash — just refresh + finish.
-                await completeReceivedQuote()
+                await completeReceivedQuote(receivedAmount: updatedQuote.amountIssued)
             }
         } catch {
             // Ignore transient polling failures and keep monitoring.
@@ -1537,50 +1568,70 @@ struct ReceiveLightningView: View {
         isMinting = true
         defer { isMinting = false }
 
-        do {
-            let _ = try await walletManager.mintTokens(quoteId: quote.id)
-            await completeReceivedQuote()
-        } catch {
-            if isAlreadyIssuedMintError(error) {
-                await completeReceivedQuote()
-                return
-            }
+        guard let result = await walletManager.refreshPendingMintQuote(quoteId: quote.id) else {
+            return
+        }
+        mintQuote = result.quote
+        guard result.hasSettledPayment else {
+            // A transient mint failure leaves the paid/issued delta intact in
+            // the durable quote. This screen and the app-wide foreground sweep
+            // will retry it; never show a false success terminal.
+            return
+        }
 
-            if quote.paymentMethod == .onchain {
-                return
-            }
+        let receivedAmount = result.newlyIssued > 0
+            ? result.newlyIssued
+            : (result.quote.amount ?? result.quote.amountIssued)
+        await completeReceivedQuote(receivedAmount: receivedAmount)
+    }
 
-            AppLogger.wallet.error(
-                "Failed to mint quote \(quote.id, privacy: .public): \(String(describing: error), privacy: .public)"
+    @MainActor
+    private func reconcileReusableOffer(_ quote: MintQuoteInfo) async {
+        guard quote.mintableAmount > 0, !isMinting else { return }
+
+        isMinting = true
+        defer { isMinting = false }
+
+        guard let result = await walletManager.refreshPendingMintQuote(quoteId: quote.id) else {
+            return
+        }
+        mintQuote = result.quote
+
+        // Only confirmed issuance earns receipt feedback. The reusable offer
+        // remains on screen and keeps monitoring after every payment.
+        if result.newlyIssued > 0 {
+            walletManager.postReceivedMintNotification(
+                amount: result.newlyIssued,
+                unit: result.quote.unit,
+                homeHaptic: false
             )
+            HapticFeedback.notification(.success)
         }
     }
 
-    /// Publish a receipt only after the receive has been issued.
+    /// Finish a one-shot receive only after quote counters (or a successful
+    /// mint response) confirm that ecash was issued.
     @MainActor
-    private func completeReceivedQuote() async {
+    private func completeReceivedQuote(receivedAmount: UInt64? = nil) async {
         guard !isPaid else { return }
         isPaid = true
         expiryTimer?.invalidate()
-        Task { @MainActor in
-            await walletManager.refreshBalance()
-            await walletManager.loadTransactions()
-        }
 
         // Fire the home-screen toast (same notification the NPC mint flow
         // posts from WalletManager) so the user sees the receipt on the home
         // screen after dismiss.
-        if let quote = mintQuote, let amount = quote.amount {
-            NotificationCenter.default.post(
-                name: .cashuTokenReceived,
-                object: nil,
-                // Pass the unit so the home delta skips a misleading "+N sat" for
-                // a non-sat mint (the sat balance didn't move).
-                userInfo: ["amount": amount, "unit": quote.unit]
+        if let quote = mintQuote,
+           let amount = receivedAmount ?? quote.amount,
+           amount > 0 {
+            walletManager.postReceivedMintNotification(
+                amount: amount,
+                unit: quote.unit,
+                homeHaptic: false
             )
         }
 
-        // Issuance is complete; the receipt stays until the user taps Done.
+        // Ecash is issued — stop polling this one-shot request. Reusable
+        // BOLT12 offers never enter this terminal path.
         quoteStatusTask?.cancel()
     }
 

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -38,6 +38,7 @@ struct ReceiveLightningView: View {
     @State private var isCreatingRequest = false
     @State private var isMinting = false
     @State private var isCheckingPayment = false
+    @State private var mintRetryStatus = MintQuoteRetryStatus()
     @State private var isPaid = false
     @State private var requestFailure: ReceiveRequestFailure?
     @State private var showMintPicker = false
@@ -228,6 +229,25 @@ struct ReceiveLightningView: View {
                 // `isAmountless` is owned by the picked `ReceiveMethodOption` now
                 // (set in `applyMethodOption`); don't recompute it from the empty
                 // field here — that would fight the user's explicit picker choice.
+            }
+            .onChange(of: mintQuote?.id) { _, quoteID in
+                mintRetryStatus = quoteID.map(walletManager.mintQuoteRetryStatus)
+                    ?? MintQuoteRetryStatus()
+            }
+            .onChange(of: mintRetryStatus.state) { oldState, newState in
+                guard oldState != newState else { return }
+                switch newState {
+                case .none:
+                    break
+                case .retryScheduled:
+                    AccessibilityNotification.Announcement(
+                        "Payment received. Ecash issuance will retry automatically."
+                    ).post()
+                case .needsAttention:
+                    AccessibilityNotification.Announcement(
+                        "Payment received, but ecash is still pending. Retry now is available."
+                    ).post()
+                }
             }
             .onChange(of: entryUnit) { oldUnit, newUnit in
                 // Only the sats↔fiat display flip re-expresses the typed string.
@@ -882,12 +902,12 @@ struct ReceiveLightningView: View {
                     ProgressView()
                         .tint(.accentColor)
                         .scaleEffect(0.8)
-                    Text(isMinting ? "Minting..." : "Checking...")
+                    Text(isMinting ? "Issuing ecash..." : "Checking...")
                 }
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
                 .transition(.opacity)
-            } else if isExpired {
+            } else if isExpired, (mintQuote?.mintableAmount ?? 0) == 0 {
                 HStack(spacing: 6) {
                     Image(systemName: "xmark.circle.fill")
                         .accessibilityHidden(true)
@@ -897,6 +917,48 @@ struct ReceiveLightningView: View {
                 // Same severity token as the countdown above it, which already
                 // moved off Color.red — the two states of one clock.
                 .foregroundStyle(ErrorSeverity.error.foreground)
+                .transition(.opacity)
+            } else if (mintQuote?.mintableAmount ?? 0) > 0,
+                      mintRetryStatus.state != .none {
+                VStack(spacing: 8) {
+                    HStack(spacing: 6) {
+                        Image(
+                            systemName: mintRetryStatus.state == .needsAttention
+                                ? "exclamationmark.triangle.fill"
+                                : "clock.arrow.circlepath"
+                        )
+                        .accessibilityHidden(true)
+                        Text(
+                            mintRetryStatus.state == .needsAttention
+                                ? "Payment received. Ecash is still pending."
+                                : "Payment received. Retrying ecash automatically."
+                        )
+                    }
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(
+                        mintRetryStatus.state == .needsAttention
+                            ? ErrorSeverity.error.foreground
+                            : Color.secondary
+                    )
+
+                    Button {
+                        retryPendingMintQuote()
+                    } label: {
+                        Label("Retry now", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityHint("Checks the payment and tries to issue the pending ecash again")
+                }
+                .transition(.opacity)
+            } else if (mintQuote?.mintableAmount ?? 0) > 0 {
+                HStack(spacing: 6) {
+                    Image(systemName: "clock.badge.checkmark")
+                        .accessibilityHidden(true)
+                    Text("Payment received. Ecash issuance is pending.")
+                }
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
                 .transition(.opacity)
             } else if let quote = mintQuote,
                       quote.paymentMethod == .bolt12,
@@ -941,6 +1003,7 @@ struct ReceiveLightningView: View {
         .animation(.easeInOut(duration: 0.2), value: isCheckingPayment)
         .animation(.easeInOut(duration: 0.2), value: isMinting)
         .animation(.easeInOut(duration: 0.2), value: isExpired)
+        .animation(.easeInOut(duration: 0.2), value: mintRetryStatus.state)
     }
 
     private var pendingStatusText: String {
@@ -1511,6 +1574,9 @@ struct ReceiveLightningView: View {
             let updatedQuote = try await walletManager.checkMintQuote(quoteId: quote.id)
             guard !Task.isCancelled, mintQuote?.id == quote.id else { return }
             mintQuote = updatedQuote
+            if updatedQuote.mintableAmount == 0 {
+                mintRetryStatus = MintQuoteRetryStatus()
+            }
 
             if updatedQuote.paymentMethod == .onchain, updatedQuote.state == .pending {
                 await refreshOnchainObservation(for: updatedQuote)
@@ -1572,6 +1638,7 @@ struct ReceiveLightningView: View {
             return
         }
         mintQuote = result.quote
+        mintRetryStatus = result.retryStatus
         guard result.hasSettledPayment else {
             // A transient mint failure leaves the paid/issued delta intact in
             // the durable quote. This screen and the app-wide foreground sweep
@@ -1596,6 +1663,7 @@ struct ReceiveLightningView: View {
             return
         }
         mintQuote = result.quote
+        mintRetryStatus = result.retryStatus
 
         // Only confirmed issuance earns receipt feedback. The reusable offer
         // remains on screen and keeps monitoring after every payment.
@@ -1606,6 +1674,17 @@ struct ReceiveLightningView: View {
                 homeHaptic: false
             )
             HapticFeedback.notification(.success)
+        }
+    }
+
+    private func retryPendingMintQuote() {
+        guard let quote = mintQuote, quote.mintableAmount > 0, !isMinting else { return }
+        Task { @MainActor in
+            if quote.paymentMethod == .bolt12 {
+                await reconcileReusableOffer(quote)
+            } else {
+                await mintQuoteIfReady(quote)
+            }
         }
     }
 

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -1405,7 +1405,9 @@ struct ReceiveLightningView: View {
             if expiryTimeRemaining <= 0 {
                 isExpired = true
                 expiryTimer?.invalidate()
-                quoteStatusTask?.cancel()
+                if quote.paymentMethod != .onchain, (mintQuote?.mintableAmount ?? 0) == 0 {
+                    quoteStatusTask?.cancel()
+                }
             }
         }
     }
@@ -1419,7 +1421,6 @@ struct ReceiveLightningView: View {
         guard let quote = mintQuote,
               quote.paymentMethod == .onchain,
               quote.state != .issued,
-              !quote.isExpired,
               !abandonedOnchainQuoteIds.contains(quote.id) else { return }
         abandonedOnchainQuoteIds.append(quote.id)
         startAbandonedQuoteWatcher()
@@ -1440,47 +1441,14 @@ struct ReceiveLightningView: View {
     private func checkAbandonedOnchainQuotes() async {
         for quoteId in abandonedOnchainQuoteIds {
             guard !isPaid, !Task.isCancelled else { return }
-            guard let info = try? await walletManager.checkMintQuote(quoteId: quoteId) else { continue }
-            // Drop quotes that expired before the mint saw any deposit; a
-            // funded-but-expired quote keeps being probed.
-            if info.isExpired, info.state == .pending, (info.amount ?? 0) == 0 {
-                abandonedOnchainQuoteIds.removeAll { $0 == quoteId }
-                continue
-            }
-            // On-chain quotes sit .pending until a mint attempt succeeds — the
-            // mint call is the probe (mintQuoteIfReady parity; not-yet-funded
-            // failures are expected and swallowed).
-            var mintedAmount: UInt64?
-            do {
-                mintedAmount = try await walletManager.mintTokens(quoteId: quoteId)
-            } catch {
-                guard isAlreadyIssuedMintError(error) else { continue }
-            }
+            guard let result = await walletManager.refreshPendingMintQuote(quoteId: quoteId),
+                  result.hasSettledPayment else { continue }
             abandonedOnchainQuoteIds.removeAll { $0 == quoteId }
-            // Stop the live quote's monitoring BEFORE swapping `mintQuote`, so
-            // the display view's onChange can't restart polling mid-swap; then
-            // reuse the standard success path.
             quoteStatusTask?.cancel()
             monitoredQuoteId = nil
             expiryTimer?.invalidate()
-            let refreshed = (try? await walletManager.checkMintQuote(quoteId: quoteId)) ?? info
-            // `receiveSuccessRows` and the home toast need a non-nil amount;
-            // fall back to the freshly minted amount if the quote lacks one.
-            mintQuote = refreshed.amount != nil ? refreshed : MintQuoteInfo(
-                id: refreshed.id,
-                request: refreshed.request,
-                amount: mintedAmount,
-                isAmountless: false,
-                paymentMethod: .onchain,
-                state: .issued,
-                expiry: refreshed.expiry,
-                createdAt: refreshed.createdAt,
-                unit: refreshed.unit,
-                mintURL: refreshed.mintURL,
-                amountPaid: mintedAmount ?? refreshed.amountPaid,
-                amountIssued: mintedAmount ?? refreshed.amountIssued
-            )
-            await completeReceivedQuote(receivedAmount: mintedAmount)
+            mintQuote = result.quote
+            await completeReceivedQuote(receivedAmount: result.quote.amountIssued)
             return
         }
     }
@@ -1518,7 +1486,7 @@ struct ReceiveLightningView: View {
                 quoteId: quoteId,
                 paymentMethod: paymentMethod
             ) {
-                while !Task.isCancelled && !isPaid && !isExpired {
+                while !Task.isCancelled && !isPaid && (!isExpired || paymentMethod == .onchain) {
                     let notification = try await subscription.recv()
                     guard !Task.isCancelled else { break }
 
@@ -1551,10 +1519,12 @@ struct ReceiveLightningView: View {
     ) async {
         var interval = initialInterval
 
-        while !Task.isCancelled && !isPaid && !isExpired && mintQuote?.id == quoteId {
+        while !Task.isCancelled && !isPaid && mintQuote?.id == quoteId {
             try? await Task.sleep(nanoseconds: interval * 1_000_000_000)
 
-            guard !Task.isCancelled, !isPaid, !isExpired, mintQuote?.id == quoteId else { break }
+            guard !Task.isCancelled, !isPaid, mintQuote?.id == quoteId,
+                  !isExpired || mintQuote?.paymentMethod == .onchain ||
+                    (mintQuote?.mintableAmount ?? 0) > 0 else { break }
             await refreshMintQuoteStatus()
 
             if interval < maxInterval {
@@ -1564,48 +1534,42 @@ struct ReceiveLightningView: View {
     }
 
     @MainActor
-    private func refreshMintQuoteStatus() async {
-        guard let quote = mintQuote, !isExpired, !isMinting else { return }
+    private func refreshMintQuoteStatus(force: Bool = false) async {
+        guard let quote = mintQuote, !isMinting, !isCheckingPayment,
+              force || !isExpired || quote.paymentMethod == .onchain || quote.mintableAmount > 0 else { return }
 
         isCheckingPayment = true
-        defer { isCheckingPayment = false }
+        isMinting = quote.mintableAmount > 0 && (force || walletManager.shouldAttemptMintQuote(quoteID: quote.id))
+        defer {
+            isCheckingPayment = false
+            isMinting = false
+        }
 
-        do {
-            let updatedQuote = try await walletManager.checkMintQuote(quoteId: quote.id)
-            guard !Task.isCancelled, mintQuote?.id == quote.id else { return }
-            mintQuote = updatedQuote
-            if updatedQuote.mintableAmount == 0 {
-                mintRetryStatus = MintQuoteRetryStatus()
-            }
+        // The first status check can itself recover an interrupted CDK saga.
+        // Keep it inside reconciliation so its issuance delta and retry deadline
+        // are handled before balance updates or receive feedback.
+        guard let result = await walletManager.refreshPendingMintQuote(quoteId: quote.id, force: force),
+              !Task.isCancelled, mintQuote?.id == quote.id else { return }
+        mintQuote = result.quote
+        mintRetryStatus = result.retryStatus
 
-            if updatedQuote.paymentMethod == .onchain, updatedQuote.state == .pending {
-                await refreshOnchainObservation(for: updatedQuote)
-                await mintQuoteIfReady(updatedQuote)
-                return
-            } else {
-                onchainObservation = nil
-            }
+        if result.quote.paymentMethod == .onchain, result.quote.state == .pending {
+            await refreshOnchainObservation(for: result.quote)
+        } else {
+            onchainObservation = nil
+        }
 
-            if updatedQuote.paymentMethod == .bolt12 {
-                // A BOLT12 offer is never terminal. Reconcile its cumulative
-                // paid/issued counters and leave the same QR active for the
-                // next payer-generated invoice.
-                await reconcileReusableOffer(updatedQuote)
-                return
+        if result.quote.paymentMethod == .bolt12 {
+            if result.newlyIssued > 0 {
+                walletManager.postReceivedMintNotification(
+                    amount: result.newlyIssued,
+                    unit: result.quote.unit,
+                    homeHaptic: false
+                )
+                HapticFeedback.notification(.success)
             }
-
-            switch updatedQuote.state {
-            case .pending:
-                return
-            case .paid:
-                // "Paid" is not success yet: keep the request visible until
-                // the quote counters prove ecash issuance completed.
-                await mintQuoteIfReady(updatedQuote)
-            case .issued:
-                await completeReceivedQuote(receivedAmount: updatedQuote.amountIssued)
-            }
-        } catch {
-            // Ignore transient polling failures and keep monitoring.
+        } else if result.hasSettledPayment {
+            await completeReceivedQuote(receivedAmount: result.quote.amountIssued)
         }
     }
 
@@ -1627,64 +1591,10 @@ struct ReceiveLightningView: View {
         )
     }
 
-    @MainActor
-    private func mintQuoteIfReady(_ quote: MintQuoteInfo) async {
-        guard !isMinting else { return }
-
-        isMinting = true
-        defer { isMinting = false }
-
-        guard let result = await walletManager.refreshPendingMintQuote(quoteId: quote.id) else {
-            return
-        }
-        mintQuote = result.quote
-        mintRetryStatus = result.retryStatus
-        guard result.hasSettledPayment else {
-            // A transient mint failure leaves the paid/issued delta intact in
-            // the durable quote. This screen and the app-wide foreground sweep
-            // will retry it; never show a false success terminal.
-            return
-        }
-
-        let receivedAmount = result.newlyIssued > 0
-            ? result.newlyIssued
-            : (result.quote.amount ?? result.quote.amountIssued)
-        await completeReceivedQuote(receivedAmount: receivedAmount)
-    }
-
-    @MainActor
-    private func reconcileReusableOffer(_ quote: MintQuoteInfo) async {
-        guard quote.mintableAmount > 0, !isMinting else { return }
-
-        isMinting = true
-        defer { isMinting = false }
-
-        guard let result = await walletManager.refreshPendingMintQuote(quoteId: quote.id) else {
-            return
-        }
-        mintQuote = result.quote
-        mintRetryStatus = result.retryStatus
-
-        // Only confirmed issuance earns receipt feedback. The reusable offer
-        // remains on screen and keeps monitoring after every payment.
-        if result.newlyIssued > 0 {
-            walletManager.postReceivedMintNotification(
-                amount: result.newlyIssued,
-                unit: result.quote.unit,
-                homeHaptic: false
-            )
-            HapticFeedback.notification(.success)
-        }
-    }
-
     private func retryPendingMintQuote() {
         guard let quote = mintQuote, quote.mintableAmount > 0, !isMinting else { return }
         Task { @MainActor in
-            if quote.paymentMethod == .bolt12 {
-                await reconcileReusableOffer(quote)
-            } else {
-                await mintQuoteIfReady(quote)
-            }
+            await refreshMintQuoteStatus(force: true)
         }
     }
 
@@ -1714,9 +1624,7 @@ struct ReceiveLightningView: View {
         quoteStatusTask?.cancel()
     }
 
-    private func isAlreadyIssuedMintError(_ error: Error) -> Bool {
-        walletManager.isAlreadyIssuedMintError(error)
-    }
+
 }
 
 #Preview {

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -1093,10 +1093,8 @@ enum SendAmountDestination: Equatable {
     var carriesAmount: Bool {
         switch self {
         case .melt(_, _, let decoded):
-            // Amountless invoices/offers never lock (the input step keeps them
-            // with a caution), so a locked bolt11/bolt12 always carries one.
             switch decoded {
-            case .bolt11, .bolt12: return true
+            case .bolt11(let amount, _), .bolt12(let amount, _): return amount != nil
             default: return false
             }
         case .cashuRequest(let summary):
@@ -1717,16 +1715,15 @@ struct UnifiedSendView: View {
         switch result {
         case .bolt11, .bolt12:
             if let notice = result.amountlessMeltCaution {
-                // Amountless invoice/offer can't be paid without an amount we don't
-                // collect here — stay on input with a clean caution instead of routing
-                // to a quote that only fails with raw mint jargon.
+                // Keep unsupported amountless request types on input with a
+                // clean caution instead of leaking raw mint jargon.
                 inputHint = notice
                 return
             }
             let request = PaymentRequestDecoder.encodedLightningRequest(from: raw)
                 ?? PaymentRequestParser.normalizeLightningRequest(raw)
             lockMelt(request: request, mode: .lightning, decoded: result)
-            routeToPayment()   // amount carried by the invoice → opens on confirm
+            routeToPayment()   // fixed amount opens on confirm; amountless opens the keypad
         case .lightningAddress(let address):
             lockMelt(request: address, mode: .lightning, decoded: result)
             routeToPayment()
@@ -2253,7 +2250,9 @@ struct UnifiedSendView: View {
                         )
                     } else {
                         quote = try await walletManager.createMeltQuote(
-                            request: request, preferredMintURL: mint.url
+                            request: request,
+                            amount: amountSats > 0 ? amountSats : nil,
+                            preferredMintURL: mint.url
                         )
                     }
                 }
@@ -3164,9 +3163,8 @@ struct MeltView: View {
             }
             .onChange(of: requestInput) {
                 syncSelectedMeltMint()
-                // Surface the amountless caution the moment a request is pasted/typed —
-                // no Get Quote tap needed to discover it carries no amount. Any other
-                // stale notice clears when the destination changes.
+                // Surface unsupported amountless request types immediately.
+                // BOLT12 instead reveals the amount keypad below.
                 if let notice = PaymentRequestDecoder.decode(requestInput).amountlessMeltCaution {
                     presentError(notice, severity: .caution)
                 } else {
@@ -3276,7 +3274,13 @@ struct MeltView: View {
     }
 
     private var amountRequired: Bool {
-        meltMode == .onchain || isHumanReadableAddress
+        if meltMode == .onchain || isHumanReadableAddress {
+            return true
+        }
+        if case .bolt12(let amount, _) = PaymentRequestDecoder.decode(requestInput) {
+            return amount == nil
+        }
+        return false
     }
 
     private var canGetQuote: Bool {
@@ -3804,8 +3808,7 @@ struct MeltView: View {
         }
 
         if let notice = PaymentRequestDecoder.decode(trimmedInput).amountlessMeltCaution {
-            // Amountless invoice/offer can't be quoted without an amount we don't collect
-            // here — surface the clean caution up-front instead of a raw mint error.
+            // Surface unsupported amountless request types before a raw mint error.
             isPreparingInitialQuote = false
             presentError(notice, severity: .caution)
             return
@@ -3855,6 +3858,7 @@ struct MeltView: View {
                         let request = PaymentRequestDecoder.encodedLightningRequest(from: trimmedInput) ?? trimmedInput
                         let quote = try await walletManager.createMeltQuote(
                             request: request,
+                            amount: amountSats > 0 ? amountSats : nil,
                             preferredMintURL: quoteMint.url
                         )
                         guard !Task.isCancelled,

--- a/ios/CashuWalletTests/ScanRouterTests.swift
+++ b/ios/CashuWalletTests/ScanRouterTests.swift
@@ -5,6 +5,9 @@ import XCTest
 /// `routeScannedPayload` so the two scanners route identically.
 final class ScanRouterTests: XCTestCase {
 
+    private let amountlessBolt12Offer =
+        "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"
+
     private func route(_ content: String) -> ScannedPayloadRoute {
         ScanRouter.route(content) { summary, _ in .payWithEcash(summary) }
     }
@@ -30,6 +33,18 @@ final class ScanRouterTests: XCTestCase {
         XCTAssertEqual(request, "user@example.com")
         XCTAssertEqual(mode, .lightning)
         XCTAssertFalse(autoQuote, "an address carries no amount — no quote to prefetch")
+        XCTAssertNil(explanation)
+    }
+
+    func testAmountlessBolt12OfferRoutesToAmountEntry() {
+        guard case .melt(let request, let mode, let autoQuote, let explanation) =
+            route(amountlessBolt12Offer) else {
+            return XCTFail("expected .melt")
+        }
+
+        XCTAssertEqual(request, amountlessBolt12Offer)
+        XCTAssertEqual(mode, .lightning)
+        XCTAssertFalse(autoQuote, "an amountless offer needs sender amount entry before quoting")
         XCTAssertNil(explanation)
     }
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -24,6 +24,82 @@ final class CashuRequestStoreBoundaryTests: XCTestCase {
     }
 }
 
+final class MintQuoteReconciliationResultTests: XCTestCase {
+    func testSuccessfulMintInfersIssuedCounterWhenVerificationIsOffline() {
+        let observed = quote(paid: 21, issued: 0)
+
+        let result = MintQuoteReconciliationResult(
+            observed: observed,
+            mintedAmount: 21,
+            verified: nil
+        )
+
+        XCTAssertEqual(result.newlyIssued, 21)
+        XCTAssertEqual(result.quote.amountIssued, 21)
+        XCTAssertEqual(result.remainingAmount, 0)
+        XCTAssertTrue(result.hasSettledPayment)
+        XCTAssertTrue(result.quote.isAmountless)
+    }
+
+    func testVerifiedCountersResolveLostMintResponse() {
+        let observed = quote(paid: 13, issued: 0)
+        let verified = quote(paid: 13, issued: 13)
+
+        let result = MintQuoteReconciliationResult(
+            observed: observed,
+            mintedAmount: 0,
+            verified: verified
+        )
+
+        XCTAssertEqual(result.newlyIssued, 13)
+        XCTAssertTrue(result.hasSettledPayment)
+        XCTAssertEqual(result.quote.state, .issued)
+    }
+
+    func testLaterReusablePaymentOnlyIssuesNewCounterDelta() {
+        let observed = quote(paid: 34, issued: 21)
+        let verified = quote(paid: 34, issued: 34)
+
+        let result = MintQuoteReconciliationResult(
+            observed: observed,
+            mintedAmount: 13,
+            verified: verified
+        )
+
+        XCTAssertEqual(result.newlyIssued, 13)
+        XCTAssertEqual(result.quote.amountIssued, 34)
+        XCTAssertTrue(result.hasSettledPayment)
+    }
+
+    func testUnissuedPaymentNeverBecomesFalseSuccess() {
+        let observed = quote(paid: 8, issued: 0)
+
+        let result = MintQuoteReconciliationResult(observed: observed)
+
+        XCTAssertEqual(result.newlyIssued, 0)
+        XCTAssertEqual(result.remainingAmount, 8)
+        XCTAssertFalse(result.hasSettledPayment)
+        XCTAssertEqual(result.quote.state, .paid)
+    }
+
+    private func quote(paid: UInt64, issued: UInt64) -> MintQuoteInfo {
+        MintQuoteInfo(
+            id: "reusable-quote",
+            request: "lno1test",
+            amount: paid > 0 ? paid : nil,
+            isAmountless: true,
+            paymentMethod: .bolt12,
+            state: paid > issued ? .paid : .issued,
+            expiry: nil,
+            createdAt: nil,
+            unit: "sat",
+            mintURL: "https://mint.example",
+            amountPaid: paid,
+            amountIssued: issued
+        )
+    }
+}
+
 final class WalletStoreTests: XCTestCase {
     private var store: WalletStore!
 

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -100,7 +100,181 @@ final class MintQuoteReconciliationResultTests: XCTestCase {
     }
 }
 
+@MainActor
+final class MintQuoteReconcilerTests: XCTestCase {
+    func testRecoveryDuringFirstCheckReportsIssuanceOnce() async {
+        let ledger = Ledger(paid: 21)
+        ledger.recoverOnNextCheck = 21
+        let recovered = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        let duplicate = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+
+        XCTAssertEqual(recovered?.newlyIssued, 21)
+        XCTAssertEqual(recovered?.hasSettledPayment, true)
+        XCTAssertEqual(duplicate?.newlyIssued, 0)
+        XCTAssertEqual(ledger.mintCalls, 0)
+    }
+
+    func testCheckRecoveryAndLaterPaymentReportCombinedDelta() async {
+        let ledger = Ledger(paid: 34)
+        ledger.recoverOnNextCheck = 21
+        let result = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+
+        XCTAssertEqual(result?.newlyIssued, 34)
+        XCTAssertEqual(result?.hasSettledPayment, true)
+        XCTAssertEqual(ledger.mintCalls, 1)
+    }
+
+    func testAutomaticRetryWaitsAcrossRecreationAndManualRetryBypassesDeadline() async throws {
+        let ledger = Ledger(paid: 8)
+        ledger.failuresBeforeIssuance = 5
+        let firstResult = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        let first = try XCTUnwrap(firstResult)
+        let calls = ledger.checkCalls
+        let record = ledger.record
+
+        // Recreate the reconciler while retaining the persisted schedule.
+        let deferred = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        XCTAssertEqual(deferred?.retryStatus, first.retryStatus)
+        XCTAssertEqual(ledger.checkCalls, calls)
+        XCTAssertEqual(ledger.mintCalls, 1)
+        XCTAssertEqual(ledger.record, record)
+
+        ledger.now = try XCTUnwrap(first.retryStatus.nextRetryAt)
+        _ = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        XCTAssertEqual(ledger.mintCalls, 2)
+
+        ledger.failuresBeforeIssuance = 0
+        let manual = await ledger.reconciler().reconcile(quoteID: ledger.quote.id, force: true)
+        XCTAssertEqual(manual?.newlyIssued, 8)
+        XCTAssertEqual(manual?.retryStatus.state, MintQuoteRetryState.none)
+        XCTAssertEqual(ledger.mintCalls, 3)
+    }
+
+    func testDepositConfirmedAfterExpiryIsIssuedOnNextSweep() async {
+        let ledger = Ledger(paid: 0, method: .onchain, expiry: 1)
+        _ = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        XCTAssertEqual(ledger.record?.isComplete, false)
+
+        ledger.quote.amountPaid = 21
+        ledger.quote.state = .paid
+        ledger.now = ledger.now.addingTimeInterval(60)
+        let selection = MintQuoteSchedulePolicy.select(
+            quoteIDs: [ledger.quote.id], existing: [ledger.quote.id: ledger.record!],
+            now: ledger.now, force: false
+        )
+        XCTAssertEqual(selection.quoteIDs, [ledger.quote.id])
+        ledger.record = selection.records[ledger.quote.id]
+        let result = await ledger.reconciler().reconcile(quoteID: ledger.quote.id)
+        XCTAssertEqual(result?.newlyIssued, 21)
+        XCTAssertEqual(result?.hasSettledPayment, true)
+    }
+
+    @MainActor
+    private final class Ledger {
+        var quote: MintQuoteInfo
+        var now = Date(timeIntervalSince1970: 10)
+        var record: MintQuoteScheduleRecord?
+        var checkCalls = 0
+        var mintCalls = 0
+        var recoverOnNextCheck: UInt64 = 0
+        var failuresBeforeIssuance = 0
+        private enum Failure: Error { case temporary }
+
+        init(paid: UInt64, method: PaymentMethodKind = .bolt12, expiry: UInt64? = nil) {
+            quote = MintQuoteInfo(
+                id: "quote", request: "request", amount: nil, isAmountless: true,
+                paymentMethod: method, state: paid > 0 ? .paid : .pending,
+                expiry: expiry, createdAt: nil, amountPaid: paid, amountIssued: 0
+            )
+        }
+
+        func reconciler() -> MintQuoteReconciler {
+            MintQuoteReconciler(
+                storedQuote: { _ in self.quote },
+                checkQuote: { _ in
+                    self.checkCalls += 1
+                    self.quote.amountIssued += self.recoverOnNextCheck
+                    self.recoverOnNextCheck = 0
+                    return self.quote
+                },
+                mintQuote: { _ in
+                    self.mintCalls += 1
+                    if self.failuresBeforeIssuance > 0 {
+                        self.failuresBeforeIssuance -= 1
+                        throw Failure.temporary
+                    }
+                    let amount = self.quote.mintableAmount
+                    self.quote.amountIssued = self.quote.amountPaid
+                    self.quote.state = .issued
+                    return amount
+                },
+                schedule: { _ in self.record },
+                observed: { quote in
+                    self.record = MintQuoteSchedulePolicy.observed(
+                        previous: self.record, quote: quote, now: self.now
+                    )
+                },
+                failed: { _, quote in
+                    let record = MintQuoteSchedulePolicy.failed(
+                        previous: self.record, now: self.now,
+                        hadOutstandingPayment: (quote?.mintableAmount ?? 0) > 0,
+                        isReusable: quote?.paymentMethod == .bolt12
+                    )
+                    self.record = record
+                    return MintQuoteSchedulePolicy.retryStatus(for: record)
+                },
+                logFailure: { _, _ in },
+                now: { self.now }
+            )
+        }
+    }
+}
+
 final class MintQuoteSchedulePolicyTests: XCTestCase {
+    func testOnchainDepositRemainsEligibleAfterExpiryAndOldScheduleReopens() {
+        let pending = MintQuoteInfo(
+            id: "pending-confirmation", request: "address", amount: nil,
+            isAmountless: true, paymentMethod: .onchain, state: .pending,
+            expiry: 100, createdAt: nil
+        )
+        let record = MintQuoteSchedulePolicy.observed(
+            previous: nil, quote: pending, now: Date(timeIntervalSince1970: 101)
+        )
+        XCTAssertFalse(record.isComplete)
+        for force in [false, true] {
+            let selection = MintQuoteSchedulePolicy.select(
+                quoteIDs: [pending.id], existing: [pending.id: record],
+                now: Date(timeIntervalSince1970: 700), force: force
+            )
+            XCTAssertEqual(selection.quoteIDs, [pending.id])
+        }
+
+        var oldRecord = record
+        oldRecord.isComplete = true
+        oldRecord.nextAttemptAt = .greatestFiniteMagnitude
+        let restored = MintQuoteSchedulePolicy.select(
+            quoteIDs: [pending.id], existing: [pending.id: oldRecord],
+            now: Date(timeIntervalSince1970: 700), force: false,
+            unsettledOnchainQuoteIDs: [pending.id]
+        )
+        XCTAssertEqual(restored.quoteIDs, [pending.id])
+    }
+
+    func testSelectingDueFailedQuoteDoesNotPostponeItsRetry() {
+        let record = MintQuoteSchedulePolicy.failed(
+            previous: nil, now: Date(timeIntervalSince1970: 10),
+            hadOutstandingPayment: true, isReusable: true
+        )
+        let now = Date(timeIntervalSince1970: record.nextAttemptAt)
+        let selection = MintQuoteSchedulePolicy.select(
+            quoteIDs: ["quote"], existing: ["quote": record], now: now, force: false
+        )
+        XCTAssertEqual(selection.quoteIDs, ["quote"])
+        XCTAssertTrue(MintQuoteSchedulePolicy.shouldAttempt(
+            record: selection.records["quote"], now: now, force: false
+        ))
+    }
+
     func testPassiveSweepsAreBoundedAndRotateFairly() {
         let ids = Set((1...5).map { "quote-\($0)" })
         let now = Date(timeIntervalSince1970: 1_000)

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -100,6 +100,149 @@ final class MintQuoteReconciliationResultTests: XCTestCase {
     }
 }
 
+final class MintQuoteSchedulePolicyTests: XCTestCase {
+    func testPassiveSweepsAreBoundedAndRotateFairly() {
+        let ids = Set((1...5).map { "quote-\($0)" })
+        let now = Date(timeIntervalSince1970: 1_000)
+        let first = MintQuoteSchedulePolicy.select(
+            quoteIDs: ids,
+            existing: [:],
+            now: now,
+            force: false
+        )
+        let second = MintQuoteSchedulePolicy.select(
+            quoteIDs: ids,
+            existing: first.records,
+            now: now,
+            force: false
+        )
+
+        XCTAssertEqual(first.quoteIDs.count, MintQuoteSchedulePolicy.passiveBatchLimit)
+        XCTAssertEqual(second.quoteIDs.count, MintQuoteSchedulePolicy.passiveBatchLimit)
+        XCTAssertTrue(Set(first.quoteIDs).isDisjoint(with: second.quoteIDs))
+    }
+
+    func testForcedSweepBypassesDueTimeButStaysBounded() {
+        let ids = Set((1...30).map { "quote-\($0)" })
+        let future = Dictionary(uniqueKeysWithValues: ids.map {
+            ($0, MintQuoteScheduleRecord(
+                firstObservedAt: 1,
+                nextAttemptAt: .greatestFiniteMagnitude
+            ))
+        })
+
+        XCTAssertTrue(MintQuoteSchedulePolicy.select(
+            quoteIDs: ids,
+            existing: future,
+            now: Date(timeIntervalSince1970: 2_000),
+            force: false
+        ).quoteIDs.isEmpty)
+        XCTAssertEqual(MintQuoteSchedulePolicy.select(
+            quoteIDs: ids,
+            existing: future,
+            now: Date(timeIntervalSince1970: 2_000),
+            force: true
+        ).quoteIDs.count, MintQuoteSchedulePolicy.forcedBatchLimit)
+    }
+
+    func testPaidFailuresEscalateFromRetryScheduledToNeedsAttention() {
+        var record: MintQuoteScheduleRecord?
+        record = nil
+        for failure in 0..<3 {
+            record = MintQuoteSchedulePolicy.failed(
+                previous: record,
+                now: Date(timeIntervalSince1970: TimeInterval(failure * 10)),
+                hadOutstandingPayment: true,
+                isReusable: true
+            )
+        }
+        XCTAssertEqual(
+            MintQuoteSchedulePolicy.retryStatus(for: record!).state,
+            .retryScheduled
+        )
+
+        record = MintQuoteSchedulePolicy.failed(
+            previous: record,
+            now: Date(timeIntervalSince1970: 40),
+            hadOutstandingPayment: true,
+            isReusable: true
+        )
+        XCTAssertEqual(MintQuoteSchedulePolicy.retryStatus(for: record!).state, .needsAttention)
+        XCTAssertEqual(record?.consecutiveFailures, 4)
+    }
+
+    func testWaitingFailureBacksOffWithoutClaimingPaymentNeedsAttention() {
+        let record = MintQuoteSchedulePolicy.failed(
+            previous: nil,
+            now: Date(timeIntervalSince1970: 10),
+            hadOutstandingPayment: false,
+            isReusable: true
+        )
+
+        XCTAssertEqual(MintQuoteSchedulePolicy.retryStatus(for: record).state, .none)
+        XCTAssertGreaterThan(record.nextAttemptAt, 10)
+    }
+
+    func testFailureCounterSaturatesWithoutOverflowing() {
+        let saturated = MintQuoteSchedulePolicy.failed(
+            previous: MintQuoteScheduleRecord(
+                firstObservedAt: 1,
+                consecutiveFailures: .max,
+                hadOutstandingPayment: true
+            ),
+            now: Date(timeIntervalSince1970: 10),
+            hadOutstandingPayment: true,
+            isReusable: true
+        )
+
+        XCTAssertEqual(saturated.consecutiveFailures, .max)
+        XCTAssertEqual(MintQuoteSchedulePolicy.retryStatus(for: saturated).state, .needsAttention)
+    }
+
+    func testReusableQuoteRemainsScheduledAfterIssuanceCatchesUp() {
+        let record = MintQuoteSchedulePolicy.observed(
+            previous: nil,
+            quote: quote(method: .bolt12),
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+
+        XCTAssertTrue(record.isReusable)
+        XCTAssertFalse(record.isComplete)
+        XCTAssertGreaterThan(record.nextAttemptAt, 1_000)
+    }
+
+    func testSettledOneShotQuoteLeavesScheduler() {
+        let record = MintQuoteSchedulePolicy.observed(
+            previous: nil,
+            quote: quote(method: .bolt11),
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+
+        XCTAssertTrue(record.isComplete)
+        XCTAssertTrue(MintQuoteSchedulePolicy.select(
+            quoteIDs: ["quote"],
+            existing: ["quote": record],
+            now: .distantFuture,
+            force: true
+        ).quoteIDs.isEmpty)
+    }
+
+    private func quote(method: PaymentMethodKind) -> MintQuoteInfo {
+        MintQuoteInfo(
+            id: "quote",
+            request: "request",
+            amount: 21,
+            isAmountless: method == .bolt12,
+            paymentMethod: method,
+            state: .issued,
+            expiry: nil,
+            createdAt: nil,
+            amountPaid: 21,
+            amountIssued: 21
+        )
+    }
+}
+
 final class WalletStoreTests: XCTestCase {
     private var store: WalletStore!
 
@@ -214,6 +357,18 @@ final class WalletStoreTests: XCTestCase {
         let ts: TimeInterval = 1_700_000_000
         store.saveMintQuoteTimestamps(["quoteA": ts])
         XCTAssertEqual(store.loadMintQuoteTimestamps()["quoteA"], ts)
+    }
+
+    func testSaveAndLoadMintQuoteSchedules() {
+        let record = MintQuoteScheduleRecord(
+            firstObservedAt: 1_700_000_000,
+            nextAttemptAt: 1_700_000_010,
+            consecutiveFailures: 2,
+            hadOutstandingPayment: true,
+            isReusable: true
+        )
+        store.saveMintQuoteSchedules(["quoteA": record])
+        XCTAssertEqual(store.loadMintQuoteSchedules()["quoteA"], record)
     }
 
     func testSaveAndLoadMintKeysetRefreshTimestamps() {
@@ -369,6 +524,18 @@ final class WalletStoreTests: XCTestCase {
         store.saveBalancesByUnit(["sat": 21, "eur": 100])
         store.removeAllWalletData()
         XCTAssertTrue(store.loadBalancesByUnit().isEmpty)
+    }
+
+    func testRemoveAllWalletDataClearsMintQuoteSchedules() {
+        store.saveMintQuoteSchedules([
+            "quote": MintQuoteScheduleRecord(
+                firstObservedAt: 1,
+                consecutiveFailures: 1,
+                hadOutstandingPayment: true
+            )
+        ])
+        store.removeAllWalletData()
+        XCTAssertTrue(store.loadMintQuoteSchedules().isEmpty)
     }
 
     func testRemoveAllWalletDataClearsRetiredPendingTokenKeys() {


### PR DESCRIPTION
## Summary

- recognize amountless BOLT12 offers throughout send/scan routing and require an explicit payer amount
- reuse one amountless BOLT12 receive offer, while creating a separate BOLT12 offer when the receiver specifies an amount
- persist and reconcile every created mint quote from authoritative `amount_paid` / `amount_issued` counters so paid funds are issued after dismissal, suspension, or process restart
- add a durable, fair scheduler with bounded passive and forced batches, retry backoff, and no duplicate issuance lane
- give iOS and Android matching, truthful payment-detected, issuing, retry-scheduled, and needs-attention states with an explicit retry action

## Recovery boundary

The integration coverage closes and reopens the wallet repository over the same durable CDK database at the paid-but-unissued boundary, then verifies exact-delta issuance and an idempotent second sweep.

A seed-only restore into an empty database cannot currently recover this state: NUT-09 cannot discover the mint-generated quote ID, and BOLT12 issuance also needs the database-held NUT-20 signing-key association. The tests document that protocol/CDK boundary rather than claiming unsupported recovery.

## Testing

- Android unit tests, debug assembly, lint, and debug instrumentation compilation
- required PR-tier Android paid-but-unissued BOLT12 database-reopen integration test against a local CDK mint
- iOS scheduler, reconciliation, and persistence unit tests
- required iOS BOLT12 mint, melt, and restart-recovery integration tests against hermetic local mints

The broader Android native-mint matrix currently stops earlier at an unrelated Nutshell P2PK receive with a CDK subtraction-underflow error; the dedicated BOLT12 recovery test passes and is independently required on pull requests.
