### PR TITLE
Keep reusable payment requests open after receiving payments

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
@@ -12,6 +12,7 @@ import com.cashu.me.App.UiRuntimePolicy
 import com.cashu.me.App.UiTestApplication
 import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
 import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.Models.TransactionStatus
 import com.cashu.me.Models.TransactionType
 import com.cashu.me.Models.WalletTransaction
@@ -44,6 +45,7 @@ object AppTestFixture {
     fun launch(
         mode: FixtureMode,
         deepLink: String? = null,
+        supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
     ): LaunchedFixture {
         val application = ApplicationProvider.getApplicationContext<UiTestApplication>()
         val usesLiveGateway = mode == FixtureMode.LiveLocalMint ||
@@ -87,6 +89,7 @@ object AppTestFixture {
             null
         } else {
             FakeWalletGateway(
+                supportedMintMethods = supportedMintMethods,
                 initialBalances = if (mode == FixtureMode.FundedWithHistory) {
                     mapOf(mintUrl to 500L)
                 } else {

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.filter
 class FakeWalletGateway(
     initialBalances: Map<String, Long> = emptyMap(),
     initialTransactions: List<WalletTransaction> = emptyList(),
+    private val supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
 ) : WalletGateway {
     private val sequence = AtomicInteger(1)
     private val walletUrls = linkedSetOf<String>()
@@ -191,7 +192,7 @@ class FakeWalletGateway(
         val flow = checkNotNull(mintQuotes[quoteId]) { "Unknown fake quote $quoteId" }
         val quote = flow.value
         check(quote.state == MintQuoteState.Paid) { "Fake quote has not been paid." }
-        val credited = quote.amountPaid.takeIf { it > 0 } ?: quote.amount ?: 0
+        val credited = (quote.amountPaid.takeIf { it > 0 } ?: quote.amount ?: 0) - quote.amountIssued
         val mintUrl = checkNotNull(quote.mintUrl)
         balances[mintUrl] = (balances[mintUrl] ?: 0) + credited
         transactions += WalletTransaction(
@@ -212,7 +213,7 @@ class FakeWalletGateway(
         )
         flow.value = quote.copy(
             state = MintQuoteState.Issued,
-            amountIssued = credited,
+            amountIssued = quote.amountIssued + credited,
         )
         return credited
     }
@@ -396,6 +397,7 @@ class FakeWalletGateway(
 
     private fun defaultMint(url: String): MintInfo = MintInfo(
         url = url,
+        supportedMintMethods = supportedMintMethods,
         name = if (url == TestMintUrl) "Nutshell UI Test Mint" else "Test Mint",
         description = "Deterministic instrumented-test mint",
         nutSupport = NutSupport(

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ReusableReceiveJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/ReusableReceiveJourneyTest.kt
@@ -1,0 +1,82 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FakeWalletGateway
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReusableReceiveJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { launched?.close() }
+    private var launched: LaunchedFixture? = null
+    private val robot by lazy { WalletJourneyRobot(compose) }
+
+    @Test fun cashuRequestReturnsToSameQRAfterEachPayment() = verifySavedRequest(quoteKind = null)
+
+    @Test fun savedBolt12ReturnsToSameQRAfterEachPayment() = verifySavedRequest(quoteKind = "bolt12")
+
+    private fun verifySavedRequest(quoteKind: String?) {
+        launched = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val store = launched!!.container.cashuRequestStore
+        robot.awaitTag(UiTestTags.WalletScreen)
+        val request = if (quoteKind == null) {
+            store.createNew(encoded = "creqAreusable", mints = listOf(FakeWalletGateway.TestMintUrl))
+        } else {
+            store.upsertQuoteIntent(
+                quoteId = "saved-offer", quoteKind = quoteKind, amount = null,
+                encoded = "lno1reusable", mints = listOf(FakeWalletGateway.TestMintUrl),
+            )
+        }
+        robot.tapText("History").tapText(request.displayTitle).awaitText("Copy")
+        for (index in 1..2) {
+            compose.runOnIdle { store.attachPayment(request.id, "payment-$index", 21) }
+            robot.awaitText("Payment Received!").tapText("Done").awaitText("Copy")
+            compose.onNodeWithText("Payment Received!").assertDoesNotExist()
+            compose.onNodeWithContentDescription("QR code. Long press for copy and share options.")
+                .performScrollTo().assertIsDisplayed()
+            assertEquals(request.encoded, store.request(request.id)?.encoded)
+            assertEquals(index, store.request(request.id)?.receivedPayments?.size)
+        }
+    }
+
+    @Test fun newBolt12ShowsEachPaymentAmountAndKeepsItsOffer() {
+        launched = AppTestFixture.launch(
+            FixtureMode.SeededWithMint,
+            supportedMintMethods = listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Bolt12),
+        )
+        val fixture = launched!!
+        val fake = fixture.fakeGateway!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletReceive)
+            .tapDescription("Bitcoin. Receive over Lightning or on-chain")
+            .tapDescription("Receive method: Lightning invoice, One-time, instant")
+            .tapText("Reusable invoice").awaitText("Copy invoice")
+        val quoteId = checkNotNull(fake.latestMintQuoteId)
+        val original = runBlocking { fake.checkMintQuote(quoteId) }.request
+        for (total in listOf(21L, 42L)) {
+            compose.runOnIdle { fake.markMintQuotePaid(quoteId, amountPaid = total) }
+            robot.awaitText("Payment Received!", timeoutMillis = 20_000)
+            compose.onNodeWithText("₿21").assertIsDisplayed()
+            robot.tapText("Done").awaitText("Copy invoice")
+            compose.onNodeWithText("Payment Received!").assertDoesNotExist()
+            assertEquals(quoteId, fake.latestMintQuoteId)
+            assertEquals(original, runBlocking { fake.checkMintQuote(quoteId) }.request)
+            assertEquals(total, runBlocking { fake.totalBalance(FakeWalletGateway.TestMintUrl) })
+        }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcReceiveTerms.kt
@@ -4,7 +4,7 @@ import com.cashu.me.Models.CashuRequest
 
 internal enum class NfcSettlementRoute { Direct, Foreign }
 
-internal fun CashuRequest.shouldOfferNfcReceive(): Boolean = receivedPayments.isEmpty()
+internal fun CashuRequest.shouldOfferNfcReceive(): Boolean = isEcashRequest || receivedPayments.isEmpty()
 
 internal fun CashuRequest.canReceiveByNfc(): Boolean =
     shouldOfferNfcReceive() && amount?.let { it > 0 } == true

--- a/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Requests/CashuRequest.kt
@@ -33,6 +33,8 @@ data class CashuRequest(
 
     val isEcashRequest: Boolean get() = quoteKind == null
 
+    val isReusable: Boolean get() = isEcashRequest || quoteKind.equals("bolt12", ignoreCase = true)
+
     val displayTitle: String
         get() = when (quoteKind?.lowercase()) {
             "bolt12" -> "Reusable Invoice"

--- a/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/CashuRequestDetailScreen.kt
@@ -196,12 +196,23 @@ fun CashuRequestDetailScreen(
         mutableStateOf(request?.receivedPayments?.map { it.transactionId })
     }
     var successPaymentId by rememberSaveable(requestId) { mutableStateOf<String?>(null) }
-    LaunchedEffect(requestId, request?.receivedPayments) {
+    LaunchedEffect(requestId, request?.receivedPayments, successPaymentId) {
+        if (successPaymentId != null) return@LaunchedEffect
         val currentPayments = request?.receivedPayments ?: return@LaunchedEffect
         newestUnseenPayment(observedPaymentIds, currentPayments)?.let { payment ->
             successPaymentId = payment.transactionId
         }
         observedPaymentIds = currentPayments.map { it.transactionId }
+    }
+
+    fun finishPayment() {
+        if (request?.isReusable == true) {
+            successPaymentId = null
+            nfcReceiveCoordinator.clearResult()
+        } else {
+            nfcReceiveCoordinator.deactivate()
+            onClose()
+        }
     }
 
     // A payment that lands while this request is open always gets the shared
@@ -258,10 +269,7 @@ fun CashuRequestDetailScreen(
                 CashuRequestSuccessTerminal(
                     amountLabel = amountLabel,
                     mintName = mintName,
-                    onDone = {
-                        nfcReceiveCoordinator.deactivate()
-                        onClose()
-                    },
+                    onDone = ::finishPayment,
                     modifier = Modifier.padding(padding),
                 )
             }
@@ -512,10 +520,7 @@ fun CashuRequestDetailScreen(
                 coordinator = nfcReceiveCoordinator,
                 successAmountLabel = nfcSuccessAmountLabel,
                 successMintName = nfcSuccessMintName,
-                onSuccessDone = {
-                    nfcReceiveCoordinator.deactivate()
-                    onClose()
-                },
+                onSuccessDone = ::finishPayment,
             )
         }
         }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveLightningScreen.kt
@@ -206,6 +206,12 @@ fun ReceiveLightningScreen(
     // When a payment lands the body crossfades to the shared receipt while the
     // sheet header stays mounted, matching iOS ReceiveLightningView.
     var successInfo by remember { mutableStateOf<ReceiveSuccessInfo?>(null) }
+    val displayedQuote = (face as? ReceiveLnFace.Display)?.quote
+    // Owned outside the animated body: returning from success must retain the
+    // cumulative issuance baseline for this exact offer.
+    val reusablePaymentObservation = remember(displayedQuote?.id) {
+        ReusableMintPaymentObservation(displayedQuote?.amountIssued ?: 0)
+    }
     // On-chain quotes abandoned via "Use new address": a payment may already be
     // racing toward the old address, so keep checking them for the life of the
     // sheet (mint-status checks only — no extra explorer polling). Set
@@ -567,7 +573,13 @@ fun ReceiveLightningScreen(
             )
             ReceiveSuccessTerminal(
                 info = terminal,
-                onDone = onClose,
+                onDone = {
+                    if (terminal.method == PaymentMethodKind.Bolt12) {
+                        successInfo = null
+                    } else {
+                        onClose()
+                    }
+                },
                 modifier = Modifier.weight(1f),
             )
         }
@@ -875,7 +887,7 @@ fun ReceiveLightningScreen(
                     // check/issue operation; durable retry truth comes from the
                     // scheduler record returned with the result.
                     fun reconcileDisplayedQuote(force: Boolean = false) {
-                        if (isReconcilingQuote) return
+                        if (isReconcilingQuote || successInfo != null) return
                         val quoteId = liveQuote.id
                         val paymentMethod = liveQuote.paymentMethod
                         isReconcilingQuote = true
@@ -893,12 +905,35 @@ fun ReceiveLightningScreen(
                                 )
                                 result.quote?.let { liveQuote = it }
                                 mintRetryStatus = result.retryStatus
-                                if (paymentMethod != PaymentMethodKind.Bolt12 &&
-                                    result.hasSettledPayment
+                                if (successInfo != null ||
+                                    (face as? ReceiveLnFace.Display)?.quote?.id != quoteId
+                                ) return@launch
+                                val settledQuote = result.quote
+                                val receivedAmount = settledQuote?.let {
+                                    if (paymentMethod == PaymentMethodKind.Bolt12) {
+                                        reusablePaymentObservation.newlyIssuedAmount(it.amountIssued)
+                                    } else if (result.hasSettledPayment) {
+                                        it.amountIssued.takeIf { issued -> issued > 0 } ?: it.amount
+                                    } else null
+                                }
+                                if (settledQuote != null &&
+                                    (receivedAmount != null ||
+                                        (paymentMethod != PaymentMethodKind.Bolt12 && result.hasSettledPayment))
                                 ) {
+                                    face = ReceiveLnFace.Display(settledQuote)
                                     successInfo = ReceiveSuccessInfo(
-                                        amountLabel = amountLabel,
-                                        mintName = activeMint?.name,
+                                        amountLabel = receivedAmount?.let {
+                                            if (settledQuote.unit.equals("sat", ignoreCase = true)) {
+                                                formatter.formatWalletSats(it, settings.useBitcoinSymbol)
+                                            } else {
+                                                CurrencyAmount(
+                                                    it, CurrencyRegistry.currencyForMintUnit(settledQuote.unit),
+                                                ).formatted()
+                                            }
+                                        },
+                                        mintName = walletState.mints.firstOrNull {
+                                            it.url == settledQuote.mintUrl
+                                        }?.name ?: settledQuote.mintUrl,
                                         method = paymentMethod,
                                     )
                                 }
@@ -916,11 +951,8 @@ fun ReceiveLightningScreen(
                         liveQuote.amountIssued,
                     ) {
                         if (liveQuote.paymentMethod == PaymentMethodKind.Bolt12) {
-                            // Reusable offers never reach the one-shot success
-                            // terminal. The synchronizer mints a newly-paid
-                            // amount when needed and always reloads History,
-                            // including the already-issued case. Keep the QR on
-                            // screen to accept the next payment.
+                            // Reconcile before showing success. The receipt uses
+                            // the issuance delta and Done restores this same QR.
                             if (liveQuote.amountPaid > 0 ||
                                 liveQuote.state == MintQuoteState.Paid ||
                                 liveQuote.state == MintQuoteState.Issued

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReusableMintPaymentObservation.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReusableMintPaymentObservation.kt
@@ -1,0 +1,11 @@
+package com.cashu.me.ui.receive
+
+/** Tracks cumulative BOLT12 issuance across receipts without replaying saved payments. */
+internal class ReusableMintPaymentObservation(private var amountIssued: Long) {
+    fun newlyIssuedAmount(currentAmountIssued: Long): Long? {
+        if (currentAmountIssued <= amountIssued) return null
+        val received = currentAmountIssued - amountIssued
+        amountIssued = currentAmountIssued
+        return received
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NfcReceive/NfcReceiveTermsTest.kt
@@ -15,10 +15,11 @@ class NfcReceiveTermsTest {
     }
 
     @Test
-    fun `nfc receive is only offered for unpaid requests`() {
+    fun `reusable cashu request remains available for another tap after payment`() {
         assertTrue(request(amount = 1).shouldOfferNfcReceive())
-        assertTrue(!paidRequest().shouldOfferNfcReceive())
-        assertTrue(!paidRequest().canReceiveByNfc())
+        assertTrue(paidRequest().shouldOfferNfcReceive())
+        assertTrue(paidRequest().canReceiveByNfc())
+        assertTrue(!paidRequest().copy(quoteKind = "bolt11").shouldOfferNfcReceive())
     }
 
     @Test

--- a/android/app/src/test/java/com/cashu/me/Models/CashuRequestDisplayTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Models/CashuRequestDisplayTest.kt
@@ -12,6 +12,7 @@ class CashuRequestDisplayTest {
 
         assertEquals("Cashu Request", request.displayTitle)
         assertTrue(request.isEcashRequest)
+        assertTrue(request.isReusable)
     }
 
     @Test
@@ -24,6 +25,9 @@ class CashuRequestDisplayTest {
         assertEquals("Reusable Invoice", bolt12.displayTitle)
         assertEquals("Bitcoin Address", onchain.displayTitle)
         assertFalse(bolt11.isEcashRequest)
+        assertFalse(bolt11.isReusable)
+        assertTrue(bolt12.isReusable)
+        assertFalse(onchain.isReusable)
 
         val payment = CashuRequestPayment("tx", 10, 1_700_000_000)
         assertEquals("Lightning received", bolt11.copy(receivedPayments = listOf(payment)).displayTitle)

--- a/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/CashuRequestPaymentObservationTest.kt
@@ -60,6 +60,16 @@ class CashuRequestPaymentObservationTest {
     }
 
     @Test
+    fun `same request can present a second payment without replaying the first`() {
+        val first = payment("first", amount = 21)
+        val second = payment("second", amount = 21)
+        assertEquals(first, newestUnseenPayment(emptyList(), listOf(first)))
+        assertNull(newestUnseenPayment(listOf(first.transactionId), listOf(first)))
+        assertEquals(second, newestUnseenPayment(listOf(first.transactionId), listOf(first, second)))
+        assertNull(newestUnseenPayment(listOf("first", "second"), listOf(first, second)))
+    }
+
+    @Test
     fun `NFC session stays mounted while payment record and success state hand off`() {
         assertTrue(shouldKeepNfcSessionMounted(false, NfcReceivePhase.Redeeming))
         assertTrue(shouldKeepNfcSessionMounted(false, NfcReceivePhase.Success))

--- a/android/app/src/test/java/com/cashu/me/ui/receive/ReusableMintPaymentObservationTest.kt
+++ b/android/app/src/test/java/com/cashu/me/ui/receive/ReusableMintPaymentObservationTest.kt
@@ -1,0 +1,28 @@
+package com.cashu.me.ui.receive
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ReusableMintPaymentObservationTest {
+    @Test
+    fun `each receipt uses the payment delta and ignores already acknowledged issuance`() {
+        val observation = ReusableMintPaymentObservation(0)
+        assertNull(observation.newlyIssuedAmount(0))
+        assertEquals(21L, observation.newlyIssuedAmount(21))
+        assertNull(observation.newlyIssuedAmount(21))
+        assertEquals(21L, observation.newlyIssuedAmount(42))
+        assertNull(observation.newlyIssuedAmount(42))
+        assertEquals(34L, observation.newlyIssuedAmount(76))
+    }
+
+    @Test
+    fun `saved offer and stale snapshots do not replay success`() {
+        val observation = ReusableMintPaymentObservation(100)
+        assertNull(observation.newlyIssuedAmount(100))
+        assertNull(observation.newlyIssuedAmount(0))
+        assertEquals(21L, observation.newlyIssuedAmount(121))
+        assertNull(observation.newlyIssuedAmount(100))
+        assertNull(observation.newlyIssuedAmount(121))
+    }
+}

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -19,7 +19,6 @@ struct CashuRequestDetailView: View {
     @State private var showUnitPicker = false
     @State private var paymentObservation: CashuRequestPaymentObservation
     @State private var regenerationError: String?
-    @State private var didAutoComplete = false
     /// Amount of the payment that just landed, for the shared success screen.
     @State private var receivedAmount: UInt64?
     @State private var showPaymentSuccess = false
@@ -124,13 +123,11 @@ struct CashuRequestDetailView: View {
                 .presentationDetents([.medium])
             }
         }
-        .onChange(of: request?.receivedPayments) { _, currentPayments in
-            guard let currentPayments,
-                  let payment = paymentObservation.newlyLinkedPayment(in: currentPayments) else { return }
-            AppLogger.wallet.notice(
-                "CashuRequestDetailView: linked payment \(payment.transactionId, privacy: .public)"
-            )
-            markPaymentReceived(amount: payment.amount)
+        .onChange(of: request?.receivedPayments) {
+            presentNextPayment()
+        }
+        .onChange(of: showPaymentSuccess) {
+            presentNextPayment()
         }
         .task(id: monitoredQuoteID) {
             guard let quoteID = monitoredQuoteID else { return }
@@ -139,13 +136,12 @@ struct CashuRequestDetailView: View {
         .compactBottomSheetSurface()
     }
 
-    /// Single-fire transition into the shared full-screen success — the same
-    /// `PaymentStatusView` every other receive/pay flow ends on, so a paid
-    /// request reads identically to a paid invoice. Stays until Done.
-    private func markPaymentReceived(amount: UInt64?) {
-        guard !didAutoComplete else { return }
-        didAutoComplete = true
-        receivedAmount = amount ?? request?.amount
+    /// Keep the current receipt stable; payments arriving during it are picked
+    /// up after Done without replaying any previously acknowledged payment.
+    private func presentNextPayment() {
+        guard !showPaymentSuccess, let request,
+              let payment = paymentObservation.newlyLinkedPayment(in: request.receivedPayments) else { return }
+        receivedAmount = payment.amount
         // PaymentStatusView owns the success haptic on appear — don't buzz here.
         showPaymentSuccess = true
     }
@@ -157,7 +153,13 @@ struct CashuRequestDetailView: View {
             phase: .success,
             successTitle: "Payment Received!",
             onDone: {
-                if let onClose { onClose() } else { dismiss() }
+                if request?.reusable == true {
+                    showPaymentSuccess = false
+                } else if let onClose {
+                    onClose()
+                } else {
+                    dismiss()
+                }
             },
             onRetry: {}
         )

--- a/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveLightningView.swift
@@ -40,6 +40,8 @@ struct ReceiveLightningView: View {
     @State private var isCheckingPayment = false
     @State private var mintRetryStatus = MintQuoteRetryStatus()
     @State private var isPaid = false
+    @State private var receivedAmount: UInt64?
+    @State private var reusablePaymentObservation = ReusableMintPaymentObservation()
     @State private var requestFailure: ReceiveRequestFailure?
     @State private var showMintPicker = false
     /// Reusable BOLT12 offer: drives the Amount-row pencil → amount picker sheet.
@@ -674,6 +676,7 @@ struct ReceiveLightningView: View {
     }
 
     private func startDisplayingQuote(_ quote: MintQuoteInfo) {
+        reusablePaymentObservation.startObserving(quoteID: quote.id, amountIssued: quote.amountIssued)
         if quote.paymentMethod == .bolt12 { persistReceiveIntent(for: quote) }
         startQuoteMonitoring(for: quote)
         if quote.paymentMethod != .bolt12 { startExpiryCountdown(quote: quote) }
@@ -699,14 +702,20 @@ struct ReceiveLightningView: View {
             details: receiveSuccessRows(quote: quote),
             phase: .success,
             successTitle: "Payment Received!",
-            onDone: { dismiss() },
+            onDone: {
+                if quote.paymentMethod == .bolt12 {
+                    isPaid = false
+                } else {
+                    dismiss()
+                }
+            },
             onRetry: {}
         )
     }
 
     private func receiveSuccessRows(quote: MintQuoteInfo) -> [PaymentStatusView.DetailRow] {
         var rows: [PaymentStatusView.DetailRow] = []
-        if let amount = quote.amount {
+        if let amount = receivedAmount ?? quote.amount {
             rows.append(.init(
                 label: "Amount",
                 value: formatQuoteAmount(amount, unit: quote.unit)
@@ -1519,7 +1528,7 @@ struct ReceiveLightningView: View {
 
     @MainActor
     private func refreshMintQuoteStatus(force: Bool = false) async {
-        guard let quote = mintQuote, !isMinting, !isCheckingPayment,
+        guard let quote = mintQuote, !isPaid, !isMinting, !isCheckingPayment,
               force || !isExpired || quote.paymentMethod == .onchain || quote.mintableAmount > 0 else { return }
 
         isCheckingPayment = true
@@ -1544,13 +1553,8 @@ struct ReceiveLightningView: View {
         }
 
         if result.quote.paymentMethod == .bolt12 {
-            if result.newlyIssued > 0 {
-                walletManager.postReceivedMintNotification(
-                    amount: result.newlyIssued,
-                    unit: result.quote.unit,
-                    homeHaptic: false
-                )
-                HapticFeedback.notification(.success)
+            if let amount = reusablePaymentObservation.newlyIssuedAmount(result.quote.amountIssued) {
+                await completeReceivedQuote(receivedAmount: amount)
             }
         } else if result.hasSettledPayment {
             await completeReceivedQuote(receivedAmount: result.quote.amountIssued)
@@ -1582,11 +1586,11 @@ struct ReceiveLightningView: View {
         }
     }
 
-    /// Finish a one-shot receive only after quote counters (or a successful
-    /// mint response) confirm that ecash was issued.
+    /// Present a receipt only after reconciliation confirms ecash was issued.
     @MainActor
     private func completeReceivedQuote(receivedAmount: UInt64? = nil) async {
         guard !isPaid else { return }
+        self.receivedAmount = receivedAmount
         isPaid = true
         expiryTimer?.invalidate()
 
@@ -1603,12 +1607,33 @@ struct ReceiveLightningView: View {
             )
         }
 
-        // Ecash is issued — stop polling this one-shot request. Reusable
-        // BOLT12 offers never enter this terminal path.
+        // Returning to a reusable QR starts monitoring again with the same
+        // issuance baseline, so the previous payment cannot replay success.
         quoteStatusTask?.cancel()
+        monitoredQuoteId = nil
     }
 
 
+}
+
+/// BOLT12 counters are cumulative. Preserve the acknowledged total across
+/// receipt dismissal and ignore stale snapshots or already-paid saved offers.
+struct ReusableMintPaymentObservation {
+    private var quoteID: String?
+    private var amountIssued: UInt64 = 0
+
+    mutating func startObserving(quoteID: String, amountIssued: UInt64) {
+        guard self.quoteID != quoteID else { return }
+        self.quoteID = quoteID
+        self.amountIssued = amountIssued
+    }
+
+    mutating func newlyIssuedAmount(_ currentAmountIssued: UInt64) -> UInt64? {
+        guard currentAmountIssued > amountIssued else { return nil }
+        let received = currentAmountIssued - amountIssued
+        amountIssued = currentAmountIssued
+        return received
+    }
 }
 
 #Preview {

--- a/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
@@ -77,4 +77,66 @@ final class CashuRequestPaymentObservationTests: XCTestCase {
 
         XCTAssertNil(observation.newlyLinkedPayment(in: [existing]))
     }
+
+    func testSameRequestReceivesAgainAfterAcknowledgingFirstPayment() throws {
+        let request = store.createNew(id: "reusable-request", encoded: "creqAreusable")
+        var observation = CashuRequestPaymentObservation(existingPayments: [])
+        for id in ["first", "second"] {
+            store.attachPayment(requestId: request.id, transactionId: id, amount: 21)
+            let current = try XCTUnwrap(store.request(withId: request.id))
+            XCTAssertEqual(current.encoded, request.encoded)
+            XCTAssertEqual(observation.newlyLinkedPayment(in: current.receivedPayments)?.transactionId, id)
+            XCTAssertNil(observation.newlyLinkedPayment(in: current.receivedPayments))
+        }
+    }
+
+    func testPaymentArrivingDuringReceiptRemainsAvailableAfterDone() {
+        var observation = CashuRequestPaymentObservation(existingPayments: [])
+        let first = CashuRequestPayment(transactionId: "first", amount: 21, receivedAt: Date())
+        let second = CashuRequestPayment(transactionId: "second", amount: 34, receivedAt: Date())
+        XCTAssertEqual(observation.newlyLinkedPayment(in: [first]), first)
+        // The screen pauses observation while showing the first receipt.
+        XCTAssertEqual(observation.newlyLinkedPayment(in: [first, second]), second)
+        XCTAssertNil(observation.newlyLinkedPayment(in: [first, second]))
+    }
+}
+
+final class ReusableMintPaymentObservationTests: XCTestCase {
+    func testSuccessUsesEachPaymentDeltaAcrossRepeatedQRPresentations() {
+        var observation = ReusableMintPaymentObservation()
+        observation.startObserving(quoteID: "offer", amountIssued: 0)
+        XCTAssertNil(observation.newlyIssuedAmount(0))
+        XCTAssertEqual(observation.newlyIssuedAmount(21), 21)
+        observation.startObserving(quoteID: "offer", amountIssued: 21)
+        XCTAssertNil(observation.newlyIssuedAmount(21))
+        XCTAssertEqual(observation.newlyIssuedAmount(42), 21)
+        observation.startObserving(quoteID: "offer", amountIssued: 42)
+        XCTAssertEqual(observation.newlyIssuedAmount(76), 34)
+    }
+
+    func testSavedOfferAndStaleSnapshotsDoNotReplaySuccess() {
+        var observation = ReusableMintPaymentObservation()
+        observation.startObserving(quoteID: "saved-offer", amountIssued: 100)
+        XCTAssertNil(observation.newlyIssuedAmount(100))
+        XCTAssertNil(observation.newlyIssuedAmount(0))
+        XCTAssertEqual(observation.newlyIssuedAmount(121), 21)
+        XCTAssertNil(observation.newlyIssuedAmount(100))
+        XCTAssertNil(observation.newlyIssuedAmount(121))
+    }
+
+    func testPaymentIssuedWhileReceiptIsOpenIsNotAbsorbedIntoBaseline() {
+        var observation = ReusableMintPaymentObservation()
+        observation.startObserving(quoteID: "offer", amountIssued: 0)
+        XCTAssertEqual(observation.newlyIssuedAmount(21), 21)
+        observation.startObserving(quoteID: "offer", amountIssued: 55)
+        XCTAssertEqual(observation.newlyIssuedAmount(55), 34)
+    }
+
+    func testSwitchingOfferEstablishesItsOwnBaseline() {
+        var observation = ReusableMintPaymentObservation()
+        observation.startObserving(quoteID: "first-offer", amountIssued: 100)
+        observation.startObserving(quoteID: "second-offer", amountIssued: 7)
+        XCTAssertNil(observation.newlyIssuedAmount(7))
+        XCTAssertEqual(observation.newlyIssuedAmount(28), 21)
+    }
 }


### PR DESCRIPTION
Reusable Cashu requests and BOLT12 offers now show payment success on iOS and Android, then return to the same QR code when Done is tapped so the receiver can accept another payment immediately. Single-use invoices retain their existing completion behavior.

The receive screens retain their payment observation state across receipts, resume monitoring when the QR returns, and use BOLT12 issuance deltas to show the new payment amount without replaying previous payments. Android Cashu requests also remain available for subsequent NFC payments.

Validation:
- 15 focused iOS tests passed, covering payment observation and quote monitoring.
- 37 focused Android unit tests passed.
- Four Android emulator journeys passed: repeated payments to a Cashu request, a saved BOLT12 offer, and a newly created BOLT12 offer, plus single-use Lightning invoice completion. These use deterministic wallet fixtures.
- Whitespace checks passed.
