### PR TITLE
Fix lingering received balance indicator on iOS

### DIFF
--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
+		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
 		A09100000000000000000007 /* LifecycleSafeWalletDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */; };
 		A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000006 /* WalletAuditRegressionTests.swift */; };
 		A09100000000000000000003 /* MintURLIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000004 /* MintURLIdentity.swift */; };
@@ -195,6 +197,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
+		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
 		A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleSafeWalletDatabase.swift; sourceTree = "<group>"; };
 		A09100000000000000000006 /* WalletAuditRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/WalletAuditRegressionTests.swift; sourceTree = "<group>"; };
 		A09100000000000000000004 /* MintURLIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintURLIdentity.swift; sourceTree = "<group>"; };
@@ -412,6 +416,7 @@
 				T1B000000000000A /* CurrencyTests.swift */,
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
 				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
+				BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */,
 				T1B0000000000100 /* ConnectMintContextTests.swift */,
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
@@ -557,6 +562,7 @@
 			isa = PBXGroup;
 			children = (
 				2100000000000007 /* MainWalletView.swift */,
+				BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */,
 				2100000000000008 /* OnboardingView.swift */,
 				2100000000000C41 /* OnboardingChassis.swift */,
 				SE00000000000014 /* SeedWordEntry.swift */,
@@ -1004,6 +1010,7 @@
 				T2B000000000000A /* CurrencyTests.swift in Sources */,
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
 				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
+				BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */,
 				T2B0000000000100 /* ConnectMintContextTests.swift in Sources */,
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
@@ -1062,6 +1069,7 @@
 				1100000000000005 /* KeychainService.swift in Sources */,
 				AB00000000000001 /* CashuRequest.swift in Sources */,
 				1100000000000007 /* MainWalletView.swift in Sources */,
+				BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */,
 				1100000000000008 /* OnboardingView.swift in Sources */,
 				1100000000000C41 /* OnboardingChassis.swift in Sources */,
 				1100000000000C55 /* OnboardingHandoff.swift in Sources */,

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -26,9 +26,9 @@ struct MainWalletView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.dynamicTypeSize) private var typeSize
     @Environment(\.cashuFonts) private var fonts
+    @Environment(\.scenePhase) private var scenePhase
 
-    @State private var receivedDelta: ReceivedDelta?
-    @State private var deltaDismissTask: Task<Void, Never>?
+    @State private var receivedFeedback = ReceivedBalanceFeedback()
     @State private var contactlessCoordinator = ContactlessPaymentCoordinator()
     @State private var selectedTransaction: WalletTransaction?
     @State private var isSheetDismissing = false
@@ -173,13 +173,15 @@ struct MainWalletView: View {
             // "+N sat".
             let unit = note.userInfo?["unit"] as? String ?? "sat"
             guard unit.lowercased() == "sat" else { return }
-            let fee = note.userInfo?["fee"] as? UInt64
             // Only background receives (poster sets "homeHaptic") buzz here; in-flow
             // receives own the success haptic on their confirmation surface.
             let playHaptic = note.userInfo?["homeHaptic"] as? Bool ?? false
-            showReceivedDelta(amount: amount, fee: fee, playHaptic: playHaptic)
+            showReceivedDelta(amount: amount, playHaptic: playHaptic)
         }
-        .onDisappear { deltaDismissTask?.cancel() }
+        .onDisappear { receivedFeedback.clear() }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .background { receivedFeedback.clear() }
+        }
     }
 
     // MARK: - Fixed Top Section
