### PR TITLE
Fix live payment updates in invoice details on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/FocusedMintQuoteMonitor.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/FocusedMintQuoteMonitor.kt
@@ -1,0 +1,39 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.PaymentMethodKind
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+/** The visible payment code owns the loop; cancellation releases maintenance. */
+internal class FocusedMintQuoteMonitor {
+    private val sessions = AtomicInteger(0)
+    val isActive: Boolean get() = sessions.get() > 0
+
+    suspend fun monitor(
+        quoteId: String,
+        refresh: suspend (String) -> MintQuoteInfo?,
+        sleep: suspend (Long) -> Unit = { delay(it) },
+    ) {
+        if (!currentCoroutineContext().isActive) return
+        sessions.incrementAndGet()
+        try {
+            while (currentCoroutineContext().isActive) {
+                // Direct reconciliation bypasses passive batch/age scheduling,
+                // while the reconciler still applies persisted failure backoff.
+                val quote = refresh(quoteId)
+                if (!currentCoroutineContext().isActive) return
+                if (quote != null && quote.paymentMethod != PaymentMethodKind.Bolt12 &&
+                    (quote.hasSettledPayment ||
+                        (quote.paymentMethod == PaymentMethodKind.Bolt11 &&
+                            quote.isExpired && quote.mintableAmount == 0L))
+                ) return
+                sleep(if (quote?.paymentMethod == PaymentMethodKind.Onchain) 10_000 else 2_000)
+            }
+        } finally {
+            sessions.decrementAndGet()
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -92,6 +92,7 @@ class WalletManager(
     private val initializationMutex = Mutex()
     private val mintMetadataFetcher = WalletMintMetadataFetcher(allowCleartextLocalTestMints)
     private val mintQuoteSyncService = WalletMintQuoteSyncService(gateway, walletStore)
+    private val focusedMintQuoteMonitor = FocusedMintQuoteMonitor()
     private val transactionLoader = WalletTransactionLoader(walletStore, gateway)
     private val npcQuotesInFlight = mutableSetOf<String>()
     private var processedNPCQuotes = walletStore.loadProcessedNPCQuotes().toMutableSet()
@@ -666,16 +667,38 @@ class WalletManager(
         quoteId: String,
         confirmationOwner: ReceiveConfirmationOwner,
         force: Boolean = false,
+        observingQuoteId: String? = null,
     ): MintQuoteSyncResult {
         val result = mintQuoteSyncService.syncPendingMintQuote(quoteId, force)
         // A prior status poll or websocket check may already have recovered
         // the issue saga. Re-read balances for an already-settled receive too.
         if (result.minted || result.hasSettledPayment) refreshBalance()
-        loadTransactions()
+        loadTransactions(observingQuoteId = observingQuoteId)
         result.receivedAmount?.let { amount ->
             publishReceivedPayment(amount, result.unit, confirmationOwner)
         }
         return result
+    }
+
+    /** The detail's lifecycle owns this job; every tick reconciles only its quote. */
+    internal suspend fun monitorDisplayedMintQuote(
+        quoteId: String,
+        confirmationOwner: ReceiveConfirmationOwner,
+    ) {
+        focusedMintQuoteMonitor.monitor(quoteId, refresh = { id ->
+            try {
+                refreshPendingMintQuote(
+                    id,
+                    confirmationOwner = confirmationOwner,
+                    observingQuoteId = id,
+                ).quote
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Throwable) {
+                AppLogger.wallet.error("Displayed mint quote sync failed", error)
+                null
+            }
+        })
     }
 
     /** Advisory UI state only; NUT-25 paid/issued counters remain authoritative. */
@@ -711,6 +734,7 @@ class WalletManager(
      *   it preempts cooldown gating (explicit user intent).
      */
     suspend fun syncPendingMintQuotes(force: Boolean = false): Int {
+        if (!force && focusedMintQuoteMonitor.isActive) return 0
         // Passive triggers collapse while an existing pass is active. An
         // explicit user refresh waits its turn instead of being silently
         // discarded — this makes `force` real rather than a documentation-only
@@ -730,6 +754,7 @@ class WalletManager(
             // quote instead of silently dropping an older/migrated offer.
             val intentQuoteIds = cashuRequestStore.state.value.requests.mapNotNull { it.quoteId }
             val quoteIds = (databaseQuotes.map { it.id } + intentQuoteIds).distinct().sorted()
+            if (!force && focusedMintQuoteMonitor.isActive) return 0
             val selectedQuoteIds = mintQuoteSyncService.selectQuoteIdsForSync(
                 quoteIds,
                 force,
@@ -740,7 +765,8 @@ class WalletManager(
             if (selectedQuoteIds.isEmpty()) return 0
 
             var mintedQuotes = 0
-            selectedQuoteIds.forEach { quoteId ->
+            for (quoteId in selectedQuoteIds) {
+                if (!force && focusedMintQuoteMonitor.isActive) break
                 val result = mintQuoteSyncService.syncPendingMintQuote(quoteId, force)
                 result.receivedAmount?.let { amount ->
                     mintedQuotes += 1
@@ -756,7 +782,7 @@ class WalletManager(
                 if (!force) yield()
             }
             if (mintedQuotes > 0) refreshBalance()
-            loadTransactions()
+            loadTransactions(includeRemoteObservations = !focusedMintQuoteMonitor.isActive)
             return mintedQuotes
         } finally {
             mintQuoteSweepMutex.unlock()
@@ -1364,8 +1390,13 @@ class WalletManager(
         throw CashuRequestMintSettling()
     }
 
-    suspend fun loadTransactions() {
-        val result = transactionLoader.load(mutableState.value.mints)
+    suspend fun loadTransactions(
+        includeRemoteObservations: Boolean = true,
+        observingQuoteId: String? = null,
+    ) {
+        val result = transactionLoader.load(
+            mutableState.value.mints, includeRemoteObservations, observingQuoteId,
+        )
         // Quote-backed requests (notably the long-lived BOLT12 offer) own their
         // received payments in history. Reconcile before publishing so the UI
         // shows the one reusable-invoice row rather than duplicate payments.

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -28,7 +28,11 @@ internal class WalletTransactionLoader(
     private val walletStore: WalletStore,
     private val gateway: CdkWalletGateway,
 ) {
-    suspend fun load(mints: List<MintInfo>): WalletTransactionLoadResult {
+    suspend fun load(
+        mints: List<MintInfo>,
+        includeRemoteObservations: Boolean = true,
+        observingQuoteId: String? = null,
+    ): WalletTransactionLoadResult {
         val trackedMintUrls = mints.map { it.url }.toSet()
         val savedTokens = walletStore.loadSavedTokens()
         val pendingReceiveTokens = walletStore.loadPendingReceiveTokens()
@@ -68,15 +72,18 @@ internal class WalletTransactionLoader(
         val mintQuoteTimestamps = walletStore.loadMintQuoteTimestamps().toMutableMap()
         val unissuedMintQuotes = runCatching { gateway.listUnissuedMintQuotes() }
             .getOrDefault(emptyList())
-        val pendingQuoteTransactions = observePendingOnchainMintQuotes(
-            pendingMintQuoteTransactions(
-                quotes = unissuedMintQuotes,
-                trackedMintUrls = trackedMintUrls,
-                quoteIdsWithTransactions = quoteIdsWithTransactions,
-                timestamps = mintQuoteTimestamps,
-                nowEpochMillis = System.currentTimeMillis(),
-            ),
+        val pendingQuotes = pendingMintQuoteTransactions(
+            quotes = unissuedMintQuotes,
+            trackedMintUrls = trackedMintUrls,
+            quoteIdsWithTransactions = quoteIdsWithTransactions,
+            timestamps = mintQuoteTimestamps,
+            nowEpochMillis = System.currentTimeMillis(),
         )
+        val pendingQuoteTransactions = if (includeRemoteObservations) {
+            observePendingOnchainMintQuotes(pendingQuotes, observingQuoteId)
+        } else {
+            pendingQuotes
+        }
         val requests = walletStore.loadCashuRequests()
         val receiveTokenTransactions = pendingReceiveTokenTransactions(pendingReceiveTokens)
         // Row id spaces are disjoint by construction (saga-derived tx ids,
@@ -97,10 +104,12 @@ internal class WalletTransactionLoader(
 
     private suspend fun observePendingOnchainMintQuotes(
         transactions: List<WalletTransaction>,
+        observingQuoteId: String?,
     ): List<WalletTransaction> =
         transactions.map { transaction ->
             if (
                 transaction.type != TransactionType.Incoming ||
+                (observingQuoteId != null && observingQuoteId != transaction.quoteId) ||
                 transaction.kind != TransactionKind.Onchain ||
                 transaction.invoice == null
             ) {

--- a/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Transactions/WalletTransaction.kt
@@ -46,8 +46,8 @@ data class WalletTransaction(
 
     /**
      * Mint-quote id to re-check when opening this row's detail, if any.
-     * Only unsettled incoming Lightning / on-chain mint quotes (not ecash,
-     * not melts). Expired unpaid invoices are included so a late-paid NUT-04
+     * Incoming unsettled mint quotes and reusable offers (not ecash or melts).
+     * Expired unpaid invoices are included so a late-paid NUT-04
      * quote can still mint after the invoice timer.
      */
     val mintQuoteIdForStatusRefresh: String?
@@ -55,7 +55,9 @@ data class WalletTransaction(
             if (type != TransactionType.Incoming) return null
             if (kind != TransactionKind.Lightning && kind != TransactionKind.Onchain) return null
             if (invoice == null) return null
-            if (status != TransactionStatus.Pending && status != TransactionStatus.Expired) return null
+            val reusableOffer = kind == TransactionKind.Lightning &&
+                status == TransactionStatus.Completed && invoice.startsWith("lno", ignoreCase = true)
+            if (status != TransactionStatus.Pending && status != TransactionStatus.Expired && !reusableOffer) return null
             return quoteId ?: id
         }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/TransactionDetailScreen.kt
@@ -40,6 +40,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.launch
 import com.cashu.me.Core.AmountFormatter
 import com.cashu.me.Core.AmountDisplayText
@@ -106,6 +109,7 @@ fun TransactionReceiptSheet(
     val scope = rememberCoroutineScope()
     val formatter = remember { AmountFormatter() }
     val confirmationToastController = LocalConfirmationToastController.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     // Pending mint-quote rows use id == quoteId; after mint CDK swaps in a new
     // transaction id with the same quoteId. Keep the open-time identity so the
@@ -126,18 +130,21 @@ fun TransactionReceiptSheet(
     var manualCheckResult: PendingTokenClaimCheckResult? by remember(transaction.id) {
         mutableStateOf(null)
     }
-    // Single-quote check on open (not the full pending list). Re-checks this
-    // mint quote against the mint and mints if already paid — same path Receive
-    // uses for its per-quote poll, without the global loading spinner. Keyed on
-    // the opening id so a successful mint → Completed transition does not
-    // cancel the in-flight check.
-    LaunchedEffect(transaction.id) {
+    // Keep the opening identity through settlement so the final balance and
+    // history refresh cannot be cancelled by its own Pending → Completed update.
+    LaunchedEffect(transaction.id, lifecycleOwner, walletState.isRuntimeReady) {
+        if (!walletState.isRuntimeReady) return@LaunchedEffect
         val quoteId = transaction.mintQuoteIdForStatusRefresh ?: return@LaunchedEffect
-        runCatching {
-            walletManager.refreshPendingMintQuote(
-                quoteId,
-                confirmationOwner = ReceiveConfirmationOwner.Home,
-            )
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            if (TransactionDisplay.showsQr(transaction)) {
+                walletManager.monitorDisplayedMintQuote(
+                    quoteId, confirmationOwner = ReceiveConfirmationOwner.Home,
+                )
+            } else {
+                walletManager.refreshPendingMintQuote(
+                    quoteId, confirmationOwner = ReceiveConfirmationOwner.Home,
+                )
+            }
         }
     }
 

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -51,6 +51,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import java.text.DateFormat
 import java.util.Date
 import com.cashu.me.Core.AmountFormatter
@@ -61,6 +64,7 @@ import com.cashu.me.Core.NfcReceive.NfcReceiveCoordinator
 import com.cashu.me.Core.NfcReceive.NfcReceivePhase
 import com.cashu.me.Core.NfcReceive.shouldOfferNfcReceive
 import com.cashu.me.Core.PaymentRequestBuilder
+import com.cashu.me.Core.ReceiveConfirmationOwner
 import com.cashu.me.Core.Protocols.CurrencyAmount
 import com.cashu.me.Core.Protocols.CurrencyRegistry
 import com.cashu.me.Core.SettingsManager
@@ -118,6 +122,7 @@ fun CashuRequestDetailScreen(
     val context = LocalContext.current
     val clipboard = LocalClipboardManager.current
     val confirmationToastController = LocalConfirmationToastController.current
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val request = storeState.requests.firstOrNull { it.id == requestId }
     val requestReadiness = remember(settings, nostrState) {
@@ -206,6 +211,19 @@ fun CashuRequestDetailScreen(
         ?.firstOrNull { it.transactionId == successPaymentId }
     val showSuccessTerminal = request != null && successPayment != null &&
         nfcState.phase != NfcReceivePhase.Success
+
+    val monitoredQuoteId = request?.quoteId.takeUnless { successPayment != null }
+    LaunchedEffect(monitoredQuoteId, lifecycleOwner, walletState.isRuntimeReady) {
+        if (!walletState.isRuntimeReady) return@LaunchedEffect
+        val quoteId = monitoredQuoteId ?: return@LaunchedEffect
+        // STARTED keeps monitoring through a native sheet/dialog, while still
+        // cancelling when the screen leaves composition or the app backgrounds.
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            walletManager.monitorDisplayedMintQuote(
+                quoteId, confirmationOwner = ReceiveConfirmationOwner.InFlow,
+            )
+        }
+    }
 
     // One gate keeps the detail and the receipt in the same composition so
     // the swap fades through instead of hard-cutting (iOS:

--- a/android/app/src/test/java/com/cashu/me/Core/FocusedMintQuoteMonitorTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/FocusedMintQuoteMonitorTest.kt
@@ -1,0 +1,123 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class FocusedMintQuoteMonitorTest {
+    @Test
+    fun `checks only displayed invoice immediately and stops after issuance`() = runBlocking {
+        val monitor = FocusedMintQuoteMonitor()
+        val ids = mutableListOf<String>()
+        val intervals = mutableListOf<Long>()
+        monitor.monitor("displayed", refresh = { id ->
+            assertTrue(monitor.isActive)
+            ids += id
+            quote(PaymentMethodKind.Bolt11, paid = 21, issued = if (ids.size == 1) 0 else 21)
+        }, sleep = { intervals += it })
+
+        assertEquals(listOf("displayed", "displayed"), ids)
+        assertEquals(listOf(2_000L), intervals)
+        assertFalse(monitor.isActive)
+    }
+
+    @Test
+    fun `previously paid reusable offer keeps checking for later payments`() = runBlocking {
+        val monitor = FocusedMintQuoteMonitor()
+        var checks = 0
+        val intervals = mutableListOf<Long>()
+        try {
+            monitor.monitor("displayed", refresh = {
+                checks++
+                val amount = if (checks == 1) 10L else 31L
+                quote(PaymentMethodKind.Bolt12, paid = amount, issued = amount)
+            }, sleep = {
+                intervals += it
+                if (intervals.size == 2) throw CancellationException()
+            })
+        } catch (_: CancellationException) {
+            // The screen closes after observing the second payment.
+        }
+        assertEquals(2, checks)
+        assertEquals(listOf(2_000L, 2_000L), intervals)
+        assertFalse(monitor.isActive)
+    }
+
+    @Test
+    fun `cancellation releases focus and reopening checks immediately`() = runBlocking {
+        val monitor = FocusedMintQuoteMonitor()
+        val sleeping = CompletableDeferred<Unit>()
+        val ids = mutableListOf<String>()
+        val job = launch {
+            monitor.monitor("first", refresh = { id ->
+                ids += id
+                null // Missing or temporarily unavailable quotes keep retrying.
+            }, sleep = {
+                sleeping.complete(Unit)
+                awaitCancellation()
+            })
+        }
+        withTimeout(2_000) { sleeping.await() }
+        assertTrue(monitor.isActive)
+        job.cancelAndJoin()
+        assertFalse(monitor.isActive)
+
+        monitor.monitor("second", refresh = { id ->
+            ids += id
+            quote(PaymentMethodKind.Bolt11, paid = 21, issued = 21)
+        }, sleep = { fail("Settled invoice must stop") })
+        assertEquals(listOf("first", "second"), ids)
+        assertFalse(monitor.isActive)
+    }
+
+    @Test
+    fun `expired unpaid invoice stops but paid unissued invoice keeps retrying`() = runBlocking {
+        val monitor = FocusedMintQuoteMonitor()
+        monitor.monitor("displayed", refresh = {
+            quote(PaymentMethodKind.Bolt11, expiry = 1)
+        }, sleep = { fail("Expired unpaid invoice must stop") })
+
+        var checks = 0
+        monitor.monitor("displayed", refresh = {
+            checks++
+            quote(PaymentMethodKind.Bolt11, paid = 21, issued = if (checks == 1) 0 else 21, expiry = 1)
+        }, sleep = {})
+        assertEquals(2, checks)
+    }
+
+    @Test
+    fun `onchain deposit keeps checking after expiry`() = runBlocking {
+        val monitor = FocusedMintQuoteMonitor()
+        var checks = 0
+        monitor.monitor("displayed", refresh = {
+            checks++
+            val amount = if (checks == 1) 0L else 21L
+            quote(PaymentMethodKind.Onchain, paid = amount, issued = amount, expiry = 1)
+        }, sleep = { assertEquals(10_000L, it) })
+        assertEquals(2, checks)
+        assertFalse(monitor.isActive)
+    }
+
+    private fun quote(
+        method: PaymentMethodKind,
+        paid: Long = 0,
+        issued: Long = 0,
+        expiry: Long? = null,
+    ) = MintQuoteInfo(
+        id = "displayed", request = "request", amount = null, paymentMethod = method,
+        state = if (paid > issued) MintQuoteState.Paid else if (paid > 0) MintQuoteState.Issued else MintQuoteState.Pending,
+        expiryEpochSeconds = expiry, amountPaid = paid, amountIssued = issued,
+    )
+}

--- a/android/app/src/test/java/com/cashu/me/Core/TransactionDetailLookupTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/TransactionDetailLookupTest.kt
@@ -11,6 +11,16 @@ import org.junit.Test
 
 class TransactionDetailLookupTest {
     @Test
+    fun detailMonitoringIncludesSettledOffersButExcludesPaidInvoicesAndOutgoingPayments() {
+        val pending = tx(id = "payment", quoteId = "quote", status = TransactionStatus.Pending)
+        assertEquals("quote", pending.mintQuoteIdForStatusRefresh)
+        assertEquals("quote", pending.copy(status = TransactionStatus.Expired).mintQuoteIdForStatusRefresh)
+        assertEquals("quote", pending.copy(status = TransactionStatus.Completed, invoice = "LNO1").mintQuoteIdForStatusRefresh)
+        assertNull(pending.copy(status = TransactionStatus.Completed).mintQuoteIdForStatusRefresh)
+        assertNull(pending.copy(type = TransactionType.Outgoing, invoice = "lno1").mintQuoteIdForStatusRefresh)
+    }
+
+    @Test
     fun prefersExactIdMatch() {
         val open = tx(id = "quote-1", quoteId = "quote-1", status = TransactionStatus.Pending)
         val other = tx(id = "cdk-9", quoteId = "quote-1", status = TransactionStatus.Completed)

--- a/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletMintQuoteSyncServiceTest.kt
@@ -16,6 +16,30 @@ import org.junit.Test
 
 class WalletMintQuoteSyncServiceTest {
     @Test
+    fun `focused monitoring respects failure backoff and settles without manual refresh`() = runBlocking {
+        val ledger = QuoteLedger(paid = 8, issued = 0).apply {
+            quote = quote.copy(paymentMethod = PaymentMethodKind.Bolt11)
+            failuresBeforeIssuance = 1
+        }
+        val service = ledger.service()
+        val monitor = FocusedMintQuoteMonitor()
+        val credits = mutableListOf<Long>()
+        var refreshes = 0
+        monitor.monitor(ledger.quote.id, refresh = { id ->
+            refreshes++
+            val result = service.syncPendingMintQuote(id)
+            result.receivedAmount?.let { credits += it }
+            result.quote
+        }, sleep = { ledger.now += 2_000 })
+
+        assertEquals(4, refreshes) // Immediate, 2s, 4s, 6s (retry is due at 5s).
+        assertEquals(2, ledger.mintCalls)
+        assertEquals(listOf(8L), credits)
+        assertEquals(8L, ledger.quote.amountIssued)
+        assertFalse(monitor.isActive)
+    }
+
+    @Test
     fun `recovery during the first check reports the issuance delta once`() = runBlocking {
         val ledger = QuoteLedger(paid = 21, issued = 0).apply { recoverOnNextCheck = 21 }
         val service = ledger.service()

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
 		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
+		F06000000000000000000004 /* FocusedMintQuoteMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06000000000000000000003 /* FocusedMintQuoteMonitorTests.swift */; };
 		EA1850000000000000000001 /* PaymentDetailContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA1850000000000000000002 /* PaymentDetailContent.swift */; };
 		A09100000000000000000007 /* LifecycleSafeWalletDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */; };
 		A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09100000000000000000006 /* WalletAuditRegressionTests.swift */; };
@@ -17,6 +18,7 @@
 		CD9100000000000000000001 /* MintDetailInfoLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000002 /* MintDetailInfoLoader.swift */; };
 		CD9100000000000000000003 /* MintDetailInfoLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */; };
 		C33400000000000000000001 /* MintQuoteReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33400000000000000000002 /* MintQuoteReconciler.swift */; };
+		F06000000000000000000001 /* FocusedMintQuoteMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F06000000000000000000002 /* FocusedMintQuoteMonitor.swift */; };
 		323A00000000000000000001 /* PriceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 323A00000000000000000002 /* PriceServiceTests.swift */; };
 		1100000000000001 /* CashuWalletApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000001 /* CashuWalletApp.swift */; };
 		1100000000000002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2100000000000002 /* ContentView.swift */; };
@@ -203,6 +205,7 @@
 /* Begin PBXFileReference section */
 		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
 		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
+		F06000000000000000000003 /* FocusedMintQuoteMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FocusedMintQuoteMonitorTests.swift; path = CashuWalletTests/FocusedMintQuoteMonitorTests.swift; sourceTree = "<group>"; };
 		EA1850000000000000000002 /* PaymentDetailContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentDetailContent.swift; sourceTree = "<group>"; };
 		A09100000000000000000008 /* LifecycleSafeWalletDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleSafeWalletDatabase.swift; sourceTree = "<group>"; };
 		A09100000000000000000006 /* WalletAuditRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/WalletAuditRegressionTests.swift; sourceTree = "<group>"; };
@@ -211,6 +214,7 @@
 		CD9100000000000000000002 /* MintDetailInfoLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintDetailInfoLoader.swift; sourceTree = "<group>"; };
 		CD9100000000000000000004 /* MintDetailInfoLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MintDetailInfoLoaderTests.swift; path = CashuWalletTests/MintDetailInfoLoaderTests.swift; sourceTree = "<group>"; };
 		C33400000000000000000002 /* MintQuoteReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MintQuoteReconciler.swift; sourceTree = "<group>"; };
+		F06000000000000000000002 /* FocusedMintQuoteMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusedMintQuoteMonitor.swift; sourceTree = "<group>"; };
 		323A00000000000000000002 /* PriceServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriceServiceTests.swift; path = CashuWalletTests/PriceServiceTests.swift; sourceTree = "<group>"; };
 		0100000000000001 /* CashuWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CashuWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2100000000000001 /* CashuWalletApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletApp.swift; sourceTree = "<group>"; };
@@ -426,6 +430,7 @@
 				T1B000000000000B /* ReceiveAutoPasteTests.swift */,
 				T1B000000000000C /* HomeActionAccessibilityTests.swift */,
 				BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */,
+				F06000000000000000000003 /* FocusedMintQuoteMonitorTests.swift */,
 				T1B0000000000100 /* ConnectMintContextTests.swift */,
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
@@ -732,6 +737,7 @@
 				BB00000000000014 /* LightningService.swift */,
 				A09100000000000000000002 /* MintQuoteRecovery.swift */,
 				C33400000000000000000002 /* MintQuoteReconciler.swift */,
+				F06000000000000000000002 /* FocusedMintQuoteMonitor.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1024,6 +1030,7 @@
 				T2B000000000000B /* ReceiveAutoPasteTests.swift in Sources */,
 				T2B000000000000C /* HomeActionAccessibilityTests.swift in Sources */,
 				BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */,
+				F06000000000000000000004 /* FocusedMintQuoteMonitorTests.swift in Sources */,
 				T2B0000000000100 /* ConnectMintContextTests.swift in Sources */,
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
@@ -1124,6 +1131,7 @@
 				BB00000000000004 /* LightningService.swift in Sources */,
 				A09100000000000000000001 /* MintQuoteRecovery.swift in Sources */,
 				C33400000000000000000001 /* MintQuoteReconciler.swift in Sources */,
+				F06000000000000000000001 /* FocusedMintQuoteMonitor.swift in Sources */,
 				CC00000000000001 /* ThemeSettingsSection.swift in Sources */,
 				CC00000000000002 /* BackupSettingsSection.swift in Sources */,
 				CC00000000000004 /* P2PKSettingsSection.swift in Sources */,

--- a/ios/CashuWallet/Core/Services/FocusedMintQuoteMonitor.swift
+++ b/ios/CashuWallet/Core/Services/FocusedMintQuoteMonitor.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The visible payment code owns this loop. Cancelling its view task releases
+/// the focus, allowing ordinary wallet maintenance to resume.
+@MainActor
+final class FocusedMintQuoteMonitor {
+    private var sessions: Set<UUID> = []
+    var isActive: Bool { !sessions.isEmpty }
+
+    func monitor(
+        quoteID: String,
+        refresh: (String) async -> MintQuoteInfo?,
+        sleep: (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+    ) async {
+        guard !Task.isCancelled else { return }
+        let session = UUID()
+        sessions.insert(session)
+        defer { sessions.remove(session) }
+
+        while !Task.isCancelled {
+            // Direct reconciliation bypasses the passive batch/age schedule,
+            // but still respects persisted failure backoff in the reconciler.
+            let quote = await refresh(quoteID)
+            guard !Task.isCancelled else { return }
+            if let quote, quote.paymentMethod != .bolt12,
+               quote.hasSettledPayment ||
+                (quote.paymentMethod == .bolt11 && quote.isExpired && quote.mintableAmount == 0) {
+                return
+            }
+            do {
+                try await sleep(quote?.paymentMethod == .onchain ? .seconds(10) : .seconds(2))
+            } catch {
+                return
+            }
+        }
+    }
+}

--- a/ios/CashuWallet/Core/Services/TransactionService.swift
+++ b/ios/CashuWallet/Core/Services/TransactionService.swift
@@ -46,7 +46,10 @@ class TransactionService: ObservableObject {
     // MARK: - Transaction Loading
 
     /// Load transaction history from all mints
-    func loadTransactions(includeRemoteObservations: Bool = true) async {
+    func loadTransactions(
+        includeRemoteObservations: Bool = true,
+        observingQuoteID: String? = nil
+    ) async {
         guard let repo = walletRepository() else { return }
 
         loadPendingReceiveTokens()
@@ -141,7 +144,8 @@ class TransactionService: ObservableObject {
                     trackedMintUrls: trackedMintUrls,
                     quoteIdsWithTransactions: quoteIdsWithTransactions,
                     timestamps: &mintQuoteTimestamps,
-                    includeRemoteObservations: includeRemoteObservations
+                    includeRemoteObservations: includeRemoteObservations,
+                    observingQuoteID: observingQuoteID
                 )
                 allTransactions.append(contentsOf: pendingQuoteTransactions)
             } catch {
@@ -299,7 +303,8 @@ class TransactionService: ObservableObject {
         trackedMintUrls: Set<String>,
         quoteIdsWithTransactions: Set<String>,
         timestamps: inout [String: TimeInterval],
-        includeRemoteObservations: Bool
+        includeRemoteObservations: Bool,
+        observingQuoteID: String?
     ) async -> [WalletTransaction] {
         var transactions: [WalletTransaction] = []
 
@@ -370,6 +375,7 @@ class TransactionService: ObservableObject {
             var statusNote: String?
 
             if includeRemoteObservations,
+               observingQuoteID == nil || observingQuoteID == quote.id,
                paymentMethod == .onchain,
                let observation = await OnchainExplorer.observePayment(
                 for: quote.request,

--- a/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+MintQuoteSync.swift
@@ -21,14 +21,20 @@ extension WalletManager {
     /// actually issued"; callers must never present success from the former.
     /// Does not touch the global loading flag.
     @discardableResult
-    func refreshPendingMintQuote(quoteId: String, force: Bool = false) async -> MintQuoteReconciliationResult? {
+    func refreshPendingMintQuote(
+        quoteId: String,
+        force: Bool = false,
+        observingQuoteID: String? = nil
+    ) async -> MintQuoteReconciliationResult? {
         do {
             return try await operationCoordinator.perform(
                 kind: .mintQuote,
                 resourceID: quoteId
             ) {
                 guard let result = await self.reconcileMintQuote(quoteId: quoteId, force: force) else {
-                    await self.loadTransactionsAssumingWalletOperationLease()
+                    await self.loadTransactionsAssumingWalletOperationLease(
+                        observingQuoteID: observingQuoteID
+                    )
                     return nil
                 }
                 // A previous status observer may already have recovered the
@@ -36,7 +42,9 @@ extension WalletManager {
                 if result.newlyIssued > 0 || result.hasSettledPayment {
                     await self.refreshBalanceAssumingWalletOperationLease()
                 }
-                await self.loadTransactionsAssumingWalletOperationLease()
+                await self.loadTransactionsAssumingWalletOperationLease(
+                    observingQuoteID: observingQuoteID
+                )
                 return result
             }
         } catch {
@@ -62,6 +70,22 @@ extension WalletManager {
     }
 
     // MARK: - Foreground polling
+
+    /// Called from a lifecycle-bound detail task. The balance and local receipt
+    /// are refreshed before feedback; unrelated quotes/explorers are not polled.
+    func monitorDisplayedMintQuote(quoteID: String, homeHaptic: Bool) async {
+        await focusedMintQuoteMonitor.monitor(quoteID: quoteID) { quoteID in
+            let result = await self.refreshPendingMintQuote(
+                quoteId: quoteID, observingQuoteID: quoteID
+            )
+            if let result, result.newlyIssued > 0 {
+                self.postReceivedMintNotification(
+                    amount: result.newlyIssued, unit: result.quote.unit, homeHaptic: homeHaptic
+                )
+            }
+            return result?.quote
+        }
+    }
 
     /// While the app is active, re-check pending quotes every
     /// `pendingQuotePollInterval` so a payment lands on its own — e.g. a
@@ -96,6 +120,7 @@ extension WalletManager {
     /// - Parameter force: `false` (poll / startup / History open) only runs
     ///   when the repository lane is idle; `true` (pull-to-refresh) preempts.
     func syncPendingMintQuotes(force: Bool = false) async {
+        guard force || !focusedMintQuoteMonitor.isActive else { return }
         if force {
             do {
                 try await operationCoordinator.perform(kind: .quotePoll) {
@@ -118,6 +143,7 @@ extension WalletManager {
 
     private func mintUnissuedQuotesAcrossWallets(force: Bool) async {
         guard walletRepository != nil else { return }
+        guard force || !focusedMintQuoteMonitor.isActive else { return }
         lastMintQuoteSyncAt = Date()
 
         // The CDK database is the durable ledger. Union it with app-level
@@ -140,6 +166,7 @@ extension WalletManager {
             }
         }
 
+        guard force || !focusedMintQuoteMonitor.isActive else { return }
         let selection = MintQuoteSchedulePolicy.select(
             quoteIDs: quoteIDs,
             existing: walletStore.loadMintQuoteSchedules(),
@@ -153,6 +180,7 @@ extension WalletManager {
         var mintedAny = false
         for quoteID in selection.quoteIDs {
             guard !Task.isCancelled else { break }
+            guard force || !focusedMintQuoteMonitor.isActive else { break }
             guard let result = await reconcileMintQuote(quoteId: quoteID, force: force) else { continue }
             if result.newlyIssued > 0 {
                 mintedAny = true
@@ -169,7 +197,9 @@ extension WalletManager {
             await refreshBalanceAssumingWalletOperationLease()
         }
 
-        await loadTransactionsAssumingWalletOperationLease()
+        await loadTransactionsAssumingWalletOperationLease(
+            includeRemoteObservations: !focusedMintQuoteMonitor.isActive
+        )
     }
 
     /// Check → mint → verify one quote while the wallet operation lane is held.
@@ -262,9 +292,13 @@ extension WalletManager {
 
     /// Internal form for workflows that already own the repository lease.
     func loadTransactionsAssumingWalletOperationLease(
-        includeRemoteObservations: Bool = true
+        includeRemoteObservations: Bool = true,
+        observingQuoteID: String? = nil
     ) async {
-        await transactionService.loadTransactions(includeRemoteObservations: includeRemoteObservations)
+        await transactionService.loadTransactions(
+            includeRemoteObservations: includeRemoteObservations,
+            observingQuoteID: observingQuoteID
+        )
         reconcileQuoteIntents()
         objectWillChange.send()
     }

--- a/ios/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager.swift
@@ -66,6 +66,7 @@ class WalletManager: ObservableObject {
     /// without pull-to-refresh (Android parity).
     var pendingQuotePollTask: Task<Void, Never>?
     let pendingQuotePollInterval: TimeInterval = 10
+    let focusedMintQuoteMonitor = FocusedMintQuoteMonitor()
 
     // MARK: - Services
 

--- a/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
+++ b/ios/CashuWallet/Models/Transactions/WalletTransaction.swift
@@ -64,15 +64,17 @@ struct WalletTransaction: Identifiable {
     }
 
     /// Mint-quote id to re-check when opening this row's detail, if any.
-    /// Only unsettled incoming Lightning / on-chain mint quotes (not ecash,
-    /// not melts). Expired unpaid invoices are included so a late-paid NUT-04
+    /// Incoming unsettled mint quotes and reusable offers (not ecash or melts).
+    /// Expired unpaid invoices are included so a late-paid NUT-04
     /// quote can still mint after the invoice timer.
     var mintQuoteIdForStatusRefresh: String? {
         guard type == .incoming else { return nil }
         guard kind == .lightning || kind == .onchain else { return nil }
         guard !isPendingReceiveToken else { return nil }
         guard invoice != nil else { return nil }
-        guard status == .pending || status == .expired else { return nil }
+        let reusableOffer = kind == .lightning && status == .completed &&
+            invoice?.lowercased().hasPrefix("lno") == true
+        guard status == .pending || status == .expired || reusableOffer else { return nil }
         return quoteId ?? id
     }
 

--- a/ios/CashuWallet/Views/History/TransactionDetailView.swift
+++ b/ios/CashuWallet/Views/History/TransactionDetailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TransactionDetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var walletManager: WalletManager
     /// Snapshot at open; [transaction] prefers the live wallet row so a
     /// successful open-check can flip Pending → Completed without dismissing.
@@ -60,6 +61,13 @@ struct TransactionDetailView: View {
     }
 
     private var showsQR: Bool { transaction.hasActionablePaymentCode }
+
+    // Keep the opening identity through settlement so a row update cannot
+    // cancel balance/history reconciliation midway through its final tick.
+    private var monitoredQuoteID: String? {
+        scenePhase == .active && walletManager.isRuntimeReady
+            ? seed.mintQuoteIdForStatusRefresh : nil
+    }
 
     private var qrContentTypeLabel: String {
         switch transaction.kind {
@@ -120,15 +128,17 @@ struct TransactionDetailView: View {
                     ShareSheet(items: [invoice])
                 }
             }
-            // Single-quote check on open (not the full pending list). Re-checks
-            // this mint quote against the mint and mints if already paid —
-            // Android TransactionDetailScreen parity.
-            .task(id: seed.id) {
-                guard let quoteId = seed.mintQuoteIdForStatusRefresh else { return }
-                _ = await walletManager.refreshPendingMintQuote(quoteId: quoteId)
-            }
             .onDisappear {
                 manualClaimCheckTask?.cancel()
+            }
+        }
+        .task(id: monitoredQuoteID) {
+            guard let quoteID = monitoredQuoteID else { return }
+            if seed.hasActionablePaymentCode {
+                await walletManager.monitorDisplayedMintQuote(quoteID: quoteID, homeHaptic: true)
+            } else {
+                // Expired receipts still get a final late-payment recovery check.
+                await walletManager.refreshPendingMintQuote(quoteId: quoteID)
             }
         }
         .fullScreenCover(item: $claimReceiveToken) { pending in

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct CashuRequestDetailView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var walletManager: WalletManager
     @ObservedObject private var store = CashuRequestStore.shared
     @ObservedObject private var settings = SettingsManager.shared
@@ -41,6 +42,11 @@ struct CashuRequestDetailView: View {
 
     private var paymentCount: Int {
         request?.receivedPayments.count ?? 0
+    }
+
+    private var monitoredQuoteID: String? {
+        scenePhase == .active && walletManager.isRuntimeReady && !showPaymentSuccess
+            ? request?.quoteId : nil
     }
 
     var body: some View {
@@ -125,6 +131,10 @@ struct CashuRequestDetailView: View {
                 "CashuRequestDetailView: linked payment \(payment.transactionId, privacy: .public)"
             )
             markPaymentReceived(amount: payment.amount)
+        }
+        .task(id: monitoredQuoteID) {
+            guard let quoteID = monitoredQuoteID else { return }
+            await walletManager.monitorDisplayedMintQuote(quoteID: quoteID, homeHaptic: false)
         }
         .compactBottomSheetSurface()
     }

--- a/ios/CashuWalletTests/FocusedMintQuoteMonitorTests.swift
+++ b/ios/CashuWalletTests/FocusedMintQuoteMonitorTests.swift
@@ -1,0 +1,122 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class FocusedMintQuoteMonitorTests: XCTestCase {
+    func testDetailMonitoringIncludesSettledOffersButExcludesPaidInvoicesAndOutgoingPayments() {
+        func transaction(
+            status: WalletTransaction.TransactionStatus,
+            invoice: String,
+            type: WalletTransaction.TransactionType = .incoming
+        ) -> WalletTransaction {
+            WalletTransaction(
+                id: "payment", amount: 21, type: type, kind: .lightning, date: Date(),
+                status: status, invoice: invoice, quoteId: "quote"
+            )
+        }
+        XCTAssertEqual(transaction(status: .pending, invoice: "lnbc1").mintQuoteIdForStatusRefresh, "quote")
+        XCTAssertEqual(transaction(status: .expired, invoice: "lnbc1").mintQuoteIdForStatusRefresh, "quote")
+        XCTAssertEqual(transaction(status: .completed, invoice: "LNO1").mintQuoteIdForStatusRefresh, "quote")
+        XCTAssertNil(transaction(status: .completed, invoice: "lnbc1").mintQuoteIdForStatusRefresh)
+        XCTAssertNil(transaction(status: .pending, invoice: "lno1", type: .outgoing).mintQuoteIdForStatusRefresh)
+    }
+
+    func testChecksOnlyDisplayedInvoiceImmediatelyAndStopsAfterIssuance() async {
+        let monitor = FocusedMintQuoteMonitor()
+        var ids: [String] = []
+        var intervals: [Duration] = []
+        await monitor.monitor(quoteID: "displayed", refresh: { id in
+            XCTAssertTrue(monitor.isActive)
+            ids.append(id)
+            return self.quote(method: .bolt11, paid: 21, issued: ids.count == 1 ? 0 : 21)
+        }, sleep: { interval in
+            intervals.append(interval)
+        })
+
+        XCTAssertEqual(ids, ["displayed", "displayed"])
+        XCTAssertEqual(intervals, [.seconds(2)])
+        XCTAssertFalse(monitor.isActive)
+    }
+
+    func testPreviouslyPaidReusableOfferKeepsCheckingForLaterPayments() async {
+        let monitor = FocusedMintQuoteMonitor()
+        var checks = 0
+        var intervals: [Duration] = []
+        await monitor.monitor(quoteID: "displayed", refresh: { _ in
+            checks += 1
+            // An issued BOLT12 counter is a baseline, never a terminal state.
+            return self.quote(method: .bolt12, paid: checks == 1 ? 10 : 31,
+                              issued: checks == 1 ? 10 : 31)
+        }, sleep: { interval in
+            intervals.append(interval)
+            if intervals.count == 2 { throw CancellationError() }
+        })
+
+        XCTAssertEqual(checks, 2)
+        XCTAssertEqual(intervals, [.seconds(2), .seconds(2)])
+        XCTAssertFalse(monitor.isActive)
+    }
+
+    func testCancellationReleasesFocusAndReopeningChecksImmediately() async {
+        let monitor = FocusedMintQuoteMonitor()
+        let sleeping = expectation(description: "Waiting between checks")
+        var ids: [String] = []
+        let task = Task {
+            await monitor.monitor(quoteID: "first", refresh: { id in
+                ids.append(id)
+                return nil // Missing/temporarily unavailable quote keeps retrying.
+            }, sleep: { _ in
+                sleeping.fulfill()
+                try await Task.sleep(for: .seconds(60))
+            })
+        }
+        await fulfillment(of: [sleeping], timeout: 2)
+        XCTAssertTrue(monitor.isActive)
+        task.cancel()
+        await task.value
+        XCTAssertFalse(monitor.isActive)
+
+        await monitor.monitor(quoteID: "second", refresh: { id in
+            ids.append(id)
+            return self.quote(method: .bolt11, paid: 21, issued: 21)
+        }, sleep: { _ in XCTFail("Settled invoice must stop") })
+        XCTAssertEqual(ids, ["first", "second"])
+        XCTAssertFalse(monitor.isActive)
+    }
+
+    func testExpiredUnpaidInvoiceStopsButPaidUnissuedInvoiceKeepsRetrying() async {
+        let monitor = FocusedMintQuoteMonitor()
+        await monitor.monitor(quoteID: "displayed", refresh: { _ in
+            self.quote(method: .bolt11, expiry: 1)
+        }, sleep: { _ in XCTFail("Expired unpaid invoice must stop") })
+
+        var checks = 0
+        await monitor.monitor(quoteID: "displayed", refresh: { _ in
+            checks += 1
+            return self.quote(method: .bolt11, paid: 21, issued: checks == 1 ? 0 : 21, expiry: 1)
+        }, sleep: { _ in })
+        XCTAssertEqual(checks, 2)
+    }
+
+    func testOnchainDepositKeepsCheckingAfterExpiry() async {
+        let monitor = FocusedMintQuoteMonitor()
+        var checks = 0
+        await monitor.monitor(quoteID: "displayed", refresh: { _ in
+            checks += 1
+            return self.quote(method: .onchain, paid: checks == 1 ? 0 : 21,
+                              issued: checks == 1 ? 0 : 21, expiry: 1)
+        }, sleep: { interval in XCTAssertEqual(interval, .seconds(10)) })
+        XCTAssertEqual(checks, 2)
+        XCTAssertFalse(monitor.isActive)
+    }
+
+    private func quote(
+        method: PaymentMethodKind, paid: UInt64 = 0, issued: UInt64 = 0, expiry: UInt64? = nil
+    ) -> MintQuoteInfo {
+        MintQuoteInfo(
+            id: "displayed", request: "request", amount: nil, isAmountless: true,
+            paymentMethod: method, state: paid > issued ? .paid : paid > 0 ? .issued : .pending,
+            expiry: expiry, createdAt: nil, amountPaid: paid, amountIssued: issued
+        )
+    }
+}

--- a/ios/CashuWalletTests/WalletStoreTests.swift
+++ b/ios/CashuWalletTests/WalletStoreTests.swift
@@ -125,6 +125,28 @@ final class MintQuoteReconciliationResultTests: XCTestCase {
 
 @MainActor
 final class MintQuoteReconcilerTests: XCTestCase {
+    func testFocusedMonitoringRespectsFailureBackoffAndSettlesWithoutManualRefresh() async {
+        let ledger = Ledger(paid: 8, method: .bolt11)
+        ledger.failuresBeforeIssuance = 1
+        let monitor = FocusedMintQuoteMonitor()
+        var credits: [UInt64] = []
+        var refreshes = 0
+        await monitor.monitor(quoteID: ledger.quote.id, refresh: { id in
+            refreshes += 1
+            let result = await ledger.reconciler().reconcile(quoteID: id)
+            if let result, result.newlyIssued > 0 { credits.append(result.newlyIssued) }
+            return result?.quote
+        }, sleep: { _ in
+            ledger.now = ledger.now.addingTimeInterval(2)
+        })
+
+        XCTAssertEqual(refreshes, 4) // Immediate, 2s, 4s, 6s (retry is due at 5s).
+        XCTAssertEqual(ledger.mintCalls, 2)
+        XCTAssertEqual(credits, [8])
+        XCTAssertEqual(ledger.quote.amountIssued, 8)
+        XCTAssertFalse(monitor.isActive)
+    }
+
     func testRecoveryDuringFirstCheckReportsIssuanceOnce() async {
         let ledger = Ledger(paid: 21)
         ledger.recoverOnNextCheck = 21


### PR DESCRIPTION
Invoice QR screens opened from History could keep showing a waiting state after payment until the wallet was refreshed. On iOS and Android, invoice details now check their own quote immediately and every two seconds while active, updating the balance and receipt after ecash issuance.

Focused monitoring pauses passive incoming quote sweeps, cancels on dismissal or backgrounding, and checks immediately when the screen becomes active again. Previously paid reusable offers remain eligible for monitoring. Reconciliation retains the shared issuance protection and persisted failure backoff; on-chain details use a ten-second interval and restrict explorer observations to the displayed quote.

Validation:

- 48 targeted iOS simulator tests passed.
- 45 targeted Android unit tests passed.
- Coverage includes cancellation and reopening, repeated reusable payments, issuance retry backoff, expiry handling, and detail lookup.
- A live payment between two devices has not been tested.
