### PR TITLE
Fix Lightning address startup and reconnection on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/NPCClient.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NPCClient.kt
@@ -1,0 +1,23 @@
+package com.cashu.me.Core
+
+import org.cashudevkit.NpubCashClient
+
+/** The service's transport boundary, allowing lifecycle tests without network or native FFI. */
+internal interface NPCClient : AutoCloseable {
+    suspend fun getQuotes(): List<NPCQuote>
+    suspend fun setMintUrl(mintUrl: String): String
+}
+
+internal class CdkNPCClient(baseUrl: String, secretKey: String) : NPCClient {
+    private val client = NpubCashClient(baseUrl = baseUrl, nostrSecretKey = secretKey)
+    override suspend fun getQuotes(): List<NPCQuote> =
+        client.getQuotes(since = null).map(NPCService::fromCdkQuote)
+
+    override suspend fun setMintUrl(mintUrl: String): String {
+        val response = client.setMintUrl(mintUrl = mintUrl)
+        if (response.error) error("Failed to change mint.")
+        return response.mintUrl ?: mintUrl
+    }
+
+    override fun close() = client.close()
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
@@ -1,6 +1,14 @@
 package com.cashu.me.Core
 
 import android.content.Context
+import android.content.SharedPreferences
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -11,10 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import com.cashu.me.Core.Protocols.StorageKeys
-import org.cashudevkit.NpubCashClient
 import org.cashudevkit.NpubCashQuote
 import org.cashudevkit.npubcashDeriveSecretKeyFromSeed
 import org.cashudevkit.npubcashGetPubkey
@@ -53,19 +58,29 @@ interface NPCQuoteClaimHandler {
     suspend fun claimNPCQuote(quote: NPCQuote, p2pkPubkey: String?): Boolean
 }
 
-class NPCService(
-    context: Context,
-    private val settingsManager: SettingsManager,
+class NPCService internal constructor(
+    private val prefs: SharedPreferences,
+    private val settingsState: StateFlow<SettingsState>,
+    private val scope: CoroutineScope,
+    private val refreshIntervalMillis: Long = 120_000L,
+    private val makeClient: (String, String) -> NPCClient = ::CdkNPCClient,
+    private val deriveKeys: (ByteArray) -> Pair<String, String> = { seed ->
+        val secret = npubcashDeriveSecretKeyFromSeed(seed)
+        secret to npubcashGetPubkey(secret)
+    },
 ) {
-    private val prefs = context.applicationContext.getSharedPreferences("npc_store", Context.MODE_PRIVATE)
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    constructor(context: Context, settingsManager: SettingsManager) : this(
+        prefs = context.applicationContext.getSharedPreferences("npc_store", Context.MODE_PRIVATE),
+        settingsState = settingsManager.state,
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+    )
     private val baseUrl = "https://npubx.cash"
     private val domain = "npubx.cash"
-    private val refreshIntervalMillis = 120_000L
     private var refreshJob: Job? = null
     private var paymentCheckJob: Job? = null
-    private val connectionMutex = Mutex()
-    private var client: NpubCashClient? = null
+    private var connectionAttempt: Deferred<Unit>? = null
+    private var sessionGeneration = 0L
+    private var client: NPCClient? = null
     private var nostrSecretKey: String? = null
     private var nostrPublicKey: String? = null
     var quoteClaimHandler: NPCQuoteClaimHandler? = null
@@ -75,7 +90,7 @@ class NPCService(
 
     init {
         scope.launch {
-            settingsManager.state.collect {
+            settingsState.collect {
                 applyPollingPreferences()
             }
         }
@@ -86,11 +101,13 @@ class NPCService(
      * NIP-06 key from the 64-byte BIP39 seed, not from the wallet's legacy
      * Nostr/P2PK key.
      */
-    fun initializeWithSeed(seed: ByteArray) {
-        val secretKey = npubcashDeriveSecretKeyFromSeed(seed)
-        val publicKey = npubcashGetPubkey(secretKey)
+    // Wallet setup also calls this from IO; publish keys and session changes
+    // on the same dispatcher that owns connection and polling jobs.
+    suspend fun initializeWithSeed(seed: ByteArray) = withContext(scope.coroutineContext.minusKey(Job)) {
+        val (secretKey, publicKey) = deriveKeys(seed)
         val npub = Bech32.encode("npub", NostrService.hexToBytes(publicKey))
 
+        if (nostrSecretKey != secretKey) disconnect()
         nostrSecretKey = secretKey
         nostrPublicKey = publicKey
         update {
@@ -100,16 +117,25 @@ class NPCService(
                 errorMessage = null,
             )
         }
-        if (mutableState.value.isEnabled) scope.launch { connect() }
+        initializeIfEnabled()
     }
 
     fun setEnabled(value: Boolean) {
+        if (mutableState.value.isEnabled == value) return
         prefs.edit().putBoolean(StorageKeys.npcEnabled, value).apply()
         update { copy(isEnabled = value, errorMessage = null) }
         if (value) {
-            scope.launch { connect() }
+            initializeIfEnabled()
         } else {
             disconnect()
+        }
+    }
+
+    /** Recover an enabled address on startup, foreground, or settings entry. */
+    fun initializeIfEnabled() {
+        scope.launch {
+            connect()
+            applyPollingPreferences()
         }
     }
 
@@ -120,11 +146,15 @@ class NPCService(
 
     fun changeMint(mintUrl: String) {
         scope.launch {
+            if (!mutableState.value.isEnabled) return@launch
+            val session = sessionGeneration
             update { copy(isLoading = true, errorMessage = null) }
             val result = runCatching {
-                if (client == null) connect()
+                connect()
+                if (!isCurrentSession(session)) throw CancellationException()
                 setRemoteMint(mintUrl)
             }
+            if (!isCurrentSession(session)) return@launch
             result.onSuccess { selected ->
                 prefs.edit().putString(StorageKeys.npcSelectedMint, selected).apply()
                 update {
@@ -137,6 +167,7 @@ class NPCService(
                     )
                 }
             }.onFailure { error ->
+                if (error is CancellationException) throw error
                 update {
                     copy(
                         isLoading = false,
@@ -152,8 +183,8 @@ class NPCService(
         paymentCheckJob = scope.launch { checkAndClaimPaymentsNow() }
     }
 
-    fun resetForWalletBoundary() {
-        stopBackgroundRefresh()
+    suspend fun resetForWalletBoundary() = withContext(scope.coroutineContext.minusKey(Job)) {
+        disconnect()
         prefs.edit()
             .remove(StorageKeys.npcEnabled)
             .remove(StorageKeys.npcAutomaticClaim)
@@ -161,94 +192,104 @@ class NPCService(
             .remove(StorageKeys.npcLastCheck)
             .apply()
         mutableState.value = NPCState()
-        client?.close()
-        client = null
         nostrSecretKey = null
         nostrPublicKey = null
     }
 
-    private suspend fun connect() {
-        connectionMutex.withLock {
-            val current = mutableState.value
-            val secretKey = nostrSecretKey
-            if (!current.isEnabled || !current.isInitialized || secretKey == null) {
-                update {
-                    copy(
-                        isConnected = false,
-                        // Key setup follows wallet-runtime initialization. This is a
-                        // readiness state, not a connection failure; the settings UI
-                        // can distinguish active setup from a setup that needs retrying.
-                        errorMessage = null,
-                    )
-                }
-                return@withLock
-            }
-            client?.close()
-            client = null
-            update { copy(isConnected = false, isLoading = true, errorMessage = null) }
-            val result = runCatching {
-                val connectedClient = NpubCashClient(baseUrl = baseUrl, nostrSecretKey = secretKey)
+    internal suspend fun connect() {
+        val current = mutableState.value
+        val secretKey = nostrSecretKey
+        if (!current.isEnabled || !current.isInitialized || secretKey == null) return
+        if (current.isConnected && client != null) return
+        connectionAttempt?.let { it.await(); return }
+
+        val session = sessionGeneration
+        update { copy(isConnected = false, isLoading = true, errorMessage = null) }
+        // Install the handle before execution, including on Main.immediate.
+        val attempt = scope.async(start = CoroutineStart.LAZY) {
+            establishConnection(secretKey, session)
+        }
+        connectionAttempt = attempt
+        attempt.await()
+    }
+
+    private suspend fun establishConnection(secretKey: String, session: Long) {
+        var candidate: NPCClient? = null
+        try {
+            val connectedClient = makeClient(baseUrl, secretKey)
+            candidate = connectedClient
+            val quotes = connectedClient.getQuotes()
+            currentCoroutineContext().ensureActive()
+            if (!isCurrentSession(session)) return
+            val selected = mutableState.value.selectedMintUrl
+            val configured = if (selected != null) {
                 try {
-                    val quotes = connectedClient.getQuotes(since = null).map(::fromCdkQuote)
-                    val selected = mutableState.value.selectedMintUrl
-                    val configured = if (selected != null) {
-                        runCatching { connectedClient.setMintUrl(mintUrl = selected) }
-                            .getOrNull()
-                            ?.takeUnless { it.error }
-                            ?.mintUrl
-                            ?: selected
-                    } else {
-                        quotes.firstNotNullOfOrNull { it.mintUrl }.orEmpty()
-                    }
-                    ConnectedNPCClient(connectedClient, configured)
-                } catch (error: Throwable) {
-                    connectedClient.close()
+                    connectedClient.setMintUrl(selected)
+                } catch (error: CancellationException) {
                     throw error
+                } catch (_: Exception) {
+                    selected
                 }
+            } else {
+                quotes.firstNotNullOfOrNull { it.mintUrl }.orEmpty()
             }
-            val connected = result.getOrElse { error ->
-                update {
-                    copy(
-                        isConnected = false,
-                        isLoading = false,
-                        errorMessage = error.message ?: "Not connected to npub.cash.",
-                    )
-                }
-                return@withLock
-            }
-            if (!mutableState.value.isEnabled || nostrSecretKey != secretKey) {
-                connected.client.close()
-                update { copy(isConnected = false, isLoading = false) }
-                return@withLock
-            }
-            client = connected.client
+            currentCoroutineContext().ensureActive()
+            if (!isCurrentSession(session)) return
+            client = connectedClient
+            candidate = null // Ownership passes to the active session.
             update {
-                copy(
-                    configuredMintUrl = connected.configuredMintUrl,
-                    isConnected = true,
-                    isLoading = false,
-                    errorMessage = null,
-                )
+                copy(configuredMintUrl = configured, isConnected = true, errorMessage = null)
             }
-            applyPollingPreferences()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            if (!isCurrentSession(session)) return
+            update {
+                copy(isConnected = false, errorMessage = error.message ?: "Not connected to npub.cash.")
+            }
+        } finally {
+            candidate?.close()
+            if (isCurrentSession(session)) {
+                connectionAttempt = null
+                update { copy(isLoading = false) }
+                applyPollingPreferences()
+            }
         }
     }
 
+    private fun isCurrentSession(session: Long): Boolean =
+        mutableState.value.isEnabled && sessionGeneration == session
+
     private fun disconnect() {
+        sessionGeneration += 1
+        connectionAttempt?.cancel()
+        connectionAttempt = null
+        paymentCheckJob?.cancel()
+        paymentCheckJob = null
         stopBackgroundRefresh()
         client?.close()
         client = null
-        update { copy(isConnected = false, isLoading = false, pendingPaidQuotes = emptyList()) }
+        update {
+            copy(
+                isConnected = false,
+                isLoading = false,
+                isCheckingPayments = false,
+                errorMessage = null,
+                pendingPaidQuotes = emptyList(),
+            )
+        }
     }
 
     private suspend fun checkAndClaimPaymentsNow() {
-        val settings = settingsManager.state.value
+        val settings = settingsState.value
         if (!mutableState.value.isEnabled || !settings.checkIncomingInvoices) return
+        val session = sessionGeneration
         if (!mutableState.value.isConnected) connect()
-        if (!mutableState.value.isConnected) return
+        if (!isCurrentSession(session) || !mutableState.value.isConnected) return
 
         update { copy(isCheckingPayments = true, errorMessage = null) }
         val result = runCatching { fetchQuotes() }
+        if (!isCurrentSession(session)) return
         result.onSuccess { quotes ->
             val now = System.currentTimeMillis()
             prefs.edit().putLong(StorageKeys.npcLastCheck, now).apply()
@@ -261,10 +302,11 @@ class NPCService(
                 processedQuoteIds = processedQuoteIds,
             )
             val claimFailures = if (mutableState.value.automaticClaim) {
-                claimPaidQuotes(paidQuotes, handler)
+                claimPaidQuotes(paidQuotes, handler, session)
             } else {
                 paidQuotes
             }
+            if (!isCurrentSession(session)) return
             update {
                 copy(
                     lastCheckEpochMillis = now,
@@ -278,8 +320,15 @@ class NPCService(
                 )
             }
         }.onFailure { error ->
+            if (error is CancellationException) {
+                update { copy(isCheckingPayments = false) }
+                throw error
+            }
+            client?.close()
+            client = null
             update {
                 copy(
+                    isConnected = false,
                     isCheckingPayments = false,
                     errorMessage = error.message ?: "Failed to check npub.cash payments.",
                 )
@@ -290,11 +339,20 @@ class NPCService(
     private suspend fun claimPaidQuotes(
         paidQuotes: List<NPCQuote>,
         handler: NPCQuoteClaimHandler?,
+        session: Long,
     ): List<NPCQuote> {
         if (handler == null) return paidQuotes
         return paidQuotes.filterNot { quote ->
-            runCatching { handler.claimNPCQuote(quote, p2pkPublicKeyFor(quote)) }
-                .getOrDefault(false) || handler.isNPCQuoteProcessed(quote.id)
+            currentCoroutineContext().ensureActive()
+            if (!isCurrentSession(session)) return emptyList()
+            val claimed = try {
+                handler.claimNPCQuote(quote, p2pkPublicKeyFor(quote))
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                false
+            }
+            claimed || handler.isNPCQuoteProcessed(quote.id)
         }
     }
 
@@ -305,11 +363,11 @@ class NPCService(
     }
 
     private fun applyPollingPreferences() {
-        val settings = settingsManager.state.value
+        val settings = settingsState.value
         val state = mutableState.value
         val shouldRun = shouldRunPeriodicInvoiceChecks(
             isEnabled = state.isEnabled,
-            isConnected = state.isConnected,
+            isInitialized = state.isInitialized,
             checkIncomingInvoices = settings.checkIncomingInvoices,
             periodicallyCheckIncomingInvoices = settings.periodicallyCheckIncomingInvoices,
         )
@@ -319,9 +377,11 @@ class NPCService(
         }
         if (refreshJob?.isActive == true) return
         refreshJob = scope.launch {
+            // Delay after failure so recovery never recursively retries.
+            if (mutableState.value.isConnected) checkAndClaimPayments()
             while (isActive) {
-                checkAndClaimPaymentsNow()
                 delay(refreshIntervalMillis)
+                checkAndClaimPayments()
             }
         }
     }
@@ -333,14 +393,12 @@ class NPCService(
 
     private suspend fun fetchQuotes(): List<NPCQuote> {
         val connectedClient = client ?: error("Not connected to npub.cash.")
-        return connectedClient.getQuotes(since = null).map(::fromCdkQuote)
+        return connectedClient.getQuotes()
     }
 
     private suspend fun setRemoteMint(mintUrl: String): String {
         val connectedClient = client ?: error("Not connected to npub.cash.")
-        val response = connectedClient.setMintUrl(mintUrl = mintUrl)
-        if (response.error) error("Failed to change mint.")
-        return response.mintUrl ?: mintUrl
+        return connectedClient.setMintUrl(mintUrl)
     }
 
     private fun loadInitialState(): NPCState {
@@ -382,15 +440,10 @@ class NPCService(
 
         internal fun shouldRunPeriodicInvoiceChecks(
             isEnabled: Boolean,
-            isConnected: Boolean,
+            isInitialized: Boolean,
             checkIncomingInvoices: Boolean,
             periodicallyCheckIncomingInvoices: Boolean,
-        ): Boolean = isEnabled && isConnected && checkIncomingInvoices && periodicallyCheckIncomingInvoices
+        ): Boolean = isEnabled && isInitialized && checkIncomingInvoices && periodicallyCheckIncomingInvoices
 
     }
-
-    private data class ConnectedNPCClient(
-        val client: NpubCashClient,
-        val configuredMintUrl: String,
-    )
 }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -881,6 +881,7 @@ class WalletManager(
         if (!pollQuotesInForeground) return
         startPendingQuoteForegroundPolling()
         if (!mutableState.value.isRuntimeReady) return
+        npcService.initializeIfEnabled()
         scope.launch {
             try {
                 syncPendingMintQuotesIfStale()

--- a/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/LightningScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -112,6 +113,7 @@ fun LightningScreen(
     val npcState by npcService.state.collectAsState()
     val settings by settingsManager.state.collectAsState()
     val scope = rememberCoroutineScope()
+    LaunchedEffect(npcService) { npcService.initializeIfEnabled() }
 
     var mintPickerOpen by remember { mutableStateOf(false) }
     var addressQrOpen by remember { mutableStateOf(false) }
@@ -421,5 +423,9 @@ private fun npcStatusColor(state: NPCState): Color {
     }
 }
 
-private fun npcStatusLabel(state: NPCState): String =
-    state.errorMessage ?: if (state.isConnected) "Connected" else "Connecting"
+internal fun npcStatusLabel(state: NPCState): String =
+    state.errorMessage ?: when {
+        state.isConnected -> "Connected"
+        state.isLoading -> "Connecting"
+        else -> "Not connected"
+    }

--- a/android/app/src/test/java/com/cashu/me/Core/NPCConnectionLifecycleTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NPCConnectionLifecycleTest.kt
@@ -1,0 +1,254 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Protocols.StorageKeys
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Assert.*
+import org.junit.Test
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class NPCConnectionLifecycleTest {
+    @Test(timeout = 10_000)
+    fun restoredEnabledAddressConnectsAfterSeedIsAvailable() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val connection = async { fixture.service.connect() }
+            fixture.client.complete()
+            connection.await()
+            assertTrue(fixture.service.state.value.isConnected)
+            assertFalse(fixture.service.state.value.isLoading)
+            assertEquals(1, fixture.clientsCreated)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun disabledAddressDoesNotConnectOnStartupOrForeground() = runBlocking {
+        val fixture = Fixture(this, enabled = false)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.service.initializeIfEnabled()
+            yield()
+            assertEquals(0, fixture.clientsCreated)
+            assertFalse(fixture.service.state.value.isConnected)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun enablingBeforeKeySetupConnectsWhenSeedArrives() = runBlocking {
+        val fixture = Fixture(this, enabled = false)
+        try {
+            fixture.service.setEnabled(true)
+            yield()
+            assertEquals(0, fixture.clientsCreated)
+            assertNull(fixture.service.state.value.errorMessage)
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val connection = async { fixture.service.connect() }
+            fixture.client.complete()
+            connection.await()
+            assertTrue(fixture.service.state.value.isConnected)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun concurrentAndRepeatedRecoveryShareOneConnection() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val first = async { fixture.service.connect() }
+            val second = async { fixture.service.connect() }
+            yield()
+            assertEquals(1, fixture.clientsCreated)
+            fixture.client.complete()
+            first.await()
+            second.await()
+            fixture.service.connect()
+            assertEquals(1, fixture.clientsCreated)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun failedStartupRecoversWithoutToggling() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val initial = async { fixture.service.connect() }
+            yield()
+            val failed = fixture.client
+            failed.fail()
+            initial.await()
+            assertFalse(fixture.service.state.value.isConnected)
+            assertNotNull(fixture.service.state.value.errorMessage)
+            assertTrue(failed.closed)
+
+            fixture.service.initializeIfEnabled()
+            val recovered = async { fixture.service.connect() }
+            yield()
+            fixture.awaitRequest()
+            fixture.client.complete()
+            recovered.await()
+            assertTrue(fixture.service.state.value.isConnected)
+            assertTrue(fixture.service.state.value.isEnabled)
+            assertNull(fixture.service.state.value.errorMessage)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun lateSuccessCannotReconnectDisabledService() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            fixture.service.setEnabled(false)
+            fixture.client.complete()
+            yield()
+            assertFalse(fixture.service.state.value.isConnected)
+            assertFalse(fixture.service.state.value.isLoading)
+            assertNull(fixture.service.state.value.errorMessage)
+            assertTrue(fixture.client.closed)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun lateFailureCannotOverwriteNewWalletConnection() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val old = fixture.client
+            fixture.service.resetForWalletBoundary()
+            fixture.service.initializeWithSeed(byteArrayOf(2))
+            fixture.service.setEnabled(true)
+            yield()
+            fixture.awaitRequest()
+            val connection = async { fixture.service.connect() }
+            fixture.client.complete()
+            connection.await()
+            val address = fixture.service.state.value.lightningAddress
+            old.fail()
+            yield()
+            assertTrue(fixture.service.state.value.isConnected)
+            assertFalse(fixture.service.state.value.isLoading)
+            assertNull(fixture.service.state.value.errorMessage)
+            assertEquals(address, fixture.service.state.value.lightningAddress)
+            assertTrue(old.closed)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun disabledAndReenabledSessionIgnoresOldSuccessEvenWithSameKeys() = runBlocking {
+        val fixture = Fixture(this)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val old = fixture.client
+            fixture.service.setEnabled(false)
+            fixture.service.setEnabled(true)
+            yield()
+            fixture.awaitRequest()
+            old.complete()
+            yield()
+            assertFalse(fixture.service.state.value.isConnected)
+            assertTrue(fixture.service.state.value.isLoading)
+            val connection = async { fixture.service.connect() }
+            fixture.client.complete()
+            connection.await()
+            assertTrue(fixture.service.state.value.isConnected)
+        } finally { fixture.close() }
+    }
+
+    @Test(timeout = 10_000)
+    fun periodicChecksRetryFailedStartup() = runBlocking {
+        val fixture = Fixture(this, periodicChecks = true)
+        try {
+            fixture.service.initializeWithSeed(byteArrayOf(1))
+            fixture.awaitRequest()
+            val initial = async { fixture.service.connect() }
+            yield()
+            fixture.client.fail()
+            initial.await()
+            assertFalse(fixture.service.state.value.isConnected)
+
+            // No foreground or UI trigger: the periodic job must initiate recovery.
+            fixture.awaitRequest()
+            val retry = async { fixture.service.connect() }
+            fixture.client.complete()
+            retry.await()
+            assertTrue(fixture.service.state.value.isConnected)
+            assertNull(fixture.service.state.value.errorMessage)
+        } finally { fixture.close() }
+    }
+
+    private class Fixture(parent: CoroutineScope, enabled: Boolean = true, periodicChecks: Boolean = false) {
+        private val scope = CoroutineScope(parent.coroutineContext + SupervisorJob(parent.coroutineContext[Job]))
+        var client = ControlledClient()
+        private val clients = mutableListOf(client)
+        private val created = Channel<ControlledClient>(Channel.UNLIMITED)
+        var clientsCreated = 0
+        val service = NPCService(
+            prefs = InMemorySharedPreferences(mutableMapOf(StorageKeys.npcEnabled to enabled)),
+            settingsState = MutableStateFlow(SettingsState(checkIncomingInvoices = periodicChecks)),
+            refreshIntervalMillis = 10,
+            scope = scope,
+            makeClient = { _, _ ->
+                if (clientsCreated > 0) {
+                    client = ControlledClient()
+                    clients += client
+                }
+                clientsCreated += 1
+                created.trySend(client)
+                client
+            },
+            deriveKeys = { seed -> seed.first().toString() to "01".repeat(32) },
+        )
+        suspend fun awaitRequest() {
+            created.receive().started.receive()
+        }
+        suspend fun close() {
+            service.resetForWalletBoundary()
+            clients.forEach { it.complete() }
+            scope.cancel()
+        }
+    }
+
+    /** Deliberately ignores cancellation, like a late native/network callback. */
+    private class ControlledClient : NPCClient {
+        val started = Channel<Unit>(Channel.UNLIMITED)
+        var closed = false
+        private var continuation: Continuation<List<NPCQuote>>? = null
+        private var requestCount = 0
+        override suspend fun getQuotes(): List<NPCQuote> {
+            requestCount += 1
+            if (requestCount > 1) return emptyList()
+            return suspendCoroutine {
+                continuation = it
+                started.trySend(Unit)
+            }
+        }
+        fun complete() {
+            val pending = continuation
+            continuation = null
+            pending?.resumeWith(Result.success(emptyList()))
+        }
+        fun fail() {
+            val pending = continuation
+            continuation = null
+            pending?.resumeWithException(IllegalStateException("Offline"))
+        }
+        override suspend fun setMintUrl(mintUrl: String): String = mintUrl
+        override fun close() { closed = true }
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
@@ -99,7 +99,7 @@ class NPCServiceTest {
         assertTrue(
             NPCService.shouldRunPeriodicInvoiceChecks(
                 isEnabled = true,
-                isConnected = true,
+                isInitialized = true,
                 checkIncomingInvoices = true,
                 periodicallyCheckIncomingInvoices = true,
             ),
@@ -107,7 +107,7 @@ class NPCServiceTest {
         assertFalse(
             NPCService.shouldRunPeriodicInvoiceChecks(
                 isEnabled = true,
-                isConnected = true,
+                isInitialized = true,
                 checkIncomingInvoices = false,
                 periodicallyCheckIncomingInvoices = true,
             ),
@@ -115,7 +115,7 @@ class NPCServiceTest {
         assertFalse(
             NPCService.shouldRunPeriodicInvoiceChecks(
                 isEnabled = true,
-                isConnected = true,
+                isInitialized = true,
                 checkIncomingInvoices = true,
                 periodicallyCheckIncomingInvoices = false,
             ),
@@ -123,7 +123,7 @@ class NPCServiceTest {
         assertFalse(
             NPCService.shouldRunPeriodicInvoiceChecks(
                 isEnabled = false,
-                isConnected = true,
+                isInitialized = true,
                 checkIncomingInvoices = true,
                 periodicallyCheckIncomingInvoices = true,
             ),
@@ -131,7 +131,7 @@ class NPCServiceTest {
         assertFalse(
             NPCService.shouldRunPeriodicInvoiceChecks(
                 isEnabled = true,
-                isConnected = false,
+                isInitialized = false,
                 checkIncomingInvoices = true,
                 periodicallyCheckIncomingInvoices = true,
             ),

--- a/android/app/src/test/java/com/cashu/me/Core/PreferenceSnapshotTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/PreferenceSnapshotTest.kt
@@ -32,7 +32,7 @@ class PreferenceSnapshotTest {
     }
 }
 
-private class InMemorySharedPreferences(
+internal class InMemorySharedPreferences(
     private val values: MutableMap<String, Any> = mutableMapOf(),
 ) : SharedPreferences {
     override fun getAll(): MutableMap<String, *> = values.toMutableMap()

--- a/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSettingsCopyTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/settings/LightningAddressSettingsCopyTest.kt
@@ -6,6 +6,15 @@ import org.junit.Test
 
 class LightningAddressSettingsCopyTest {
     @Test
+    fun statusOnlySaysConnectingWhileARequestIsRunning() {
+        val state = com.cashu.me.Core.NPCState(isEnabled = true, isInitialized = true)
+        assertEquals("Not connected", npcStatusLabel(state))
+        assertEquals("Connecting", npcStatusLabel(state.copy(isLoading = true)))
+        assertEquals("Connected", npcStatusLabel(state.copy(isConnected = true)))
+        assertEquals("Offline", npcStatusLabel(state.copy(errorMessage = "Offline")))
+    }
+
+    @Test
     fun enableControlLeadsWithTheUserOutcome() {
         assertEquals(
             "Enable Lightning Address",

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA9600000000000000000001 /* NPCServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9600000000000000000002 /* NPCServiceTests.swift */; };
 		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
 		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
 		EA1850000000000000000001 /* PaymentDetailContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1850000000000000000002 /* PaymentDetailContent.swift */; };
@@ -201,6 +202,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA9600000000000000000002 /* NPCServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/NPCServiceTests.swift; sourceTree = "<group>"; };
 		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
 		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
 		EA1850000000000000000002 /* PaymentDetailContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailContent.swift; sourceTree = "<group>"; };
@@ -436,6 +438,7 @@
 				A09100000000000000000006 /* WalletAuditRegressionTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
+				AA9600000000000000000002 /* NPCServiceTests.swift */,
 				CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */,
 				SE00000000000013 /* SeedPhraseEntryTests.swift */,
 				T1B0000000000010 /* WalletSurfaceCoordinatorTests.swift */,
@@ -1034,6 +1037,7 @@
 				A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
+				AA9600000000000000000001 /* NPCServiceTests.swift in Sources */,
 				CD9100000000000000000003 /* MintDetailInfoLoaderTests.swift in Sources */,
 				SE00000000000003 /* SeedPhraseEntryTests.swift in Sources */,
 				T2B0000000000010 /* WalletSurfaceCoordinatorTests.swift in Sources */,

--- a/ios/CashuWallet/App/CashuWalletApp.swift
+++ b/ios/CashuWallet/App/CashuWalletApp.swift
@@ -120,9 +120,8 @@ struct CashuWalletApp: App {
                     Task { await walletManager.syncPendingMintQuotesIfStale() }
                     Task { await walletManager.syncPendingMeltQuotes() }
                     Task { await NWCManager.shared.startIfEnabled() }
-                    // Re-arm the pollers stopped on `.background` (both are idempotent
-                    // and self-gate on their enabled/connected state).
-                    NPCService.shared.applyPollingPreferences()
+                    // Recover enabled services and re-arm polling after backgrounding.
+                    Task { await NPCService.shared.initializeIfEnabled() }
                     if PriceService.shared.isEnabled {
                         PriceService.shared.startAutoRefresh()
                     }

--- a/ios/CashuWallet/Core/NPCService.swift
+++ b/ios/CashuWallet/Core/NPCService.swift
@@ -12,6 +12,7 @@ class NPCService: ObservableObject {
     
     @Published var isEnabled: Bool {
         didSet {
+            guard isEnabled != oldValue else { return }
             settingsStore.npcEnabled = isEnabled
             if isEnabled {
                 Task { await connect() }
@@ -59,13 +60,16 @@ class NPCService: ObservableObject {
     
     // MARK: - Private
     
-    private var client: NpubCashClient?
+    private var client: (any NpubCashClientProtocol)?
+    private var connectionTask: Task<Void, Never>?
+    private var sessionID = UUID()
+    private let makeClient: (String, String) throws -> any NpubCashClientProtocol
     private var nostrSecretKey: String?
     private var nostrPubkey: String?
     private var refreshTimer: Timer?
     private var paymentCheckInProgress = false
-    private let settingsStore = SettingsStore.shared
-    private let refreshInterval: TimeInterval = 120  // Check every 2 minutes
+    private let settingsStore: SettingsStore
+    private let refreshInterval: TimeInterval
     private var shouldCheckIncomingInvoices: Bool {
         settingsStore.checkIncomingInvoices
     }
@@ -75,7 +79,16 @@ class NPCService: ObservableObject {
     
     // MARK: - Initialization
     
-    private init() {
+    init(
+        settingsStore: SettingsStore = .shared,
+        refreshInterval: TimeInterval = 120,
+        makeClient: @escaping (String, String) throws -> any NpubCashClientProtocol = {
+            try NpubCashClient(baseUrl: $0, nostrSecretKey: $1)
+        }
+    ) {
+        self.settingsStore = settingsStore
+        self.refreshInterval = refreshInterval
+        self.makeClient = makeClient
         self.isEnabled = settingsStore.npcEnabled
         self.automaticClaim = settingsStore.npcAutomaticClaim
         self.selectedMintUrl = settingsStore.npcSelectedMint
@@ -85,11 +98,10 @@ class NPCService: ObservableObject {
     /// Initialize connection on app startup if enabled
     /// Should be called after wallet seed is available
     func initializeIfEnabled() async {
-        if isEnabled {
-            await connect()
-        }
+        await connect()
+        applyPollingPreferences()
     }
-    
+
     // MARK: - Key Derivation
     
     /// Initialize with wallet seed
@@ -101,11 +113,19 @@ class NPCService: ObservableObject {
         // Convert hex pubkey to bech32 npub format for Lightning address
         let npub = try hexToNpub(derivedPubkey)
         
+        if nostrSecretKey != derivedSecretKey {
+            disconnect()
+            configuredMintUrl = ""
+        }
         nostrSecretKey = derivedSecretKey
         nostrPubkey = derivedPubkey
         lightningAddress = "\(npub)@\(domain)"
         
-        print("NPC: Initialized with npub: \(npub.prefix(20))...")
+        // Restored settings do not invoke isEnabled.didSet. Start only after
+        // keys exist, without blocking local wallet startup on the network.
+        if isEnabled {
+            Task { await initializeIfEnabled() }
+        }
     }
     
     /// Get the npub (bech32 public key) for display
@@ -140,63 +160,75 @@ class NPCService: ObservableObject {
     
     // MARK: - Connection
     
-    /// Initialize NPC connection
+    /// Share one attempt across startup, foreground, settings, and payment checks.
     func connect() async {
-        guard isEnabled else { return }
-        
-        guard let secretKey = nostrSecretKey else {
-            errorMessage = "Nostr keys not initialized"
+        guard isEnabled, let secretKey = nostrSecretKey else { return }
+        if isConnected, client != nil { return }
+        if let connectionTask {
+            await connectionTask.value
             return
         }
-        
+
+        let session = sessionID
         isLoading = true
         errorMessage = nil
-        
-        defer { isLoading = false }
-        
+        let task = Task { await establishConnection(secretKey: secretKey, session: session) }
+        connectionTask = task
+        await task.value
+    }
+
+    private func establishConnection(secretKey: String, session: UUID) async {
+        defer {
+            if sessionID == session {
+                connectionTask = nil
+                isLoading = false
+            }
+        }
+        guard isCurrentSession(session), !Task.isCancelled else { return }
         do {
-            // Create NpubCashClient with CDK.
-            let connectedClient = try NpubCashClient(baseUrl: baseURL, nostrSecretKey: secretKey)
-            client = connectedClient
-            
-            // Try to get user info by fetching quotes (this validates connection)
-            // The client handles authentication internally
+            let connectedClient = try makeClient(baseURL, secretKey)
             let quotes = try await connectedClient.getQuotes(since: nil)
-            print("NPC: Connected successfully, found \(quotes.count) quotes")
-            
-            // Reconcile the server-side mint with the local selection. The server
-            // falls back to its own default mint for accounts that never set one,
-            // so re-assert the user's choice on every connect.
+            guard isCurrentSession(session), !Task.isCancelled else { return }
+
+            var configured = quotes.compactMap(\.mintUrl).first ?? ""
             if let selected = selectedMintUrl {
                 do {
                     let response = try await connectedClient.setMintUrl(mintUrl: selected)
                     if !response.error, let confirmed = response.mintUrl {
-                        configuredMintUrl = confirmed
+                        configured = confirmed
                     }
                 } catch {
+                    // A mint reconciliation failure does not invalidate authentication.
                     print("NPC: mint reconciliation failed: \(error)")
                 }
-            } else if let firstQuote = quotes.first, let mintUrl = firstQuote.mintUrl {
-                // No local choice yet: surface the server's mint for display,
-                // but don't persist it as if the user picked it.
-                configuredMintUrl = mintUrl
             }
-            
+            guard isCurrentSession(session), !Task.isCancelled else { return }
+            client = connectedClient
+            configuredMintUrl = configured
             isConnected = true
             errorMessage = nil
-            
-            // Start background refresh
             startBackgroundRefresh()
-            
         } catch {
-            errorMessage = error.userFacingWalletMessage
-            print("NPC connection error: \(error)")
+            guard isCurrentSession(session), !Task.isCancelled else { return }
+            client = nil
             isConnected = false
+            errorMessage = error.userFacingWalletMessage
+            // Keep periodic recovery available after a failed initial attempt.
+            startBackgroundRefresh()
         }
     }
-    
+
+    private func isCurrentSession(_ session: UUID) -> Bool {
+        isEnabled && sessionID == session
+    }
+
     /// Disconnect and stop background refresh
     func disconnect() {
+        sessionID = UUID()
+        connectionTask?.cancel()
+        connectionTask = nil
+        isLoading = false
+        paymentCheckInProgress = false
         stopBackgroundRefresh()
         isConnected = false
         client = nil
@@ -211,14 +243,13 @@ class NPCService: ObservableObject {
     /// Local selection is only persisted once the server confirms the change,
     /// otherwise incoming payments keep landing on the server's default mint.
     func changeMint(to mintUrl: String) async throws {
-        if client == nil {
-            await connect()
-        }
-        guard let client = client else {
-            throw NPCError.notConnected
-        }
+        let session = sessionID
+        await connect()
+        guard isCurrentSession(session) else { throw CancellationError() }
+        guard let client, isConnected else { throw NPCError.notConnected }
 
         let response = try await client.setMintUrl(mintUrl: mintUrl)
+        guard isCurrentSession(session) else { throw CancellationError() }
 
         if response.error {
             throw NPCError.apiError("Failed to change mint")
@@ -244,17 +275,21 @@ class NPCService: ObservableObject {
         guard isEnabled, shouldCheckIncomingInvoices else { return }
         guard !paymentCheckInProgress else { return }
 
+        let session = sessionID
         paymentCheckInProgress = true
-        defer { paymentCheckInProgress = false }
+        defer {
+            if sessionID == session { paymentCheckInProgress = false }
+        }
 
         if !isConnected || client == nil {
             await connect()
         }
 
-        guard isConnected, client != nil else { return }
+        guard isCurrentSession(session), isConnected, client != nil else { return }
         
         do {
             let quotes = try await getQuotes(since: nil)
+            guard isCurrentSession(session), !Task.isCancelled else { return }
             lastCheck = Date()
             errorMessage = nil
             
@@ -266,6 +301,7 @@ class NPCService: ObservableObject {
                 }
             
             for quote in paidQuotes {
+                guard isCurrentSession(session), !Task.isCancelled else { return }
                 if automaticClaim {
                     await claimQuote(quote)
                 } else {
@@ -275,6 +311,9 @@ class NPCService: ObservableObject {
             }
             
         } catch {
+            guard isCurrentSession(session), !Task.isCancelled else { return }
+            isConnected = false
+            client = nil
             errorMessage = error.userFacingWalletMessage
             print("Failed to check NPC payments: \(error)")
         }
@@ -321,10 +360,12 @@ class NPCService: ObservableObject {
     func startBackgroundRefresh() {
         stopBackgroundRefresh()
 
-        guard shouldCheckIncomingInvoices else { return }
+        guard isEnabled, isInitialized, shouldCheckIncomingInvoices else { return }
 
-        // Initial check
-        Task { await checkAndClaimPayments() }
+        // A failed connection waits for the timer; do not immediately recurse.
+        if isConnected {
+            Task { await checkAndClaimPayments() }
+        }
 
         guard shouldPeriodicallyCheckIncomingInvoices else { return }
 
@@ -342,7 +383,7 @@ class NPCService: ObservableObject {
     }
 
     func applyPollingPreferences() {
-        guard isEnabled, isConnected else {
+        guard isEnabled, isInitialized else {
             stopBackgroundRefresh()
             return
         }

--- a/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
@@ -63,6 +63,7 @@ struct LightningAddressSettingsSection: View {
                 }
             }
         }
+        .task { await npcService.initializeIfEnabled() }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: npcService.isEnabled)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: npcService.errorMessage)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: settings.checkIncomingInvoices)
@@ -77,6 +78,8 @@ struct LightningAddressSettingsSection: View {
                     Task {
                         do {
                             try await npcService.changeMint(to: mintUrl)
+                        } catch is CancellationError {
+                            // The address was disabled or the wallet changed.
                         } catch {
                             npcService.errorMessage = error.userFacingWalletMessage
                         }
@@ -164,7 +167,8 @@ struct LightningAddressSettingsSection: View {
 
     private var statusLabel: String {
         if let error = npcService.errorMessage { return error }
-        return npcService.isConnected ? "Connected" : "Connecting"
+        if npcService.isConnected { return "Connected" }
+        return npcService.isLoading ? "Connecting" : "Not connected"
     }
 
     // MARK: - Receiving Mint row

--- a/ios/CashuWalletTests/NPCServiceTests.swift
+++ b/ios/CashuWalletTests/NPCServiceTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+import Cdk
+@testable import CashuWallet
+
+@MainActor
+final class NPCServiceTests: XCTestCase {
+    func testRestoredEnabledAddressConnectsWhenSeedBecomesAvailable() async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client)
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let connection = Task { await service.connect() }
+        client.complete(.success([]))
+        await connection.value
+
+        XCTAssertTrue(service.isConnected)
+        XCTAssertFalse(service.isLoading)
+        XCTAssertNil(service.errorMessage)
+        XCTAssertEqual(client.requestCount, 1)
+        service.disconnect()
+    }
+
+    func testDisabledAddressDoesNotConnectAtStartupOrForeground() async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client, enabled: false)
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await service.initializeIfEnabled()
+        XCTAssertEqual(client.requestCount, 0)
+        XCTAssertFalse(service.isConnected)
+    }
+
+    func testEnablingBeforeKeysAreReadyWaitsForSeed() async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client, enabled: false)
+        service.isEnabled = true
+        await service.connect()
+        XCTAssertNil(service.errorMessage)
+        XCTAssertEqual(client.requestCount, 0)
+
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let connection = Task { await service.connect() }
+        client.complete(.success([]))
+        await connection.value
+        XCTAssertTrue(service.isConnected)
+        service.disconnect()
+    }
+
+    func testConcurrentAndRepeatedRecoveryShareConnection() async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client)
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let first = Task { await service.initializeIfEnabled() }
+        let second = Task { await service.connect() }
+        await Task.yield()
+        XCTAssertEqual(client.requestCount, 1)
+        client.complete(.success([]))
+        await first.value
+        await second.value
+        await service.initializeIfEnabled()
+        XCTAssertEqual(client.requestCount, 1)
+        XCTAssertTrue(service.isConnected)
+        service.disconnect()
+    }
+
+    func testFailedStartupCanRecoverWithoutTogglingAddress() async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client)
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let initial = Task { await service.connect() }
+        await Task.yield()
+        client.complete(.failure(URLError(.notConnectedToInternet)))
+        await initial.value
+        XCTAssertFalse(service.isConnected)
+        XCTAssertFalse(service.isLoading)
+        XCTAssertNotNil(service.errorMessage)
+
+        let foreground = Task { await service.initializeIfEnabled() }
+        await client.nextRequest()
+        client.complete(.success([]))
+        await foreground.value
+        XCTAssertTrue(service.isEnabled)
+        XCTAssertTrue(service.isConnected)
+        XCTAssertNil(service.errorMessage)
+        service.disconnect()
+    }
+
+    func testLateSuccessCannotReconnectDisabledAddress() async throws {
+        try await assertLateResponseIgnored(.success([]))
+    }
+
+    func testLateFailureCannotPublishErrorAfterDisable() async throws {
+        try await assertLateResponseIgnored(.failure(URLError(.timedOut)))
+    }
+
+    func testOldConnectionCannotOverwriteNewWalletSession() async throws {
+        let oldClient = ControlledNPCClient()
+        let newClient = ControlledNPCClient()
+        var clients = [oldClient, newClient]
+        let settings = makeSettings(enabled: true)
+        let service = NPCService(settingsStore: settings, makeClient: { _, _ in clients.removeFirst() })
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await oldClient.nextRequest()
+        let oldConnection = Task { await service.connect() }
+        await Task.yield()
+        service.resetForWalletBoundary()
+        try service.initializeWithSeed(Data(repeating: 2, count: 64))
+        service.isEnabled = true
+        await newClient.nextRequest()
+        let newConnection = Task { await service.connect() }
+        newClient.complete(.success([]))
+        await newConnection.value
+        let address = service.lightningAddress
+
+        oldClient.complete(.failure(URLError(.timedOut)))
+        await oldConnection.value
+        XCTAssertTrue(service.isConnected)
+        XCTAssertFalse(service.isLoading)
+        XCTAssertNil(service.errorMessage)
+        XCTAssertEqual(service.lightningAddress, address)
+        service.disconnect()
+    }
+
+    func testPeriodicChecksRetryFailedStartup() async throws {
+        let client = ControlledNPCClient()
+        client.automaticResponsesAfter = 2
+        let settings = makeSettings(enabled: true)
+        settings.checkIncomingInvoices = true
+        settings.periodicallyCheckIncomingInvoices = true
+        let service = NPCService(settingsStore: settings, refreshInterval: 0.01, makeClient: { _, _ in client })
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let initial = Task { await service.connect() }
+        await Task.yield()
+        client.complete(.failure(URLError(.notConnectedToInternet)))
+        await initial.value
+        XCTAssertFalse(service.isConnected)
+
+        // The service's timer starts a new attempt without any foreground/UI call.
+        await client.nextRequest()
+        let retry = Task { await service.connect() }
+        client.complete(.success([]))
+        await retry.value
+        XCTAssertTrue(service.isConnected)
+        XCTAssertNil(service.errorMessage)
+        service.disconnect()
+    }
+
+    func testRapidDisableAndEnableIgnoresOldSuccessWithSameKeys() async throws {
+        let oldClient = ControlledNPCClient()
+        let newClient = ControlledNPCClient()
+        var clients = [oldClient, newClient]
+        let service = NPCService(settingsStore: makeSettings(enabled: true), makeClient: { _, _ in clients.removeFirst() })
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await oldClient.nextRequest()
+        let oldConnection = Task { await service.connect() }
+        await Task.yield()
+        service.isEnabled = false
+        service.isEnabled = true
+        await newClient.nextRequest()
+        oldClient.complete(.success([]))
+        await oldConnection.value
+        XCTAssertFalse(service.isConnected)
+        XCTAssertTrue(service.isLoading)
+        let newConnection = Task { await service.connect() }
+        newClient.complete(.success([]))
+        await newConnection.value
+        XCTAssertTrue(service.isConnected)
+        service.disconnect()
+    }
+
+    private func assertLateResponseIgnored(_ response: Result<[NpubCashQuote], Error>) async throws {
+        let client = ControlledNPCClient()
+        let service = makeService(client: client)
+        try service.initializeWithSeed(Data(repeating: 1, count: 64))
+        await client.nextRequest()
+        let connection = Task { await service.connect() }
+        await Task.yield()
+        service.isEnabled = false
+        client.complete(response)
+        await connection.value
+        XCTAssertFalse(service.isConnected)
+        XCTAssertFalse(service.isLoading)
+        XCTAssertNil(service.errorMessage)
+    }
+
+    private func makeService(client: ControlledNPCClient, enabled: Bool = true) -> NPCService {
+        NPCService(settingsStore: makeSettings(enabled: enabled), makeClient: { _, _ in client })
+    }
+
+    private func makeSettings(enabled: Bool) -> SettingsStore {
+        let settings = SettingsStore(storage: InMemoryStorage())
+        settings.npcEnabled = enabled
+        settings.checkIncomingInvoices = false
+        return settings
+    }
+}
+
+/// Deliberately ignores cancellation to exercise late FFI/network completions.
+@MainActor
+private final class ControlledNPCClient: NpubCashClientProtocol {
+    private(set) var requestCount = 0
+    var automaticResponsesAfter: Int?
+    private var unobservedRequests = 0
+    private var started: CheckedContinuation<Void, Never>?
+    private var response: CheckedContinuation<[NpubCashQuote], Error>?
+
+    func getQuotes(since: UInt64?) async throws -> [NpubCashQuote] {
+        requestCount += 1
+        if let automaticResponsesAfter, requestCount > automaticResponsesAfter { return [] }
+        return try await withCheckedThrowingContinuation { continuation in
+            response = continuation
+            if let started {
+                self.started = nil
+                started.resume()
+            } else {
+                unobservedRequests += 1
+            }
+        }
+    }
+
+    func nextRequest() async {
+        if unobservedRequests > 0 {
+            unobservedRequests -= 1
+            return
+        }
+        await withCheckedContinuation { started = $0 }
+    }
+
+    func complete(_ result: Result<[NpubCashQuote], Error>) {
+        let continuation = response
+        response = nil
+        continuation?.resume(with: result)
+    }
+
+    func setMintUrl(mintUrl: String) async throws -> NpubCashUserResponse {
+        NpubCashUserResponse(error: false, pubkey: "", mintUrl: mintUrl, lockQuote: false)
+    }
+    func getMissingQuotes(quoteIds: [String]) async throws -> [NpubCashQuote] { [] }
+    func getUserInfo() async throws -> NpubCashUserResponse { throw NPCError.invalidResponse }
+    func setQuoteLocking(lockQuotes: Bool) async throws -> NpubCashUserResponse { throw NPCError.invalidResponse }
+}


### PR DESCRIPTION
An enabled Lightning address on iOS could remain at “Connecting” after launch until it was disabled and enabled again. Startup restored the address keys but did not start the connection; restoring the persisted setting does not invoke its change observer.

Start the enabled service once its keys are available. On both iOS and Android, recover when the app returns to the foreground or Lightning settings open, and retain periodic recovery after failed attempts when invoice-check preferences permit it. Share concurrent connection attempts and reject stale responses after disabling the address or changing wallets. Show “Connecting” only while a request is running. Android already connected during startup; this also improves its failure recovery and serializes wallet setup with connection state changes.

Validation:

- iOS: all 10 connection lifecycle tests passed, covering restored settings, concurrent requests, failure recovery, periodic retry, and late responses across disable/re-enable and wallet replacement.
- Android: all 36 selected connection, Lightning settings, startup, and wallet replacement tests passed.
- Both apps compiled successfully; `git diff --check` passed.
- An additional iOS wallet regression run passed 23 of 24 tests. `testLightningServiceMintsIntoTheQuotesWalletAfterActiveMintChanges` could not complete because the local Nutshell test mint was not running (connection refused).