@@ -325,8 +327,8 @@ struct MainWalletView: View {
     @ViewBuilder
     private func balanceStatusLine(_ display: AmountDisplayText, secondaryValue: Double?) -> some View {
         ZStack {
-            if let delta = receivedDelta {
-                receivedDeltaBeat(delta)
+            if let amount = receivedFeedback.amount {
+                receivedDeltaBeat(amount)
                     .transition(reduceMotion ? .opacity : .asymmetric(insertion: .scale(scale: 0.9).combined(with: .opacity), removal: .opacity))
             } else if !walletManager.isRuntimeReady {
                 Text("Preparing wallet…")
@@ -352,8 +354,8 @@ struct MainWalletView: View {
     /// no unit (the balance beside it carries it), no directional arrow (the
     /// down-arrow stays exclusive to row badges). VoiceOver-hidden; the balance
     /// announces the new total.
-    private func receivedDeltaBeat(_ delta: ReceivedDelta) -> some View {
-        Text("+\(settings.formatAmountShort(delta.amount))")
+    private func receivedDeltaBeat(_ amount: UInt64) -> some View {
+        Text("+\(settings.formatAmountShort(amount))")
             .monospacedDigit()
             .font(.body.weight(.semibold))
             .foregroundStyle(.secondary)
@@ -373,19 +375,9 @@ struct MainWalletView: View {
     /// confirms (npub.cash). In-flow receives (Lightning / ecash paste via
     /// PaymentStatusView, a watched Cashu request) already own a success haptic,
     /// so they leave it off to avoid a double-buzz.
-    private func showReceivedDelta(amount: UInt64, fee: UInt64?, playHaptic: Bool) {
-        deltaDismissTask?.cancel()
+    private func showReceivedDelta(amount: UInt64, playHaptic: Bool) {
         if playHaptic { HapticFeedback.notification(.success) }
-        withAnimation(receivedDeltaAnimation) {
-            receivedDelta = ReceivedDelta(amount: amount, fee: fee)
-        }
-        deltaDismissTask = Task { @MainActor in
-            try? await Task.sleep(for: .seconds(2.5))
-            guard !Task.isCancelled else { return }
-            withAnimation(receivedDeltaAnimation) {
-                receivedDelta = nil
-            }
-        }
+        receivedFeedback.show(amount: amount, animation: receivedDeltaAnimation)
     }
 
     // MARK: - Action Buttons (Receive + Send)
@@ -793,14 +785,6 @@ struct MainWalletView: View {
         )
         .environmentObject(walletManager)
     }
-}
-
-/// A just-received amount, surfaced as the transient balance beat. The `id`
-/// makes rapid successive receives re-trigger the entrance + checkmark bounce.
-private struct ReceivedDelta: Identifiable, Equatable {
-    let id = UUID()
-    let amount: UInt64
-    let fee: UInt64?
 }
 
 private struct TopInsetHeightKey: PreferenceKey {

--- a/ios/CashuWallet/Views/Main/ReceivedBalanceFeedback.swift
+++ b/ios/CashuWallet/Views/Main/ReceivedBalanceFeedback.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// Owns the received amount and its timer together, so leaving the wallet
+/// cannot cancel dismissal while retaining a permanently visible "+N".
+@MainActor
+@Observable
+final class ReceivedBalanceFeedback {
+    private(set) var amount: UInt64?
+
+    @ObservationIgnored private var dismissTask: Task<Void, Never>?
+    private let sleep: @MainActor (Duration) async throws -> Void
+
+    init(sleep: @escaping @MainActor (Duration) async throws -> Void = {
+        try await Task.sleep(for: $0)
+    }) {
+        self.sleep = sleep
+    }
+
+    func show(amount: UInt64, animation: Animation?) {
+        dismissTask?.cancel()
+        withAnimation(animation) {
+            self.amount = amount
+        }
+        dismissTask = Task { @MainActor [weak self, sleep] in
+            do {
+                try await sleep(.seconds(2.5))
+            } catch {
+                return
+            }
+            // A cancelled timer must never dismiss a newer receipt, including
+            // another receipt with exactly the same amount.
+            guard !Task.isCancelled else { return }
+            withAnimation(animation) {
+                self?.clear()
+            }
+        }
+    }
+
+    /// Used when the screen disappears or the app enters the background.
+    /// Always clear both state and work; SwiftUI can preserve state offscreen.
+    func clear() {
+        dismissTask?.cancel()
+        dismissTask = nil
+        amount = nil
+    }
+
+    deinit {
+        dismissTask?.cancel()
+    }
+}

--- a/ios/CashuWalletTests/ReceivedBalanceFeedbackTests.swift
+++ b/ios/CashuWalletTests/ReceivedBalanceFeedbackTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class ReceivedBalanceFeedbackTests: XCTestCase {
+    private var pendingSleeps: [CheckedContinuation<Void, Never>] = []
+    private var durations: [Duration] = []
+
+    func testReceiptDismissesAfterTwoAndAHalfSeconds() async {
+        let started = expectation(description: "Dismiss timer started")
+        let finished = expectation(description: "Dismiss timer finished")
+        let feedback = makeFeedback(started: [started], finished: [finished])
+        feedback.show(amount: 1, animation: nil)
+        XCTAssertEqual(feedback.amount, 1)
+        await fulfillment(of: [started], timeout: 1)
+        XCTAssertEqual(durations, [.seconds(2.5)])
+
+        pendingSleeps.removeFirst().resume()
+        await fulfillment(of: [finished], timeout: 1)
+        XCTAssertNil(feedback.amount)
+    }
+
+    func testLeavingScreenClearsReceiptBeforeTimerFinishes() async {
+        let started = expectation(description: "Dismiss timer started")
+        let finished = expectation(description: "Dismiss timer finished")
+        let feedback = makeFeedback(started: [started], finished: [finished])
+        feedback.show(amount: 1, animation: nil)
+        await fulfillment(of: [started], timeout: 1)
+
+        // The view invokes this on disappearance/backgrounding. Returning to
+        // the retained view must not bring back the old amount.
+        feedback.clear()
+        XCTAssertNil(feedback.amount)
+
+        pendingSleeps.removeFirst().resume()
+        await fulfillment(of: [finished], timeout: 1)
+        XCTAssertNil(feedback.amount)
+    }
+
+    func testRapidReceiptsGiveLatestAmountAFullDismissalTimer() async {
+        await assertReplacementSurvivesCancelledTimer(nextAmount: 21, clearFirst: false)
+    }
+
+    func testRepeatedEqualReceiptsRestartDismissalTimer() async {
+        await assertReplacementSurvivesCancelledTimer(nextAmount: 1, clearFirst: false)
+    }
+
+    func testNewReceiptAfterReturningSurvivesOldCancelledTimer() async {
+        await assertReplacementSurvivesCancelledTimer(nextAmount: 1, clearFirst: true)
+    }
+
+    private func assertReplacementSurvivesCancelledTimer(nextAmount: UInt64, clearFirst: Bool) async {
+        let firstStarted = expectation(description: "First dismiss timer started")
+        let nextStarted = expectation(description: "Next dismiss timer started")
+        let firstFinished = expectation(description: "First dismiss timer finished")
+        let nextFinished = expectation(description: "Next dismiss timer finished")
+        let feedback = makeFeedback(
+            started: [firstStarted, nextStarted],
+            finished: [firstFinished, nextFinished]
+        )
+        feedback.show(amount: 1, animation: nil)
+        await fulfillment(of: [firstStarted], timeout: 1)
+        if clearFirst { feedback.clear() }
+
+        feedback.show(amount: nextAmount, animation: nil)
+        await fulfillment(of: [nextStarted], timeout: 1)
+        pendingSleeps.removeFirst().resume()
+        await fulfillment(of: [firstFinished], timeout: 1)
+        XCTAssertEqual(feedback.amount, nextAmount)
+        XCTAssertEqual(durations, [.seconds(2.5), .seconds(2.5)])
+
+        pendingSleeps.removeFirst().resume()
+        await fulfillment(of: [nextFinished], timeout: 1)
+        XCTAssertNil(feedback.amount)
+    }
+
+    private func makeFeedback(
+        started: [XCTestExpectation],
+        finished: [XCTestExpectation]
+    ) -> ReceivedBalanceFeedback {
+        ReceivedBalanceFeedback { duration in
+            let index = self.durations.count
+            self.durations.append(duration)
+            // Intentionally ignore cancellation until explicitly resumed to
+            // exercise the stale-timer race without waiting real seconds.
+            await withCheckedContinuation { continuation in
+                self.pendingSleeps.append(continuation)
+                started[index].fulfill()
+            }
+            // The sleep and the feedback update both run on MainActor, so
+            // the update completes before the waiting test resumes there.
+            finished[index].fulfill()
+        }
+    }
+}


### PR DESCRIPTION
Receiving a payment and leaving the iOS wallet screen before its 2.5-second dismissal timer finished could leave the `+N` balance indicator visible indefinitely. The screen cancelled the timer while retaining the displayed amount.

Keep the amount and its timer together in `ReceivedBalanceFeedback`, and clear both when the wallet screen disappears or the app enters the background. Preserve the existing animation, Reduce Motion behavior, and 2.5-second timeout. Cancelled timers cannot dismiss a newer receipt, including another receipt of the same amount.

Android was checked: its screen-local receipt state is discarded with its timer when the screen leaves composition, so it does not share this failure path.

Validation:

- iOS simulator build succeeded.
- All 7 focused tests passed: 5 received-balance regression tests and 2 existing home-action accessibility tests.
- Regression coverage includes normal expiry, clearing before expiry, rapid receipts, repeated equal amounts, and receiving again after returning to the wallet.
- `git diff --check` passed.
