### PR TITLE
Unify activity payment detail sheets across iOS and Android

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -32,7 +31,7 @@ class ActivityDetailJourneyTest {
     private var launched: LaunchedFixture? = null
     private val robot by lazy { WalletJourneyRobot(compose) }
 
-    @Test fun receiptStartsCollapsedAndRetiresCodeWhenPaymentSettles() {
+    @Test fun receiptShowsCodeImmediatelyAndRetiresItWhenPaymentSettles() {
         launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
         val fixture = launched!!
         robot.awaitTag(UiTestTags.WalletScreen)
@@ -43,13 +42,10 @@ class ActivityDetailJourneyTest {
         fixture.fakeGateway!!.addTransaction(tx)
         runBlocking { fixture.container.walletManager.loadTransactions() }
         robot.tapText("History").tapText("Lightning invoice").awaitTag(UiTestTags.TransactionReceiptSheet)
-        compose.onNodeWithText("Status").assertIsDisplayed()
-        compose.onNodeWithText("Date").assertIsDisplayed()
+        compose.onNodeWithText("Status").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Date").performScrollTo().assertIsDisplayed()
         compose.onNodeWithContentDescription("Close").assertDoesNotExist()
-        compose.onNodeWithContentDescription("QR code. Long press for copy and share options.").assertDoesNotExist()
         screenshot("activity-pending")
-        compose.onNodeWithText("Show QR code").performScrollTo().performClick()
-        compose.onNodeWithText("Hide QR code").assertIsDisplayed()
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
             .performScrollTo().assertIsDisplayed()
         fixture.fakeGateway!!.addTransaction(tx.copy(status = TransactionStatus.Completed, isUnpaidInvoice = false))
@@ -74,12 +70,11 @@ class ActivityDetailJourneyTest {
             mintUrl = FakeWalletGateway.TestMintUrl, quoteId = "activity-offer"))
         runBlocking { fixture.container.walletManager.loadTransactions() }
         robot.tapText("History").tapText("Reusable Invoice").awaitText("Active")
-        compose.onNodeWithText("Status").assertIsDisplayed()
-        compose.onNodeWithText("Date").assertIsDisplayed()
+        compose.onNodeWithText("Status").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithText("Date").performScrollTo().assertIsDisplayed()
         compose.onNodeWithText("Total received").assertIsDisplayed()
         compose.onNodeWithContentDescription("Close").assertDoesNotExist()
         screenshot("activity-reusable")
-        compose.onNodeWithText("Show QR code").performScrollTo().performClick()
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
             .performScrollTo().assertIsDisplayed()
         robot.pressSystemBack().awaitTag(UiTestTags.HistoryScreen)

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
@@ -1,0 +1,92 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.core.graphics.writeToTestStorage
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FakeWalletGateway
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ActivityDetailJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { launched?.close() }
+    private var launched: LaunchedFixture? = null
+    private val robot by lazy { WalletJourneyRobot(compose) }
+
+    @Test fun receiptStartsCollapsedAndRetiresCodeWhenPaymentSettles() {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val fixture = launched!!
+        robot.awaitTag(UiTestTags.WalletScreen)
+        val tx = WalletTransaction(id = "activity-invoice", amount = 2100,
+            type = TransactionType.Incoming, kind = TransactionKind.Lightning,
+            dateEpochMillis = System.currentTimeMillis(), status = TransactionStatus.Pending,
+            invoice = "lnbc1fixture", mintUrl = FakeWalletGateway.TestMintUrl, isUnpaidInvoice = true)
+        fixture.fakeGateway!!.addTransaction(tx)
+        runBlocking { fixture.container.walletManager.loadTransactions() }
+        robot.tapText("History").tapText("Lightning invoice").awaitTag(UiTestTags.TransactionReceiptSheet)
+        compose.onNodeWithText("Status").assertIsDisplayed()
+        compose.onNodeWithText("Date").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Close").assertDoesNotExist()
+        compose.onNodeWithContentDescription("QR code. Long press for copy and share options.").assertDoesNotExist()
+        screenshot("activity-pending")
+        compose.onNodeWithText("Show QR code").performScrollTo().performClick()
+        compose.onNodeWithText("Hide QR code").assertIsDisplayed()
+        compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
+            .performScrollTo().assertIsDisplayed()
+        fixture.fakeGateway!!.addTransaction(tx.copy(status = TransactionStatus.Completed, isUnpaidInvoice = false))
+        runBlocking { fixture.container.walletManager.loadTransactions() }
+        robot.awaitText("Paid")
+        compose.onNodeWithText("Show QR code").assertDoesNotExist()
+        compose.onNodeWithText("Hide QR code").assertDoesNotExist()
+        compose.onNodeWithContentDescription("QR code. Long press for copy and share options.").assertDoesNotExist()
+        robot.pressSystemBack().awaitTag(UiTestTags.HistoryScreen)
+    }
+
+    @Test fun reusableInvoiceUsesSameSheetAndKeepsCodeAfterPayment() {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val fixture = launched!!
+        robot.awaitTag(UiTestTags.WalletScreen)
+        fixture.container.cashuRequestStore.upsertQuoteIntent(
+            quoteId = "activity-offer", quoteKind = "bolt12", amount = null,
+            mints = listOf(FakeWalletGateway.TestMintUrl), memo = "Coffee tips", encoded = "lno1fixture")
+        fixture.fakeGateway!!.addTransaction(WalletTransaction(id = "activity-payment", amount = 2100,
+            type = TransactionType.Incoming, kind = TransactionKind.Lightning,
+            dateEpochMillis = System.currentTimeMillis(), status = TransactionStatus.Completed,
+            mintUrl = FakeWalletGateway.TestMintUrl, quoteId = "activity-offer"))
+        runBlocking { fixture.container.walletManager.loadTransactions() }
+        robot.tapText("History").tapText("Reusable Invoice").awaitText("Active")
+        compose.onNodeWithText("Status").assertIsDisplayed()
+        compose.onNodeWithText("Date").assertIsDisplayed()
+        compose.onNodeWithText("Total received").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Close").assertDoesNotExist()
+        screenshot("activity-reusable")
+        compose.onNodeWithText("Show QR code").performScrollTo().performClick()
+        compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
+            .performScrollTo().assertIsDisplayed()
+        robot.pressSystemBack().awaitTag(UiTestTags.HistoryScreen)
+    }
+
+    private fun screenshot(name: String) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        checkNotNull(instrumentation.uiAutomation.takeScreenshot()).writeToTestStorage(name)
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ActivityDetailJourneyTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.core.graphics.writeToTestStorage
@@ -45,12 +48,15 @@ class ActivityDetailJourneyTest {
         compose.onNodeWithText("Status").performScrollTo().assertIsDisplayed()
         compose.onNodeWithText("Date").performScrollTo().assertIsDisplayed()
         compose.onNodeWithContentDescription("Close").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Share").assertIsDisplayed()
         screenshot("activity-pending")
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
             .performScrollTo().assertIsDisplayed()
         fixture.fakeGateway!!.addTransaction(tx.copy(status = TransactionStatus.Completed, isUnpaidInvoice = false))
         runBlocking { fixture.container.walletManager.loadTransactions() }
         robot.awaitText("Paid")
+        compose.onNodeWithContentDescription("Completed").assertIsDisplayed()
+        compose.onNodeWithContentDescription("Share").assertDoesNotExist()
         compose.onNodeWithText("Show QR code").assertDoesNotExist()
         compose.onNodeWithText("Hide QR code").assertDoesNotExist()
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.").assertDoesNotExist()
@@ -69,15 +75,55 @@ class ActivityDetailJourneyTest {
             dateEpochMillis = System.currentTimeMillis(), status = TransactionStatus.Completed,
             mintUrl = FakeWalletGateway.TestMintUrl, quoteId = "activity-offer"))
         runBlocking { fixture.container.walletManager.loadTransactions() }
-        robot.tapText("History").tapText("Reusable Invoice").awaitText("Active")
-        compose.onNodeWithText("Status").performScrollTo().assertIsDisplayed()
-        compose.onNodeWithText("Date").performScrollTo().assertIsDisplayed()
+        robot.tapText("History").tapText("Reusable Invoice").awaitText("1 payment received")
+        compose.onNodeWithText("Created").performScrollTo().assertIsDisplayed()
+        compose.onNodeWithContentDescription("Share").assertIsDisplayed()
+        compose.onNodeWithText("New Request").assertDoesNotExist()
         compose.onNodeWithText("Total received").assertIsDisplayed()
         compose.onNodeWithContentDescription("Close").assertDoesNotExist()
         screenshot("activity-reusable")
         compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
             .performScrollTo().assertIsDisplayed()
         robot.pressSystemBack().awaitTag(UiTestTags.HistoryScreen)
+    }
+
+    @Test fun cashuRequestKeepsInlineEditingAndNewRequest() {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val fixture = launched!!
+        robot.awaitTag(UiTestTags.WalletScreen)
+        val original = fixture.container.cashuRequestStore.createNew(
+            id = "activity-request", mints = listOf(FakeWalletGateway.TestMintUrl),
+            memo = "Coffee tips", encoded = "creqAfixture")
+        robot.tapText("History").tapText("Cashu Request").awaitText("New Request")
+        compose.onNodeWithContentDescription("Close").assertDoesNotExist()
+        compose.onNodeWithContentDescription("Share").assertIsDisplayed()
+        compose.onNodeWithText("Copy").assertIsDisplayed()
+        compose.onNodeWithText("New Request").assertIsDisplayed().performClick()
+        compose.waitUntil(5_000) {
+            fixture.container.cashuRequestStore.request(original.id)?.encoded != original.encoded
+        }
+        val updated = checkNotNull(fixture.container.cashuRequestStore.request(original.id))
+        assertTrue(updated.encoded.startsWith("creqA"))
+        assertEquals(original.memo, updated.memo)
+        assertEquals(original.mints, updated.mints)
+        assertEquals(1, fixture.container.cashuRequestStore.state.value.requests.size)
+        compose.onNodeWithText("Amount").performScrollTo().performClick()
+        robot.awaitText("Done").pressSystemBack().awaitText("New Request")
+        robot.pressSystemBack().awaitTag(UiTestTags.HistoryScreen)
+    }
+
+    @Test fun failedPaymentKeepsRedFailureGlyph() {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val fixture = launched!!
+        robot.awaitTag(UiTestTags.WalletScreen)
+        fixture.fakeGateway!!.addTransaction(WalletTransaction(
+            id = "activity-failed", amount = 2100, type = TransactionType.Outgoing,
+            kind = TransactionKind.Lightning, dateEpochMillis = System.currentTimeMillis(),
+            status = TransactionStatus.Failed, mintUrl = FakeWalletGateway.TestMintUrl))
+        runBlocking { fixture.container.walletManager.loadTransactions() }
+        robot.tapText("History").tapText("Lightning paid").awaitTag(UiTestTags.TransactionReceiptSheet)
+        compose.onNodeWithContentDescription("Failed").assertIsDisplayed()
+        compose.onNodeWithText("Failed").assertIsDisplayed()
     }
 
     private fun screenshot(name: String) {

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
@@ -136,6 +136,8 @@ class FunctionalWalletJourneyTest {
         robot.tapText("History")
             .awaitTag(UiTestTags.HistoryScreen)
             .tapTag(UiTestTags.transactionRow(pending.tokenId))
+            .awaitTag(UiTestTags.TransactionReceiptSheet)
+            .tapTextWithinTag(UiTestTags.TransactionReceiptSheet, "Receive")
             .awaitTag(UiTestTags.ReceiveEcashDetail)
             .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Memo")
             .awaitTextWithinTag(UiTestTags.ReceiveEcashDetail, "Coffee from Alice")

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -19,7 +19,7 @@ data class TransactionDetailField(
 object TransactionDisplay {
     // Kind-first, capitalized kind, lowercase verb — single source of truth for
     // rows AND the detail title, so a row and the sheet it opens read identically.
-    fun title(transaction: WalletTransaction): String = when (transaction.kind) {
+    fun title(transaction: WalletTransaction): String = if (transaction.isPendingReceiveToken) "Ecash to claim" else when (transaction.kind) {
         TransactionKind.Lightning -> when {
             transaction.type != TransactionType.Incoming -> "Lightning paid"
             // Nothing has been received while the invoice awaits payment.
@@ -38,7 +38,7 @@ object TransactionDisplay {
         }
     }
 
-    // The Status detail row: monochrome value, the hero glyph carries colour.
+    // Explicit, monochrome lifecycle text in the shared receipt inspector.
     fun statusText(transaction: WalletTransaction): String = when (transaction.status) {
         TransactionStatus.Completed -> when (transaction.kind) {
             TransactionKind.Ecash -> "Claimed"
@@ -54,24 +54,23 @@ object TransactionDisplay {
         transaction.token ?: transaction.invoice
 
     /**
-     * The QR hero appears only while the artifact remains useful. Ecash is
-     * shareable only for an unclaimed outgoing send; an incoming pending token
-     * is money to claim, not a payment code. One-shot Lightning invoices retire
-     * after settlement, reusable BOLT12 offers stay live, and on-chain addresses
-     * retire once the deposit is minted — a confirmed receive is a historical
-     * receipt (checkmark hero), not a payment code to re-present.
+     * Availability behind Show QR code. Incoming tokens need claiming; outgoing
+     * Lightning/on-chain payments are receipts. Reusable incoming offers remain
+     * usable after payment, while settled one-shot artifacts retire.
      */
     fun showsQr(transaction: WalletTransaction): Boolean = when (transaction.kind) {
         TransactionKind.Ecash ->
-            transaction.token != null &&
+            !transaction.token.isNullOrEmpty() &&
                 transaction.type == TransactionType.Outgoing &&
                 transaction.status == TransactionStatus.Pending
         TransactionKind.Lightning ->
-            transaction.invoice != null &&
+            transaction.type == TransactionType.Incoming && !transaction.invoice.isNullOrEmpty() &&
                 (transaction.status == TransactionStatus.Pending ||
-                    transaction.invoice.startsWith("lno", ignoreCase = true))
+                    (transaction.status == TransactionStatus.Completed &&
+                        transaction.invoice.startsWith("lno", ignoreCase = true)))
         TransactionKind.Onchain ->
-            transaction.invoice != null && transaction.status == TransactionStatus.Pending
+            transaction.type == TransactionType.Incoming && !transaction.invoice.isNullOrEmpty() &&
+                transaction.status == TransactionStatus.Pending
     }
 
     /**

--- a/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/TransactionDisplay.kt
@@ -53,23 +53,19 @@ object TransactionDisplay {
     fun qrContent(transaction: WalletTransaction): String? =
         transaction.token ?: transaction.invoice
 
-    /**
-     * Availability behind Show QR code. Incoming tokens need claiming; outgoing
-     * Lightning/on-chain payments are receipts. Reusable incoming offers remain
-     * usable after payment, while settled one-shot artifacts retire.
-     */
+    /** Pending payment artifacts retain their QR, Copy and Share; reusable offers stay live. */
     fun showsQr(transaction: WalletTransaction): Boolean = when (transaction.kind) {
         TransactionKind.Ecash ->
             !transaction.token.isNullOrEmpty() &&
                 transaction.type == TransactionType.Outgoing &&
                 transaction.status == TransactionStatus.Pending
         TransactionKind.Lightning ->
-            transaction.type == TransactionType.Incoming && !transaction.invoice.isNullOrEmpty() &&
+            !transaction.invoice.isNullOrEmpty() &&
                 (transaction.status == TransactionStatus.Pending ||
                     (transaction.status == TransactionStatus.Completed &&
                         transaction.invoice.startsWith("lno", ignoreCase = true)))
         TransactionKind.Onchain ->
-            transaction.type == TransactionType.Incoming && !transaction.invoice.isNullOrEmpty() &&
+            !transaction.invoice.isNullOrEmpty() &&
                 transaction.status == TransactionStatus.Pending
     }
 

--- a/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
@@ -13,18 +13,12 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import com.cashu.me.ui.theme.CashuTheme
 
-/** Shared native history inspector: title, amount, facts, optional code, actions. */
+/** Shared native history inspector: title, optional QR, amount, facts, actions. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivityDetailSheet(
@@ -59,7 +53,7 @@ fun ActivityDetailSheet(
     }
 }
 
-/** A consistent, initially collapsed code, independent of receipt status/amount layout. */
+/** Visible payment code above the amount and facts, with native Copy/Share actions. */
 @Composable
 fun ActivityPaymentCode(
     content: String,
@@ -67,28 +61,16 @@ fun ActivityPaymentCode(
     staticOnly: Boolean = true,
     confirmationMessage: String = "Copied payment request",
 ) {
-    var expanded by rememberSaveable(content) { mutableStateOf(false) }
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        SecondaryButton(
-            text = if (expanded) "Hide QR code" else "Show QR code",
-            onClick = { expanded = !expanded },
-            modifier = Modifier.semantics {
-                stateDescription = if (expanded) "Expanded" else "Collapsed"
-            },
+    BoxWithConstraints(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        QrCard(
+            content = content,
+            size = minOf(240.dp, maxWidth - 32.dp),
+            staticOnly = staticOnly,
+            shareSubject = title,
+            confirmationMessage = confirmationMessage,
         )
-        if (expanded) {
-            BoxWithConstraints(
-                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                QrCard(
-                    content = content,
-                    size = minOf(240.dp, maxWidth - 32.dp),
-                    staticOnly = staticOnly,
-                    shareSubject = title,
-                    confirmationMessage = confirmationMessage,
-                )
-            }
-        }
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
@@ -1,30 +1,27 @@
 package com.cashu.me.ui.components
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.IosShare
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.cashu.me.ui.theme.CashuTheme
 
-/** Shared native history inspector: title, optional QR, amount, facts, actions. */
+/** Shared native presentation; bodies retain their QR sizing and pinned actions. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ActivityDetailSheet(
     title: String,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    onShare: (() -> Unit)? = null,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val state = rememberBottomSheetState(
@@ -38,39 +35,15 @@ fun ActivityDetailSheet(
     ) {
         CompactSheetContent {
             Column(modifier = modifier.fillMaxWidth()) {
-                SheetHeader(title = title)
-                Column(
-                    modifier = Modifier.fillMaxWidth()
-                        .verticalScroll(rememberScrollState())
-                        .padding(horizontal = CashuTheme.spacing.comfortable)
-                        .padding(bottom = CashuTheme.spacing.comfortable),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.section),
-                    content = content,
-                )
+                SheetHeader(title = title, actions = {
+                    if (onShare != null) {
+                        IconButton(onClick = onShare) {
+                            ToolbarIcon(imageVector = Icons.Outlined.IosShare, contentDescription = "Share")
+                        }
+                    }
+                })
+                content()
             }
         }
-    }
-}
-
-/** Visible payment code above the amount and facts, with native Copy/Share actions. */
-@Composable
-fun ActivityPaymentCode(
-    content: String,
-    title: String,
-    staticOnly: Boolean = true,
-    confirmationMessage: String = "Copied payment request",
-) {
-    BoxWithConstraints(
-        modifier = Modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
-    ) {
-        QrCard(
-            content = content,
-            size = minOf(240.dp, maxWidth - 32.dp),
-            staticOnly = staticOnly,
-            shareSubject = title,
-            confirmationMessage = confirmationMessage,
-        )
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/components/ActivityDetailSheet.kt
@@ -1,0 +1,94 @@
+package com.cashu.me.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.rememberBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import com.cashu.me.ui.theme.CashuTheme
+
+/** Shared native history inspector: title, amount, facts, optional code, actions. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ActivityDetailSheet(
+    title: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val state = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    )
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        sheetState = state,
+        containerColor = CashuTheme.colors.compactSheetContainer,
+    ) {
+        CompactSheetContent {
+            Column(modifier = modifier.fillMaxWidth()) {
+                SheetHeader(title = title)
+                Column(
+                    modifier = Modifier.fillMaxWidth()
+                        .verticalScroll(rememberScrollState())
+                        .padding(horizontal = CashuTheme.spacing.comfortable)
+                        .padding(bottom = CashuTheme.spacing.comfortable),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.section),
+                    content = content,
+                )
+            }
+        }
+    }
+}
+
+/** A consistent, initially collapsed code, independent of receipt status/amount layout. */
+@Composable
+fun ActivityPaymentCode(
+    content: String,
+    title: String,
+    staticOnly: Boolean = true,
+    confirmationMessage: String = "Copied payment request",
+) {
+    var expanded by rememberSaveable(content) { mutableStateOf(false) }
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        SecondaryButton(
+            text = if (expanded) "Hide QR code" else "Show QR code",
+            onClick = { expanded = !expanded },
+            modifier = Modifier.semantics {
+                stateDescription = if (expanded) "Expanded" else "Collapsed"
+            },
+        )
+        if (expanded) {
+            BoxWithConstraints(
+                modifier = Modifier.fillMaxWidth().padding(top = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                QrCard(
+                    content = content,
+                    size = minOf(240.dp, maxWidth - 32.dp),
+                    staticOnly = staticOnly,
+                    shareSubject = title,
+                    confirmationMessage = confirmationMessage,
+                )
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
@@ -1,0 +1,146 @@
+package com.cashu.me.ui.history
+
+import android.content.ClipData
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import com.cashu.me.Core.AmountFormatter
+import com.cashu.me.Core.CashuRequestStore
+import com.cashu.me.Core.PriceService
+import com.cashu.me.Core.ReceiveConfirmationOwner
+import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.TransactionDisplay
+import com.cashu.me.Core.WalletManager
+import com.cashu.me.Core.displayMintUnitAmount
+import com.cashu.me.Models.CashuRequest
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.ui.components.ActivityDetailSheet
+import com.cashu.me.ui.components.ActivityPaymentCode
+import com.cashu.me.ui.components.AmountHero
+import com.cashu.me.ui.components.DescriptionDetailRow
+import com.cashu.me.ui.components.InspectorRow
+import com.cashu.me.ui.components.LocalConfirmationToastController
+import com.cashu.me.ui.components.SecondaryButton
+import com.cashu.me.ui.theme.AmountScale
+import kotlinx.coroutines.launch
+import java.net.URI
+import java.text.DateFormat
+import java.util.Date
+
+@Composable
+fun CashuRequestReceiptSheet(
+    request: CashuRequest,
+    walletManager: WalletManager,
+    settingsManager: SettingsManager,
+    priceService: PriceService,
+    store: CashuRequestStore,
+    onDismissRequest: () -> Unit,
+    onManageRequest: (String) -> Unit,
+    onOpenPayment: (WalletTransaction) -> Unit,
+) {
+    val storeState by store.state.collectAsState()
+    val wallet by walletManager.state.collectAsState()
+    val settings by settingsManager.state.collectAsState()
+    val prices by priceService.state.collectAsState()
+    val current = storeState.requests.firstOrNull { it.id == request.id } ?: request
+    val payments = wallet.transactions.filter { tx -> current.receivedPayments.any { it.transactionId == tx.id } }
+    val total = current.receivedPayments.sumOf { payment ->
+        payments.firstOrNull { it.id == payment.transactionId }?.amount ?: payment.amount
+    }
+    val reusable = current.isEcashRequest || current.quoteKind.equals("bolt12", ignoreCase = true)
+    val quoteTransaction = wallet.transactions.firstOrNull {
+        current.quoteId != null && (it.id == current.quoteId || it.quoteId == current.quoteId)
+    }
+    val status = when {
+        reusable && current.receivedPayments.isNotEmpty() -> "Active"
+        current.receivedPayments.isNotEmpty() -> if (current.quoteKind == "onchain") "Confirmed" else "Paid"
+        quoteTransaction?.status == TransactionStatus.Expired -> "Expired"
+        quoteTransaction?.status == TransactionStatus.Failed -> "Failed"
+        quoteTransaction?.status == TransactionStatus.Completed -> TransactionDisplay.statusText(quoteTransaction)
+        else -> "Waiting for payment"
+    }
+    val codeAvailable = !current.encoded.isBlank() && (reusable ||
+        (current.receivedPayments.isEmpty() && quoteTransaction?.let(TransactionDisplay::showsQr) == true))
+    val formatter = remember { AmountFormatter() }
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    val toast = LocalConfirmationToastController.current
+    fun amountDisplay(amount: Long) = formatter.displayMintUnitAmount(
+        amount = amount, unit = current.unit, preferredPrimary = settings.homeBalancePrimary,
+        showFiat = settings.showFiatBalance, btcPrice = prices.btcPrice,
+        currencyCode = settings.bitcoinPriceCurrency, useBitcoinSymbol = settings.useBitcoinSymbol,
+    )
+    fun date(epochMillis: Long) = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(epochMillis))
+
+    LaunchedEffect(request.id) {
+        current.quoteId?.let { quoteId ->
+            runCatching {
+                walletManager.refreshPendingMintQuote(quoteId, confirmationOwner = ReceiveConfirmationOwner.Home)
+            }
+        }
+    }
+
+    ActivityDetailSheet(title = current.displayTitle, onDismissRequest = onDismissRequest) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            if (current.receivedPayments.isNotEmpty()) {
+                Text("Total received", style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            val amount = if (current.receivedPayments.isEmpty()) current.amount else total
+            if (amount != null) {
+                val display = amountDisplay(amount)
+                AmountHero(parts = display.primaryParts, scale = AmountScale.Confirm, accessibilityPrefix = "Amount")
+                display.secondary?.let {
+                    Text(it, style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+            } else {
+                Text("Any amount", style = MaterialTheme.typography.headlineLarge)
+            }
+        }
+        Column(Modifier.fillMaxWidth()) {
+            InspectorRow(label = "Status", value = status)
+            InspectorRow(label = "Date", value = date(current.createdAtEpochMillis))
+            InspectorRow(label = "Mint", value = current.mints.joinToString(", ") { url ->
+                wallet.mints.firstOrNull { it.url == url }?.name
+                    ?: runCatching { URI(url).host }.getOrNull() ?: url
+            }.ifEmpty { "Any mint" })
+            current.displayDescription?.let { DescriptionDetailRow(it) }
+            if (reusable) {
+                InspectorRow(label = "Requested amount", value = current.amount?.let { amountDisplay(it).primary } ?: "Any amount")
+                InspectorRow(label = "Payments received", value = current.receivedPayments.size.toString())
+            }
+            payments.forEach { payment ->
+                InspectorRow(label = date(payment.dateEpochMillis), value = amountDisplay(payment.amount).primary,
+                    trailingIcon = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
+                    onClick = { onOpenPayment(payment) })
+            }
+        }
+        if (codeAvailable) {
+            ActivityPaymentCode(content = current.encoded, title = current.displayTitle)
+            SecondaryButton(text = "Copy", onClick = {
+                scope.launch {
+                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Payment request", current.encoded)))
+                    toast?.show("Copied payment request")
+                }
+            })
+        }
+        if (current.isEcashRequest) {
+            SecondaryButton(text = "Manage request", onClick = { onManageRequest(current.id) })
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
@@ -95,6 +95,9 @@ fun CashuRequestReceiptSheet(
     }
 
     ActivityDetailSheet(title = current.displayTitle, onDismissRequest = onDismissRequest) {
+        if (codeAvailable) {
+            ActivityPaymentCode(content = current.encoded, title = current.displayTitle)
+        }
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             if (current.receivedPayments.isNotEmpty()) {
                 Text("Total received", style = MaterialTheme.typography.bodyMedium,
@@ -131,7 +134,6 @@ fun CashuRequestReceiptSheet(
             }
         }
         if (codeAvailable) {
-            ActivityPaymentCode(content = current.encoded, title = current.displayTitle)
             SecondaryButton(text = "Copy", onClick = {
                 scope.launch {
                     clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Payment request", current.encoded)))

--- a/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/CashuRequestReceiptSheet.kt
@@ -1,148 +1,33 @@
 package com.cashu.me.ui.history
 
-import android.content.ClipData
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowRight
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
-import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.CashuRequestStore
-import com.cashu.me.Core.PriceService
-import com.cashu.me.Core.ReceiveConfirmationOwner
+import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
+import com.cashu.me.Core.NostrService
 import com.cashu.me.Core.SettingsManager
-import com.cashu.me.Core.TransactionDisplay
 import com.cashu.me.Core.WalletManager
-import com.cashu.me.Core.displayMintUnitAmount
 import com.cashu.me.Models.CashuRequest
-import com.cashu.me.Models.TransactionStatus
-import com.cashu.me.Models.WalletTransaction
-import com.cashu.me.ui.components.ActivityDetailSheet
-import com.cashu.me.ui.components.ActivityPaymentCode
-import com.cashu.me.ui.components.AmountHero
-import com.cashu.me.ui.components.DescriptionDetailRow
-import com.cashu.me.ui.components.InspectorRow
-import com.cashu.me.ui.components.LocalConfirmationToastController
-import com.cashu.me.ui.components.SecondaryButton
-import com.cashu.me.ui.theme.AmountScale
-import kotlinx.coroutines.launch
-import java.net.URI
-import java.text.DateFormat
-import java.util.Date
+import com.cashu.me.ui.receive.CashuRequestDetailScreen
 
+/** History retains request editing, regeneration and live receive behavior in a sheet. */
 @Composable
 fun CashuRequestReceiptSheet(
     request: CashuRequest,
     walletManager: WalletManager,
     settingsManager: SettingsManager,
-    priceService: PriceService,
+    nostrService: NostrService,
+    nfcReceiveCoordinator: NfcReceiveCoordinator,
     store: CashuRequestStore,
     onDismissRequest: () -> Unit,
-    onManageRequest: (String) -> Unit,
-    onOpenPayment: (WalletTransaction) -> Unit,
 ) {
-    val storeState by store.state.collectAsState()
-    val wallet by walletManager.state.collectAsState()
-    val settings by settingsManager.state.collectAsState()
-    val prices by priceService.state.collectAsState()
-    val current = storeState.requests.firstOrNull { it.id == request.id } ?: request
-    val payments = wallet.transactions.filter { tx -> current.receivedPayments.any { it.transactionId == tx.id } }
-    val total = current.receivedPayments.sumOf { payment ->
-        payments.firstOrNull { it.id == payment.transactionId }?.amount ?: payment.amount
-    }
-    val reusable = current.isEcashRequest || current.quoteKind.equals("bolt12", ignoreCase = true)
-    val quoteTransaction = wallet.transactions.firstOrNull {
-        current.quoteId != null && (it.id == current.quoteId || it.quoteId == current.quoteId)
-    }
-    val status = when {
-        reusable && current.receivedPayments.isNotEmpty() -> "Active"
-        current.receivedPayments.isNotEmpty() -> if (current.quoteKind == "onchain") "Confirmed" else "Paid"
-        quoteTransaction?.status == TransactionStatus.Expired -> "Expired"
-        quoteTransaction?.status == TransactionStatus.Failed -> "Failed"
-        quoteTransaction?.status == TransactionStatus.Completed -> TransactionDisplay.statusText(quoteTransaction)
-        else -> "Waiting for payment"
-    }
-    val codeAvailable = !current.encoded.isBlank() && (reusable ||
-        (current.receivedPayments.isEmpty() && quoteTransaction?.let(TransactionDisplay::showsQr) == true))
-    val formatter = remember { AmountFormatter() }
-    val clipboard = LocalClipboard.current
-    val scope = rememberCoroutineScope()
-    val toast = LocalConfirmationToastController.current
-    fun amountDisplay(amount: Long) = formatter.displayMintUnitAmount(
-        amount = amount, unit = current.unit, preferredPrimary = settings.homeBalancePrimary,
-        showFiat = settings.showFiatBalance, btcPrice = prices.btcPrice,
-        currencyCode = settings.bitcoinPriceCurrency, useBitcoinSymbol = settings.useBitcoinSymbol,
+    CashuRequestDetailScreen(
+        walletManager = walletManager,
+        settingsManager = settingsManager,
+        nostrService = nostrService,
+        cashuRequestStore = store,
+        nfcReceiveCoordinator = nfcReceiveCoordinator,
+        requestId = request.id,
+        onClose = onDismissRequest,
+        asActivitySheet = true,
     )
-    fun date(epochMillis: Long) = DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.SHORT).format(Date(epochMillis))
-
-    LaunchedEffect(request.id) {
-        current.quoteId?.let { quoteId ->
-            runCatching {
-                walletManager.refreshPendingMintQuote(quoteId, confirmationOwner = ReceiveConfirmationOwner.Home)
-            }
-        }
-    }
-
-    ActivityDetailSheet(title = current.displayTitle, onDismissRequest = onDismissRequest) {
-        if (codeAvailable) {
-            ActivityPaymentCode(content = current.encoded, title = current.displayTitle)
-        }
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            if (current.receivedPayments.isNotEmpty()) {
-                Text("Total received", style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant)
-            }
-            val amount = if (current.receivedPayments.isEmpty()) current.amount else total
-            if (amount != null) {
-                val display = amountDisplay(amount)
-                AmountHero(parts = display.primaryParts, scale = AmountScale.Confirm, accessibilityPrefix = "Amount")
-                display.secondary?.let {
-                    Text(it, style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant)
-                }
-            } else {
-                Text("Any amount", style = MaterialTheme.typography.headlineLarge)
-            }
-        }
-        Column(Modifier.fillMaxWidth()) {
-            InspectorRow(label = "Status", value = status)
-            InspectorRow(label = "Date", value = date(current.createdAtEpochMillis))
-            InspectorRow(label = "Mint", value = current.mints.joinToString(", ") { url ->
-                wallet.mints.firstOrNull { it.url == url }?.name
-                    ?: runCatching { URI(url).host }.getOrNull() ?: url
-            }.ifEmpty { "Any mint" })
-            current.displayDescription?.let { DescriptionDetailRow(it) }
-            if (reusable) {
-                InspectorRow(label = "Requested amount", value = current.amount?.let { amountDisplay(it).primary } ?: "Any amount")
-                InspectorRow(label = "Payments received", value = current.receivedPayments.size.toString())
-            }
-            payments.forEach { payment ->
-                InspectorRow(label = date(payment.dateEpochMillis), value = amountDisplay(payment.amount).primary,
-                    trailingIcon = Icons.AutoMirrored.Outlined.KeyboardArrowRight,
-                    onClick = { onOpenPayment(payment) })
-            }
-        }
-        if (codeAvailable) {
-            SecondaryButton(text = "Copy", onClick = {
-                scope.launch {
-                    clipboard.setClipEntry(ClipEntry(ClipData.newPlainText("Payment request", current.encoded)))
-                    toast?.show("Copied payment request")
-                }
-            })
-        }
-        if (current.isEcashRequest) {
-            SecondaryButton(text = "Manage request", onClick = { onManageRequest(current.id) })
-        }
-    }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -95,7 +95,6 @@ fun HistoryScreen(
     priceService: PriceService,
     cashuRequestStore: CashuRequestStore,
     onOpenTransaction: (WalletTransaction) -> Unit,
-    onClaimReceiveToken: (String) -> Unit,
     onOpenCashuRequest: (CashuRequest) -> Unit,
     contentPadding: PaddingValues,
 ) {
@@ -317,13 +316,7 @@ fun HistoryScreen(
                                             ),
                                             onClick = {
                                                 keyboardController?.hide()
-                                                val pending = walletState.pendingReceiveTokens
-                                                    .firstOrNull { it.tokenId == tx.id }
-                                                if (tx.isPendingReceiveToken && pending != null) {
-                                                    onClaimReceiveToken(pending.token)
-                                                } else {
-                                                    onOpenTransaction(tx)
-                                                }
+                                                onOpenTransaction(tx)
                                             },
                                             onLongClick = if (tx.isPendingReceiveToken) {
                                                 { receiveTokenPendingDelete = tx }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -3,12 +3,20 @@ package com.cashu.me.ui.history
 import android.content.ClipData
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -21,14 +29,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -50,7 +59,7 @@ import com.cashu.me.Models.TransactionType
 import com.cashu.me.Models.WalletTransaction
 import com.cashu.me.Models.liveDetail
 import com.cashu.me.ui.components.ActivityDetailSheet
-import com.cashu.me.ui.components.ActivityPaymentCode
+import com.cashu.me.ui.components.shareText
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.AmountHero
 import com.cashu.me.ui.components.ExplorerLinkRow
@@ -60,6 +69,8 @@ import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.LocalConfirmationToastController
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
+import com.cashu.me.ui.components.PaymentDetailContent
+import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SecondaryButton
 import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.theme.AmountScale
@@ -69,7 +80,14 @@ import com.cashu.me.ui.theme.atSize
 import com.cashu.me.ui.theme.withMonoDigits
 import com.cashu.me.ui.testing.UiTestTags
 
-/** Receipt-first history sheet shared by all incoming and outgoing rails. */
+/**
+ * Content-fitting bottom sheet for any transaction, settled or live. Every
+ * detail opens over the originating list instead of replacing it with a pushed
+ * full-screen destination (iOS `TransactionDetailView` parity): a live request
+ * shows its QR hero, a completed receipt the green check, a failed one the red
+ * X, above the shared rows and actions. Live artifacts share through the
+ * visible trailing Share action and the QR long-press menu.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransactionReceiptSheet(
@@ -146,6 +164,31 @@ fun TransactionReceiptSheet(
         transaction = current,
     )
 
+    val hero: @Composable (Dp) -> Unit = { qrSize ->
+        when {
+            showsQr && qrContent != null -> QrCard(
+                content = qrContent,
+                size = qrSize,
+                staticOnly = current.kind != TransactionKind.Ecash,
+                shareSubject = title,
+                confirmationMessage =
+                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+            )
+            current.status == TransactionStatus.Completed -> Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = "Completed",
+                tint = CashuTheme.colors.onReceivedContainer,
+                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
+            )
+            current.status == TransactionStatus.Failed -> Icon(
+                imageVector = Icons.Filled.Cancel,
+                contentDescription = "Failed",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(FAILED_GLYPH_SIZE),
+            )
+            else -> Unit
+        }
+    }
     val details: @Composable () -> Unit = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -159,6 +202,7 @@ fun TransactionReceiptSheet(
                 showFiat = settings.showFiatBalance,
                 btcPrice = priceState.btcPrice,
                 currencyCode = priceState.currencyCode,
+                compact = showsQr,
             )
 
             Column(modifier = Modifier.fillMaxWidth()) {
@@ -233,7 +277,7 @@ fun TransactionReceiptSheet(
                 )
             } else {
                 if (copyableContent != null) {
-                    SecondaryButton(
+                        SecondaryButton(
                         text = "Copy",
                         onClick = {
                             scope.launch {
@@ -288,20 +332,43 @@ fun TransactionReceiptSheet(
     ActivityDetailSheet(
         title = title,
         onDismissRequest = onDismissRequest,
+        onShare = if (showsQr && qrContent != null) {
+            { context.shareText(qrContent, subject = title) }
+        } else null,
         modifier = Modifier.testTag(UiTestTags.TransactionReceiptSheet),
     ) {
-        if (showsQr && qrContent != null) {
-            ActivityPaymentCode(
-                content = qrContent,
-                title = title,
-                staticOnly = current.kind != TransactionKind.Ecash,
-                confirmationMessage = "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-            )
+        if (showsQr && description != null) {
+            PaymentDetailContent(
+                modifier = Modifier.weight(1f, fill = false),
+                hero = hero,
+            ) { details() }
+            Column(modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable)) {
+                actions()
+            }
+            Spacer(Modifier.height(CashuTheme.spacing.comfortable))
+        } else {
+            Column(
+                modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())
+                    .padding(horizontal = CashuTheme.spacing.comfortable)
+                    .padding(bottom = CashuTheme.spacing.comfortable),
+                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
+                ) {
+                    hero(280.dp)
+                    details()
+                }
+                actions()
+            }
         }
-        details()
-        actions()
     }
 }
+
+// Status glyphs stay at the same restrained scale for every outcome.
+private val COMPLETED_RECEIPT_GLYPH_SIZE = 64.dp
+private val FAILED_GLYPH_SIZE = 64.dp
 
 private val MonospacedLabels = setOf("Request", "Address", "Payment Proof", "Transaction ID", "Quote ID", "Mint")
 
@@ -324,6 +391,7 @@ private fun HeroAmount(
     showFiat: Boolean,
     btcPrice: Double,
     currencyCode: String,
+    compact: Boolean,
 ) {
     val display = transactionReceiptAmountDisplay(
         transaction = transaction,
@@ -340,7 +408,7 @@ private fun HeroAmount(
     ) {
         AmountHero(
             parts = display.primaryParts,
-            scale = AmountScale.Confirm,
+            scale = if (compact) AmountScale.Compact else AmountScale.Confirm,
             accessibilityPrefix = "Amount",
         )
         display.secondary?.let { secondary ->

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -2,26 +2,14 @@ package com.cashu.me.ui.history
 
 import android.content.ClipData
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cancel
-import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetValue
-import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -41,7 +29,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
@@ -62,9 +49,10 @@ import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
 import com.cashu.me.Models.WalletTransaction
 import com.cashu.me.Models.liveDetail
+import com.cashu.me.ui.components.ActivityDetailSheet
+import com.cashu.me.ui.components.ActivityPaymentCode
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.AmountHero
-import com.cashu.me.ui.components.CompactSheetContent
 import com.cashu.me.ui.components.ExplorerLinkRow
 import com.cashu.me.ui.components.DescriptionDetailRow
 import com.cashu.me.ui.components.InspectorRow
@@ -72,10 +60,7 @@ import com.cashu.me.ui.components.InlineNotice
 import com.cashu.me.ui.components.LocalConfirmationToastController
 import com.cashu.me.ui.components.NoticeSeverity
 import com.cashu.me.ui.components.PrimaryButton
-import com.cashu.me.ui.components.PaymentDetailContent
-import com.cashu.me.ui.components.QrCard
 import com.cashu.me.ui.components.SecondaryButton
-import com.cashu.me.ui.components.SheetHeader
 import com.cashu.me.ui.components.openInBrowser
 import com.cashu.me.ui.theme.AmountScale
 import com.cashu.me.ui.theme.CashuTheme
@@ -84,14 +69,7 @@ import com.cashu.me.ui.theme.atSize
 import com.cashu.me.ui.theme.withMonoDigits
 import com.cashu.me.ui.testing.UiTestTags
 
-/**
- * Content-fitting bottom sheet for any transaction, settled or live. Every
- * detail opens over the originating list instead of replacing it with a pushed
- * full-screen destination (iOS `TransactionDetailView` parity): a live request
- * shows its QR hero, a completed receipt the green check, a failed one the red
- * X, above the shared rows and actions. Sharing a live artifact stays on the
- * QR itself (long-press menu), not in chrome.
- */
+/** Receipt-first history sheet shared by all incoming and outgoing rails. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TransactionReceiptSheet(
@@ -109,10 +87,6 @@ fun TransactionReceiptSheet(
     val clipboard = LocalClipboard.current
     val scope = rememberCoroutineScope()
     val formatter = remember { AmountFormatter() }
-    val sheetState = rememberBottomSheetState(
-        initialValue = SheetValue.Hidden,
-        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
-    )
     val confirmationToastController = LocalConfirmationToastController.current
 
     // Pending mint-quote rows use id == quoteId; after mint CDK swaps in a new
@@ -172,31 +146,6 @@ fun TransactionReceiptSheet(
         transaction = current,
     )
 
-    val hero: @Composable (Dp) -> Unit = { qrSize ->
-        when {
-            showsQr && qrContent != null -> QrCard(
-                content = qrContent,
-                size = qrSize,
-                staticOnly = current.kind != TransactionKind.Ecash,
-                shareSubject = title,
-                confirmationMessage =
-                    "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
-            )
-            current.status == TransactionStatus.Completed -> Icon(
-                imageVector = Icons.Filled.CheckCircle,
-                contentDescription = "Completed",
-                tint = CashuTheme.colors.onReceivedContainer,
-                modifier = Modifier.size(COMPLETED_RECEIPT_GLYPH_SIZE),
-            )
-            current.status == TransactionStatus.Failed -> Icon(
-                imageVector = Icons.Filled.Cancel,
-                contentDescription = "Failed",
-                tint = MaterialTheme.colorScheme.error,
-                modifier = Modifier.size(FAILED_GLYPH_SIZE),
-            )
-            else -> Unit
-        }
-    }
     val details: @Composable () -> Unit = {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -210,7 +159,6 @@ fun TransactionReceiptSheet(
                 showFiat = settings.showFiatBalance,
                 btcPrice = priceState.btcPrice,
                 currencyCode = priceState.currencyCode,
-                compact = showsQr,
             )
 
             Column(modifier = Modifier.fillMaxWidth()) {
@@ -285,7 +233,7 @@ fun TransactionReceiptSheet(
                 )
             } else {
                 if (copyableContent != null) {
-                        SecondaryButton(
+                    SecondaryButton(
                         text = "Copy",
                         onClick = {
                             scope.launch {
@@ -337,56 +285,23 @@ fun TransactionReceiptSheet(
         }
     }
 
-    ModalBottomSheet(
+    ActivityDetailSheet(
+        title = title,
         onDismissRequest = onDismissRequest,
-        sheetState = sheetState,
-        containerColor = CashuTheme.colors.compactSheetContainer,
+        modifier = Modifier.testTag(UiTestTags.TransactionReceiptSheet),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .testTag(UiTestTags.TransactionReceiptSheet),
-        ) {
-            CompactSheetContent {
-                if (showsQr && description != null) {
-                    Column(modifier = Modifier.fillMaxWidth()) {
-                        SheetHeader(title = title)
-                        PaymentDetailContent(
-                            modifier = Modifier.weight(1f, fill = false),
-                            hero = hero,
-                        ) { details() }
-                        Column(modifier = Modifier.padding(horizontal = CashuTheme.spacing.comfortable)) {
-                            actions()
-                        }
-                        Spacer(Modifier.height(CashuTheme.spacing.comfortable))
-                    }
-                } else {
-                    Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
-                        SheetHeader(title = title)
-                        Column(
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = CashuTheme.spacing.comfortable)
-                                .padding(bottom = CashuTheme.spacing.comfortable),
-                            verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.default),
-                        ) {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally,
-                                verticalArrangement = Arrangement.spacedBy(CashuTheme.spacing.comfortable),
-                            ) {
-                                hero(280.dp)
-                                details()
-                            }
-                            actions()
-                        }
-                    }
-                }
-            }
+        details()
+        if (showsQr && qrContent != null) {
+            ActivityPaymentCode(
+                content = qrContent,
+                title = title,
+                staticOnly = current.kind != TransactionKind.Ecash,
+                confirmationMessage = "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
+            )
         }
+        actions()
     }
 }
-
-// Status glyphs stay at the same restrained scale for every outcome.
-private val COMPLETED_RECEIPT_GLYPH_SIZE = 64.dp
-private val FAILED_GLYPH_SIZE = 64.dp
 
 private val MonospacedLabels = setOf("Request", "Address", "Payment Proof", "Transaction ID", "Quote ID", "Mint")
 
@@ -409,7 +324,6 @@ private fun HeroAmount(
     showFiat: Boolean,
     btcPrice: Double,
     currencyCode: String,
-    compact: Boolean,
 ) {
     val display = transactionReceiptAmountDisplay(
         transaction = transaction,
@@ -426,7 +340,7 @@ private fun HeroAmount(
     ) {
         AmountHero(
             parts = display.primaryParts,
-            scale = if (compact) AmountScale.Compact else AmountScale.Confirm,
+            scale = AmountScale.Confirm,
             accessibilityPrefix = "Amount",
         )
         display.secondary?.let { secondary ->

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -290,7 +290,6 @@ fun TransactionReceiptSheet(
         onDismissRequest = onDismissRequest,
         modifier = Modifier.testTag(UiTestTags.TransactionReceiptSheet),
     ) {
-        details()
         if (showsQr && qrContent != null) {
             ActivityPaymentCode(
                 content = qrContent,
@@ -299,6 +298,7 @@ fun TransactionReceiptSheet(
                 confirmationMessage = "Copied ${TransactionDisplay.qrLabel(current).replaceFirstChar { it.lowercase() }}",
             )
         }
+        details()
         actions()
     }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -31,7 +31,9 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.cashu.me.App.AppContainer
 import com.cashu.me.Core.Platform.ConnectivityState
+import com.cashu.me.Models.CashuRequest
 import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.ui.history.CashuRequestReceiptSheet
 import com.cashu.me.ui.history.HistoryScreen
 import com.cashu.me.ui.history.TransactionReceiptSheet
 import com.cashu.me.ui.home.HomeScreen
@@ -79,8 +81,9 @@ fun CashuNavHost(
     modifier: Modifier = Modifier,
 ) {
     var receiptTransaction by remember { mutableStateOf<WalletTransaction?>(null) }
+    var receiptRequest by remember { mutableStateOf<CashuRequest?>(null) }
     val receiptBackdropBlur by animateDpAsState(
-        targetValue = if (receiptTransaction != null) 2.dp else 0.dp,
+        targetValue = if (receiptTransaction != null || receiptRequest != null) 2.dp else 0.dp,
         animationSpec = tween(durationMillis = 180),
         label = "transaction-receipt-backdrop-blur",
     )
@@ -107,10 +110,10 @@ fun CashuNavHost(
             onSend = onSend,
             pendingMintScan = pendingMintScan,
             onPendingMintScanConsumed = onPendingMintScanConsumed,
-            onClaimReceiveToken = onClaimReceiveToken,
             // Every transaction detail — settled or live — opens as the same
             // receipt-family sheet over the originating list (iOS parity).
             onOpenTransaction = { transaction -> receiptTransaction = transaction },
+            onOpenRequest = { request -> receiptRequest = request },
         )
         composable(
             route = Routes.MINT_DETAIL,
@@ -262,6 +265,22 @@ fun CashuNavHost(
         }
     }
 
+    receiptRequest?.let { request ->
+        CashuRequestReceiptSheet(
+            request = request,
+            walletManager = container.walletManager,
+            settingsManager = container.settingsManager,
+            priceService = container.priceService,
+            store = container.cashuRequestStore,
+            onDismissRequest = { receiptRequest = null },
+            onManageRequest = { id ->
+                receiptRequest = null
+                navController.navigate(cashuRequestDetailRouteFor(id))
+            },
+            onOpenPayment = { payment -> receiptTransaction = payment },
+        )
+    }
+
     receiptTransaction?.let { transaction ->
         TransactionReceiptSheet(
             transaction = transaction,
@@ -301,7 +320,7 @@ private fun NavGraphBuilder.tabDestinations(
     pendingMintScan: String?,
     onPendingMintScanConsumed: () -> Unit,
     onOpenTransaction: (WalletTransaction) -> Unit,
-    onClaimReceiveToken: (String) -> Unit,
+    onOpenRequest: (CashuRequest) -> Unit,
 ) {
     composable(
         route = Routes.HOME,
@@ -340,10 +359,7 @@ private fun NavGraphBuilder.tabDestinations(
             priceService = container.priceService,
             cashuRequestStore = container.cashuRequestStore,
             onOpenTransaction = onOpenTransaction,
-            onClaimReceiveToken = onClaimReceiveToken,
-            onOpenCashuRequest = { req ->
-                navController.navigate(cashuRequestDetailRouteFor(req.id))
-            },
+            onOpenCashuRequest = onOpenRequest,
             contentPadding = contentPadding,
         )
     }

--- a/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/navigation/CashuNavHost.kt
@@ -270,14 +270,10 @@ fun CashuNavHost(
             request = request,
             walletManager = container.walletManager,
             settingsManager = container.settingsManager,
-            priceService = container.priceService,
+            nostrService = container.nostrService,
+            nfcReceiveCoordinator = container.nfcReceiveCoordinator,
             store = container.cashuRequestStore,
             onDismissRequest = { receiptRequest = null },
-            onManageRequest = { id ->
-                receiptRequest = null
-                navController.navigate(cashuRequestDetailRouteFor(id))
-            },
-            onOpenPayment = { payment -> receiptTransaction = payment },
         )
     }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -67,6 +68,7 @@ import com.cashu.me.Core.UnitAmountEntry
 import com.cashu.me.Core.Wallet.userFacingWalletMessage
 import com.cashu.me.Core.WalletManager
 import com.cashu.me.Models.CashuRequestPayment
+import com.cashu.me.ui.components.ActivityDetailSheet
 import com.cashu.me.ui.components.AmountEntryHero
 import com.cashu.me.ui.components.AmountText
 import com.cashu.me.ui.components.DetailActionFooter
@@ -105,6 +107,7 @@ fun CashuRequestDetailScreen(
     nfcReceiveCoordinator: NfcReceiveCoordinator,
     requestId: String,
     onClose: () -> Unit,
+    asActivitySheet: Boolean = false,
 ) {
     val storeState by cashuRequestStore.state.collectAsState()
     val walletState by walletManager.state.collectAsState()
@@ -228,16 +231,11 @@ fun CashuRequestDetailScreen(
             val mintName = creditedMintUrl?.let { url ->
                 walletState.mints.firstOrNull { it.url == url }?.name ?: url
             }
-            Scaffold(
-                topBar = {
-                    CashuRequestDetailTopBar(
-                        title = request.displayTitle,
-                        onClose = onClose,
-                        onShare = {
-                            context.shareText(request.encoded, subject = request.displayTitle)
-                        },
-                    )
-                },
+            CashuRequestDetailContainer(
+                title = request.displayTitle,
+                onClose = onClose,
+                onShare = { context.shareText(request.encoded, subject = request.displayTitle) },
+                asActivitySheet = asActivitySheet,
             ) { padding ->
                 CashuRequestSuccessTerminal(
                     amountLabel = amountLabel,
@@ -251,21 +249,13 @@ fun CashuRequestDetailScreen(
             }
         } else {
 
-        Scaffold(
-            topBar = {
-                CashuRequestDetailTopBar(
-                    title = request?.displayTitle ?: "Cashu Request",
-                    onClose = onClose,
-                    onShare = request?.let { current ->
-                        {
-                            context.shareText(
-                                current.encoded,
-                                subject = current.displayTitle,
-                            )
-                        }
-                    },
-                )
+        CashuRequestDetailContainer(
+            title = request?.displayTitle ?: "Cashu Request",
+            onClose = onClose,
+            onShare = request?.let { current ->
+                { context.shareText(current.encoded, subject = current.displayTitle) }
             },
+            asActivitySheet = asActivitySheet,
         ) { padding ->
             if (request == null) {
                 Column(
@@ -282,7 +272,7 @@ fun CashuRequestDetailScreen(
                     Spacer(Modifier.height(CashuTheme.spacing.comfortable))
                     GhostButton(text = "Back", onClick = onClose)
                 }
-                return@Scaffold
+                return@CashuRequestDetailContainer
             }
 
             if (keepNfcSessionMounted) {
@@ -511,6 +501,27 @@ fun CashuRequestDetailScreen(
             )
         }
         }
+    }
+}
+
+/** History uses the sheet header while creation flows retain their full-screen toolbar. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CashuRequestDetailContainer(
+    title: String,
+    onClose: () -> Unit,
+    onShare: (() -> Unit)?,
+    asActivitySheet: Boolean,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    if (asActivitySheet) {
+        ActivityDetailSheet(title = title, onDismissRequest = onClose, onShare = onShare) {
+            content(PaddingValues())
+        }
+    } else {
+        Scaffold(topBar = {
+            CashuRequestDetailTopBar(title = title, onClose = onClose, onShare = onShare)
+        }, content = content)
     }
 }
 

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -184,7 +184,7 @@ class TransactionDisplayTest {
                     ).copy(status = status)
                     val expected = status == TransactionStatus.Pending &&
                         if (kind == TransactionKind.Ecash) direction == TransactionType.Outgoing
-                        else direction == TransactionType.Incoming
+                        else true
                     assertEquals("$kind $direction $status", expected, TransactionDisplay.showsQr(tx))
                 }
             }
@@ -192,12 +192,12 @@ class TransactionDisplayTest {
     }
 
     @Test
-    fun failedAndOutgoingReusableOfferPaymentsDoNotExposeCodes() {
+    fun failedOffersRetireWhilePendingOutgoingArtifactsRemainAvailable() {
         val offer = transaction(kind = TransactionKind.Lightning, type = TransactionType.Incoming,
             invoice = "LNO1offer")
         assertTrue(TransactionDisplay.showsQr(offer))
         assertTrue(!TransactionDisplay.showsQr(offer.copy(status = TransactionStatus.Failed)))
-        assertTrue(!TransactionDisplay.showsQr(offer.copy(type = TransactionType.Outgoing,
+        assertTrue(TransactionDisplay.showsQr(offer.copy(type = TransactionType.Outgoing,
             status = TransactionStatus.Pending)))
     }
 

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDisplayTest.kt
@@ -173,6 +173,34 @@ class TransactionDisplayTest {
         assertTrue(TransactionDisplay.detailFields(withoutMemo).none { it.label == "Memo" })
     }
 
+    @Test
+    fun paymentCodesFollowDirectionAndLifecycleForEveryRail() {
+        TransactionKind.entries.forEach { kind ->
+            TransactionType.entries.forEach { direction ->
+                TransactionStatus.entries.forEach { status ->
+                    val tx = transaction(kind = kind, type = direction,
+                        token = if (kind == TransactionKind.Ecash) "cashu-token" else null,
+                        invoice = if (kind == TransactionKind.Ecash) null else "one-shot-request",
+                    ).copy(status = status)
+                    val expected = status == TransactionStatus.Pending &&
+                        if (kind == TransactionKind.Ecash) direction == TransactionType.Outgoing
+                        else direction == TransactionType.Incoming
+                    assertEquals("$kind $direction $status", expected, TransactionDisplay.showsQr(tx))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun failedAndOutgoingReusableOfferPaymentsDoNotExposeCodes() {
+        val offer = transaction(kind = TransactionKind.Lightning, type = TransactionType.Incoming,
+            invoice = "LNO1offer")
+        assertTrue(TransactionDisplay.showsQr(offer))
+        assertTrue(!TransactionDisplay.showsQr(offer.copy(status = TransactionStatus.Failed)))
+        assertTrue(!TransactionDisplay.showsQr(offer.copy(type = TransactionType.Outgoing,
+            status = TransactionStatus.Pending)))
+    }
+
     private fun transaction(
         kind: TransactionKind,
         type: TransactionType,

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -195,28 +195,27 @@ What this system explicitly rejects, pulled verbatim from docs/product/PRODUCT.m
 
 ### Unified activity detail sheets (2026-09-06)
 
-This contract supersedes the older status-hero and share-at-top rules
-below **for History and Home activity details** on both iOS and Android. Creation,
-request management, and live payment success screens retain their own flow UI.
+History and Home activity details share native sheet presentation on iOS and
+Android, while retaining the existing payment-specific content and actions.
 
-- Every incoming/outgoing transaction and stored receive request opens a native,
-  content-fitting bottom sheet with a centered title and drag handle. Dismiss by
-  swiping, native accessibility dismissal, or Android Back; no close/share toolbar.
-- Stable order: actionable QR when available, amount at `amountConfirm`, Status,
-  Date, fee when applicable, Mint, Description, reference/proof rows, then actions.
-  No check/X hero and no changing amount scale between payment states.
-- Actionable QR codes remain visible above the amount and facts, with no expand/
-  collapse control. Keep native Copy/Share context actions and a visible Copy button.
-- QR eligibility: pending outgoing ecash; pending incoming Lightning/on-chain;
-  active reusable ecash requests and BOLT12 offers. Settled/expired/failed one-shot
-  codes, incoming tokens to claim, and outgoing Lightning/on-chain payments never
-  offer payment QR codes. Settled ecash keeps its existing passive Copy receipt.
-- Reusable requests show **Total received**, **Active** after a payment, requested
-  amount, payment count, and links to individual payment receipts. They keep their
-  code available after receiving. **Manage request** opens the ecash request editor.
-- Unclaimed incoming ecash opens the same inspector and offers **Receive** to enter
-  the claim flow. Manual outgoing-token status checks remain available as before.
-- Content scrolls at large text sizes and on short screens.
+- Every transaction and stored receive request opens a sheet over its list with
+  a centered title and drag handle. Dismiss by swipe, native accessibility escape,
+  or Android Back. No redundant top-left close X.
+- Show a visible Share action at the top right whenever the payment artifact is
+  shareable. QR context-menu Copy/Share and the visible Copy button remain.
+- Keep QR codes immediately visible in their original position above the amount.
+  Preserve adaptive QR sizing, compact amounts beside a QR, normal receipt amounts,
+  and the existing rows and spacing. No QR disclosure or collapse animation.
+- Preserve the green check for completed receipts and red cross for failed
+  receipts, plus the lifecycle text. Reusable requests retain their payment-count
+  status and live QR after receiving payments.
+- Keep Copy, New Request, and inline Mint/Amount/Unit editing directly available
+  on Cashu Requests. Reuse the existing request view and its delivery behavior.
+- Preserve pending outbound invoice/address QR and copy/share availability,
+  settled ecash Copy, explorer/proof references, and manual token status checks.
+  Settled one-shot codes retire as before.
+- Unclaimed incoming ecash opens the shared sheet with Receive to enter the
+  claim flow. Keep action footers visible while long detail content scrolls.
 
 ## 2. Colors: The Inverted-Ink Palette
 

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -193,6 +193,33 @@ What this system explicitly rejects, pulled verbatim from docs/product/PRODUCT.m
   `pencil` hint glyph. Tap opens a `.medium`-detent sub-sheet rather than pushing
   a screen. No leading field icon — see The Iconless-Row Rule, §5.
 
+### Unified activity detail sheets (2026-09-06)
+
+This contract supersedes the older hero-slot, QR-at-top, and share-at-top rules
+below **for History and Home activity details** on both iOS and Android. Creation,
+request management, and live payment success screens retain their own flow UI.
+
+- Every incoming/outgoing transaction and stored receive request opens a native,
+  content-fitting bottom sheet with a centered title and drag handle. Dismiss by
+  swiping, native accessibility dismissal, or Android Back; no close/share toolbar.
+- Stable order: amount at `amountConfirm`, Status, Date, fee when applicable, Mint,
+  Description, reference/proof rows, then relevant actions. No changing QR/check/X
+  hero and no changing amount scale between pending, completed, failed, and expired.
+- Actionable artifacts have an initially collapsed **Show QR code** disclosure below
+  the facts. Expanding it preserves the receipt and exposes the QR's native Copy/
+  Share context actions. A visible Copy button remains below it.
+- QR eligibility: pending outgoing ecash; pending incoming Lightning/on-chain;
+  active reusable ecash requests and BOLT12 offers. Settled/expired/failed one-shot
+  codes, incoming tokens to claim, and outgoing Lightning/on-chain payments never
+  offer payment QR codes. Settled ecash keeps its existing passive Copy receipt.
+- Reusable requests show **Total received**, **Active** after a payment, requested
+  amount, payment count, and links to individual payment receipts. They keep their
+  code available after receiving. **Manage request** opens the ecash request editor.
+- Unclaimed incoming ecash opens the same inspector and offers **Receive** to enter
+  the claim flow. Manual outgoing-token status checks remain available as before.
+- Content scrolls at large text sizes and on short screens. The native iOS
+  disclosure and Android expandable button expose their expanded/collapsed state.
+
 ## 2. Colors: The Inverted-Ink Palette
 
 A semantic-only palette built on iOS system colors plus three state hues. The

--- a/docs/product/DESIGN.md
+++ b/docs/product/DESIGN.md
@@ -195,19 +195,18 @@ What this system explicitly rejects, pulled verbatim from docs/product/PRODUCT.m
 
 ### Unified activity detail sheets (2026-09-06)
 
-This contract supersedes the older hero-slot, QR-at-top, and share-at-top rules
+This contract supersedes the older status-hero and share-at-top rules
 below **for History and Home activity details** on both iOS and Android. Creation,
 request management, and live payment success screens retain their own flow UI.
 
 - Every incoming/outgoing transaction and stored receive request opens a native,
   content-fitting bottom sheet with a centered title and drag handle. Dismiss by
   swiping, native accessibility dismissal, or Android Back; no close/share toolbar.
-- Stable order: amount at `amountConfirm`, Status, Date, fee when applicable, Mint,
-  Description, reference/proof rows, then relevant actions. No changing QR/check/X
-  hero and no changing amount scale between pending, completed, failed, and expired.
-- Actionable artifacts have an initially collapsed **Show QR code** disclosure below
-  the facts. Expanding it preserves the receipt and exposes the QR's native Copy/
-  Share context actions. A visible Copy button remains below it.
+- Stable order: actionable QR when available, amount at `amountConfirm`, Status,
+  Date, fee when applicable, Mint, Description, reference/proof rows, then actions.
+  No check/X hero and no changing amount scale between payment states.
+- Actionable QR codes remain visible above the amount and facts, with no expand/
+  collapse control. Keep native Copy/Share context actions and a visible Copy button.
 - QR eligibility: pending outgoing ecash; pending incoming Lightning/on-chain;
   active reusable ecash requests and BOLT12 offers. Settled/expired/failed one-shot
   codes, incoming tokens to claim, and outgoing Lightning/on-chain payments never
@@ -217,8 +216,7 @@ request management, and live payment success screens retain their own flow UI.
   code available after receiving. **Manage request** opens the ecash request editor.
 - Unclaimed incoming ecash opens the same inspector and offers **Receive** to enter
   the claim flow. Manual outgoing-token status checks remain available as before.
-- Content scrolls at large text sizes and on short screens. The native iOS
-  disclosure and Android expandable button expose their expanded/collapsed state.
+- Content scrolls at large text sizes and on short screens.
 
 ## 2. Colors: The Inverted-Ink Palette
 

--- a/ios/CashuWallet/App/CashuWalletApp.swift
+++ b/ios/CashuWallet/App/CashuWalletApp.swift
@@ -54,6 +54,7 @@ struct CashuWalletApp: App {
                 ComponentCatalogView(
                     page: .init(rawValue: IntegrationTestConfig.componentCatalogPage)
                 )
+                .environmentObject(walletManager)
             } else {
                 root
             }

--- a/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
+++ b/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
@@ -76,17 +76,17 @@ struct WalletTransaction: Identifiable {
         return quoteId ?? id
     }
 
-    /// Only artifacts that can still receive money belong behind Show QR code.
+    /// Preserve pending payment artifacts and live reusable offers in history.
     var hasActionablePaymentCode: Bool {
         switch kind {
         case .ecash:
             return type == .outgoing && status == .pending && token?.isEmpty == false
         case .lightning:
-            guard type == .incoming, let invoice, !invoice.isEmpty else { return false }
+            guard let invoice, !invoice.isEmpty else { return false }
             return status == .pending ||
                 (status == .completed && invoice.lowercased().hasPrefix("lno"))
         case .onchain:
-            return type == .incoming && status == .pending && invoice?.isEmpty == false
+            return status == .pending && invoice?.isEmpty == false
         }
     }
 

--- a/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
+++ b/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
@@ -40,8 +40,7 @@ struct WalletTransaction: Identifiable {
     var sagaId: String? = nil
 
     /// Incoming ecash the user hasn't claimed yet (a "Receive Later" token or
-    /// a NUT-18 payment held for approval). Rows with this flag open the
-    /// claim flow instead of a plain receipt.
+    /// a NUT-18 payment held for approval). Its receipt offers the claim flow.
     var isPendingReceiveToken: Bool = false
 
     /// Source Cashu Request id when this incoming ecash transaction was
@@ -75,6 +74,20 @@ struct WalletTransaction: Identifiable {
         guard invoice != nil else { return nil }
         guard status == .pending || status == .expired else { return nil }
         return quoteId ?? id
+    }
+
+    /// Only artifacts that can still receive money belong behind Show QR code.
+    var hasActionablePaymentCode: Bool {
+        switch kind {
+        case .ecash:
+            return type == .outgoing && status == .pending && token?.isEmpty == false
+        case .lightning:
+            guard type == .incoming, let invoice, !invoice.isEmpty else { return false }
+            return status == .pending ||
+                (status == .completed && invoice.lowercased().hasPrefix("lno"))
+        case .onchain:
+            return type == .incoming && status == .pending && invoice?.isEmpty == false
+        }
     }
 
     var displayStatusText: String {

--- a/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
+++ b/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
@@ -31,56 +31,40 @@ struct PaymentDetailContent<Hero: View, Details: View>: View {
     }
 }
 
-/// Shared history inspector with an optional visible QR above the amount and facts.
+
+/// Native activity presentation shared by transactions and stored requests.
+/// Each body retains its adaptive QR, status cues and pinned actions.
 struct ActivityDetailSheet<Content: View>: View {
     let title: String
+    var contentHeight: CGFloat = 0
+    var fitsContent = false
+    var onShare: (() -> Void)?
     @ViewBuilder var content: () -> Content
     @Environment(\.dismiss) private var dismiss
-    @State private var contentHeight: CGFloat = 0
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24, content: content)
-                .padding(.horizontal, 16)
-                .padding(.top, 16)
-                .padding(.bottom, 16)
-                .contentFitMeasured { contentHeight = $0 }
-                .navigationTitle(title)
+            content()
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(.hidden, for: .navigationBar)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        Text(title).font(.headline)
+                    }
+                    if let onShare {
+                        ToolbarItem(placement: .topBarTrailing) {
+                            Button(action: onShare) {
+                                Image(systemName: "square.and.arrow.up")
+                                    .toolbarIconTapTarget()
+                            }
+                            .accessibilityLabel("Share")
+                        }
+                    }
+                }
         }
         .compactBottomSheetSurface()
-        .contentFitDetent(contentHeight, estimate: 420, navigationBar: true)
+        .contentFitDetent(contentHeight, enabled: fitsContent, estimate: 500, navigationBar: true)
         .presentationDragIndicator(.visible)
         .accessibilityAction(.escape) { dismiss() }
-    }
-}
-
-struct ActivityPaymentCode: View {
-    let content: String
-    var staticOnly = true
-    let onCopy: () -> Void
-    let onShare: () -> Void
-
-    var body: some View {
-        ViewThatFits(in: .horizontal) {
-            code(size: 240)
-            code(size: 180)
-            code(size: 120)
-        }
-        .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("cashu.history.payment-code")
-    }
-
-    private func code(size: CGFloat) -> some View {
-        QRCodeView(content: content, showControls: false, staticOnly: staticOnly,
-                   onCopy: onCopy, onShare: onShare)
-            .frame(width: size, height: size)
-            .padding(16)
-            .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-            .contextMenu {
-                Button("Copy", systemImage: "doc.on.doc", action: onCopy)
-                Button("Share", systemImage: "square.and.arrow.up", action: onShare)
-            }
     }
 }

--- a/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
+++ b/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
@@ -31,8 +31,7 @@ struct PaymentDetailContent<Hero: View, Details: View>: View {
     }
 }
 
-/// History always opens on the same compact inspector. Optional payment codes
-/// expand below the facts, without replacing the amount or changing its scale.
+/// Shared history inspector with an optional visible QR above the amount and facts.
 struct ActivityDetailSheet<Content: View>: View {
     let title: String
     @ViewBuilder var content: () -> Content
@@ -62,22 +61,14 @@ struct ActivityPaymentCode: View {
     var staticOnly = true
     let onCopy: () -> Void
     let onShare: () -> Void
-    @State private var expanded = false
 
     var body: some View {
-        DisclosureGroup(isExpanded: $expanded) {
-            ViewThatFits(in: .horizontal) {
-                code(size: 240)
-                code(size: 180)
-                code(size: 120)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-        } label: {
-            Text(expanded ? "Hide QR code" : "Show QR code")
-                .font(.subheadline.weight(.medium))
-                .frame(minHeight: 44)
+        ViewThatFits(in: .horizontal) {
+            code(size: 240)
+            code(size: 180)
+            code(size: 120)
         }
+        .frame(maxWidth: .infinity)
         .accessibilityIdentifier("cashu.history.payment-code")
     }
 

--- a/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
+++ b/ios/CashuWallet/Views/Components/PaymentDetailContent.swift
@@ -30,3 +30,66 @@ struct PaymentDetailContent<Hero: View, Details: View>: View {
         }
     }
 }
+
+/// History always opens on the same compact inspector. Optional payment codes
+/// expand below the facts, without replacing the amount or changing its scale.
+struct ActivityDetailSheet<Content: View>: View {
+    let title: String
+    @ViewBuilder var content: () -> Content
+    @Environment(\.dismiss) private var dismiss
+    @State private var contentHeight: CGFloat = 0
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24, content: content)
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .padding(.bottom, 16)
+                .contentFitMeasured { contentHeight = $0 }
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.hidden, for: .navigationBar)
+        }
+        .compactBottomSheetSurface()
+        .contentFitDetent(contentHeight, estimate: 420, navigationBar: true)
+        .presentationDragIndicator(.visible)
+        .accessibilityAction(.escape) { dismiss() }
+    }
+}
+
+struct ActivityPaymentCode: View {
+    let content: String
+    var staticOnly = true
+    let onCopy: () -> Void
+    let onShare: () -> Void
+    @State private var expanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $expanded) {
+            ViewThatFits(in: .horizontal) {
+                code(size: 240)
+                code(size: 180)
+                code(size: 120)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+        } label: {
+            Text(expanded ? "Hide QR code" : "Show QR code")
+                .font(.subheadline.weight(.medium))
+                .frame(minHeight: 44)
+        }
+        .accessibilityIdentifier("cashu.history.payment-code")
+    }
+
+    private func code(size: CGFloat) -> some View {
+        QRCodeView(content: content, showControls: false, staticOnly: staticOnly,
+                   onCopy: onCopy, onShare: onShare)
+            .frame(width: size, height: size)
+            .padding(16)
+            .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
+            .contextMenu {
+                Button("Copy", systemImage: "doc.on.doc", action: onCopy)
+                Button("Share", systemImage: "square.and.arrow.up", action: onShare)
+            }
+    }
+}

--- a/ios/CashuWallet/Views/Debug/ComponentCatalogView.swift
+++ b/ios/CashuWallet/Views/Debug/ComponentCatalogView.swift
@@ -20,10 +20,10 @@ struct ComponentCatalogView: View {
     /// Which page to render. Split in two so each fits one screenshot without
     /// scrolling, and so each pairs with its Android counterpart.
     enum Page {
-        case matrix, variants
+        case matrix, variants, activity
 
         init(rawValue: String?) {
-            self = rawValue == "variants" ? .variants : .matrix
+            self = rawValue == "activity" ? .activity : rawValue == "variants" ? .variants : .matrix
         }
     }
 
@@ -35,6 +35,8 @@ struct ComponentCatalogView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             switch page {
+            case .activity:
+                ActivityDetailCatalog()
             case .matrix:
                 noticeMatrix
                 bannerSection
@@ -144,6 +146,55 @@ struct ComponentCatalogView: View {
             content()
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// Deterministic receipts for native UI checks; no wallet initialization or mint is needed.
+private struct ActivityDetailCatalog: View {
+    @State private var selectedTransaction: WalletTransaction?
+    @State private var selectedRequest: CashuRequest?
+    private let date = Date(timeIntervalSince1970: 1_788_768_000)
+
+    private var transactions: [WalletTransaction] {
+        [
+            .init(id: "pending-lightning", amount: 2100, type: .incoming, kind: .lightning,
+                  date: date, memo: "Coffee payment", status: .pending,
+                  mintUrl: "https://mint.example", invoice: "lnbc1test", isUnpaidInvoice: true),
+            .init(id: "paid-lightning", amount: 2100, type: .incoming, kind: .lightning,
+                  date: date, memo: "Coffee payment", status: .completed,
+                  mintUrl: "https://mint.example", invoice: "lnbc1test"),
+            .init(id: "sent-lightning", amount: 2100, type: .outgoing, kind: .lightning,
+                  date: date, status: .completed, mintUrl: "https://mint.example",
+                  preimage: "0123456789abcdef0123456789abcdef", fee: 2),
+            .init(id: "pending-ecash", amount: 2100, type: .outgoing, kind: .ecash,
+                  date: date, status: .pending, mintUrl: "https://mint.example", token: "cashu-token"),
+            .init(id: "received-ecash", amount: 2100, type: .incoming, kind: .ecash,
+                  date: date, status: .completed, mintUrl: "https://mint.example", token: "cashu-token"),
+            .init(id: "received-bitcoin", amount: 2100, type: .incoming, kind: .onchain,
+                  date: date, status: .completed, mintUrl: "https://mint.example",
+                  preimage: "0123456789abcdef0123456789abcdef", invoice: "bc1qfixture"),
+        ]
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Activity details").font(.title)
+            ForEach(transactions) { transaction in
+                Button(transaction.displayTitle) { selectedTransaction = transaction }
+                    .accessibilityIdentifier(transaction.id)
+            }
+            Button("Reusable Invoice") {
+                selectedRequest = CashuRequest(
+                    id: "catalog-offer", encoded: "lno1fixture", mints: ["https://mint.example"],
+                    memo: "Coffee tips", createdAt: date,
+                    receivedPayments: [.init(transactionId: "fixture-payment", amount: 2100, receivedAt: date)],
+                    rail: .bolt12, reusable: true
+                )
+            }
+            .accessibilityIdentifier("reusable-invoice")
+        }
+        .sheet(item: $selectedTransaction) { TransactionDetailView(transaction: $0) }
+        .sheet(item: $selectedRequest) { CashuRequestReceiptView(request: $0) }
     }
 }
 

--- a/ios/CashuWallet/Views/Debug/ComponentCatalogView.swift
+++ b/ios/CashuWallet/Views/Debug/ComponentCatalogView.swift
@@ -166,6 +166,8 @@ private struct ActivityDetailCatalog: View {
             .init(id: "sent-lightning", amount: 2100, type: .outgoing, kind: .lightning,
                   date: date, status: .completed, mintUrl: "https://mint.example",
                   preimage: "0123456789abcdef0123456789abcdef", fee: 2),
+            .init(id: "failed-lightning", amount: 2100, type: .outgoing, kind: .lightning,
+                  date: date, status: .failed, mintUrl: "https://mint.example"),
             .init(id: "pending-ecash", amount: 2100, type: .outgoing, kind: .ecash,
                   date: date, status: .pending, mintUrl: "https://mint.example", token: "cashu-token"),
             .init(id: "received-ecash", amount: 2100, type: .incoming, kind: .ecash,
@@ -183,19 +185,29 @@ private struct ActivityDetailCatalog: View {
                 Button(transaction.displayTitle) { selectedTransaction = transaction }
                     .accessibilityIdentifier(transaction.id)
             }
-            Button("Reusable Invoice") {
-                selectedRequest = CashuRequest(
-                    id: "catalog-offer", encoded: "lno1fixture", mints: ["https://mint.example"],
-                    memo: "Coffee tips", createdAt: date,
-                    receivedPayments: [.init(transactionId: "fixture-payment", amount: 2100, receivedAt: date)],
-                    rail: .bolt12, reusable: true
-                )
-            }
-            .accessibilityIdentifier("reusable-invoice")
+            Button("Reusable Invoice") { openRequest(rail: .bolt12) }
+                .accessibilityIdentifier("reusable-invoice")
+            Button("Cashu Request") { openRequest(rail: .ecash) }
+                .accessibilityIdentifier("cashu-request")
         }
         .sheet(item: $selectedTransaction) { TransactionDetailView(transaction: $0) }
         .sheet(item: $selectedRequest) { CashuRequestReceiptView(request: $0) }
     }
+
+    private func openRequest(rail: CashuRequest.Rail) {
+        let store = CashuRequestStore.shared
+        let id = rail == .ecash ? "catalog-request" : "catalog-offer"
+        store.delete(id: id)
+        let request = store.create(
+            id: id, rail: rail, encoded: rail == .ecash ? "creqAfixture" : "lno1fixture",
+            mints: ["https://mint.example"], memo: "Coffee tips", reusable: true
+        )
+        if rail == .bolt12 {
+            store.attachPayment(requestId: id, transactionId: "fixture-payment", amount: 2100)
+        }
+        selectedRequest = store.request(withId: id) ?? request
+    }
+
 }
 
 #Preview("Inline error catalog — matrix") {

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -35,9 +35,6 @@ struct HistoryView: View {
     @State private var isSheetDismissing = false
     @State private var requestPendingDeletion: CashuRequest?
     @State private var receiveTokenPendingDeletion: WalletTransaction?
-    /// Unclaimed incoming token being claimed (rows open the claim flow
-    /// directly — one Receive tap, no intermediate detail sheet).
-    @State private var claimReceiveToken: PendingReceiveToken?
     @State private var transactionUpdateRevision = 0
     @State private var didInitialLoad = false
 
@@ -156,25 +153,10 @@ struct HistoryView: View {
                     .environmentObject(walletManager)
                     .observeBottomSheetDismissal { isSheetDismissing = $0 }
             }
-            // Claim flow for an unclaimed incoming token. `item:` captures the
-            // pending token at presentation, so the content stays stable while
-            // the claim removes it from the store (a live lookup here would go
-            // nil mid-flow and blank the screen).
-            .fullScreenCover(item: $claimReceiveToken) { pending in
-                ReceiveTokenDetailView(
-                    tokenString: pending.token,
-                    onComplete: { claimReceiveToken = nil },
-                    claim: { try await walletManager.claimPendingReceiveToken(pending) }
-                )
-                .environmentObject(walletManager)
-            }
             .sheet(item: $selectedRequest) { request in
-                NavigationStack {
-                    CashuRequestDetailView(request: request)
-                        .environmentObject(walletManager)
-                }
-                .compactBottomSheetSurface()
-                .observeBottomSheetDismissal { isSheetDismissing = $0 }
+                CashuRequestReceiptView(request: request)
+                    .environmentObject(walletManager)
+                    .observeBottomSheetDismissal { isSheetDismissing = $0 }
             }
             .confirmationDialog(
                 "Remove this Cashu Request from history?",
@@ -578,15 +560,7 @@ struct HistoryView: View {
         return Button {
             HapticFeedback.selection()
             isSearchFocused = false
-            // Unclaimed incoming ecash goes straight to the claim flow — the
-            // receive screen already shows amount, fee, mint, and memo, so an
-            // intermediate detail sheet would just add a second Receive tap.
-            if transaction.isPendingReceiveToken,
-               let pending = walletManager.pendingReceiveTokens.first(where: { $0.tokenId == transaction.id }) {
-                claimReceiveToken = pending
-            } else {
-                selectedTransaction = transaction
-            }
+            selectedTransaction = transaction
         } label: {
             HStack(spacing: 14) {
                 rowIcon(for: transaction)

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -9,7 +9,7 @@ struct TransactionDetailView: View {
     @ObservedObject var settings = SettingsManager.shared
     @ObservedObject private var priceService = PriceService.shared
 
-    @State private var contentHeight: CGFloat = 0
+    @State private var claimReceiveToken: PendingReceiveToken?
     @State private var showShareSheet = false
     @State private var isCheckingClaim = false
     @State private var manualClaimCheckResult: PendingTokenClaimCheckResult?
@@ -44,7 +44,8 @@ struct TransactionDetailView: View {
     /// See DESIGN.md → the settled-ecash receipt carve-out.
     private var copyableContent: String? {
         if showsQR { return qrContent }
-        if transaction.kind == .ecash, let token = transaction.token { return token }
+        if transaction.kind == .ecash, transaction.status == .completed,
+           let token = transaction.token { return token }
         return nil
     }
 
@@ -58,35 +59,7 @@ struct TransactionDetailView: View {
         )
     }
 
-    /// A reusable BOLT12 offer — its bech32 human-readable prefix is `lno`.
-    private var isReusableOffer: Bool {
-        transaction.invoice?.lowercased().hasPrefix("lno") == true
-    }
-
-    /// Whether the stored request is still worth showing as a QR. A record of a
-    /// *settled* one-shot invoice shouldn't reoffer a dead payment code, so the QR
-    /// (and its Copy / Share) appears only while the content is still actionable.
-    private var showsQR: Bool {
-        switch transaction.kind {
-        case .ecash:
-            // Governs the scannable/shareable artifacts (QR hero + top Share).
-            // A claimed token is spent, so only an unclaimed (pending) send is
-            // still worth re-presenting. The passive Copy button is separate — it
-            // extends to settled tokens as a receipt via `copyableContent`.
-            // An unclaimed *incoming* token is money to claim, not a payment
-            // code to hand out — its detail leads with the Receive button.
-            if transaction.isPendingReceiveToken { return false }
-            return transaction.token != nil && transaction.status == .pending
-        case .lightning:
-            guard transaction.invoice != nil else { return false }
-            return transaction.status == .pending || isReusableOffer
-        case .onchain:
-            // The address is only worth re-presenting while the deposit is
-            // still awaited; once confirmed this is a historical receipt like
-            // a settled invoice — checkmark hero, no QR.
-            return transaction.invoice != nil && transaction.status == .pending
-        }
-    }
+    private var showsQR: Bool { transaction.hasActionablePaymentCode }
 
     private var qrContentTypeLabel: String {
         switch transaction.kind {
@@ -104,68 +77,47 @@ struct TransactionDetailView: View {
         }
     }
 
-    // Keep upstream's content-fitting receipt sizing. Described live QRs use
-    // the adaptive receive layout so Mint and Description remain visible.
-    private var usesAdaptiveQR: Bool { showsQR && transaction.displayDescription != nil }
-
     var body: some View {
-        NavigationStack {
-            Group {
-                if usesAdaptiveQR {
-                    VStack(spacing: 0) {
-                        PaymentDetailContent { qrSize in
-                            heroSlot(qrSize: qrSize)
-                        } details: {
-                            receiptDetails
-                        }
-                        receiptActions
-                            .padding(.horizontal)
-                            .padding(.bottom, 16)
-                    }
-                } else {
-                    VStack(spacing: 12) {
-                        VStack(spacing: 16) {
-                            heroSlot(qrSize: 280)
-                            receiptDetails
-                        }
-                        receiptActions
-                    }
-                    .padding(.horizontal)
-                    .padding(.bottom, 16)
-                    .contentFitMeasured { contentHeight = $0 }
-                }
+        ActivityDetailSheet(title: transaction.displayTitle) {
+            receiptDetails
+            if showsQR, let content = qrContent {
+                ActivityPaymentCode(
+                    content: content,
+                    staticOnly: transaction.kind != .ecash,
+                    onCopy: { copyContent(content) },
+                    onShare: { showShareSheet = true }
+                )
             }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .toolbar {
-                // Title only — no close or share chrome. Like every receipt
-                // sheet, dismissal is the drag indicator / swipe, and sharing
-                // stays on the QR itself (context menu + VoiceOver action).
-                ToolbarItem(placement: .principal) {
-                    Text(transaction.displayTitle).font(.headline)
-                }
-            }
-            .sheet(isPresented: $showShareSheet) {
-                if let token = transaction.token {
-                    CashuTokenShareSheet(token: token)
-                } else if let invoice = transaction.invoice {
-                    ShareSheet(items: [invoice])
-                }
-            }
-            // Single-quote check on open (not the full pending list). Re-checks
-            // this mint quote against the mint and mints if already paid —
-            // Android TransactionDetailScreen parity.
-            .task(id: seed.id) {
-                guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
-                _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
-            }
-            .onDisappear {
-                manualClaimCheckTask?.cancel()
+            receiptActions
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let token = transaction.token {
+                CashuTokenShareSheet(token: token)
+            } else if let invoice = transaction.invoice {
+                ShareSheet(items: [invoice])
             }
         }
-        .compactBottomSheetSurface()
-        .contentFitDetent(contentHeight, enabled: !usesAdaptiveQR, estimate: 500, navigationBar: true)
-        .presentationDragIndicator(.visible)
+        // Single-quote check on open (not the full pending list). Re-checks
+        // this mint quote against the mint and mints if already paid —
+        // Android TransactionDetailScreen parity.
+        .task(id: seed.id) {
+            guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
+            _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
+        }
+        .onDisappear {
+            manualClaimCheckTask?.cancel()
+        }
+        .fullScreenCover(item: $claimReceiveToken) { pending in
+            ReceiveTokenDetailView(
+                tokenString: pending.token,
+                onComplete: {
+                    claimReceiveToken = nil
+                    dismiss()
+                },
+                claim: { try await walletManager.claimPendingReceiveToken(pending) }
+            )
+            .environmentObject(walletManager)
+        }
     }
 
     // MARK: - Subviews
@@ -173,17 +125,16 @@ struct TransactionDetailView: View {
     private var receiptDetails: some View {
         VStack(spacing: 24) {
             // Receipt amounts use the same primary/secondary ordering
-            // as Home and History. The glyph above carries state colour.
+            // as Home and History, at one stable scale for every lifecycle.
             TransactionReceiptAmountPair(
                 transaction: transaction,
-                role: showsQR ? .amountCompact : .amountConfirm,
+                role: .amountConfirm,
                 preferredPrimary: settings.homeBalancePrimary,
                 showFiat: settings.showFiatBalance,
                 btcPrice: priceService.btcPriceUSD,
                 currencyCode: settings.bitcoinPriceCurrency,
                 useBitcoinSymbol: settings.useBitcoinSymbol
             )
-            .padding(.top, heroSlotIsEmpty ? 16 : 0)
 
             // Detail rows on canvas, led by Status + Date. Type is
             // omitted — the nav title names it.
@@ -232,8 +183,12 @@ struct TransactionDetailView: View {
 
     @ViewBuilder
     private var receiptActions: some View {
-        if offersManualClaimCheck || copyableContent != nil {
+        if offersManualClaimCheck || copyableContent != nil || pendingReceive != nil {
             VStack(spacing: 12) {
+                if let pending = pendingReceive {
+                    Button("Receive") { claimReceiveToken = pending }
+                        .glassButton()
+                }
                 if let content = copyableContent {
                     Button(action: { copyContent(content) }) {
                         Text("Copy")
@@ -262,62 +217,12 @@ struct TransactionDetailView: View {
     }
 
 
-    /// The hero above the amount. An actionable request shows its QR; otherwise a
-    /// state glyph bounces in on open — green check (completed) / red X (failed),
-    /// same size as the payment-success screen. A pending, no-QR tx shows nothing.
-    @ViewBuilder
-    private func heroSlot(qrSize: CGFloat) -> some View {
-        if showsQR, let content = qrContent {
-            QRCodeView(
-                content: content,
-                showControls: false,
-                // Lightning invoices / Bitcoin addresses are standard QR formats;
-                // ecash tokens are long and benefit from UR-animated encoding.
-                staticOnly: transaction.kind != .ecash,
-                onCopy: { copyContent(content) },
-                onShare: { showShareSheet = true }
-            )
-            .frame(width: qrSize, height: qrSize)
-            .padding(16)
-            .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
-            .contextMenu {
-                Button(action: { copyContent(content) }) {
-                    Label("Copy", systemImage: "doc.on.doc")
-                }
-                Button(action: { showShareSheet = true }) {
-                    Label("Share", systemImage: "square.and.arrow.up")
-                }
-            }
-        } else if transaction.status == .completed {
-            // Static glyph — no `.symbolEffect(.bounce)`. This is historical review
-            // (a detail screen re-opened often), not the live payment-received moment
-            // that owns the bounce (DESIGN.md §6). The status already happened.
-            // Status hero, not an inline notice — but it speaks the same
-            // severity vocabulary, so it takes the same tokens rather than
-            // raw .green/.red.
-            Image(systemName: "checkmark.circle.fill")
-                .font(.statusGlyph)
-                .foregroundStyle(ErrorSeverity.success.foreground)
-                .padding(.top, 16)
-                .accessibilityLabel("Completed")
-        } else if transaction.status == .failed {
-            Image(systemName: "xmark.circle.fill")
-                .font(.statusGlyph)
-                .foregroundStyle(ErrorSeverity.error.foreground)
-                .padding(.top, 16)
-                .accessibilityLabel("Failed")
-        }
+    private var pendingReceive: PendingReceiveToken? {
+        guard transaction.isPendingReceiveToken, transaction.status == .pending else { return nil }
+        return walletManager.pendingReceiveTokens.first { $0.tokenId == transaction.id }
     }
 
-    /// True when the hero renders nothing (a no-QR transaction still pending, or
-    /// an expired invoice — deliberately quiet, no glyph), so the amount gets top
-    /// breathing room instead of butting against the nav bar.
-    private var heroSlotIsEmpty: Bool {
-        !showsQR && transaction.isUnsettled
-    }
-
-    /// The lifecycle word for the Status row. Direction/rail come from the nav
-    /// title, so this only names the state: completed → Claimed/Paid/Confirmed.
+    /// Direction and rail come from the title; this row names the lifecycle.
     private var statusFieldValue: String {
         switch transaction.status {
         case .completed:
@@ -387,8 +292,7 @@ struct TransactionDetailView: View {
             Text(value)
                 .fontWeight(.medium)
                 .multilineTextAlignment(.trailing)
-                .lineLimit(1)
-                .truncationMode(.middle)
+                .fixedSize(horizontal: false, vertical: true)
                 .textSelection(.enabled)
         }
         .font(.subheadline)
@@ -669,5 +573,153 @@ private struct PaymentDescriptionView: View {
                 }
             }
         }
+    }
+}
+
+/// Stored receive intents use the same inspector as individual transactions.
+/// Creating or editing a request remains an explicit action from the receipt.
+struct CashuRequestReceiptView: View {
+    private let seed: CashuRequest
+    @EnvironmentObject private var walletManager: WalletManager
+    @ObservedObject private var store = CashuRequestStore.shared
+    @ObservedObject private var settings = SettingsManager.shared
+    @ObservedObject private var priceService = PriceService.shared
+    @State private var showShareSheet = false
+    @State private var showManageRequest = false
+    @State private var selectedPayment: WalletTransaction?
+
+    init(request: CashuRequest) { seed = request }
+
+    private var request: CashuRequest { store.request(withId: seed.id) ?? seed }
+    private var payments: [WalletTransaction] {
+        let ids = Set(request.receivedPayments.map(\.transactionId))
+        return walletManager.transactions.filter { ids.contains($0.id) }
+    }
+    private var totalReceived: UInt64 {
+        request.receivedPayments.reduce(0) { total, payment in
+            total + (payments.first { $0.id == payment.transactionId }?.amount ?? payment.amount)
+        }
+    }
+    private var status: String {
+        switch request.lifecycle {
+        case .waiting: return "Waiting for payment"
+        case .collecting: return "Active"
+        case .received: return request.rail == .onchain ? "Confirmed" : "Paid"
+        case .expired: return "Expired"
+        }
+    }
+    private var codeAvailable: Bool {
+        !request.encoded.isEmpty && (request.lifecycle == .waiting || request.lifecycle == .collecting)
+    }
+
+    var body: some View {
+        // One-shot expiry can pass while a receipt is open, even without a store update.
+        TimelineView(.periodic(from: .now, by: 1)) { _ in
+            ActivityDetailSheet(title: request.displayTitle) {
+                VStack(spacing: 4) {
+                    if !request.receivedPayments.isEmpty {
+                        Text("Total received").font(.subheadline).foregroundStyle(.secondary)
+                    }
+                    if let amount = request.receivedPayments.isEmpty ? request.amount : totalReceived {
+                        let display = amountDisplay(amount)
+                        AmountLockup(parts: display.primaryParts, role: .amountConfirm,
+                                     value: Double(amount), accessibilityPrefix: "Amount")
+                        if let secondary = display.secondary {
+                            Text(secondary).cashuText(.bodyEmphasis).monospacedDigit()
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        Text("Any amount").cashuText(.amountConfirm)
+                    }
+                }
+
+                VStack(spacing: 0) {
+                    row("Status", status)
+                    row("Date", request.createdAt.formatted(date: .abbreviated, time: .shortened))
+                    row("Mint", request.mints.isEmpty ? "Any mint" : request.mints.map { url in
+                        walletManager.mints.first { $0.url == url }?.name ?? URL(string: url)?.host ?? url
+                    }.joined(separator: ", "))
+                    if let description = request.displayDescription {
+                        DescriptionDetailRow(description: description)
+                    }
+                    if request.reusable {
+                        row("Requested amount", request.amount.map { amountDisplay($0).primary } ?? "Any amount")
+                        row("Payments received", "\(request.receivedPayments.count)")
+                    }
+                    ForEach(payments) { payment in
+                        Button { selectedPayment = payment } label: {
+                            HStack {
+                                Text(payment.date.formatted(date: .abbreviated, time: .shortened))
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text(amountDisplay(payment.amount).primary)
+                                Image(systemName: "chevron.right").font(.caption)
+                            }
+                            .font(.subheadline)
+                            .padding(.vertical, 12)
+                            .frame(minHeight: 44)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens payment details")
+                    }
+                }
+                if codeAvailable {
+                    ActivityPaymentCode(content: request.encoded,
+                                        onCopy: copyRequest, onShare: { showShareSheet = true })
+                    Button("Copy", action: copyRequest)
+                        .flatSheetSecondaryButton()
+                        .accessibilityLabel("Copy payment request")
+                }
+                if request.rail == .ecash {
+                    Button("Manage request") { showManageRequest = true }
+                        .flatSheetSecondaryButton()
+                }
+            }
+        }
+        .sheet(isPresented: $showShareSheet) { ShareSheet(items: [request.encoded]) }
+        .sheet(isPresented: $showManageRequest) {
+            NavigationStack {
+                CashuRequestDetailView(request: request)
+                    .environmentObject(walletManager)
+            }
+        }
+        .sheet(item: $selectedPayment) { payment in
+            TransactionDetailView(transaction: payment).environmentObject(walletManager)
+        }
+        .task(id: seed.id) {
+            if let quoteId = request.quoteId {
+                _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
+            }
+        }
+    }
+
+    private func row(_ label: String, _ value: String) -> some View {
+        HStack {
+            Text(label).foregroundStyle(.secondary)
+            Spacer()
+            Text(value).fontWeight(.medium).multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true).textSelection(.enabled)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 4)
+        .padding(.vertical, 12)
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(value)
+    }
+
+    private func amountDisplay(_ amount: UInt64) -> AmountDisplayText {
+        AmountFormatter.displayMintUnitAmount(
+            amount: amount, unit: request.unit, preferredPrimary: settings.homeBalancePrimary,
+            showFiat: settings.showFiatBalance, btcPrice: priceService.btcPriceUSD,
+            currencyCode: settings.bitcoinPriceCurrency, useBitcoinSymbol: settings.useBitcoinSymbol
+        )
+    }
+
+    private func copyRequest() {
+        UIPasteboard.general.string = request.encoded
+        HapticFeedback.notification(.success)
+        ConfirmationToast.show("Copied payment request")
     }
 }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -9,6 +9,7 @@ struct TransactionDetailView: View {
     @ObservedObject var settings = SettingsManager.shared
     @ObservedObject private var priceService = PriceService.shared
 
+    @State private var contentHeight: CGFloat = 0
     @State private var claimReceiveToken: PendingReceiveToken?
     @State private var showShareSheet = false
     @State private var isCheckingClaim = false
@@ -44,8 +45,7 @@ struct TransactionDetailView: View {
     /// See DESIGN.md → the settled-ecash receipt carve-out.
     private var copyableContent: String? {
         if showsQR { return qrContent }
-        if transaction.kind == .ecash, transaction.status == .completed,
-           let token = transaction.token { return token }
+        if transaction.kind == .ecash, let token = transaction.token { return token }
         return nil
     }
 
@@ -77,35 +77,59 @@ struct TransactionDetailView: View {
         }
     }
 
+    // Keep upstream's content-fitting receipt sizing. Described live QRs use
+    // the adaptive receive layout so Mint and Description remain visible.
+    private var usesAdaptiveQR: Bool { showsQR && transaction.displayDescription != nil }
+
     var body: some View {
-        ActivityDetailSheet(title: transaction.displayTitle) {
-            if showsQR, let content = qrContent {
-                ActivityPaymentCode(
-                    content: content,
-                    staticOnly: transaction.kind != .ecash,
-                    onCopy: { copyContent(content) },
-                    onShare: { showShareSheet = true }
-                )
+        ActivityDetailSheet(
+            title: transaction.displayTitle,
+            contentHeight: contentHeight,
+            fitsContent: !usesAdaptiveQR,
+            onShare: showsQR ? { showShareSheet = true } : nil
+        ) {
+            Group {
+                if usesAdaptiveQR {
+                    VStack(spacing: 0) {
+                        PaymentDetailContent { qrSize in
+                            heroSlot(qrSize: qrSize)
+                        } details: {
+                            receiptDetails
+                        }
+                        receiptActions
+                            .padding(.horizontal)
+                            .padding(.bottom, 16)
+                    }
+                } else {
+                    VStack(spacing: 12) {
+                        VStack(spacing: 16) {
+                            heroSlot(qrSize: 280)
+                            receiptDetails
+                        }
+                        receiptActions
+                    }
+                    .padding(.horizontal)
+                    .padding(.bottom, 16)
+                    .contentFitMeasured { contentHeight = $0 }
+                }
             }
-            receiptDetails
-            receiptActions
-        }
-        .sheet(isPresented: $showShareSheet) {
-            if let token = transaction.token {
-                CashuTokenShareSheet(token: token)
-            } else if let invoice = transaction.invoice {
-                ShareSheet(items: [invoice])
+            .sheet(isPresented: $showShareSheet) {
+                if let token = transaction.token {
+                    CashuTokenShareSheet(token: token)
+                } else if let invoice = transaction.invoice {
+                    ShareSheet(items: [invoice])
+                }
             }
-        }
-        // Single-quote check on open (not the full pending list). Re-checks
-        // this mint quote against the mint and mints if already paid —
-        // Android TransactionDetailScreen parity.
-        .task(id: seed.id) {
-            guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
-            _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
-        }
-        .onDisappear {
-            manualClaimCheckTask?.cancel()
+            // Single-quote check on open (not the full pending list). Re-checks
+            // this mint quote against the mint and mints if already paid —
+            // Android TransactionDetailScreen parity.
+            .task(id: seed.id) {
+                guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
+                _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
+            }
+            .onDisappear {
+                manualClaimCheckTask?.cancel()
+            }
         }
         .fullScreenCover(item: $claimReceiveToken) { pending in
             ReceiveTokenDetailView(
@@ -125,16 +149,17 @@ struct TransactionDetailView: View {
     private var receiptDetails: some View {
         VStack(spacing: 24) {
             // Receipt amounts use the same primary/secondary ordering
-            // as Home and History, at one stable scale for every lifecycle.
+            // as Home and History. The glyph above carries state colour.
             TransactionReceiptAmountPair(
                 transaction: transaction,
-                role: .amountConfirm,
+                role: showsQR ? .amountCompact : .amountConfirm,
                 preferredPrimary: settings.homeBalancePrimary,
                 showFiat: settings.showFiatBalance,
                 btcPrice: priceService.btcPriceUSD,
                 currencyCode: settings.bitcoinPriceCurrency,
                 useBitcoinSymbol: settings.useBitcoinSymbol
             )
+            .padding(.top, heroSlotIsEmpty ? 16 : 0)
 
             // Detail rows on canvas, led by Status + Date. Type is
             // omitted — the nav title names it.
@@ -222,7 +247,63 @@ struct TransactionDetailView: View {
         return walletManager.pendingReceiveTokens.first { $0.tokenId == transaction.id }
     }
 
-    /// Direction and rail come from the title; this row names the lifecycle.
+    /// The hero above the amount. An actionable request shows its QR; otherwise a
+    /// state glyph bounces in on open — green check (completed) / red X (failed),
+    /// same size as the payment-success screen. A pending, no-QR tx shows nothing.
+    @ViewBuilder
+    private func heroSlot(qrSize: CGFloat) -> some View {
+        if showsQR, let content = qrContent {
+            QRCodeView(
+                content: content,
+                showControls: false,
+                // Lightning invoices / Bitcoin addresses are standard QR formats;
+                // ecash tokens are long and benefit from UR-animated encoding.
+                staticOnly: transaction.kind != .ecash,
+                onCopy: { copyContent(content) },
+                onShare: { showShareSheet = true }
+            )
+            .accessibilityIdentifier("cashu.history.payment-code")
+            .frame(width: qrSize, height: qrSize)
+            .padding(16)
+            .background(Color.white, in: RoundedRectangle(cornerRadius: 20))
+            .contextMenu {
+                Button(action: { copyContent(content) }) {
+                    Label("Copy", systemImage: "doc.on.doc")
+                }
+                Button(action: { showShareSheet = true }) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            }
+        } else if transaction.status == .completed {
+            // Static glyph — no `.symbolEffect(.bounce)`. This is historical review
+            // (a detail screen re-opened often), not the live payment-received moment
+            // that owns the bounce (DESIGN.md §6). The status already happened.
+            // Status hero, not an inline notice — but it speaks the same
+            // severity vocabulary, so it takes the same tokens rather than
+            // raw .green/.red.
+            Image(systemName: "checkmark.circle.fill")
+                .font(.statusGlyph)
+                .foregroundStyle(ErrorSeverity.success.foreground)
+                .padding(.top, 16)
+                .accessibilityLabel("Completed")
+        } else if transaction.status == .failed {
+            Image(systemName: "xmark.circle.fill")
+                .font(.statusGlyph)
+                .foregroundStyle(ErrorSeverity.error.foreground)
+                .padding(.top, 16)
+                .accessibilityLabel("Failed")
+        }
+    }
+
+    /// True when the hero renders nothing (a no-QR transaction still pending, or
+    /// an expired invoice — deliberately quiet, no glyph), so the amount gets top
+    /// breathing room instead of butting against the nav bar.
+    private var heroSlotIsEmpty: Bool {
+        !showsQR && transaction.isUnsettled
+    }
+
+    /// The lifecycle word for the Status row. Direction/rail come from the nav
+    /// title, so this only names the state: completed → Claimed/Paid/Confirmed.
     private var statusFieldValue: String {
         switch transaction.status {
         case .completed:
@@ -576,152 +657,21 @@ private struct PaymentDescriptionView: View {
     }
 }
 
-/// Stored receive intents use the same inspector as individual transactions.
-/// Creating or editing a request remains an explicit action from the receipt.
+
+/// History keeps the original request controls inside the shared activity sheet.
 struct CashuRequestReceiptView: View {
-    private let seed: CashuRequest
-    @EnvironmentObject private var walletManager: WalletManager
+    let request: CashuRequest
     @ObservedObject private var store = CashuRequestStore.shared
-    @ObservedObject private var settings = SettingsManager.shared
-    @ObservedObject private var priceService = PriceService.shared
     @State private var showShareSheet = false
-    @State private var showManageRequest = false
-    @State private var selectedPayment: WalletTransaction?
 
-    init(request: CashuRequest) { seed = request }
-
-    private var request: CashuRequest { store.request(withId: seed.id) ?? seed }
-    private var payments: [WalletTransaction] {
-        let ids = Set(request.receivedPayments.map(\.transactionId))
-        return walletManager.transactions.filter { ids.contains($0.id) }
-    }
-    private var totalReceived: UInt64 {
-        request.receivedPayments.reduce(0) { total, payment in
-            total + (payments.first { $0.id == payment.transactionId }?.amount ?? payment.amount)
-        }
-    }
-    private var status: String {
-        switch request.lifecycle {
-        case .waiting: return "Waiting for payment"
-        case .collecting: return "Active"
-        case .received: return request.rail == .onchain ? "Confirmed" : "Paid"
-        case .expired: return "Expired"
-        }
-    }
-    private var codeAvailable: Bool {
-        !request.encoded.isEmpty && (request.lifecycle == .waiting || request.lifecycle == .collecting)
-    }
+    private var current: CashuRequest { store.request(withId: request.id) ?? request }
 
     var body: some View {
-        // One-shot expiry can pass while a receipt is open, even without a store update.
-        TimelineView(.periodic(from: .now, by: 1)) { _ in
-            ActivityDetailSheet(title: request.displayTitle) {
-                if codeAvailable {
-                    ActivityPaymentCode(content: request.encoded,
-                                        onCopy: copyRequest, onShare: { showShareSheet = true })
-                }
-                VStack(spacing: 4) {
-                    if !request.receivedPayments.isEmpty {
-                        Text("Total received").font(.subheadline).foregroundStyle(.secondary)
-                    }
-                    if let amount = request.receivedPayments.isEmpty ? request.amount : totalReceived {
-                        let display = amountDisplay(amount)
-                        AmountLockup(parts: display.primaryParts, role: .amountConfirm,
-                                     value: Double(amount), accessibilityPrefix: "Amount")
-                        if let secondary = display.secondary {
-                            Text(secondary).cashuText(.bodyEmphasis).monospacedDigit()
-                                .foregroundStyle(.secondary)
-                        }
-                    } else {
-                        Text("Any amount").cashuText(.amountConfirm)
-                    }
-                }
-
-                VStack(spacing: 0) {
-                    row("Status", status)
-                    row("Date", request.createdAt.formatted(date: .abbreviated, time: .shortened))
-                    row("Mint", request.mints.isEmpty ? "Any mint" : request.mints.map { url in
-                        walletManager.mints.first { $0.url == url }?.name ?? URL(string: url)?.host ?? url
-                    }.joined(separator: ", "))
-                    if let description = request.displayDescription {
-                        DescriptionDetailRow(description: description)
-                    }
-                    if request.reusable {
-                        row("Requested amount", request.amount.map { amountDisplay($0).primary } ?? "Any amount")
-                        row("Payments received", "\(request.receivedPayments.count)")
-                    }
-                    ForEach(payments) { payment in
-                        Button { selectedPayment = payment } label: {
-                            HStack {
-                                Text(payment.date.formatted(date: .abbreviated, time: .shortened))
-                                    .foregroundStyle(.secondary)
-                                Spacer()
-                                Text(amountDisplay(payment.amount).primary)
-                                Image(systemName: "chevron.right").font(.caption)
-                            }
-                            .font(.subheadline)
-                            .padding(.vertical, 12)
-                            .frame(minHeight: 44)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityHint("Opens payment details")
-                    }
-                }
-                if codeAvailable {
-                    Button("Copy", action: copyRequest)
-                        .flatSheetSecondaryButton()
-                        .accessibilityLabel("Copy payment request")
-                }
-                if request.rail == .ecash {
-                    Button("Manage request") { showManageRequest = true }
-                        .flatSheetSecondaryButton()
-                }
-            }
+        ActivityDetailSheet(title: current.displayTitle, onShare: { showShareSheet = true }) {
+            CashuRequestDetailView(request: current, showsNavigationHeader: false)
         }
-        .sheet(isPresented: $showShareSheet) { ShareSheet(items: [request.encoded]) }
-        .sheet(isPresented: $showManageRequest) {
-            NavigationStack {
-                CashuRequestDetailView(request: request)
-                    .environmentObject(walletManager)
-            }
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(items: [current.encoded])
         }
-        .sheet(item: $selectedPayment) { payment in
-            TransactionDetailView(transaction: payment).environmentObject(walletManager)
-        }
-        .task(id: seed.id) {
-            if let quoteId = request.quoteId {
-                _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
-            }
-        }
-    }
-
-    private func row(_ label: String, _ value: String) -> some View {
-        HStack {
-            Text(label).foregroundStyle(.secondary)
-            Spacer()
-            Text(value).fontWeight(.medium).multilineTextAlignment(.trailing)
-                .fixedSize(horizontal: false, vertical: true).textSelection(.enabled)
-        }
-        .font(.subheadline)
-        .padding(.horizontal, 4)
-        .padding(.vertical, 12)
-        .frame(minHeight: 44)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(label)
-        .accessibilityValue(value)
-    }
-
-    private func amountDisplay(_ amount: UInt64) -> AmountDisplayText {
-        AmountFormatter.displayMintUnitAmount(
-            amount: amount, unit: request.unit, preferredPrimary: settings.homeBalancePrimary,
-            showFiat: settings.showFiatBalance, btcPrice: priceService.btcPriceUSD,
-            currencyCode: settings.bitcoinPriceCurrency, useBitcoinSymbol: settings.useBitcoinSymbol
-        )
-    }
-
-    private func copyRequest() {
-        UIPasteboard.general.string = request.encoded
-        HapticFeedback.notification(.success)
-        ConfirmationToast.show("Copied payment request")
     }
 }

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -79,7 +79,6 @@ struct TransactionDetailView: View {
 
     var body: some View {
         ActivityDetailSheet(title: transaction.displayTitle) {
-            receiptDetails
             if showsQR, let content = qrContent {
                 ActivityPaymentCode(
                     content: content,
@@ -88,6 +87,7 @@ struct TransactionDetailView: View {
                     onShare: { showShareSheet = true }
                 )
             }
+            receiptDetails
             receiptActions
         }
         .sheet(isPresented: $showShareSheet) {
@@ -616,6 +616,10 @@ struct CashuRequestReceiptView: View {
         // One-shot expiry can pass while a receipt is open, even without a store update.
         TimelineView(.periodic(from: .now, by: 1)) { _ in
             ActivityDetailSheet(title: request.displayTitle) {
+                if codeAvailable {
+                    ActivityPaymentCode(content: request.encoded,
+                                        onCopy: copyRequest, onShare: { showShareSheet = true })
+                }
                 VStack(spacing: 4) {
                     if !request.receivedPayments.isEmpty {
                         Text("Total received").font(.subheadline).foregroundStyle(.secondary)
@@ -664,8 +668,6 @@ struct CashuRequestReceiptView: View {
                     }
                 }
                 if codeAvailable {
-                    ActivityPaymentCode(content: request.encoded,
-                                        onCopy: copyRequest, onShare: { showShareSheet = true })
                     Button("Copy", action: copyRequest)
                         .flatSheetSecondaryButton()
                         .accessibilityLabel("Copy payment request")

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -10,6 +10,7 @@ struct CashuRequestDetailView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let onClose: (() -> Void)?
+    let showsNavigationHeader: Bool
 
     @State private var requestId: String
     @State private var showMintPicker = false
@@ -25,12 +26,13 @@ struct CashuRequestDetailView: View {
     /// imperatively, so the accessibility action presents the share sheet.
     @State private var showShareSheet = false
 
-    init(request: CashuRequest, onClose: (() -> Void)? = nil) {
+    init(request: CashuRequest, onClose: (() -> Void)? = nil, showsNavigationHeader: Bool = true) {
         self._requestId = State(initialValue: request.id)
         self._paymentObservation = State(
             initialValue: CashuRequestPaymentObservation(existingPayments: request.receivedPayments)
         )
         self.onClose = onClose
+        self.showsNavigationHeader = showsNavigationHeader
     }
 
     private var request: CashuRequest? {
@@ -65,22 +67,24 @@ struct CashuRequestDetailView: View {
         .navigationBarBackButtonHidden(true)
         .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar {
-            ToolbarItem(placement: .principal) {
-                Text(request?.displayTitle ?? "Cashu Request")
-                    .font(.headline)
-            }
-            ToolbarItem(placement: .cancellationAction) {
-                SheetCloseButton {
-                    if let onClose { onClose() } else { dismiss() }
+            if showsNavigationHeader {
+                ToolbarItem(placement: .principal) {
+                    Text(request?.displayTitle ?? "Cashu Request")
+                        .font(.headline)
                 }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                if let request {
-                    ShareLink(item: request.encoded) {
-                        Image(systemName: "square.and.arrow.up")
-                            .toolbarIconTapTarget()
+                ToolbarItem(placement: .cancellationAction) {
+                    SheetCloseButton {
+                        if let onClose { onClose() } else { dismiss() }
                     }
-                    .accessibilityLabel("Share request")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if let request {
+                        ShareLink(item: request.encoded) {
+                            Image(systemName: "square.and.arrow.up")
+                                .toolbarIconTapTarget()
+                        }
+                        .accessibilityLabel("Share request")
+                    }
                 }
             }
         }
@@ -305,6 +309,7 @@ struct CashuRequestDetailView: View {
             onCopy: { copy(request.encoded) },
             onShare: { showShareSheet = true }
         )
+        .accessibilityIdentifier("cashu.history.payment-code")
         .frame(width: size, height: size)
         .padding(16)
         .background(Color.white, in: RoundedRectangle(cornerRadius: 20))

--- a/ios/CashuWalletTests/QRContextAccessibilityTests.swift
+++ b/ios/CashuWalletTests/QRContextAccessibilityTests.swift
@@ -37,7 +37,7 @@ final class QRContextAccessibilityTests: XCTestCase {
                         invoice: kind == .ecash ? nil : "one-shot-request"
                     )
                     let expected = status == .pending &&
-                        (kind == .ecash ? direction == .outgoing : direction == .incoming)
+                        (kind != .ecash || direction == .outgoing)
                     XCTAssertEqual(transaction.hasActionablePaymentCode, expected,
                                    "Unexpected QR availability for \(kind), \(direction), \(status)")
                 }
@@ -45,7 +45,7 @@ final class QRContextAccessibilityTests: XCTestCase {
         }
     }
 
-    func testReusableOfferStaysAvailableAfterPaymentButNeverOnOutgoingReceipt() {
+    func testReusableOfferStaysAvailableAndPendingOutgoingArtifactIsPreserved() {
         var transaction = WalletTransaction(
             id: "offer", amount: 21, type: .incoming, kind: .lightning, date: .now,
             status: .completed, invoice: "LNO1offer"
@@ -57,7 +57,7 @@ final class QRContextAccessibilityTests: XCTestCase {
             id: "payment", amount: 21, type: .outgoing, kind: .lightning, date: .now,
             status: .pending, invoice: "lno1offer"
         )
-        XCTAssertFalse(outgoing.hasActionablePaymentCode)
+        XCTAssertTrue(outgoing.hasActionablePaymentCode)
     }
 
 }

--- a/ios/CashuWalletTests/QRContextAccessibilityTests.swift
+++ b/ios/CashuWalletTests/QRContextAccessibilityTests.swift
@@ -26,4 +26,38 @@ final class QRContextAccessibilityTests: XCTestCase {
         XCTAssertTrue(copied)
         XCTAssertTrue(shared)
     }
+
+    func testHistoryPaymentCodeAvailabilityAcrossDirectionsAndStates() {
+        for kind in [WalletTransaction.TransactionKind.ecash, .lightning, .onchain] {
+            for direction in [WalletTransaction.TransactionType.incoming, .outgoing] {
+                for status in [WalletTransaction.TransactionStatus.pending, .completed, .failed, .expired] {
+                    let transaction = WalletTransaction(
+                        id: "receipt", amount: 21, type: direction, kind: kind, date: .now,
+                        status: status, token: kind == .ecash ? "cashu-token" : nil,
+                        invoice: kind == .ecash ? nil : "one-shot-request"
+                    )
+                    let expected = status == .pending &&
+                        (kind == .ecash ? direction == .outgoing : direction == .incoming)
+                    XCTAssertEqual(transaction.hasActionablePaymentCode, expected,
+                                   "Unexpected QR availability for \(kind), \(direction), \(status)")
+                }
+            }
+        }
+    }
+
+    func testReusableOfferStaysAvailableAfterPaymentButNeverOnOutgoingReceipt() {
+        var transaction = WalletTransaction(
+            id: "offer", amount: 21, type: .incoming, kind: .lightning, date: .now,
+            status: .completed, invoice: "LNO1offer"
+        )
+        XCTAssertTrue(transaction.hasActionablePaymentCode)
+        transaction.status = .failed
+        XCTAssertFalse(transaction.hasActionablePaymentCode)
+        let outgoing = WalletTransaction(
+            id: "payment", amount: 21, type: .outgoing, kind: .lightning, date: .now,
+            status: .pending, invoice: "lno1offer"
+        )
+        XCTAssertFalse(outgoing.hasActionablePaymentCode)
+    }
+
 }

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -111,3 +111,45 @@ final class MainTabUITests: UITestBase {
         tapTab("Wallet")
     }
 }
+
+
+/// Actual receipt sheets with deterministic catalog records, without a live mint.
+final class ActivityDetailUITests: XCTestCase {
+    func testReceiptLayoutAndPaymentCodeDisclosure() {
+        continueAfterFailure = false
+        let app = XCUIApplication()
+        app.launchEnvironment = ["SHOW_COMPONENT_CATALOG": "activity", "CI_INTEGRATION_TEST": "1"]
+        app.launchArguments = ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launch()
+        defer { app.terminate() }
+
+        for id in ["pending-lightning", "paid-lightning", "sent-lightning", "received-ecash", "received-bitcoin", "reusable-invoice"] {
+            let row = app.buttons[id]
+            XCTAssertTrue(row.waitForExistence(timeout: 10))
+            row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+            XCTAssertTrue(app.staticTexts["Status"].waitForExistence(timeout: 5))
+            XCTAssertTrue(app.staticTexts["Date"].exists)
+            XCTAssertTrue(app.staticTexts["Mint"].exists)
+            XCTAssertFalse(app.buttons["Close"].exists)
+            let attachment = XCTAttachment(screenshot: app.screenshot())
+            attachment.name = id
+            attachment.lifetime = .keepAlways
+            add(attachment)
+
+            if id == "pending-lightning" || id == "reusable-invoice" {
+                let code = app.buttons["cashu.history.payment-code"]
+                XCTAssertTrue(code.exists)
+                code.tap()
+                XCTAssertTrue(app.staticTexts["Hide QR code"].waitForExistence(timeout: 5))
+                code.tap()
+            } else {
+                XCTAssertFalse(app.buttons["cashu.history.payment-code"].exists)
+            }
+            // Native sheet gesture, starting on the title to avoid scrolling its body.
+            let title = app.navigationBars.firstMatch
+            title.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+                .press(forDuration: 0.1, thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.98)))
+            XCTAssertTrue(title.waitForNonExistence(timeout: 5))
+        }
+    }
+}

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -123,12 +123,21 @@ final class ActivityDetailUITests: XCTestCase {
         app.launch()
         defer { app.terminate() }
 
-        for id in ["pending-lightning", "paid-lightning", "sent-lightning", "received-ecash", "received-bitcoin", "reusable-invoice"] {
+        for id in ["pending-lightning", "paid-lightning", "sent-lightning", "received-ecash", "received-bitcoin", "failed-lightning", "reusable-invoice", "cashu-request"] {
             let row = app.buttons[id]
             XCTAssertTrue(row.waitForExistence(timeout: 10))
             row.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
-            XCTAssertTrue(app.staticTexts["Status"].waitForExistence(timeout: 5))
-            XCTAssertTrue(app.staticTexts["Date"].exists)
+            let isRequest = id == "reusable-invoice" || id == "cashu-request"
+            XCTAssertTrue(app.staticTexts[isRequest ? "Created" : "Status"].waitForExistence(timeout: 5))
+            if !isRequest { XCTAssertTrue(app.staticTexts["Date"].exists) }
+            if id == "cashu-request" {
+                XCTAssertTrue(app.buttons["New Request"].isHittable)
+                XCTAssertTrue(app.buttons["Amount"].isHittable)
+            }
+            if id == "failed-lightning" { XCTAssertTrue(app.images["Failed"].exists) }
+            if ["paid-lightning", "sent-lightning", "received-ecash", "received-bitcoin"].contains(id) {
+                XCTAssertTrue(app.images["Completed"].exists)
+            }
             XCTAssertTrue(app.staticTexts["Mint"].exists)
             XCTAssertFalse(app.buttons["Close"].exists)
             let attachment = XCTAttachment(screenshot: app.screenshot())
@@ -136,7 +145,8 @@ final class ActivityDetailUITests: XCTestCase {
             attachment.lifetime = .keepAlways
             add(attachment)
 
-            if id == "pending-lightning" || id == "reusable-invoice" {
+            if id == "pending-lightning" || isRequest {
+                XCTAssertTrue(app.buttons["Share"].isHittable)
                 XCTAssertTrue(app.descendants(matching: .any)["cashu.history.payment-code"].firstMatch.exists)
             } else {
                 XCTAssertFalse(app.descendants(matching: .any)["cashu.history.payment-code"].firstMatch.exists)

--- a/ios/CashuWalletUITests/MainTabUITests.swift
+++ b/ios/CashuWalletUITests/MainTabUITests.swift
@@ -115,7 +115,7 @@ final class MainTabUITests: UITestBase {
 
 /// Actual receipt sheets with deterministic catalog records, without a live mint.
 final class ActivityDetailUITests: XCTestCase {
-    func testReceiptLayoutAndPaymentCodeDisclosure() {
+    func testReceiptLayoutAndVisiblePaymentCode() {
         continueAfterFailure = false
         let app = XCUIApplication()
         app.launchEnvironment = ["SHOW_COMPONENT_CATALOG": "activity", "CI_INTEGRATION_TEST": "1"]
@@ -137,14 +137,12 @@ final class ActivityDetailUITests: XCTestCase {
             add(attachment)
 
             if id == "pending-lightning" || id == "reusable-invoice" {
-                let code = app.buttons["cashu.history.payment-code"]
-                XCTAssertTrue(code.exists)
-                code.tap()
-                XCTAssertTrue(app.staticTexts["Hide QR code"].waitForExistence(timeout: 5))
-                code.tap()
+                XCTAssertTrue(app.descendants(matching: .any)["cashu.history.payment-code"].firstMatch.exists)
             } else {
-                XCTAssertFalse(app.buttons["cashu.history.payment-code"].exists)
+                XCTAssertFalse(app.descendants(matching: .any)["cashu.history.payment-code"].firstMatch.exists)
             }
+            XCTAssertFalse(app.buttons["Show QR code"].exists)
+            XCTAssertFalse(app.buttons["Hide QR code"].exists)
             // Native sheet gesture, starting on the title to avoid scrolling its body.
             let title = app.navigationBars.firstMatch
             title.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))


### PR DESCRIPTION
Activity details previously used different presentation for transactions and stored requests. Incoming and outgoing payments now share native sheet presentation on iOS and Android: a centered title, drag handle, no redundant top-left close button, and a visible Share action for shareable artifacts.

The original detail layouts and functionality are preserved: immediately visible adaptive QR codes, compact amounts with QR codes, green success checks, red failure crosses, receipt facts, Copy, explorer/proof references, manual token checks, and Cashu Request inline editing plus New Request. Stored requests reuse the original editor and receive behavior inside the shared sheet. Unclaimed ecash opens the sheet with Receive.

Validation: both apps and UI test targets build. Android passes 11 policy unit tests, 4 interaction regressions and 10 capture journeys. iOS passes 5 QR/accessibility unit tests, the 8-state UI regression and the 10-state capture journey. Native Share opening, request editing and regeneration are included in [52 reviewed screenshots](https://github.com/cashubtc/wallet/pull/338#issuecomment-5559214836), using Android 17/API 37 and the approved iOS 26.5 fallback. Existing platform typography, color, button, calendar and request-total differences are documented in the report. Dark appearance, large text, hardware and live payments are outside the screenshot matrix.
