### PR TITLE
Fix cancelled mint-info refreshes on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailInfoLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailInfoLoader.kt
@@ -1,0 +1,59 @@
+package com.cashu.me.ui.mints
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.cashu.me.Core.Wallet.userFacingWalletMessage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+
+internal enum class MintConnectionState(val label: String) {
+    NotChecked("Not checked"),
+    Checking("Checking…"),
+    Online("Online"),
+    Offline("Offline"),
+}
+
+/** Used from the UI coroutine scope; only the latest request may publish state. */
+internal class MintDetailInfoLoader<Info : Any> {
+    var info by mutableStateOf<Info?>(null)
+        private set
+    var connection by mutableStateOf(MintConnectionState.NotChecked)
+        private set
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+    private var requestID = 0L
+
+    suspend fun load(fetch: suspend () -> Info?) {
+        currentCoroutineContext().ensureActive()
+        val request = ++requestID
+        connection = MintConnectionState.Checking
+        errorMessage = null
+        try {
+            val fetched = fetch()
+            currentCoroutineContext().ensureActive()
+            if (request != requestID) return
+            if (fetched == null) {
+                connection = MintConnectionState.Offline
+                errorMessage = "The mint did not respond."
+            } else {
+                info = fetched
+                connection = MintConnectionState.Online
+            }
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (error: Exception) {
+            currentCoroutineContext().ensureActive()
+            if (request != requestID) return
+            connection = MintConnectionState.Offline
+            errorMessage = error.userFacingWalletMessage
+        } finally {
+            // Cancellation is not evidence that the mint is offline. Do not let
+            // cleanup from a superseded request stop a newer loading indicator.
+            if (request == requestID && connection == MintConnectionState.Checking) {
+                connection = MintConnectionState.NotChecked
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -172,29 +172,13 @@ fun MintDetailScreen(
             // persisted mint until it lands (persisted supplies balance/icon/name).
             // A failed fetch surfaces an inline explanation + Retry, and the rows
             // below keep showing the saved record (stale), never a fake success.
-            var liveInfo by remember(mint.url) { mutableStateOf<MintInfo?>(null) }
-            var connection by remember(mint.url) { mutableStateOf(MintConnectionState.Checking) }
-            var infoError by remember(mint.url) { mutableStateOf<String?>(null) }
+            val infoLoader = remember(mint.url) { MintDetailInfoLoader<MintInfo>() }
+            val liveInfo = infoLoader.info
+            val connection = infoLoader.connection
+            val infoError = infoLoader.errorMessage
             var refreshNonce by remember(mint.url) { mutableStateOf(0) }
             LaunchedEffect(mint.url, refreshNonce) {
-                connection = MintConnectionState.Checking
-                infoError = null
-                runCatching { walletManager.fetchLiveMintInfo(mint.url) }
-                    .fold(
-                        { fetched ->
-                            if (fetched != null) {
-                                liveInfo = fetched
-                                connection = MintConnectionState.Online
-                            } else {
-                                connection = MintConnectionState.Offline
-                                infoError = "The mint did not respond."
-                            }
-                        },
-                        { error ->
-                            connection = MintConnectionState.Offline
-                            infoError = error.userFacingWalletMessage
-                        },
-                    )
+                infoLoader.load { walletManager.fetchLiveMintInfo(mint.url) }
             }
             val info = liveInfo ?: mint
 
@@ -246,6 +230,7 @@ fun MintDetailScreen(
                     leadingIcon = Icons.Outlined.Public,
                     valueColor = when (connection) {
                         MintConnectionState.Offline -> MaterialTheme.colorScheme.error
+                        MintConnectionState.NotChecked,
                         MintConnectionState.Checking -> MaterialTheme.colorScheme.onSurfaceVariant
                         MintConnectionState.Online -> null
                     },
@@ -749,13 +734,6 @@ private fun NutRow(code: String, label: String, supported: Boolean) {
             modifier = Modifier.size(16.dp),
         )
     }
-}
-
-// Three-state mint reachability, derived from a live info fetch (iOS parity).
-private enum class MintConnectionState(val label: String) {
-    Checking("Checking…"),
-    Online("Online"),
-    Offline("Offline"),
 }
 
 /// Per-channel contact glyph (iOS `contactIcon`).

--- a/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/MintDiscoveryManagerTest.kt
@@ -1,8 +1,19 @@
 package com.cashu.me.Core
 
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -123,15 +134,31 @@ class MintDiscoveryManagerTest {
 
     @Test
     fun retryResetsExhaustedStateWhileDiscovering() = runBlocking {
-        val manager = discoveryManager()
+        val isRetry = AtomicBoolean(false)
+        val retryStarted = CompletableDeferred<Unit>()
+        val finishRetry = CountDownLatch(1)
+        val manager = discoveryManager(client = FailedRelayClient {
+            if (isRetry.get()) {
+                retryStarted.complete(Unit)
+                check(finishRetry.await(5, TimeUnit.SECONDS)) { "Retry was not released by the test" }
+            }
+        })
         manager.discoverMints()
         assertTrue(manager.state.value.hasCompletedDiscovery)
 
+        isRetry.set(true)
         val retry = async(start = CoroutineStart.UNDISPATCHED) { manager.discoverMints() }
 
-        val retrying = manager.state.value
-        assertTrue(retrying.isDiscovering)
-        assertFalse(retrying.hasCompletedDiscovery)
+        try {
+            // Hold the relay request until the in-progress state is inspected.
+            // A real refused connection can finish before these assertions run.
+            withTimeout(5_000) { retryStarted.await() }
+            val retrying = manager.state.value
+            assertTrue(retrying.isDiscovering)
+            assertFalse(retrying.hasCompletedDiscovery)
+        } finally {
+            finishRetry.countDown()
+        }
         retry.await()
         assertTrue(manager.state.value.hasCompletedDiscovery)
         assertFalse(manager.state.value.isDiscovering)
@@ -165,11 +192,32 @@ class MintDiscoveryManagerTest {
 
     private fun discoveryManager(
         useWebsockets: Boolean = true,
-        relays: List<String> = listOf("ws://127.0.0.1:9"),
+        relays: List<String> = listOf("wss://relay.example"),
+        client: OkHttpClient = FailedRelayClient(),
     ) = MintDiscoveryManager(
         settings = FakeMintDiscoverySettings(useWebsockets, relays),
+        client = client,
         previewFetcher = MintPreviewFetcher { null },
     )
+
+    /** Completes empty discovery without opening sockets or depending on network timing. */
+    private class FailedRelayClient(
+        private val beforeConnect: () -> Unit = {},
+    ) : OkHttpClient() {
+        override fun newWebSocket(request: Request, listener: WebSocketListener): WebSocket {
+            beforeConnect()
+            val socket = object : WebSocket {
+                override fun request(): Request = request
+                override fun queueSize(): Long = 0
+                override fun send(text: String): Boolean = false
+                override fun send(bytes: ByteString): Boolean = false
+                override fun close(code: Int, reason: String?): Boolean = true
+                override fun cancel() = Unit
+            }
+            listener.onFailure(socket, IOException("Simulated unavailable relay"), null)
+            return socket
+        }
+    }
 
     private class FakeMintDiscoverySettings(
         override var useWebsockets: Boolean,

--- a/android/app/src/test/java/com/cashu/me/ui/mints/MintDetailInfoLoaderTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/mints/MintDetailInfoLoaderTest.kt
@@ -1,0 +1,157 @@
+package com.cashu.me.ui.mints
+
+import java.io.IOException
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MintDetailInfoLoaderTest {
+    @Test
+    fun cancellationPropagatesWithoutShowingFailureOrLeavingLoading() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        var propagated = false
+        try {
+            loader.load { throw CancellationException("View left") }
+        } catch (_: CancellationException) {
+            propagated = true
+        }
+        assertTrue(propagated)
+        assertNull(loader.info)
+        assertNull(loader.errorMessage)
+        assertEquals(MintConnectionState.NotChecked, loader.connection)
+    }
+
+    @Test
+    fun cancelledNativeRequestCannotPublishSuccessOrFailure() = runBlocking {
+        for (result in listOf(Result.success("late"), Result.failure(IOException("Timed out")))) {
+            val loader = MintDetailInfoLoader<String>()
+            val fetch = SuspendedFetch()
+            val task = launch(start = CoroutineStart.UNDISPATCHED) { loader.load { fetch.value() } }
+            task.cancel()
+            fetch.finish(result)
+            task.join()
+
+            assertNull(loader.info)
+            assertNull(loader.errorMessage)
+            assertEquals(MintConnectionState.NotChecked, loader.connection)
+        }
+    }
+
+    @Test
+    fun cancelledRefreshPreservesLoadedInformation() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        loader.load { "saved" }
+        try {
+            loader.load { throw CancellationException("View left") }
+        } catch (_: CancellationException) {
+            // The screen's LaunchedEffect owns this cancellation.
+        }
+        assertEquals("saved", loader.info)
+        assertNull(loader.errorMessage)
+        assertEquals(MintConnectionState.NotChecked, loader.connection)
+    }
+
+    @Test
+    fun failureAfterSuccessKeepsInformationButReportsOffline() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        loader.load { "saved" }
+        loader.load { throw IOException("Timed out") }
+
+        assertEquals("saved", loader.info)
+        assertEquals(
+            "The mint took too long to respond. Check your connection and try again.",
+            loader.errorMessage,
+        )
+        assertEquals(MintConnectionState.Offline, loader.connection)
+    }
+
+    @Test
+    fun emptyResponseFailsAndRetryClearsError() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        loader.load { null }
+        assertEquals("The mint did not respond.", loader.errorMessage)
+        assertEquals(MintConnectionState.Offline, loader.connection)
+
+        loader.load { "fresh" }
+        assertEquals("fresh", loader.info)
+        assertNull(loader.errorMessage)
+        assertEquals(MintConnectionState.Online, loader.connection)
+    }
+
+    @Test
+    fun supersededCompletionCannotOverwriteNewerSuccess() = runBlocking {
+        val results = listOf(
+            Result.success("stale"),
+            Result.failure(CancellationException("View left")),
+            Result.failure(IOException("Timed out")),
+        )
+        for (result in results) {
+            val loader = MintDetailInfoLoader<String>()
+            val fetch = SuspendedFetch()
+            val old = launch(start = CoroutineStart.UNDISPATCHED) { loader.load { fetch.value() } }
+            loader.load { "fresh" }
+            fetch.finish(result)
+            old.join()
+
+            assertEquals("fresh", loader.info)
+            assertNull(loader.errorMessage)
+            assertEquals(MintConnectionState.Online, loader.connection)
+        }
+    }
+
+    @Test
+    fun olderCancellationCannotStopNewerLoadingIndicator() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        val firstFetch = SuspendedFetch()
+        val first = launch(start = CoroutineStart.UNDISPATCHED) { loader.load { firstFetch.value() } }
+        val secondFetch = SuspendedFetch()
+        val second = launch(start = CoroutineStart.UNDISPATCHED) { loader.load { secondFetch.value() } }
+
+        first.cancel()
+        firstFetch.finish(Result.failure(CancellationException("View left")))
+        first.join()
+        assertEquals(MintConnectionState.Checking, loader.connection)
+        assertNull(loader.errorMessage)
+
+        secondFetch.finish(Result.success("fresh"))
+        second.join()
+        assertEquals(MintConnectionState.Online, loader.connection)
+    }
+
+    @Test
+    fun alreadyCancelledTaskDoesNotStartFetch() = runBlocking {
+        val loader = MintDetailInfoLoader<String>()
+        var didFetch = false
+        val task = launch {
+            cancel()
+            loader.load {
+                didFetch = true
+                "unexpected"
+            }
+        }
+        task.join()
+        assertFalse(didFetch)
+        assertEquals(MintConnectionState.NotChecked, loader.connection)
+    }
+
+    /** Ignores cancellation so tests can finish native work after its caller leaves. */
+    private class SuspendedFetch {
+        private var continuation: Continuation<String?>? = null
+
+        suspend fun value(): String? = suspendCoroutine { continuation = it }
+
+        fun finish(result: Result<String?>) {
+            checkNotNull(continuation).resumeWith(result)
+            continuation = null
+        }
+    }
+}

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD9100000000000000000001 /* MintDetailInfoLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000002 /* MintDetailInfoLoader.swift */; };
+		CD9100000000000000000003 /* MintDetailInfoLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */; };
 		323A00000000000000000001 /* PriceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A00000000000000000002 /* PriceServiceTests.swift */; };
 		1100000000000001 /* CashuWalletApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000001 /* CashuWalletApp.swift */; };
 		1100000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000002 /* ContentView.swift */; };
@@ -190,6 +192,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CD9100000000000000000002 /* MintDetailInfoLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintDetailInfoLoader.swift; sourceTree = "<group>"; };
+		CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MintDetailInfoLoaderTests.swift; path = CashuWalletTests/MintDetailInfoLoaderTests.swift; sourceTree = "<group>"; };
 		323A00000000000000000002 /* PriceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriceServiceTests.swift; path = CashuWalletTests/PriceServiceTests.swift; sourceTree = "<group>"; };
 		0100000000000001 /* CashuWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CashuWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2100000000000001 /* CashuWalletApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletApp.swift; sourceTree = "<group>"; };
@@ -411,6 +415,7 @@
 				MW00000000000011 /* MeltSettlementWaitTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
+				CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */,
 				SE00000000000013 /* SeedPhraseEntryTests.swift */,
 				T1B0000000000010 /* WalletSurfaceCoordinatorTests.swift */,
 				T1B0000000000011 /* ScanRouterTests.swift */,
@@ -580,6 +585,7 @@
 			children = (
 				210000000000000C /* MintsListView.swift */,
 				21000000000000CC /* MintDetailView.swift */,
+				CD9100000000000000000002 /* MintDetailInfoLoader.swift */,
 				21000000000000CE /* AddMintSheet.swift */,
 				2100000000000100 /* ConnectMintView.swift */,
 				21000000000000CD /* MintDiscoverySheet.swift */,
@@ -998,6 +1004,7 @@
 				MW00000000000001 /* MeltSettlementWaitTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
+				CD9100000000000000000003 /* MintDetailInfoLoaderTests.swift in Sources */,
 				SE00000000000003 /* SeedPhraseEntryTests.swift in Sources */,
 				T2B0000000000010 /* WalletSurfaceCoordinatorTests.swift in Sources */,
 				T2B0000000000011 /* ScanRouterTests.swift in Sources */,
@@ -1059,6 +1066,7 @@
 				110000000000000B /* SendView.swift in Sources */,
 				110000000000000C /* MintsListView.swift in Sources */,
 				11000000000000CC /* MintDetailView.swift in Sources */,
+				CD9100000000000000000001 /* MintDetailInfoLoader.swift in Sources */,
 				11000000000000CE /* AddMintSheet.swift in Sources */,
 				1100000000000100 /* ConnectMintView.swift in Sources */,
 				11000000000000CF /* MintMethodIcons.swift in Sources */,

--- a/ios/CashuWallet/Views/Mints/MintDetailInfoLoader.swift
+++ b/ios/CashuWallet/Views/Mints/MintDetailInfoLoader.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Observation
+
+/// Owns the latest metadata request without tying cached information to reachability.
+@MainActor
+@Observable
+final class MintDetailInfoLoader<Info> {
+    enum Connection {
+        case notChecked, checking, online, offline
+    }
+
+    private(set) var info: Info?
+    private(set) var connection: Connection = .notChecked
+    private(set) var errorMessage: String?
+    private var requestID = UUID()
+
+    var isLoading: Bool { connection == .checking }
+
+    func load(fetch: () async throws -> Info?) async {
+        guard !Task.isCancelled else { return }
+        let request = UUID()
+        requestID = request
+        connection = .checking
+        errorMessage = nil
+
+        do {
+            let fetched = try await fetch()
+            try Task.checkCancellation()
+            guard requestID == request else { return }
+            guard let fetched else {
+                connection = .offline
+                errorMessage = "The mint did not respond."
+                return
+            }
+            info = fetched
+            connection = .online
+        } catch {
+            // An older request must not overwrite a newer success or loading state.
+            guard requestID == request else { return }
+            if Task.isCancelled || error is CancellationError
+                || (error as? URLError)?.code == .cancelled {
+                connection = .notChecked
+            } else {
+                connection = .offline
+                errorMessage = error.userFacingWalletMessage
+            }
+        }
+    }
+}

--- a/ios/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/ios/CashuWallet/Views/Mints/MintDetailView.swift
@@ -16,9 +16,9 @@ struct MintDetailView: View {
         walletManager.mints.first(where: { $0.url == mint.url }) ?? mint
     }
 
-    @State private var cdkInfo: Cdk.MintInfo?
-    @State private var isLoading = true
-    @State private var errorMessage: String?
+    @State private var infoLoader = MintDetailInfoLoader<Cdk.MintInfo>()
+    @State private var refreshID = UUID()
+
     @State private var showRemoveConfirmation = false
     @State private var nutsExpanded = false
     @State private var aboutExpanded = false
@@ -30,6 +30,10 @@ struct MintDetailView: View {
     /// is the cached `mint.balance`). Where a freshly-minted eur/usd shows up.
     @State private var unitBalances: [String: UInt64] = [:]
 
+    private var cdkInfo: Cdk.MintInfo? { infoLoader.info }
+    private var isLoading: Bool { infoLoader.isLoading }
+    private var errorMessage: String? { infoLoader.errorMessage }
+
     /// The mint's non-sat units (sat is shown by `balanceRow`).
     private var nonSatUnits: [String] {
         liveMint.units.filter { $0.lowercased() != "sat" }.sorted()
@@ -37,14 +41,6 @@ struct MintDetailView: View {
 
     private var isDefaultMint: Bool {
         walletManager.activeMint?.url == liveMint.url
-    }
-
-    private enum Connection { case checking, online, offline }
-
-    private var connection: Connection {
-        if cdkInfo != nil { return .online }
-        if errorMessage != nil { return .offline }
-        return .checking
     }
 
     private var showFiat: Bool {
@@ -62,7 +58,7 @@ struct MintDetailView: View {
                     ErrorBannerView(
                         message: errorMessage,
                         severity: .error,
-                        retry: { Task { await loadMintInfo() } }
+                        retry: { refreshID = UUID() }
                     )
                         .padding(.bottom, 12)
                 }
@@ -121,7 +117,7 @@ struct MintDetailView: View {
                 .accessibilityLabel("Share mint")
             }
         }
-        .task { await loadMintInfo() }
+        .task(id: refreshID) { await loadMintInfo() }
         .task { await loadUnitBalances() }
         .confirmationDialog(
             "Remove Mint",
@@ -254,7 +250,9 @@ struct MintDetailView: View {
             Label("Connection", systemImage: "network")
                 .foregroundStyle(.secondary)
             Spacer()
-            switch connection {
+            switch infoLoader.connection {
+            case .notChecked:
+                Text("Not checked").foregroundStyle(.secondary)
             case .checking:
                 Text("Checking…").foregroundStyle(.secondary)
             case .online:
@@ -697,17 +695,8 @@ struct MintDetailView: View {
     }
 
     private func loadMintInfo() async {
-        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
-            isLoading = true
-            errorMessage = nil
-        }
-        do {
-            cdkInfo = try await walletManager.fetchFullMintInfo(mintUrl: liveMint.url)
-        } catch {
-            errorMessage = error.userFacingWalletMessage
-        }
-        withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
-            isLoading = false
+        await infoLoader.load {
+            try await walletManager.fetchFullMintInfo(mintUrl: mint.url)
         }
     }
 

--- a/ios/CashuWalletTests/MintDetailInfoLoaderTests.swift
+++ b/ios/CashuWalletTests/MintDetailInfoLoaderTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class MintDetailInfoLoaderTests: XCTestCase {
+    func testCancellationErrorsDoNotShowFailureOrLeaveLoading() async {
+        for error in [CancellationError(), URLError(.cancelled)] as [Error] {
+            let loader = MintDetailInfoLoader<String>()
+            await loader.load { throw error }
+
+            XCTAssertNil(loader.errorMessage)
+            XCTAssertNil(loader.info)
+            XCTAssertFalse(loader.isLoading)
+            XCTAssertEqual(loader.connection, .notChecked)
+        }
+    }
+
+    func testCancelledNativeRequestCannotPublishSuccessOrFailure() async {
+        for result in [Result<String?, Error>.success("late"), .failure(URLError(.timedOut))] {
+            let loader = MintDetailInfoLoader<String>()
+            let fetch = SuspendedFetch()
+            let task = Task { await loader.load { try await fetch.value() } }
+            await fulfillment(of: [fetch.started], timeout: 2)
+            task.cancel()
+            fetch.finish(with: result)
+            await task.value
+
+            XCTAssertNil(loader.info)
+            XCTAssertNil(loader.errorMessage)
+            XCTAssertFalse(loader.isLoading)
+            XCTAssertEqual(loader.connection, .notChecked)
+        }
+    }
+
+    func testCancelledRefreshPreservesLoadedInformation() async {
+        let loader = MintDetailInfoLoader<String>()
+        await loader.load { "saved" }
+        await loader.load { throw CancellationError() }
+
+        XCTAssertEqual(loader.info, "saved")
+        XCTAssertNil(loader.errorMessage)
+        XCTAssertEqual(loader.connection, .notChecked)
+    }
+
+    func testFailureAfterSuccessKeepsInformationButReportsOffline() async {
+        let loader = MintDetailInfoLoader<String>()
+        await loader.load { "saved" }
+        await loader.load { throw URLError(.timedOut) }
+
+        XCTAssertEqual(loader.info, "saved")
+        XCTAssertNotNil(loader.errorMessage)
+        XCTAssertEqual(loader.connection, .offline)
+        XCTAssertFalse(loader.isLoading)
+    }
+
+    func testEmptyResponseFailsAndRetryClearsError() async {
+        let loader = MintDetailInfoLoader<String>()
+        await loader.load { nil }
+        XCTAssertEqual(loader.errorMessage, "The mint did not respond.")
+        XCTAssertEqual(loader.connection, .offline)
+
+        await loader.load { "fresh" }
+        XCTAssertEqual(loader.info, "fresh")
+        XCTAssertNil(loader.errorMessage)
+        XCTAssertEqual(loader.connection, .online)
+    }
+
+    func testSupersededCompletionCannotOverwriteNewerSuccess() async {
+        let results: [Result<String?, Error>] = [
+            .success("stale"), .failure(CancellationError()), .failure(URLError(.timedOut))
+        ]
+        for result in results {
+            let loader = MintDetailInfoLoader<String>()
+            let fetch = SuspendedFetch()
+            let old = Task { await loader.load { try await fetch.value() } }
+            await fulfillment(of: [fetch.started], timeout: 2)
+            await loader.load { "fresh" }
+            fetch.finish(with: result)
+            await old.value
+
+            XCTAssertEqual(loader.info, "fresh")
+            XCTAssertNil(loader.errorMessage)
+            XCTAssertEqual(loader.connection, .online)
+        }
+    }
+
+    func testOlderCancellationCannotStopNewerLoadingIndicator() async {
+        let loader = MintDetailInfoLoader<String>()
+        let firstFetch = SuspendedFetch()
+        let first = Task { await loader.load { try await firstFetch.value() } }
+        await fulfillment(of: [firstFetch.started], timeout: 2)
+        let secondFetch = SuspendedFetch()
+        let second = Task { await loader.load { try await secondFetch.value() } }
+        await fulfillment(of: [secondFetch.started], timeout: 2)
+
+        first.cancel()
+        firstFetch.finish(with: .failure(CancellationError()))
+        await first.value
+        XCTAssertTrue(loader.isLoading)
+        XCTAssertNil(loader.errorMessage)
+
+        secondFetch.finish(with: .success("fresh"))
+        await second.value
+        XCTAssertEqual(loader.connection, .online)
+    }
+
+    func testAlreadyCancelledTaskDoesNotStartFetch() async {
+        let loader = MintDetailInfoLoader<String>()
+        var didFetch = false
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await loader.load {
+                didFetch = true
+                return "unexpected"
+            }
+        }
+        await task.value
+        XCTAssertFalse(didFetch)
+        XCTAssertEqual(loader.connection, .notChecked)
+    }
+}
+
+/// Deliberately ignores cancellation, like a native call finishing after its view leaves.
+@MainActor
+private final class SuspendedFetch {
+    let started = XCTestExpectation(description: "Mint info fetch started")
+    private var continuation: CheckedContinuation<String?, Error>?
+
+    func value() async throws -> String? {
+        try await withCheckedThrowingContinuation {
+            continuation = $0
+            started.fulfill()
+        }
+    }
+
+    func finish(with result: Result<String?, Error>) {
+        continuation?.resume(with: result)
+        continuation = nil
+    }
+}


### PR DESCRIPTION
A cancelled mint-info refresh could display `Swift.CancellationError` while the iOS details screen still showed “Online” from an earlier successful fetch. Android also treated coroutine cancellation as a connection failure.

Move metadata loading into small, testable state holders on both platforms. Cancelled loads finish without an error notice and leave connection status as “Not checked”; real failures still show an explanation and Retry while preserving previously fetched information. Only the latest request may update metadata, connection status, or loading state. iOS retries now use the view's managed task, and Android propagates coroutine cancellation.

The discovery retry regression also uses a controlled failing relay instead of a real refused connection, so its loading-state assertions cannot race network completion.

Validation:

- iOS simulator build and 12 selected tests passed: 8 new mint-info regressions and 4 existing error-message tests.
- Full Android JVM suite passed: 651 passed, 6 skipped, no failures. Android debug compilation and `:app:lintDebug` also passed.
- The previously timing-dependent discovery retry test passed 100 consecutive runs with the controlled relay.
- Regression coverage includes cancellation, native work completing after cancellation, outdated success/failure/cancellation arriving after a newer request, loading-state races, failed refreshes after success, empty responses, and retries.
