### PR TITLE
Protect wallet recovery, deferred receipts, and payment settlement

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
@@ -29,6 +29,60 @@ class StorageDataStoreInstrumentedTest {
     private val json = Json { encodeDefaults = true }
 
     @Test
+    fun restoreBackupBarrierSurvivesReloadAndWalletRollback() {
+        val storeName = uniqueStoreName("restore_barrier")
+        val store = SettingsStore(context, storeName)
+        store.walletRestoreIncomplete = true
+        val snapshot = store.snapshotWalletScopedData()
+        store.clearWalletScopedData()
+        assertFalse(SettingsStore(context, storeName).walletRestoreIncomplete)
+        store.restoreWalletScopedData(snapshot)
+        assertTrue(SettingsStore(context, storeName).walletRestoreIncomplete)
+    }
+
+    @Test
+    fun replacementCheckpointPreservesSqliteWalContents() {
+        val root = java.io.File(context.cacheDir, "replacement-checkpoint-" + UUID.randomUUID()).apply { mkdirs() }
+        val isolatedContext = object : android.content.ContextWrapper(context) {
+            override fun getApplicationContext(): Context = this
+            override fun getFilesDir(): java.io.File = root
+        }
+        val paths = com.cashu.me.Core.Platform.WalletDatabasePathManager(isolatedContext)
+        try {
+            android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(paths.databaseFile, null).use { db ->
+                db.enableWriteAheadLogging()
+                db.execSQL("CREATE TABLE recovery_test (value TEXT NOT NULL)")
+                db.execSQL("INSERT INTO recovery_test VALUES ('proofs before replacement')")
+                paths.checkpointBeforeReplacement()
+            }
+            android.database.sqlite.SQLiteDatabase.openDatabase(paths.databaseFile.path, null, 0).use { reopened ->
+                reopened.rawQuery("SELECT value FROM recovery_test", null).use { cursor ->
+                    assertTrue(cursor.moveToFirst())
+                    assertEquals("proofs before replacement", cursor.getString(0))
+                }
+            }
+        } finally { root.deleteRecursively() }
+    }
+
+    @Test
+    fun replacementCheckpointNeverDeletesAnUnreadableDatabase() {
+        val root = java.io.File(context.cacheDir, "replacement-corrupt-" + UUID.randomUUID()).apply { mkdirs() }
+        val isolatedContext = object : android.content.ContextWrapper(context) {
+            override fun getApplicationContext(): Context = this
+            override fun getFilesDir(): java.io.File = root
+        }
+        val paths = com.cashu.me.Core.Platform.WalletDatabasePathManager(isolatedContext)
+        try {
+            paths.databaseFile.writeText("unreadable original database")
+            try {
+                paths.checkpointBeforeReplacement()
+                org.junit.Assert.fail("Unreadable database must block preparation")
+            } catch (_: Exception) { }
+            assertEquals("unreadable original database", paths.databaseFile.readText())
+        } finally { root.deleteRecursively() }
+    }
+
+    @Test
     fun walletStoreMigratesSharedPreferencesAndClearsWalletBoundary() {
         val storeName = uniqueStoreName("wallet_store")
         val mint = MintInfo(url = "https://mint.example.com", name = "Example", balance = 21)

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -89,6 +89,40 @@ class NativeWalletLocalMintInstrumentedTest {
         }
     }
 
+    @Test
+    fun foreignNfcChangeRemainsSpendableAfterDatabaseReopen() = runBlocking {
+        assumeNativeMatrixEnabled()
+        assertMintEndpointReady(nutshellMintUrl)
+        assertMintEndpointReady(cdkMintUrl)
+        workDir.mkdirs()
+        val payer = TestWallet("nfc-payer")
+        val receiver = TestWallet("nfc-receiver")
+        try {
+            payer.open()
+            receiver.open()
+            payer.gateway.ensureWallet(nutshellMintUrl)
+            receiver.gateway.ensureWallet(cdkMintUrl)
+            val quote = payer.gateway.createMintQuote(1_000, PaymentMethodKind.Bolt11, nutshellMintUrl, "sat")
+            val paid = quote.awaitPaid(payer.gateway)
+            payer.gateway.mintTokens(paid.id)
+            val token = payer.gateway.sendEcashToken(1_000, null, null, nutshellMintUrl).token
+            val result = receiver.gateway.settleForeignNfcToken(token, cdkMintUrl)
+            val sourceChange = receiver.gateway.totalBalance(nutshellMintUrl)
+            assertTrue("Conversion must retain unused fee reserve and overhead", sourceChange > 0)
+            assertEquals(1_000L, result.amountReceived + sourceChange + result.feePaid)
+            val seed = receiver.mnemonic
+            receiver.close()
+            receiver.open(seed)
+            assertEquals(sourceChange, receiver.gateway.totalBalance(nutshellMintUrl))
+            assertEquals(result.amountReceived, receiver.gateway.totalBalance(cdkMintUrl))
+            val changeToken = receiver.gateway.sendEcashToken(sourceChange, null, null, nutshellMintUrl)
+            assertEquals(sourceChange, payer.gateway.receiveEcashToken(changeToken.token))
+        } finally {
+            payer.close()
+            receiver.close()
+        }
+    }
+
     @FullOnly
     @Test
     fun nativeCdkWalletMatrixAgainstLocalMints() = runBlocking {

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/NativeWalletLocalMintInstrumentedTest.kt
@@ -123,6 +123,47 @@ class NativeWalletLocalMintInstrumentedTest {
         }
     }
 
+    @Test
+    fun spentForeignNfcTokenNeverBecomesSpendableThroughRecovery() = runBlocking {
+        assumeNativeMatrixEnabled()
+        assertMintEndpointReady(nutshellMintUrl)
+        assertMintEndpointReady(cdkMintUrl)
+        workDir.mkdirs()
+        val payer = TestWallet("spent-nfc-payer")
+        val receiver = TestWallet("spent-nfc-receiver")
+        try {
+            payer.open()
+            receiver.open()
+            payer.gateway.ensureWallet(nutshellMintUrl)
+            receiver.gateway.ensureWallet(cdkMintUrl)
+            val quote = payer.gateway.createMintQuote(1_000, PaymentMethodKind.Bolt11, nutshellMintUrl, "sat")
+            payer.gateway.mintTokens(quote.awaitPaid(payer.gateway).id)
+            val token = payer.gateway.sendEcashToken(1_000, null, null, nutshellMintUrl).token
+            // The sender redeemed the bearer token before presenting its old
+            // copy over NFC. Compensation must never credit those spent proofs.
+            assertEquals(1_000L, payer.gateway.receiveEcashToken(token))
+            val failure = runCatching { receiver.gateway.settleForeignNfcToken(token, cdkMintUrl) }
+            assertTrue("Spent token must be rejected", failure.isFailure)
+            receiver.gateway.recoverIncompleteSagas(nutshellMintUrl)
+            assertEquals(0L, receiver.gateway.totalBalance(nutshellMintUrl))
+            assertEquals(0L, receiver.gateway.totalBalance(cdkMintUrl))
+
+            val seed = receiver.mnemonic
+            receiver.close()
+            receiver.open(seed)
+            // Startup recreates tracked mints; the rejected token never made
+            // a quote or transaction that would persist the target wallet.
+            receiver.gateway.ensureWallet(nutshellMintUrl)
+            receiver.gateway.ensureWallet(cdkMintUrl)
+            receiver.gateway.recoverIncompleteSagas(nutshellMintUrl)
+            assertEquals(0L, receiver.gateway.totalBalance(nutshellMintUrl))
+            assertEquals(0L, receiver.gateway.totalBalance(cdkMintUrl))
+        } finally {
+            payer.close()
+            receiver.close()
+        }
+    }
+
     @FullOnly
     @Test
     fun nativeCdkWalletMatrixAgainstLocalMints() = runBlocking {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -91,10 +91,7 @@ internal const val LIGHTNING_SETTLEMENT_WAIT_MS = 30_000L
  * In-lane settlement wait for an async-accepted melt. Returns the
  * [CdkFinalizedMelt] when the melt is a lightning method and CDK's `wait()`
  * reaches a terminal state within [waitMs]; null when the method doesn't wait
- * (on-chain/unknown), the cap expires, or the wait fails ambiguously — the
- * caller then falls back to the pending result + handle, and never surfaces a
- * false terminal failure. Cancellation propagates: Kotlin's CDK bindings drop
- * the Rust future cleanly.
+ * or the cap expires. Errors propagate to the status-aware recovery path.
  */
 internal suspend fun awaitLightningSettlementOrNull(
     method: CdkPaymentMethod?,
@@ -102,13 +99,7 @@ internal suspend fun awaitLightningSettlementOrNull(
     wait: suspend () -> CdkFinalizedMelt,
 ): CdkFinalizedMelt? {
     if (method != CdkPaymentMethod.Bolt11 && method != CdkPaymentMethod.Bolt12) return null
-    return try {
-        withTimeoutOrNull(waitMs) { wait() }
-    } catch (cancelled: CancellationException) {
-        throw cancelled
-    } catch (_: Exception) {
-        null
-    }
+    return withTimeoutOrNull(waitMs) { wait() }
 }
 
 /** Builds CDK's explicit amount override for amountless Lightning requests. */
@@ -503,79 +494,123 @@ class CdkWalletGatewayImpl : WalletGateway {
     override suspend fun meltTokens(quoteId: String, mintUrl: String?): MeltConfirmation = cdkCall {
         val quote = database?.getMeltQuote(quoteId)
         val wallet = walletFor(mintUrl ?: quote?.mintUrl?.url ?: firstWallet().mintUrl().url)
-        val prepared = wallet.prepareMelt(quoteId)
-        // `respond-async` lets the mint accept the payment and pay out in the
-        // background (NUT-05) instead of holding the request open — the usual
-        // shape for on-chain melts (iOS LightningService.meltTokens parity).
-        when (val outcome = prepared.confirmPreferAsync()) {
-            is CdkMeltConfirmOutcome.Paid -> {
-                val finalized = outcome.finalized
-                MeltConfirmation(
-                    result = MeltPaymentResult(
-                        preimage = finalized.preimage,
-                        amount = finalized.amount.value.toLong(),
-                        feePaid = finalized.feePaid.value.toLong(),
-                        mintUrl = wallet.mintUrl().url,
-                        paymentMethod = quote?.paymentMethod?.toDomain(),
-                        request = quote?.request,
-                        settlement = MeltSettlement.Settled,
-                    ),
-                    pendingMelt = null,
-                )
-            }
-            is CdkMeltConfirmOutcome.Pending -> {
-                // A lightning melt settles in seconds in the healthy case, so
-                // hold the lane and let CDK's `wait()` drive the saga to a
-                // terminal state — it polls the mint internally; the app adds
-                // no polling of its own. Kotlin's bindings cancel cleanly, so
-                // the cap is a plain timeout: on expiry the Rust future is
-                // dropped and the handle goes back to the manager, whose
-                // `watchPendingMelt` re-arms a fresh wait outside the lane
-                // (iOS `MeltSettlementWait` parity). On-chain melts genuinely
-                // take minutes and keep the immediate pending path.
-                val finalized = awaitLightningSettlementOrNull(method = quote?.paymentMethod) {
-                    outcome.pending.wait()
-                }
-                when {
-                    finalized != null &&
-                        (finalized.state == CdkQuoteState.PAID || finalized.state == CdkQuoteState.ISSUED) ->
-                        MeltConfirmation(
-                            result = MeltPaymentResult(
-                                preimage = finalized.preimage,
-                                amount = finalized.amount.value.toLong(),
-                                feePaid = finalized.feePaid.value.toLong(),
-                                mintUrl = wallet.mintUrl().url,
-                                paymentMethod = quote?.paymentMethod?.toDomain(),
-                                request = quote?.request,
-                                settlement = MeltSettlement.Settled,
-                            ),
-                            pendingMelt = null,
-                        )
-                    finalized != null ->
-                        // Wait finished UNPAID: the payment failed and CDK has
-                        // already compensated the proofs back. The quote can't
-                        // be reused.
-                        throw CdkGatewayUnavailable(
-                            "Payment failed — the mint returned your funds. Get a new quote and try again.",
-                        )
-                    else -> MeltConfirmation(
-                        // Amount and fee aren't final until the payment settles;
-                        // report the quote's numbers (fee = reserve upper bound)
-                        // so the UI has facts to show.
+        val prepared = try { wallet.prepareMelt(quoteId) } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (failure: Exception) {
+            val stored = try { checkNotNull(database).getMeltQuote(quoteId) }
+                catch (_: Exception) { throw MeltPaymentRecoveryException(quoteId, null, unresolved = true) }
+            val operation = stored?.usedByOperation ?: throw failure
+            return@cdkCall resolveMeltFailure(wallet, quoteId, operation)
+        }
+        try {
+            // `respond-async` lets the mint accept the payment and pay out in the
+            // background (NUT-05) instead of holding the request open — the usual
+            // shape for on-chain melts (iOS LightningService.meltTokens parity).
+            when (val outcome = prepared.confirmPreferAsync()) {
+                is CdkMeltConfirmOutcome.Paid -> {
+                    val finalized = outcome.finalized
+                    MeltConfirmation(
                         result = MeltPaymentResult(
-                            preimage = null,
-                            amount = quote?.amount?.value?.toLong() ?: 0,
-                            feePaid = quote?.feeReserve?.value?.toLong() ?: 0,
+                            preimage = finalized.preimage,
+                            amount = finalized.amount.value.toLong(),
+                            feePaid = finalized.feePaid.value.toLong(),
                             mintUrl = wallet.mintUrl().url,
                             paymentMethod = quote?.paymentMethod?.toDomain(),
                             request = quote?.request,
-                            settlement = MeltSettlement.Pending,
+                            settlement = MeltSettlement.Settled,
                         ),
-                        pendingMelt = outcome.pending,
+                        pendingMelt = null,
                     )
                 }
+                is CdkMeltConfirmOutcome.Pending -> {
+                    // A lightning melt settles in seconds in the healthy case, so
+                    // hold the lane and let CDK's `wait()` drive the saga to a
+                    // terminal state — it polls the mint internally; the app adds
+                    // no polling of its own. Kotlin's bindings cancel cleanly, so
+                    // the cap is a plain timeout: on expiry the Rust future is
+                    // dropped and the handle goes back to the manager, whose
+                    // `watchPendingMelt` re-arms a fresh wait outside the lane
+                    // (iOS `MeltSettlementWait` parity). On-chain melts genuinely
+                    // take minutes and keep the immediate pending path.
+                    val finalized = awaitLightningSettlementOrNull(method = quote?.paymentMethod) {
+                        outcome.pending.wait()
+                    }
+                    when {
+                        finalized != null &&
+                            (finalized.state == CdkQuoteState.PAID || finalized.state == CdkQuoteState.ISSUED) ->
+                            MeltConfirmation(
+                                result = MeltPaymentResult(
+                                    preimage = finalized.preimage,
+                                    amount = finalized.amount.value.toLong(),
+                                    feePaid = finalized.feePaid.value.toLong(),
+                                    mintUrl = wallet.mintUrl().url,
+                                    paymentMethod = quote?.paymentMethod?.toDomain(),
+                                    request = quote?.request,
+                                    settlement = MeltSettlement.Settled,
+                                ),
+                                pendingMelt = null,
+                            )
+                        finalized != null ->
+                            // A non-paid result still needs reservation checks before
+                            // the UI may describe the funds as returned.
+                            resolveMeltFailure(wallet, quoteId, prepared.operationId())
+                        else -> MeltConfirmation(
+                            // Amount and fee aren't final until the payment settles;
+                            // report the quote's numbers (fee = reserve upper bound)
+                            // so the UI has facts to show.
+                            result = MeltPaymentResult(
+                                preimage = null,
+                                amount = quote?.amount?.value?.toLong() ?: 0,
+                                feePaid = quote?.feeReserve?.value?.toLong() ?: 0,
+                                mintUrl = wallet.mintUrl().url,
+                                paymentMethod = quote?.paymentMethod?.toDomain(),
+                                request = quote?.request,
+                                settlement = MeltSettlement.Pending,
+                            ),
+                            pendingMelt = outcome.pending,
+                        )
+                    }
+                }
             }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (recovery: MeltPaymentRecoveryException) {
+            throw recovery
+        } catch (_: Exception) {
+            resolveMeltFailure(wallet, quoteId, prepared.operationId())
         }
+    }
+
+    private suspend fun resolveMeltFailure(wallet: CdkWallet, quoteId: String, operationId: String): MeltConfirmation {
+        val checked = resolveAmbiguousMelt(
+            quoteId = quoteId,
+            operationId = operationId,
+            checkStatus = { wallet.checkMeltQuoteStatus(quoteId) },
+            recoverSagas = { wallet.recoverIncompleteSagas(); Unit },
+            state = { it.state },
+            compensationComplete = {
+                val db = checkNotNull(database)
+                db.getSaga(operationId) == null &&
+                    db.getMeltQuote(quoteId)?.usedByOperation == null &&
+                    db.getReservedProofs(operationId).isEmpty()
+            },
+        )
+        val settled = checked.state == CdkQuoteState.PAID || checked.state == CdkQuoteState.ISSUED
+        val transaction = if (settled) runCatching {
+            wallet.listTransactions(CdkTransactionDirection.OUTGOING).lastOrNull { it.quoteId == quoteId }
+        }.getOrNull() else null
+        return MeltConfirmation(
+            result = MeltPaymentResult(
+                preimage = transaction?.paymentProof ?: checked.paymentProof,
+                amount = transaction?.amount?.value?.toLong() ?: checked.amount.value.toLong(),
+                feePaid = transaction?.fee?.value?.toLong() ?: checked.feeReserve.value.toLong(),
+                mintUrl = wallet.mintUrl().url,
+                paymentMethod = checked.paymentMethod.toDomain(),
+                request = checked.request,
+                settlement = if (settled) MeltSettlement.Settled else MeltSettlement.Pending,
+            ),
+            pendingMelt = null,
+        )
     }
 
     override suspend fun checkMeltQuoteStatus(quoteId: String, mintUrl: String?): MeltQuoteInfo = cdkCall {
@@ -685,7 +720,7 @@ class CdkWalletGatewayImpl : WalletGateway {
         tokenString: String,
         settlementMintUrl: String,
     ): ForeignNfcSettlement = cdkCall {
-        settleForeignNfcTokenWithCdk(requireRepository(), database, tokenString, settlementMintUrl)
+        settleForeignNfcTokenWithCdk(requireRepository(), checkNotNull(database), tokenString, settlementMintUrl)
     }
 
     override suspend fun calculateReceiveFee(tokenString: String): Long = cdkCall {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/MeltPaymentRecovery.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/MeltPaymentRecovery.kt
@@ -1,0 +1,39 @@
+package com.cashu.me.Core.CDK
+
+import kotlinx.coroutines.CancellationException
+import org.cashudevkit.QuoteState
+
+class MeltPaymentRecoveryException(
+    val quoteId: String,
+    val operationId: String?,
+    val unresolved: Boolean,
+) : IllegalStateException(if (unresolved) {
+    "Payment status is unknown. Do not send it again yet. Refresh History to check settlement."
+} else {
+    "The mint returned your funds. Create a new quote before trying again."
+})
+
+/** Only successful status AND reservation reads can establish that retrying is safe. */
+internal suspend fun <T> resolveAmbiguousMelt(
+    quoteId: String,
+    operationId: String?,
+    checkStatus: suspend () -> T,
+    recoverSagas: suspend () -> Unit,
+    state: (T) -> QuoteState,
+    compensationComplete: suspend () -> Boolean,
+): T {
+    fun unresolved() = MeltPaymentRecoveryException(quoteId, operationId, unresolved = true)
+    val checked = try {
+        checkStatus()
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        try { recoverSagas() } catch (cancelled: CancellationException) { throw cancelled } catch (_: Exception) { }
+        try { checkStatus() } catch (cancelled: CancellationException) { throw cancelled } catch (_: Exception) { throw unresolved() }
+    }
+    if (state(checked) == QuoteState.PAID || state(checked) == QuoteState.ISSUED || state(checked) == QuoteState.PENDING) return checked
+    val compensated = try {
+        operationId != null && compensationComplete()
+    } catch (cancelled: CancellationException) { throw cancelled } catch (_: Exception) { false }
+    throw MeltPaymentRecoveryException(quoteId, operationId, unresolved = !compensated)
+}

--- a/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CashuRequestListener.kt
@@ -274,7 +274,7 @@ class CashuRequestListener(
         }
 
         val pending = PendingReceiveToken(
-            tokenId = payload.token.take(64),
+            tokenId = PendingReceiveToken.idFor(payload.token),
             token = payload.token,
             amount = info.amount,
             dateEpochMillis = System.currentTimeMillis(),

--- a/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NPCService.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -185,15 +186,37 @@ class NPCService internal constructor(
 
     suspend fun resetForWalletBoundary() = withContext(scope.coroutineContext.minusKey(Job)) {
         disconnect()
-        prefs.edit()
+        val committed = prefs.edit()
             .remove(StorageKeys.npcEnabled)
             .remove(StorageKeys.npcAutomaticClaim)
             .remove(StorageKeys.npcSelectedMint)
             .remove(StorageKeys.npcLastCheck)
-            .apply()
+            .commit()
+        check(committed) { "npub.cash settings could not be cleared." }
         mutableState.value = NPCState()
         nostrSecretKey = null
         nostrPublicKey = null
+    }
+
+    internal fun snapshotWalletScopedData(): PreferenceSnapshot = prefs.snapshot(setOf(
+        StorageKeys.npcEnabled, StorageKeys.npcAutomaticClaim, StorageKeys.npcSelectedMint, StorageKeys.npcLastCheck,
+    ))
+
+    internal suspend fun pauseForWalletBoundary() = withContext(scope.coroutineContext.minusKey(Job)) {
+        val jobs = listOfNotNull(refreshJob, paymentCheckJob, connectionAttempt)
+        disconnect()
+        mutableState.value = mutableState.value.copy(isEnabled = false)
+        jobs.forEach { it.cancelAndJoin() }
+    }
+
+    internal suspend fun restoreWalletScopedData(snapshot: PreferenceSnapshot) {
+        prefs.restore(snapshot, synchronous = true)
+        reloadStoredSettings()
+    }
+
+    internal suspend fun reloadStoredSettings() = withContext(scope.coroutineContext.minusKey(Job)) {
+        disconnect()
+        mutableState.value = loadInitialState()
     }
 
     internal suspend fun connect() {

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
@@ -1,15 +1,16 @@
 package com.cashu.me.Core.NfcReceive
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import com.cashu.me.Core.CDK.CdkGatewayUnavailable
 import com.cashu.me.Core.CDK.ForeignNfcSettlement
 import org.cashudevkit.Amount
 import org.cashudevkit.CurrencyUnit
-import org.cashudevkit.KeySetInfo
-import org.cashudevkit.KeysetLoadPolicy
 import org.cashudevkit.MeltConfirmOptions
 import org.cashudevkit.PaymentMethod
 import org.cashudevkit.QuoteState
+import org.cashudevkit.ReceiveOptions
 import org.cashudevkit.SplitTarget
 import org.cashudevkit.Token
 import org.cashudevkit.WalletRepository
@@ -31,17 +32,17 @@ internal suspend fun settleForeignNfcTokenWithCdk(
     val gross = token.value().value.toLong()
     require(gross > 1L) { "Payment is too small to convert." }
 
-    // Use the seed-backed repository database: CDK persists external proofs, the
-    // melt saga, and returned change here. Startup recovery can then finish a
-    // conversion even if the NFC session or process disappears after mint acceptance.
+    // Secure the incoming token through CDK's receive/swap saga first. Melt
+    // compensation assumes its inputs already belong to this wallet and returns
+    // them to Unspent, including after a restart before confirmation.
     repository.createWallet(org.cashudevkit.MintUrl(sourceMint), CurrencyUnit.Sat, null)
     val sourceWallet = repository.getWallet(org.cashudevkit.MintUrl(sourceMint), CurrencyUnit.Sat)
     val targetWallet = repository.getWallet(org.cashudevkit.MintUrl(targetMint), CurrencyUnit.Sat)
-    val keysets = sourceWallet.keysets(KeysetLoadPolicy.REFRESH).map {
-        KeySetInfo(id = it.id, unit = it.unit, active = it.active ?: false, inputFeePpk = it.inputFeePpk)
-    }
-    val proofs = token.proofs(keysets)
-    require(proofs.isNotEmpty()) { "The foreign-mint token contains no proofs." }
+    val received = sourceWallet.receive(
+        token,
+        ReceiveOptions(SplitTarget.None, emptyList(), emptyList(), emptyMap()),
+    ).value.toLong()
+    val receiveFee = gross - received
 
     val existingTransactionIds = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
         .map { it.id.hex }
@@ -54,18 +55,28 @@ internal suspend fun settleForeignNfcTokenWithCdk(
     val estimateMelt = sourceWallet.meltQuote(PaymentMethod.Bolt11, estimateQuote.request, null, null)
     val reserve = estimateMelt.feeReserve.value.toLong()
     runCatching { database.removeMintQuote(estimateQuote.id) }
-    require(reserve <= maximumFee) { "Foreign mint fee exceeds the 5% safety limit." }
+    require(receiveFee + reserve <= maximumFee) { "Foreign mint fee exceeds the 5% safety limit. Received funds remain at the source mint." }
 
     val minimumOverhead = kotlin.math.ceil(gross * 0.005).toLong().coerceAtLeast(1L)
-    val targetAmount = gross - reserve - minimumOverhead
+    val targetAmount = received - reserve - minimumOverhead
     require(targetAmount > 0) { "Payment is too small after conversion fees." }
     val targetQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(targetAmount.toULong()), null, null)
     val meltQuote = sourceWallet.meltQuote(PaymentMethod.Bolt11, targetQuote.request, null, null)
-    require(meltQuote.amount.value.toLong() + meltQuote.feeReserve.value.toLong() <= gross) {
+    require(meltQuote.amount.value.toLong() + meltQuote.feeReserve.value.toLong() <= received) {
         "Foreign mint requires more ecash than was received."
     }
-    val finalized = sourceWallet.prepareMeltProofs(meltQuote.id, proofs)
-        .confirmWithOptions(MeltConfirmOptions(skipSwap = true))
+    val prepared = sourceWallet.prepareMelt(meltQuote.id)
+    // Selection may include larger proofs from an existing source balance. Its
+    // change is retained, but this receipt must cover all of the actual costs.
+    val feeBudget = minOf(received - meltQuote.amount.value.toLong(), maximumFee - receiveFee)
+    val reserveCost = meltQuote.feeReserve.value
+    if (feeBudget < 0 || reserveCost > feeBudget.toULong() ||
+        prepared.inputFeeWithoutSwap().value > feeBudget.toULong() - reserveCost
+    ) {
+        withContext(NonCancellable) { prepared.cancel() }
+        throw CdkGatewayUnavailable("Foreign mint fee exceeds the conversion budget. Received funds remain at the source mint.")
+    }
+    val finalized = prepared.confirmWithOptions(MeltConfirmOptions(skipSwap = true))
     require(finalized.state == QuoteState.PAID) { "Foreign mint did not settle the payment." }
 
     var checked = targetWallet.checkMintQuote(targetQuote.id)
@@ -89,8 +100,8 @@ internal suspend fun settleForeignNfcTokenWithCdk(
         amountReceived = credited,
         transactionId = transactionId,
         // The difference also includes change kept at the source mint.
-        // CDK's finalized fee is the actual conversion cost.
-        feePaid = finalized.feePaid.value.toLong(),
+        // Include the receive swap as well as the melt's actual cost.
+        feePaid = receiveFee + finalized.feePaid.value.toLong(),
         sourceMintUrl = sourceMint,
         settlementMintUrl = targetMint,
     )

--- a/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NfcReceive/NfcForeignMintSettlement.kt
@@ -12,18 +12,14 @@ import org.cashudevkit.PaymentMethod
 import org.cashudevkit.QuoteState
 import org.cashudevkit.SplitTarget
 import org.cashudevkit.Token
-import org.cashudevkit.Wallet
-import org.cashudevkit.WalletConfig
 import org.cashudevkit.WalletRepository
 import org.cashudevkit.WalletSqliteDatabase
-import org.cashudevkit.WalletStore
-import org.cashudevkit.generateMnemonic
 import org.cashudevkit.proofsTotalAmount
 
 /** CDK implementation of Numo-style foreign-mint settlement. */
 internal suspend fun settleForeignNfcTokenWithCdk(
     repository: WalletRepository,
-    database: WalletSqliteDatabase?,
+    database: WalletSqliteDatabase,
     tokenString: String,
     settlementMintUrl: String,
 ): ForeignNfcSettlement {
@@ -35,75 +31,69 @@ internal suspend fun settleForeignNfcTokenWithCdk(
     val gross = token.value().value.toLong()
     require(gross > 1L) { "Payment is too small to convert." }
 
-    val tempDatabase = WalletSqliteDatabase.newInMemory()
-    val tempWallet = Wallet(
-        sourceMint,
-        CurrencyUnit.Sat,
-        generateMnemonic(),
-        WalletStore.Custom(tempDatabase),
-        WalletConfig(targetProofCount = 10u),
-    )
-    try {
-        val keysets = tempWallet.keysets(KeysetLoadPolicy.REFRESH).map {
-            KeySetInfo(id = it.id, unit = it.unit, active = it.active ?: false, inputFeePpk = it.inputFeePpk)
-        }
-        val proofs = token.proofs(keysets)
-        require(proofs.isNotEmpty()) { "The foreign-mint token contains no proofs." }
-
-        val targetWallet = repository.getWallet(org.cashudevkit.MintUrl(targetMint), CurrencyUnit.Sat)
-        val existingTransactionIds = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
-            .map { it.id.hex }
-            .toSet()
-        val maximumFee = kotlin.math.ceil(gross * 0.05).toLong().coerceAtLeast(1L)
-        val estimateAmount = gross - maximumFee
-        require(estimateAmount > 0) { "Payment is too small after the conversion fee limit." }
-
-        val estimateQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(estimateAmount.toULong()), null, null)
-        val estimateMelt = tempWallet.meltQuote(PaymentMethod.Bolt11, estimateQuote.request, null, null)
-        val reserve = estimateMelt.feeReserve.value.toLong()
-        runCatching { database?.removeMintQuote(estimateQuote.id) }
-        require(reserve <= maximumFee) { "Foreign mint fee exceeds the 5% safety limit." }
-
-        val minimumOverhead = kotlin.math.ceil(gross * 0.005).toLong().coerceAtLeast(1L)
-        val targetAmount = gross - reserve - minimumOverhead
-        require(targetAmount > 0) { "Payment is too small after conversion fees." }
-        val targetQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(targetAmount.toULong()), null, null)
-        val meltQuote = tempWallet.meltQuote(PaymentMethod.Bolt11, targetQuote.request, null, null)
-        require(meltQuote.amount.value.toLong() + meltQuote.feeReserve.value.toLong() <= gross) {
-            "Foreign mint requires more ecash than was received."
-        }
-        val finalized = tempWallet.prepareMeltProofs(meltQuote.id, proofs)
-            .confirmWithOptions(MeltConfirmOptions(skipSwap = true))
-        require(finalized.state == QuoteState.PAID) { "Foreign mint did not settle the payment." }
-
-        var checked = targetWallet.checkMintQuote(targetQuote.id)
-        for (attempt in 0 until 20) {
-            if (checked.state == QuoteState.PAID || checked.state == QuoteState.ISSUED) break
-            delay(500)
-            checked = targetWallet.checkMintQuote(targetQuote.id)
-        }
-        val credited = when (checked.state) {
-            QuoteState.PAID -> proofsTotalAmount(
-                targetWallet.mintUnified(targetQuote.id, SplitTarget.None, null),
-            ).value.toLong()
-            QuoteState.ISSUED -> targetAmount
-            else -> throw CdkGatewayUnavailable("Settlement mint has not credited the paid quote yet.")
-        }
-        val transactionId = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
-            .firstOrNull { it.id.hex !in existingTransactionIds && it.quoteId == targetQuote.id }
-            ?.id?.hex
-            ?: throw CdkGatewayUnavailable("CDK did not record the NFC settlement transaction.")
-        return ForeignNfcSettlement(
-            amountReceived = credited,
-            transactionId = transactionId,
-            feePaid = gross - credited,
-            sourceMintUrl = sourceMint,
-            settlementMintUrl = targetMint,
-        )
-    } finally {
-        runCatching { tempWallet.close() }
-        runCatching { tempDatabase.close() }
+    // Use the seed-backed repository database: CDK persists external proofs, the
+    // melt saga, and returned change here. Startup recovery can then finish a
+    // conversion even if the NFC session or process disappears after mint acceptance.
+    repository.createWallet(org.cashudevkit.MintUrl(sourceMint), CurrencyUnit.Sat, null)
+    val sourceWallet = repository.getWallet(org.cashudevkit.MintUrl(sourceMint), CurrencyUnit.Sat)
+    val targetWallet = repository.getWallet(org.cashudevkit.MintUrl(targetMint), CurrencyUnit.Sat)
+    val keysets = sourceWallet.keysets(KeysetLoadPolicy.REFRESH).map {
+        KeySetInfo(id = it.id, unit = it.unit, active = it.active ?: false, inputFeePpk = it.inputFeePpk)
     }
+    val proofs = token.proofs(keysets)
+    require(proofs.isNotEmpty()) { "The foreign-mint token contains no proofs." }
+
+    val existingTransactionIds = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
+        .map { it.id.hex }
+        .toSet()
+    val maximumFee = kotlin.math.ceil(gross * 0.05).toLong().coerceAtLeast(1L)
+    val estimateAmount = gross - maximumFee
+    require(estimateAmount > 0) { "Payment is too small after the conversion fee limit." }
+
+    val estimateQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(estimateAmount.toULong()), null, null)
+    val estimateMelt = sourceWallet.meltQuote(PaymentMethod.Bolt11, estimateQuote.request, null, null)
+    val reserve = estimateMelt.feeReserve.value.toLong()
+    runCatching { database.removeMintQuote(estimateQuote.id) }
+    require(reserve <= maximumFee) { "Foreign mint fee exceeds the 5% safety limit." }
+
+    val minimumOverhead = kotlin.math.ceil(gross * 0.005).toLong().coerceAtLeast(1L)
+    val targetAmount = gross - reserve - minimumOverhead
+    require(targetAmount > 0) { "Payment is too small after conversion fees." }
+    val targetQuote = targetWallet.mintQuote(PaymentMethod.Bolt11, Amount(targetAmount.toULong()), null, null)
+    val meltQuote = sourceWallet.meltQuote(PaymentMethod.Bolt11, targetQuote.request, null, null)
+    require(meltQuote.amount.value.toLong() + meltQuote.feeReserve.value.toLong() <= gross) {
+        "Foreign mint requires more ecash than was received."
+    }
+    val finalized = sourceWallet.prepareMeltProofs(meltQuote.id, proofs)
+        .confirmWithOptions(MeltConfirmOptions(skipSwap = true))
+    require(finalized.state == QuoteState.PAID) { "Foreign mint did not settle the payment." }
+
+    var checked = targetWallet.checkMintQuote(targetQuote.id)
+    for (attempt in 0 until 20) {
+        if (checked.state == QuoteState.PAID || checked.state == QuoteState.ISSUED) break
+        delay(500)
+        checked = targetWallet.checkMintQuote(targetQuote.id)
+    }
+    val credited = when (checked.state) {
+        QuoteState.PAID -> proofsTotalAmount(
+            targetWallet.mintUnified(targetQuote.id, SplitTarget.None, null),
+        ).value.toLong()
+        QuoteState.ISSUED -> targetAmount
+        else -> throw CdkGatewayUnavailable("Settlement mint has not credited the paid quote yet.")
+    }
+    val transactionId = targetWallet.listTransactions(org.cashudevkit.TransactionDirection.INCOMING)
+        .firstOrNull { it.id.hex !in existingTransactionIds && it.quoteId == targetQuote.id }
+        ?.id?.hex
+        ?: throw CdkGatewayUnavailable("CDK did not record the NFC settlement transaction.")
+    return ForeignNfcSettlement(
+        amountReceived = credited,
+        transactionId = transactionId,
+        // The difference also includes change kept at the source mint.
+        // CDK's finalized fee is the actual conversion cost.
+        feePaid = finalized.feePaid.value.toLong(),
+        sourceMintUrl = sourceMint,
+        settlementMintUrl = targetMint,
+    )
 }
 
 private fun normalizeMint(url: String): String = url.trim().trimEnd('/')

--- a/android/app/src/main/java/com/cashu/me/Core/NostrMintBackupService.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NostrMintBackupService.kt
@@ -15,6 +15,7 @@ sealed class NostrMintBackupException(message: String) : IllegalStateException(m
     class WebSocketsDisabled : NostrMintBackupException("Websocket connections are disabled.")
     class NoRelays : NostrMintBackupException("No Nostr relays are configured.")
     class NothingToBackUp : NostrMintBackupException("There are no mints to back up yet.")
+    class RestoreIncomplete : NostrMintBackupException("Finish restoring the wallet before replacing its backup.")
 }
 
 /**
@@ -40,6 +41,7 @@ class NostrMintBackupService(
      * triggered the backup must not surface a relay error.
      */
     suspend fun backupCurrentMintsIfEnabled() {
+        if (settingsStore.walletRestoreIncomplete) return
         if (!settingsManager.state.value.nostrMintBackupEnabled) return
         try {
             backupMints()
@@ -51,6 +53,7 @@ class NostrMintBackupService(
     }
 
     suspend fun backupMints() {
+        if (settingsStore.walletRestoreIncomplete) throw NostrMintBackupException.RestoreIncomplete()
         val relays = requireBackupPreconditions()
 
         // NUT-27 backups are addressable events: publishing replaces the

--- a/android/app/src/main/java/com/cashu/me/Core/NwcManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/NwcManager.kt
@@ -26,6 +26,7 @@ data class NwcState(
     val errorMessage: String? = null,
 )
 
+@kotlinx.serialization.Serializable
 internal data class NwcStoredSettings(
     val isEnabled: Boolean = false,
     val selectedMintUrl: String? = null,
@@ -88,6 +89,7 @@ internal class SecureNwcStore(
     }
 }
 
+@kotlinx.serialization.Serializable
 internal data class NwcWalletScopedSnapshot(val settings: NwcStoredSettings)
 
 /**
@@ -127,6 +129,8 @@ class NwcManager internal constructor(
             withBusy { startServiceLocked() }
         }
     }
+
+    internal suspend fun stop() = lifecycleMutex.withLock { stopServiceLocked() }
 
     suspend fun setEnabled(value: Boolean, defaultMintUrl: String? = null) = lifecycleMutex.withLock {
         if (value && mutableState.value.selectedMintUrl == null) {

--- a/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Platform/WalletDatabasePathManager.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Core.Platform
 
 import android.content.Context
+import android.database.sqlite.SQLiteDatabase
 import com.cashu.me.Core.AppLogger
 import java.io.File
 import java.io.IOException
@@ -8,6 +9,35 @@ import java.util.UUID
 
 class WalletDatabasePathManager(context: Context) {
     private val files = WalletDatabaseFiles(context.applicationContext.filesDir)
+
+    internal fun replacementBoundaryFiles(): List<File> = files.walletBoundaryFiles()
+
+    internal fun checkpointBeforeReplacement() {
+        val databases = files.walletBoundaryFiles().flatMap { file ->
+            if (file.isDirectory) file.listFiles()?.filter { it.name.endsWith(".db") }.orEmpty()
+            else listOf(file).filter { it.name.endsWith(".db") }
+        }
+        databases.filter(File::exists).forEach { file ->
+            // Flush WAL before copying. Native wrapper destruction can outlive
+            // the repository reference; a busy writer must block replacement.
+            SQLiteDatabase.openDatabase(
+                file.path,
+                null,
+                SQLiteDatabase.OPEN_READWRITE or SQLiteDatabase.NO_LOCALIZED_COLLATORS,
+                android.database.DatabaseErrorHandler {
+                    // Android's default corruption handler deletes database files.
+                    // Replacement preparation must preserve them on every failure.
+                    throw IOException("Cannot checkpoint the wallet database; original files were preserved.")
+                },
+            ).use { db ->
+                db.rawQuery("PRAGMA wal_checkpoint(TRUNCATE)", null).use { cursor ->
+                    if (!cursor.moveToFirst() || cursor.getInt(0) != 0) {
+                        throw IOException("Wallet database is still busy. Try again in a moment.")
+                    }
+                }
+            }
+        }
+    }
 
     val walletDirectory: File
         get() = files.walletDirectory
@@ -507,7 +537,7 @@ internal class WalletDatabaseFiles(
         "${destination.name}.move-displaced.${UUID.randomUUID()}",
     )
 
-    private fun walletBoundaryFiles(): List<File> {
+    internal fun walletBoundaryFiles(): List<File> {
         val legacy = File(filesDir, legacyDatabaseFilename)
         return listOf(walletDirectoryFile, legacy) + sidecars.map { File(legacy.absolutePath + it) }
     }

--- a/android/app/src/main/java/com/cashu/me/Core/PreferenceSnapshot.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/PreferenceSnapshot.kt
@@ -1,11 +1,53 @@
 package com.cashu.me.Core
 
 import android.content.SharedPreferences
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
+@Serializable(with = PreferenceSnapshotSerializer::class)
 internal data class PreferenceSnapshot(
     val keys: Set<String>,
     val values: Map<String, Any>,
 )
+
+/** Explicit type tags preserve Android preference types across process restarts. */
+internal object PreferenceSnapshotSerializer : KSerializer<PreferenceSnapshot> {
+    @Serializable
+    private data class Value(val type: String, val text: String = "", val strings: Set<String> = emptySet())
+    @Serializable
+    private data class Stored(val keys: Set<String>, val values: Map<String, Value>)
+    override val descriptor = Stored.serializer().descriptor
+    override fun serialize(encoder: Encoder, value: PreferenceSnapshot) {
+        val values = value.values.mapValues { (_, item) ->
+            when (item) {
+                is String -> Value("string", item)
+                is Boolean -> Value("boolean", item.toString())
+                is Int -> Value("int", item.toString())
+                is Long -> Value("long", item.toString())
+                is Float -> Value("float", item.toString())
+                is Set<*> -> Value("set", strings = item.filterIsInstance<String>().toSet())
+                else -> error("Unsupported wallet preference type.")
+            }
+        }
+        encoder.encodeSerializableValue(Stored.serializer(), Stored(value.keys, values))
+    }
+    override fun deserialize(decoder: Decoder): PreferenceSnapshot {
+        val stored = decoder.decodeSerializableValue(Stored.serializer())
+        return PreferenceSnapshot(stored.keys, stored.values.mapValues { (_, item) ->
+            when (item.type) {
+                "string" -> item.text
+                "boolean" -> item.text.toBooleanStrict()
+                "int" -> item.text.toInt()
+                "long" -> item.text.toLong()
+                "float" -> item.text.toFloat()
+                "set" -> item.strings
+                else -> error("Unknown wallet preference type.")
+            }
+        })
+    }
+}
 
 internal fun SharedPreferences.snapshot(keys: Set<String>): PreferenceSnapshot {
     val currentValues = all
@@ -15,7 +57,7 @@ internal fun SharedPreferences.snapshot(keys: Set<String>): PreferenceSnapshot {
     return PreferenceSnapshot(keys = keys, values = values)
 }
 
-internal fun SharedPreferences.restore(snapshot: PreferenceSnapshot) {
+internal fun SharedPreferences.restore(snapshot: PreferenceSnapshot, synchronous: Boolean = false) {
     val editor = edit()
     snapshot.keys.forEach { key ->
         when (val value = snapshot.values[key]) {
@@ -29,7 +71,8 @@ internal fun SharedPreferences.restore(snapshot: PreferenceSnapshot) {
             else -> editor.remove(key)
         }
     }
-    editor.apply()
+    if (synchronous) check(editor.commit()) { "Wallet preferences could not be restored." }
+    else editor.apply()
 }
 
 internal fun Any.snapshotPreferenceValue(): Any = when (this) {

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -41,6 +41,7 @@ fun SecureStorage.hasNostrPrivateKey(): Boolean = contains(StorageKeys.secureNos
 
 object StorageKeys {
     const val walletDataPrefix = "wallet."
+    const val walletRestoreIncomplete = "wallet.restoreIncomplete"
     const val settingsDataPrefix = "settings."
     const val npcDataPrefix = "npc."
     const val priceDataPrefix = "price."

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsManager.kt
@@ -108,6 +108,7 @@ data class PrimaryP2PKKey(
     val privateKeyHex: String,
 )
 
+@kotlinx.serialization.Serializable
 internal data class SettingsWalletScopedSnapshot(
     val preferences: PreferenceSnapshot,
     val p2pkKeys: List<P2PKKeyInfo>,
@@ -442,6 +443,10 @@ class SettingsManager internal constructor(
 
     val hasOnboardingCompletionMarker: Boolean
         get() = settingsStore.hasOnboardingCompletionMarker
+
+    var walletRestoreIncomplete: Boolean
+        get() = settingsStore.walletRestoreIncomplete
+        set(value) { settingsStore.walletRestoreIncomplete = value }
 
     internal fun snapshotWalletScopedData(): SettingsWalletScopedSnapshot =
         SettingsWalletScopedSnapshot(

--- a/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/SettingsStore.kt
@@ -99,6 +99,10 @@ class SettingsStore(
         get() = store.boolean(StorageKeys.onboardingCompleted, false)
         set(value) = store.putBoolean(StorageKeys.onboardingCompleted, value)
 
+    var walletRestoreIncomplete: Boolean
+        get() = store.boolean(StorageKeys.walletRestoreIncomplete, false)
+        set(value) = store.putBoolean(StorageKeys.walletRestoreIncomplete, value)
+
     val hasOnboardingCompletionMarker: Boolean
         get() = StorageKeys.onboardingCompleted in store.keys()
 
@@ -294,6 +298,7 @@ class SettingsStore(
         StorageKeys.nwcSelectedMint,
         StorageKeys.nwcBudgetSats,
         StorageKeys.onboardingCompleted,
+        StorageKeys.walletRestoreIncomplete,
     )
 }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/DurableWalletReplacement.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/DurableWalletReplacement.kt
@@ -1,0 +1,87 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Protocols.SecureStorage
+import java.io.File
+import java.io.IOException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** The journal (including the previous seed) lives in encrypted, synchronously committed storage.
+ * Backups are copies of a closed database and are never consumed by rollback, so recovery itself
+ * can be killed and safely repeated. No seed or preferences are read by startup before recovery.
+ */
+internal class DurableWalletReplacement(
+    private val storage: SecureStorage,
+    private val files: List<File>,
+) {
+    @Serializable
+    private data class Record(val phase: Phase, val existed: List<Boolean>, val state: String)
+    @Serializable
+    private enum class Phase { Preparing, Installing, Committed, Restored }
+
+    private val backups get() = files.map { File(it.path + ".replacement-backup-v1") }
+    private fun read(): Record? = storage.loadString(KEY)?.let {
+        try { Json.decodeFromString<Record>(it) }
+        catch (_: Exception) { throw IOException("Wallet recovery journal could not be decoded.") }
+    }
+    private fun write(record: Record) = storage.saveString(KEY, Json.encodeToString(record))
+
+    fun begin(state: String) {
+        check(read() == null) { "Wallet replacement recovery must finish first." }
+        check(backups.none(File::exists)) { "An unclaimed wallet backup needs recovery." }
+        val record = Record(Phase.Preparing, files.map(File::exists), state)
+        write(record)
+        files.forEachIndexed { i, file -> if (record.existed[i]) copy(file, backups[i]) }
+        // Until this write, the original database and preferences are untouched.
+        write(record.copy(phase = Phase.Installing))
+        files.forEach(::remove)
+    }
+
+    fun commit() {
+        val record = checkNotNull(read())
+        check(record.phase == Phase.Installing)
+        write(record.copy(phase = Phase.Committed))
+    }
+
+    suspend fun recover(
+        restoreState: suspend (String) -> Unit,
+        cleanupCommittedState: suspend (String) -> Unit,
+    ) {
+        var record = read() ?: return
+        check(record.existed.size == files.size) { "Unknown wallet replacement journal format." }
+        if (record.phase == Phase.Installing) {
+            check(backups.indices.all { !record.existed[it] || backups[it].exists() }) {
+                "A wallet recovery backup is missing."
+            }
+            files.forEachIndexed { i, file ->
+                remove(file)
+                if (record.existed[i]) copy(backups[i], file)
+            }
+            restoreState(record.state)
+            record = record.copy(phase = Phase.Restored)
+            write(record)
+        }
+        if (record.phase == Phase.Committed) cleanupCommittedState(record.state)
+        backups.forEach(::remove)
+        storage.delete(KEY)
+    }
+
+    private fun remove(file: File) {
+        if (file.exists() && !file.deleteRecursively()) throw IOException("Wallet recovery cleanup failed.")
+    }
+
+    private fun copy(source: File, destination: File) {
+        if (source.isDirectory) {
+            check(destination.mkdirs() || destination.isDirectory)
+            val children = source.listFiles() ?: throw IOException("Cannot read wallet recovery directory.")
+            children.forEach { copy(it, File(destination, it.name)) }
+        } else {
+            source.inputStream().use { input ->
+                destination.outputStream().use { output -> input.copyTo(output); output.fd.sync() }
+            }
+        }
+    }
+
+    companion object { const val KEY = "wallet_replacement_journal_v1" }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -30,7 +31,9 @@ import org.cashudevkit.QuoteState as CdkQuoteState
 import org.cashudevkit.npubcashDeriveSecretKeyFromSeed
 import com.cashu.me.Core.CDK.CdkWalletGateway
 import com.cashu.me.Core.Platform.WalletDatabasePathManager
-import com.cashu.me.Core.Platform.WalletFileBackup
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import com.cashu.me.Core.Protocols.SecureStorage
 import com.cashu.me.Core.Protocols.StorageKeys
 import com.cashu.me.Core.Protocols.WalletServiceProtocol
@@ -68,11 +71,14 @@ class WalletManager(
     private val externalServicesEnabled: Boolean = true,
     private val allowCleartextLocalTestMints: Boolean = false,
 ) : WalletServiceProtocol, NPCQuoteClaimHandler {
+    @Serializable
     private data class WalletReplacementSnapshot(
-        val databaseBackups: List<WalletFileBackup>,
+        val mnemonic: String?,
+        val nostrPrivateKey: String?,
         val wallet: PreferenceSnapshot,
         val settings: SettingsWalletScopedSnapshot,
         val nwc: NwcWalletScopedSnapshot,
+        val npc: PreferenceSnapshot,
     )
 
     internal var cashuRequestListener: CashuRequestListener? = null
@@ -90,6 +96,7 @@ class WalletManager(
     )
     val receivedPayments: SharedFlow<ReceivedPaymentEvent> = mutableReceivedPayments.asSharedFlow()
     private val initializationMutex = Mutex()
+    private val replacement = DurableWalletReplacement(secureStorage, databasePathManager.replacementBoundaryFiles())
     private val mintMetadataFetcher = WalletMintMetadataFetcher(allowCleartextLocalTestMints)
     private val mintQuoteSyncService = WalletMintQuoteSyncService(gateway, walletStore)
     private val focusedMintQuoteMonitor = FocusedMintQuoteMonitor()
@@ -119,12 +126,22 @@ class WalletManager(
     // mint + melt quotes while the app is active so a payment lands without
     // pull-to-refresh (iOS parity).
     private var pendingQuotePollJob: Job? = null
+    private var startupMaintenanceJob: Job? = null
 
     override suspend fun initialize() {
         initializationMutex.withLock {
             if (mutableState.value.isRuntimeReady) return@withLock
 
             withContext(Dispatchers.IO) {
+                try {
+                    recoverWalletReplacement()
+                } catch (error: Exception) {
+                    AppLogger.wallet.error("Wallet replacement recovery failed", error)
+                    update { copy(isInitialized = true, isRuntimeReady = false, isLoading = false,
+                        startupFailure = walletStartupFailure(true),
+                        errorMessage = "Wallet recovery could not finish. Restart to try again.") }
+                    return@withContext
+                }
                 val hasStoredWallet = secureStorage.contains(StorageKeys.secureWalletMnemonic)
 
                 // Publish the complete cached home model before opening SQLite,
@@ -138,7 +155,7 @@ class WalletManager(
                     if (!settingsManager.hasOnboardingCompletionMarker) {
                         settingsManager.onboardingCompleted = true
                     }
-                    loadCachedState(needsOnboarding = !settingsManager.onboardingCompleted)
+                    loadCachedState(needsOnboarding = !settingsManager.onboardingCompleted || settingsManager.walletRestoreIncomplete)
                 } else {
                     update {
                         copy(
@@ -212,7 +229,8 @@ class WalletManager(
     }
 
     private fun startDeferredStartupMaintenance(hasStoredWallet: Boolean) {
-        scope.launch(Dispatchers.IO) {
+        startupMaintenanceJob?.cancel()
+        startupMaintenanceJob = scope.launch(Dispatchers.IO) {
             // Give Compose a scheduling opportunity to render cached state before
             // background maintenance contends for CDK's operation mutex.
             kotlinx.coroutines.yield()
@@ -330,25 +348,20 @@ class WalletManager(
         }
         require(gateway.validateMnemonic(normalized)) { "Invalid seed phrase." }
         val keepOnboarding = mutableState.value.needsOnboarding
-        withLoading { installCleanWallet(normalized, needsOnboarding = keepOnboarding) }
+        withLoading { installCleanWallet(normalized, needsOnboarding = keepOnboarding, restoring = true) }
     }
 
     override suspend fun restoreWallet(mnemonic: String) {
-        val normalized = MnemonicInput.normalize(mnemonic)
-        require(MnemonicInput.hasSupportedWordCount(normalized)) {
-            "Seed phrase must be ${MnemonicInput.supportedWordCountLabel} words."
-        }
-        require(gateway.validateMnemonic(normalized)) { "Invalid seed phrase." }
-        withLoading {
-            installCleanWallet(normalized, needsOnboarding = false)
-        }
+        initializeRestoredWallet(mnemonic)
     }
 
     override suspend fun deleteWallet() {
         withLoading {
             cashuRequestListener?.pauseForWalletBoundary()
-            nwcManager.resetForWalletBoundary()
+            nwcManager.stop()
             gateway.closeWalletRepository()
+            recoverWalletReplacement()
+            nwcManager.resetForWalletBoundary()
             secureStorage.delete(StorageKeys.secureWalletMnemonic)
             secureStorage.delete(StorageKeys.secureNostrPrivateKey)
             databasePathManager.removeWalletDatabaseFiles()
@@ -828,7 +841,13 @@ class WalletManager(
 
     override suspend fun meltTokens(quoteId: String, mintUrl: String?): MeltPaymentResult =
         withLoadingResult {
-            val confirmation = gateway.meltTokens(quoteId, mintUrl)
+            val confirmation = try {
+                gateway.meltTokens(quoteId, mintUrl)
+            } catch (failure: com.cashu.me.Core.CDK.MeltPaymentRecoveryException) {
+                refreshBalance()
+                loadTransactions()
+                throw failure
+            }
             val result = confirmation.result
             val pendingMelt = confirmation.pendingMelt
             if (pendingMelt != null) {
@@ -1096,10 +1115,18 @@ class WalletManager(
         val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
         val settlement = withLoadingResult {
             require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
-            gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
-                walletStore.saveProcessedCashuRequests(
-                    (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
-                )
+            val source = requireNotNull(com.cashu.me.Models.TokenInfo.parse(tokenString)) { "Invalid token." }
+            // Persist discovery before CDK may consume proofs. Source change and
+            // compensated funds must remain visible and participate in startup recovery.
+            ensureMintTracked(source.mint)
+            ensureMintTracked(settlementMintUrl)
+            try {
+                gateway.settleForeignNfcToken(tokenString, settlementMintUrl).also {
+                    walletStore.saveProcessedCashuRequests(
+                        (walletStore.loadProcessedCashuRequests() + processedId).distinct().sorted(),
+                    )
+                }
+            } finally {
                 refreshBalance()
                 loadTransactions()
             }
@@ -1114,7 +1141,7 @@ class WalletManager(
 
     fun savePendingReceiveToken(token: PendingReceiveToken) {
         val current = walletStore.loadPendingReceiveTokens()
-        val updated = current.filterNot { it.tokenId == token.tokenId } + token
+        val updated = PendingReceiveToken.upsert(current, token)
         walletStore.savePendingReceiveTokens(updated)
         update { copy(pendingReceiveTokens = updated) }
     }
@@ -1427,6 +1454,7 @@ class WalletManager(
 
     suspend fun completeOnboarding() {
         settingsManager.onboardingCompleted = true
+        settingsManager.walletRestoreIncomplete = false
         loadCachedState(needsOnboarding = false)
         refreshBalance()
         loadTransactions()
@@ -1443,114 +1471,99 @@ class WalletManager(
         }
     }
 
-    private suspend fun installCleanWallet(mnemonic: String, needsOnboarding: Boolean) {
+    private fun decodeReplacementSnapshot(encoded: String): WalletReplacementSnapshot = try {
+        Json.decodeFromString<WalletReplacementSnapshot>(encoded)
+    } catch (_: Exception) {
+        // Serialization diagnostics can include input values; this payload contains secrets.
+        throw IllegalStateException("Wallet recovery state could not be decoded.")
+    }
+
+    private suspend fun recoverWalletReplacement() = withContext(Dispatchers.IO) {
+        replacement.recover(
+            restoreState = { encoded ->
+                val snapshot = decodeReplacementSnapshot(encoded)
+                if (snapshot.mnemonic == null) secureStorage.delete(StorageKeys.secureWalletMnemonic)
+                else secureStorage.saveString(StorageKeys.secureWalletMnemonic, snapshot.mnemonic)
+                walletStore.restoreWalletScopedData(snapshot.wallet)
+                settingsManager.restoreWalletScopedData(snapshot.settings)
+                nwcManager.restoreWalletScopedData(snapshot.nwc)
+                npcService.restoreWalletScopedData(snapshot.npc)
+                cashuRequestStore.reload()
+                nostrMintBackupService.reloadStoredState()
+            },
+            cleanupCommittedState = { encoded ->
+                val snapshot = decodeReplacementSnapshot(encoded)
+                settingsManager.deleteWalletScopedSecrets(snapshot.settings, deleteNostrPrivateKey = false)
+                // Cleanup may be retried on a later launch. Do not delete a new
+                // imported key the user saved after this replacement committed.
+                if (snapshot.nostrPrivateKey != null &&
+                    secureStorage.loadString(StorageKeys.secureNostrPrivateKey) == snapshot.nostrPrivateKey
+                ) secureStorage.delete(StorageKeys.secureNostrPrivateKey)
+            },
+        )
+    }
+
+    private suspend fun installCleanWallet(mnemonic: String, needsOnboarding: Boolean, restoring: Boolean = false) = initializationMutex.withLock {
+        // Finish any previous recovery before starting another replacement.
+        recoverWalletReplacement()
         val previousMnemonic = secureStorage.loadString(StorageKeys.secureWalletMnemonic)
         cashuRequestListener?.pauseForWalletBoundary()
-        val replacementSnapshot = try {
-            WalletReplacementSnapshot(
-                // Capture preference state before moving the database so a
-                // preparation failure can resume the untouched wallet.
-                wallet = walletStore.snapshotWalletScopedData(),
-                settings = settingsManager.snapshotWalletScopedData(),
-                nwc = nwcManager.snapshotWalletScopedData(),
-                databaseBackups = databasePathManager.backupWalletDatabaseFiles(),
-            )
-        } catch (error: Throwable) {
-            cashuRequestListener?.resetForWalletBoundary(
-                restart = externalServicesEnabled && previousMnemonic != null,
-            )
-            throw error
-        }
-        val backups = replacementSnapshot.databaseBackups
-        val walletSnapshot = replacementSnapshot.wallet
-        val settingsSnapshot = replacementSnapshot.settings
-        val nwcSnapshot = replacementSnapshot.nwc
+        npcService.pauseForWalletBoundary()
+        pendingQuotePollJob?.cancelAndJoin()
+        startupMaintenanceJob?.cancelAndJoin()
+        pendingMeltWaiters.values.toList().forEach { it.cancelAndJoin() }
+        pendingMeltWaiters.clear()
+        nwcManager.stop()
+        gateway.closeWalletRepository()
+        update { copy(isRuntimeReady = false) }
 
         runWalletReplacementCommit(
             installAndCommit = {
-                // NwcService retains the native CDK wallet, so it must stop before
-                // the repository/database it is backed by is closed.
+                withContext(Dispatchers.IO) { databasePathManager.checkpointBeforeReplacement() }
+                val snapshot = WalletReplacementSnapshot(
+                    mnemonic = previousMnemonic,
+                    nostrPrivateKey = secureStorage.loadString(StorageKeys.secureNostrPrivateKey),
+                    wallet = walletStore.snapshotWalletScopedData(),
+                    settings = settingsManager.snapshotWalletScopedData(),
+                    nwc = nwcManager.snapshotWalletScopedData(),
+                    npc = npcService.snapshotWalletScopedData(),
+                )
+                withContext(Dispatchers.IO) { replacement.begin(Json.encodeToString(snapshot)) }
                 nwcManager.resetForWalletBoundary()
-                gateway.closeWalletRepository()
                 cashuRequestStore.resetForWalletBoundary()
                 walletStore.removeAllWalletData()
                 settingsManager.prepareForWalletReplacement()
+                settingsManager.walletRestoreIncomplete = restoring
                 nostrService.resetForWalletBoundary(deleteStoredKey = false)
                 npcService.resetForWalletBoundary()
                 openWalletRepositoryWithRecovery(mnemonic)
                 deriveNostrKey(mnemonic)
                 secureStorage.saveString(StorageKeys.secureWalletMnemonic, mnemonic)
                 nostrMintBackupService.resetForWalletBoundary()
-                loadCachedState(needsOnboarding = needsOnboarding)
-                // A wallet installed during first-launch onboarding is incomplete
-                // until completeOnboarding(); installs from Settings skip
-                // onboarding entirely and are complete immediately. This durable
-                // marker is the final rollback-eligible commit step.
                 settingsManager.onboardingCompleted = !needsOnboarding
+                withContext(Dispatchers.IO) { replacement.commit() }
             },
             rollback = {
-                try {
-                    gateway.closeWalletRepository()
-                    databasePathManager.restoreWalletFileBackups(
-                        backups = backups,
-                        beforeCommit = {
-                            if (previousMnemonic != null) {
-                                secureStorage.saveString(StorageKeys.secureWalletMnemonic, previousMnemonic)
-                            } else {
-                                secureStorage.delete(StorageKeys.secureWalletMnemonic)
-                            }
-                        },
-                        onRollback = {
-                            secureStorage.saveString(StorageKeys.secureWalletMnemonic, mnemonic)
-                        },
-                    )
-                    walletStore.restoreWalletScopedData(walletSnapshot)
-                    cashuRequestStore.reload()
-                    settingsManager.restoreWalletScopedData(settingsSnapshot)
-                    nwcManager.restoreWalletScopedData(nwcSnapshot)
-                    nostrMintBackupService.reloadStoredState()
-                    if (previousMnemonic != null) {
-                        runCatching {
-                            openWalletRepositoryWithRecovery(previousMnemonic)
-                            deriveNostrKey(previousMnemonic)
-                            loadCachedState(needsOnboarding = false)
-                            if (startNwc) nwcManager.startIfEnabled()
-                        }
-                        cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled)
-                    } else {
-                        update {
-                            WalletState(
-                                isInitialized = true,
-                                isRuntimeReady = true,
-                                needsOnboarding = true,
-                                canExitOnboarding = false,
-                            )
-                        }
-                        cashuRequestListener?.resetForWalletBoundary(restart = false)
-                    }
-                } catch (rollbackError: Throwable) {
-                    AppLogger.wallet.error("Failed to restore the previous wallet transaction", rollbackError)
-                    runCatching {
-                        cashuRequestListener?.resetForWalletBoundary(restart = false)
-                    }.exceptionOrNull()?.let(rollbackError::addSuppressed)
-                    throw rollbackError
+                gateway.closeWalletRepository()
+                recoverWalletReplacement()
+                val recoveredMnemonic = secureStorage.loadString(StorageKeys.secureWalletMnemonic)
+                if (recoveredMnemonic != null) {
+                    npcService.reloadStoredSettings()
+                    openWalletRepositoryWithRecovery(recoveredMnemonic)
+                    deriveNostrKey(recoveredMnemonic)
+                    loadCachedState(needsOnboarding = !settingsManager.onboardingCompleted || settingsManager.walletRestoreIncomplete)
+                    update { copy(isRuntimeReady = true) }
+                    if (startNwc) nwcManager.startIfEnabled()
+                } else {
+                    update { WalletState(isInitialized = true, isRuntimeReady = true, needsOnboarding = true) }
                 }
+                cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled && previousMnemonic != null)
             },
-            cleanupSteps = listOf(
-                WalletReplacementCleanupStep("old wallet secrets") {
-                    settingsManager.deleteWalletScopedSecrets(
-                        settingsSnapshot,
-                        deleteNostrPrivateKey = true,
-                    )
-                },
-                WalletReplacementCleanupStep("wallet database backups") {
-                    databasePathManager.removeWalletFileBackups(backups)
-                },
-            ),
-            onCleanupFailure = { description, error ->
-                AppLogger.wallet.error("Post-commit $description cleanup failed", error)
-            },
+            cleanupSteps = listOf(WalletReplacementCleanupStep("wallet recovery journal") { recoverWalletReplacement() }),
+            onCleanupFailure = { description, error -> AppLogger.wallet.error("Post-commit $description cleanup failed", error) },
         )
+        loadCachedState(needsOnboarding = needsOnboarding)
+        update { copy(isRuntimeReady = true) }
         cashuRequestListener?.resetForWalletBoundary(restart = externalServicesEnabled && !needsOnboarding)
     }
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
@@ -15,6 +15,7 @@ data class WalletMessage(
     val text: String,
     val severity: WalletMessageSeverity = WalletMessageSeverity.Error,
     val isTerminal: Boolean = false,
+    val title: String? = null,
 ) {
     val isRetryable: Boolean get() = !isTerminal
 }
@@ -42,6 +43,14 @@ object WalletErrorMessages {
         "The wallet couldn't finish that action. Try again in a moment."
 
     fun classify(error: Throwable): WalletMessage {
+        if (error is com.cashu.me.Core.CDK.MeltPaymentRecoveryException) {
+            return WalletMessage(
+                text = checkNotNull(error.message),
+                severity = WalletMessageSeverity.Caution,
+                isTerminal = true,
+                title = if (error.unresolved) "Payment status unknown" else "Payment returned",
+            )
+        }
         val raw = error.message ?: error.toString()
 
         classifyRawMessage(raw)?.let { return it }

--- a/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
+++ b/android/app/src/main/java/com/cashu/me/Models/Tokens/TokenTransferModels.kt
@@ -1,6 +1,7 @@
 package com.cashu.me.Models
 
 import kotlinx.serialization.Serializable
+import java.security.MessageDigest
 
 @Serializable
 data class SendTokenResult(
@@ -26,4 +27,14 @@ data class PendingReceiveToken(
 ) {
     val id: String get() = tokenId
     val isCashuRequestPayment: Boolean get() = cashuRequestId != null || processedId != null
+
+    companion object {
+        fun idFor(token: String): String = MessageDigest.getInstance("SHA-256")
+            .digest(token.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+        /** Compare the complete bearer token, including entries saved with legacy prefix IDs. */
+        fun upsert(current: List<PendingReceiveToken>, token: PendingReceiveToken): List<PendingReceiveToken> =
+            current.filterNot { it.token == token.token } + token.copy(tokenId = idFor(token.token))
+    }
 }

--- a/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/receive/ReceiveTokenReview.kt
@@ -250,7 +250,7 @@ internal suspend fun claimToken(
 /** "Receive later": persist the token for a future claim. */
 internal fun pendingReceiveTokenFrom(review: TokenReview): PendingReceiveToken =
     PendingReceiveToken(
-        tokenId = review.token.take(64),
+        tokenId = PendingReceiveToken.idFor(review.token),
         token = review.token,
         amount = review.info.amount,
         mintUrl = review.info.mint,

--- a/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/UnifiedSendScreen.kt
@@ -893,7 +893,7 @@ private fun SendStatusTerminal(
         title = when (status) {
             is SendStatus.Sending -> "Sending payment…"
             is SendStatus.Sent -> if (settlementPending) "Payment processing" else "Payment sent"
-            is SendStatus.Failed -> "Payment failed"
+            is SendStatus.Failed -> status.message.title ?: "Payment failed"
         },
         detail = when {
             failure != null -> failure.text

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/MeltPaymentRecoveryTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/MeltPaymentRecoveryTest.kt
@@ -1,0 +1,62 @@
+package com.cashu.me.Core.CDK
+
+import com.cashu.me.Core.Wallet.walletMessage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.cashudevkit.QuoteState
+import org.junit.Assert.*
+import org.junit.Test
+
+class MeltPaymentRecoveryTest {
+    @Test fun lostConfirmResponseResolvesPaidOrPendingWithoutRetry() = runBlocking {
+        for (state in listOf(QuoteState.PAID, QuoteState.ISSUED, QuoteState.PENDING)) {
+            assertEquals(state, resolveAmbiguousMelt("quote", "operation", { state },
+                { fail("No recovery needed") }, { it }, { error("Must not release proofs") }))
+        }
+    }
+
+    @Test fun statusFailureRunsSagaRecoveryThenChecksAgain() = runBlocking {
+        var checks = 0
+        var recoveries = 0
+        val state = resolveAmbiguousMelt("quote", "operation",
+            { if (++checks == 1) error("Lost response") else QuoteState.PAID },
+            { recoveries++ }, { it }, { false })
+        assertEquals(QuoteState.PAID, state)
+        assertEquals(1, recoveries)
+        assertEquals(2, checks)
+    }
+
+    @Test fun offlineMintBlocksRetryAndDoesNotClaimFailure() = runBlocking {
+        try {
+            resolveAmbiguousMelt<QuoteState>("quote", "operation", { error("offline") }, {}, { it }, { true })
+            fail("Unknown status must block retry")
+        } catch (error: MeltPaymentRecoveryException) {
+            assertTrue(error.unresolved)
+            assertTrue(error.walletMessage.isTerminal)
+            assertEquals("Payment status unknown", error.walletMessage.title)
+        }
+    }
+
+    @Test fun unpaidIsNotRetryableUntilAllReservationReadsSucceed() = runBlocking {
+        for (reserved in listOf(true, false)) {
+            try {
+                resolveAmbiguousMelt("quote", "operation", { QuoteState.UNPAID }, {}, { it }, { !reserved })
+                fail("UNPAID must require a fresh quote or further recovery")
+            } catch (error: MeltPaymentRecoveryException) {
+                assertEquals(reserved, error.unresolved)
+                assertTrue(error.walletMessage.isTerminal)
+            }
+        }
+        try {
+            resolveAmbiguousMelt("quote", "operation", { QuoteState.UNPAID }, {}, { it }, { error("database unavailable") })
+            fail("A failed read is not compensation")
+        } catch (error: MeltPaymentRecoveryException) { assertTrue(error.unresolved) }
+    }
+
+    @Test fun cancellationPreservesCoroutineCancellation() = runBlocking {
+        try {
+            resolveAmbiguousMelt<QuoteState>("quote", "operation", { throw CancellationException() }, {}, { it }, { true })
+            fail("Cancellation must propagate")
+        } catch (_: CancellationException) { }
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/MeltSettlementWaitTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/MeltSettlementWaitTest.kt
@@ -71,10 +71,14 @@ class MeltSettlementWaitTest {
     }
 
     @Test
-    fun `an ambiguous wait failure falls back to pending`() = runBlocking {
-        val result = awaitLightningSettlementOrNull(method = CdkPaymentMethod.Bolt11) {
-            throw IllegalStateException("transport died")
+    fun `an ambiguous wait failure reaches status recovery`() = runBlocking {
+        try {
+            awaitLightningSettlementOrNull(method = CdkPaymentMethod.Bolt11) {
+                throw IllegalStateException("transport died")
+            }
+            org.junit.Assert.fail("The caller must reconcile an ambiguous failure")
+        } catch (error: IllegalStateException) {
+            assertEquals("transport died", error.message)
         }
-        assertNull(result)
     }
 }

--- a/android/app/src/test/java/com/cashu/me/Core/DurableWalletReplacementTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/DurableWalletReplacementTest.kt
@@ -1,0 +1,113 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Protocols.SecureStorage
+import java.io.File
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.Assert.*
+import org.junit.Test
+
+class DurableWalletReplacementTest {
+    private class Storage : SecureStorage {
+        val values = mutableMapOf<String, String>()
+        var writes = 0
+        var failWrite = 0
+        override fun loadString(key: String) = values[key]
+        override fun contains(key: String) = key in values
+        override fun saveString(key: String, value: String) {
+            if (++writes == failWrite) error("Simulated interruption")
+            values[key] = value
+        }
+        override fun delete(key: String) { values.remove(key) }
+    }
+
+    private fun scenario(block: suspend (File, Storage) -> Unit) = runBlocking {
+        val root = Files.createTempDirectory("wallet-replacement-test").toFile()
+        try { block(root, Storage()) } finally { root.deleteRecursively() }
+    }
+
+    @Test fun relaunchRecoversOldDatabaseSeedAndPreferencesAfterSeedWasChanged() = scenario { root, storage ->
+        val db = File(root, "wallet").apply { mkdirs() }
+        File(db, "wallet.db").writeText("old proofs")
+        File(db, "wallet.db-wal").writeText("old journal")
+        storage.values["seed"] = "old seed"
+        DurableWalletReplacement(storage, listOf(db)).begin("old preferences")
+        db.mkdirs()
+        File(db, "wallet.db").writeText("new proofs")
+        storage.values["seed"] = "new seed"
+        DurableWalletReplacement(storage, listOf(db)).recover({ state ->
+            assertEquals("old preferences", state)
+            storage.values["seed"] = "old seed"
+        }, { fail("Uncommitted replacement must not delete old secrets") })
+        assertEquals("old seed", storage.values["seed"])
+        assertEquals("old proofs", File(db, "wallet.db").readText())
+        assertEquals("old journal", File(db, "wallet.db-wal").readText())
+        assertFalse(storage.contains(DurableWalletReplacement.KEY))
+    }
+
+    @Test fun interruptionDuringBackupLeavesOriginalUntouched() = scenario { root, storage ->
+        val db = File(root, "wallet.db").apply { writeText("old") }
+        storage.failWrite = 2
+        assertThrows(IllegalStateException::class.java) { DurableWalletReplacement(storage, listOf(db)).begin("old seed") }
+        DurableWalletReplacement(storage, listOf(db)).recover({ fail("Original state was never changed") }, {})
+        assertEquals("old", db.readText())
+    }
+
+    @Test fun interruptedRollbackCanBeRepeatedWithoutConsumingBackups() = scenario { root, storage ->
+        val db = File(root, "wallet.db").apply { writeText("old") }
+        DurableWalletReplacement(storage, listOf(db)).begin("state")
+        db.writeText("new")
+        try {
+            DurableWalletReplacement(storage, listOf(db)).recover({ error("Seed storage temporarily unavailable") }, {})
+            fail("Recovery should stop")
+        } catch (_: IllegalStateException) { }
+        db.writeText("partial rollback")
+        DurableWalletReplacement(storage, listOf(db)).recover({}, {})
+        assertEquals("old", db.readText())
+    }
+
+    @Test fun committedReplacementSurvivesRelaunchAndCleanupFailure() = scenario { root, storage ->
+        val db = File(root, "wallet.db").apply { writeText("old") }
+        val replacement = DurableWalletReplacement(storage, listOf(db))
+        replacement.begin("old secrets")
+        db.writeText("new")
+        replacement.commit()
+        try {
+            replacement.recover({ fail("Committed wallet must never roll back") }, { error("Cleanup interrupted") })
+        } catch (_: IllegalStateException) { }
+        DurableWalletReplacement(storage, listOf(db)).recover({ fail("Committed wallet must never roll back") }, {})
+        assertEquals("new", db.readText())
+        assertFalse(storage.contains(DurableWalletReplacement.KEY))
+    }
+
+    @Test fun missingBackupFailsBeforeRestoringSeed() = scenario { root, storage ->
+        val db = File(root, "wallet.db").apply { writeText("old") }
+        DurableWalletReplacement(storage, listOf(db)).begin("state")
+        File(db.path + ".replacement-backup-v1").delete()
+        db.writeText("new")
+        try {
+            DurableWalletReplacement(storage, listOf(db)).recover({ fail("Must not mismatch the seed") }, {})
+            fail("Missing backup must block launch")
+        } catch (_: IllegalStateException) { }
+        assertEquals("new", db.readText())
+        assertTrue(storage.contains(DurableWalletReplacement.KEY))
+    }
+
+    @Test fun newWalletWithoutPreviousDatabaseRollsBackToAbsence() = scenario { root, storage ->
+        val db = File(root, "wallet.db")
+        DurableWalletReplacement(storage, listOf(db)).begin("no seed")
+        db.writeText("new")
+        DurableWalletReplacement(storage, listOf(db)).recover({ assertEquals("no seed", it) }, {})
+        assertFalse(db.exists())
+    }
+
+    @Test fun journalPreferencesPreserveEveryStoredTypeAndMissingKeys() {
+        val snapshot = PreferenceSnapshot(setOf("missing", "string", "boolean", "int", "long", "float", "set"), mapOf(
+            "string" to "synthetic token", "boolean" to true, "int" to 1, "long" to Long.MAX_VALUE,
+            "float" to 1.5f, "set" to setOf("a", "b"),
+        ))
+        assertEquals(snapshot, Json.decodeFromString<PreferenceSnapshot>(Json.encodeToString(snapshot)))
+    }
+}

--- a/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/NPCServiceTest.kt
@@ -4,9 +4,34 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import kotlinx.coroutines.cancel
 import org.cashudevkit.NpubCashQuote
 
 class NPCServiceTest {
+    @Test
+    fun walletReplacementRestoresSeparateNpcPreferencesAndRuntimeState() = kotlinx.coroutines.runBlocking {
+        val prefs = InMemorySharedPreferences()
+        prefs.edit()
+            .putBoolean(com.cashu.me.Core.Protocols.StorageKeys.npcEnabled, true)
+            .putBoolean(com.cashu.me.Core.Protocols.StorageKeys.npcAutomaticClaim, false)
+            .putString(com.cashu.me.Core.Protocols.StorageKeys.npcSelectedMint, "https://mint.example")
+            .putLong(com.cashu.me.Core.Protocols.StorageKeys.npcLastCheck, 123L)
+            .commit()
+        val scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Unconfined)
+        try {
+            val service = NPCService(prefs, kotlinx.coroutines.flow.MutableStateFlow(SettingsState()), scope)
+            service.pauseForWalletBoundary()
+            val snapshot = service.snapshotWalletScopedData()
+            service.resetForWalletBoundary()
+            assertFalse(service.state.value.isEnabled)
+            service.restoreWalletScopedData(snapshot)
+            assertTrue(service.state.value.isEnabled)
+            assertFalse(service.state.value.automaticClaim)
+            assertEquals("https://mint.example", service.state.value.selectedMintUrl)
+            assertEquals(123L, service.state.value.lastCheckEpochMillis)
+        } finally { scope.cancel() }
+    }
+
     @Test
     fun mapsCdkQuoteWithoutReimplementingTheWireFormat() {
         val quote = NPCService.fromCdkQuote(

--- a/android/app/src/test/java/com/cashu/me/Models/PendingReceiveTokenPersistenceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Models/PendingReceiveTokenPersistenceTest.kt
@@ -11,6 +11,26 @@ class PendingReceiveTokenPersistenceTest {
     private val json = Json { encodeDefaults = true }
 
     @Test
+    fun distinctTokensWithTheSamePrefixSurviveSaveAndReload() {
+        val prefix = "cashuA" + "a".repeat(80)
+        val first = pendingReceiveToken(null).copy(token = prefix + "first", tokenId = prefix.take(64))
+        val second = first.copy(token = prefix + "second")
+        val saved = PendingReceiveToken.upsert(listOf(first), second)
+        val restored = json.decodeFromString<List<PendingReceiveToken>>(json.encodeToString(saved))
+        assertEquals(listOf(first.token, second.token), restored.map { it.token })
+        org.junit.Assert.assertNotEquals(restored[0].id, restored[1].id)
+    }
+
+    @Test
+    fun receivingTheSameLegacyTokenAgainUpdatesWithoutDuplicatingIt() {
+        val legacy = pendingReceiveToken(null)
+        val saved = PendingReceiveToken.upsert(listOf(legacy), legacy.copy(memo = "Updated"))
+        assertEquals(1, saved.size)
+        assertEquals("Updated", saved.single().memo)
+        assertEquals(PendingReceiveToken.idFor(legacy.token), saved.single().id)
+    }
+
+    @Test
     fun memoSurvivesPersistenceRoundTrip() {
         val original = pendingReceiveToken(memo = "Coffee from Alice")
 

--- a/ios/CashuWallet/Core/NPCService.swift
+++ b/ios/CashuWallet/Core/NPCService.swift
@@ -12,7 +12,7 @@ class NPCService: ObservableObject {
     
     @Published var isEnabled: Bool {
         didSet {
-            guard isEnabled != oldValue else { return }
+            guard !suppressSettingsSideEffects, isEnabled != oldValue else { return }
             settingsStore.npcEnabled = isEnabled
             if isEnabled {
                 Task { await connect() }
@@ -61,6 +61,7 @@ class NPCService: ObservableObject {
     // MARK: - Private
     
     private var client: (any NpubCashClientProtocol)?
+    private var suppressSettingsSideEffects = false
     private var connectionTask: Task<Void, Never>?
     private var sessionID = UUID()
     private let makeClient: (String, String) throws -> any NpubCashClientProtocol
@@ -100,6 +101,15 @@ class NPCService: ObservableObject {
     func initializeIfEnabled() async {
         await connect()
         applyPollingPreferences()
+    }
+
+    func reloadWalletScopedData() {
+        suppressSettingsSideEffects = true
+        defer { suppressSettingsSideEffects = false }
+        isEnabled = settingsStore.npcEnabled
+        automaticClaim = settingsStore.npcAutomaticClaim
+        selectedMintUrl = settingsStore.npcSelectedMint
+        lastCheck = settingsStore.npcLastCheck
     }
 
     // MARK: - Key Derivation

--- a/ios/CashuWallet/Core/NWCManager.swift
+++ b/ios/CashuWallet/Core/NWCManager.swift
@@ -101,6 +101,15 @@ final class NWCManager: ObservableObject {
 
     // MARK: - Wiring
 
+    func reloadWalletScopedData() {
+        suppressSideEffects = true
+        defer { suppressSideEffects = false }
+        isEnabled = settingsStore.nwcEnabled
+        selectedMintUrl = settingsStore.nwcSelectedMint
+        budgetSats = settingsStore.nwcBudgetSats
+        connectionUri = settingsStore.nwcConnectionUri
+    }
+
     /// Inject the wallet/seed providers. Call once from `WalletManager` after the
     /// wallet is available.
     func configure(

--- a/ios/CashuWallet/Core/NostrMintBackupService.swift
+++ b/ios/CashuWallet/Core/NostrMintBackupService.swift
@@ -24,6 +24,7 @@ final class NostrMintBackupService: ObservableObject {
     /// `performICloudBackup()`. Failures only log; the mint operation that
     /// triggered the backup must not surface a relay error.
     func backupCurrentMintsIfEnabled() async {
+        guard !ICloudRestoreState.isIncomplete() else { return }
         guard SettingsManager.shared.nostrMintBackupEnabled else { return }
         do {
             try await backupMints()
@@ -35,6 +36,9 @@ final class NostrMintBackupService: ObservableObject {
     }
 
     func backupMints() async throws {
+        guard !ICloudRestoreState.isIncomplete() else {
+            throw WalletError.networkError("Finish restoring the wallet before replacing its backup.")
+        }
         guard SettingsManager.shared.useWebsockets else {
             throw NostrMintBackupError.webSocketsDisabled
         }

--- a/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -278,7 +278,7 @@ enum StorageKeys {
 
     static var walletBoundaryKeys: [String] {
         walletDataKeys + walletDataLegacyKeys + walletScopedSettingsKeys + walletScopedSettingsLegacyKeys
-            + [onboardingCompleted]
+            + [onboardingCompleted, ICloudRestoreState.incompleteKey]
     }
     
     // Keychain (Secure Storage)

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -79,6 +79,9 @@ class LightningService: ObservableObject {
     private let getActiveMint: () -> MintInfo?
     private let getMints: () -> [MintInfo]
     private var mintQuotesInFlight: Set<String> = []
+    // These native waits can outlive the wallet operation lease. They cannot
+    // be cancelled by Swift and must survive clearState() until they return.
+    private var activeMeltSettlementWaits = 0
     
     // MARK: - Initialization
     
@@ -97,6 +100,12 @@ class LightningService: ObservableObject {
     func clearState() {
         isLoading = false
         mintQuotesInFlight.removeAll()
+    }
+
+    func requireNoActiveMeltSettlement() throws {
+        guard activeMeltSettlementWaits == 0 else {
+            throw WalletError.networkError("A payment is still settling. Wait for it to finish before replacing or deleting the wallet.")
+        }
     }
     
     // MARK: - Minting (NUT-04) - Receive via Lightning
@@ -850,7 +859,11 @@ class LightningService: ObservableObject {
         // is serialized; it exists because both will reach it.
         final class ResumeGate { var resumed = false }
         let gate = ResumeGate()
-        let waitTask = Task { try await wait() }
+        activeMeltSettlementWaits += 1
+        let waitTask = Task {
+            defer { activeMeltSettlementWaits -= 1 }
+            return try await wait()
+        }
         return await withCheckedContinuation { continuation in
             func resumeOnce(_ outcome: BoundedMeltWaitOutcome) {
                 guard !gate.resumed else { return }

--- a/ios/CashuWallet/Core/SettingsManager.swift
+++ b/ios/CashuWallet/Core/SettingsManager.swift
@@ -425,6 +425,26 @@ class SettingsManager: ObservableObject {
         NostrMintBackupService.shared.resetForWalletBoundary()
         settingsStore.clearWalletScopedData()
     }
+
+    /// Included in the encrypted replacement journal before any keys are removed.
+    var walletReplacementSecretKeys: [String] {
+        let ids = Set(p2pkKeys.map(\.id)).union(settingsStore.p2pkPendingDeletionIDs)
+        return ids.flatMap { [Self.secureP2PKPrivateKey($0), Self.secureP2PKRemovalFallback($0)] }
+            + [StorageKeys.Secure.nostrPrivateKey]
+    }
+
+    func reloadWalletScopedData() {
+        let previousSuppression = suppressPaymentRequestSideEffects
+        suppressPaymentRequestSideEffects = true
+        defer { suppressPaymentRequestSideEffects = previousSuppression }
+        let loaded = Self.loadP2PKKeys(settingsStore: settingsStore, secureStorage: secureStorage)
+        pendingLegacyP2PKSecrets = loaded.pendingLegacySecrets
+        p2pkKeys = loaded.keys
+        showP2PKButtonInDrawer = settingsStore.showP2PKButtonInDrawer
+        enablePaymentRequests = settingsStore.enablePaymentRequests
+        receivePaymentRequestsAutomatically = settingsStore.receivePaymentRequestsAutomatically
+        nostrMintBackupEnabled = settingsStore.nostrMintBackupEnabled
+    }
     
     private struct LoadedP2PKKeys {
         let keys: [P2PKKey]

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Backup.swift
@@ -19,7 +19,8 @@ enum ICloudBackupOutcome: Equatable {
 }
 
 enum ICloudRestoreState {
-    private static let incompleteKey = "cashu.local.icloudRestoreIncomplete"
+    // Retain the existing key for upgrades; the barrier now covers every seed restore.
+    static let incompleteKey = "cashu.local.icloudRestoreIncomplete"
 
     static func isIncomplete(defaults: UserDefaults = .standard) -> Bool {
         defaults.bool(forKey: incompleteKey)
@@ -240,7 +241,6 @@ extension WalletManager {
         // Keep the user's backup preference intact while independently
         // suppressing writes. Persist the marker so an interruption cannot make
         // a partial wallet look complete on the next launch.
-        setICloudRestoreIncomplete(true)
         try await initializeRestoredWallet(mnemonic: recoveredMnemonic)
 
         var failedMintCount = 0

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Cdk
 import os
 
@@ -508,6 +509,7 @@ extension WalletManager {
 
         var publishedCachedWallet = false
         do {
+            try await recoverWalletReplacement()
             // Keychain I/O is synchronous. Read it away from the main actor so
             // the first SwiftUI frame is never held behind Security.framework.
             let storedMnemonic = try await Task.detached(priority: .userInitiated) {
@@ -638,7 +640,7 @@ extension WalletManager {
         }
 
         try proveWalletCanInitialize(mnemonic: normalizedMnemonic)
-        try await installCleanWallet(mnemonic: normalizedMnemonic)
+        try await installCleanWallet(mnemonic: normalizedMnemonic, restoring: true)
         SentryService.breadcrumb("Wallet restored from seed", category: "wallet.lifecycle")
     }
 
@@ -719,10 +721,9 @@ extension WalletManager {
         CashuRequestListener.shared.requestStart()
     }
 
-    /// Legacy restore for backward compatibility (initializes + completes without NUT-09)
+    /// Legacy entry point. Mint recovery and explicit completion are still required.
     func restoreWallet(mnemonic: String) async throws {
         try await initializeRestoredWallet(mnemonic: mnemonic)
-        await completeRestore()
     }
 
     func deleteWallet() async throws {
@@ -736,6 +737,7 @@ extension WalletManager {
         try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
             await self.operationCoordinator.cancelPendingOperations()
             resetRuntimeState()
+            try await recoverWalletReplacement()
             try keychainService.deleteMnemonic()
             try? keychainService.deleteNostrPrivateKey()
             OnboardingCompletionState.clear()
@@ -760,117 +762,123 @@ extension WalletManager {
         let values: [String: Any]
     }
 
-    private func installCleanWallet(mnemonic newMnemonic: String) async throws {
+    private struct ReplacementState: Codable, Sendable {
+        let mnemonic: String?
+        let defaults: Data
+        let secrets: [String: String]
+    }
+
+    private func recoverWalletReplacement() async throws {
+        let urls = try walletDatabaseBoundaryURLs()
+        let restored = try await Task.detached(priority: .userInitiated) {
+            let storage = KeychainService()
+            var restored = false
+            try DurableWalletReplacement(storage: storage, urls: urls).recover { data in
+                let state = try PropertyListDecoder().decode(ReplacementState.self, from: data)
+                guard let snapshot = try PropertyListSerialization.propertyList(from: state.defaults, format: nil) as? [String: Any],
+                      let keys = snapshot["keys"] as? [String], let values = snapshot["values"] as? [String: Any] else {
+                    throw CocoaError(.fileReadCorruptFile)
+                }
+                try WalletMnemonicRollback.restore(previousMnemonic: state.mnemonic, secureStorage: storage)
+                for (key, value) in state.secrets { try storage.saveSecret(value, forKey: key) }
+                let defaults = UserDefaults.standard
+                let currentKeys = defaults.dictionaryRepresentation().keys.filter {
+                    $0.hasPrefix(StorageKeys.walletDataPrefix) || $0.hasPrefix(StorageKeys.npcDataPrefix)
+                }
+                for key in Set(StorageKeys.walletBoundaryKeys + currentKeys).union(keys) {
+                    if let value = values[key] { defaults.set(value, forKey: key) }
+                    else { defaults.removeObject(forKey: key) }
+                }
+                guard defaults.synchronize() else { throw CocoaError(.fileWriteUnknown) }
+                restored = true
+            }
+            return restored
+        }.value
+        if restored {
+            SettingsManager.shared.reloadWalletScopedData()
+            NWCManager.shared.reloadWalletScopedData()
+            NPCService.shared.reloadWalletScopedData()
+            CashuRequestStore.shared.reloadFromDefaults()
+        }
+    }
+
+    private func installCleanWallet(mnemonic newMnemonic: String, restoring: Bool = false) async throws {
         await CashuRequestListener.shared.resetForWalletBoundary()
         await NWCManager.shared.stop()
         try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
             await self.operationCoordinator.cancelPendingOperations()
-            try await self.installCleanWalletAssumingLease(mnemonic: newMnemonic)
+            try await self.installCleanWalletAssumingLease(mnemonic: newMnemonic, restoring: restoring)
         }
     }
 
-    private func installCleanWalletAssumingLease(mnemonic newMnemonic: String) async throws {
-        let previousMnemonic: String?
-        if let mnemonic {
-            previousMnemonic = mnemonic
-        } else {
-            previousMnemonic = try keychainService.loadMnemonic()
-        }
+    private func installCleanWalletAssumingLease(mnemonic newMnemonic: String, restoring: Bool) async throws {
+        try await recoverWalletReplacement()
+        let previousMnemonic = try mnemonic ?? keychainService.loadMnemonic()
         let defaultsSnapshot = walletBoundaryDefaultsSnapshot()
-
-        let fileBackups: [WalletFileBackup]
-        do {
-            fileBackups = try backupWalletDatabaseFiles()
-        } catch {
-            // The transactional backup helper restores any files moved before
-            // the failure. Runtime state has not changed, so reopen listener
-            // intake for the still-attached wallet.
-            restoreWalletBoundaryDefaults(defaultsSnapshot)
-            resumeCashuRequestListenerAfterWalletBoundaryRollback()
-            throw error
+        var secrets: [String: String] = [:]
+        for key in SettingsManager.shared.walletReplacementSecretKeys {
+            if let value = try keychainService.loadSecret(forKey: key) { secrets[key] = value }
         }
-
+        let snapshot = ReplacementState(
+            mnemonic: previousMnemonic,
+            defaults: try PropertyListSerialization.data(
+                fromPropertyList: ["keys": Array(defaultsSnapshot.keys), "values": defaultsSnapshot.values],
+                format: .binary, options: 0
+            ),
+            secrets: secrets
+        )
+        let replacementURLs = try walletDatabaseBoundaryURLs()
+        let snapshotData = try PropertyListEncoder().encode(snapshot)
+        // Release CDK and its SQLite connection before copying any database files.
+        resetRuntimeState()
         do {
-            resetRuntimeState()
+            try await Task.detached(priority: .userInitiated) {
+                try WalletReplacementCheckpoint.flushDatabases(in: replacementURLs)
+                try DurableWalletReplacement(storage: KeychainService(), urls: replacementURLs).begin(state: snapshotData)
+            }.value
             removeWalletBoundaryDefaults(defaultsSnapshot)
             walletStore.removeAllWalletData()
             SettingsStore.shared.clearWalletScopedData()
+            // Applies to manual seed restores as well as iCloud restores, before
+            // any operation can publish an empty/partial replacement backup.
+            setICloudRestoreIncomplete(restoring)
             NostrService.shared.resetForWalletBoundary(deleteStoredKey: false)
             NPCService.shared.resetForWalletBoundary()
             NWCManager.shared.resetForWalletBoundary()
             CashuRequestStore.shared.resetForWalletBoundary()
-
             try initializeWalletForCreation(mnemonic: newMnemonic)
             try keychainService.saveMnemonic(newMnemonic)
             mnemonic = newMnemonic
-            // A freshly installed wallet has not finished onboarding; only
-            // completeOnboarding()/completeRestore() may flip this to done.
             OnboardingCompletionState.setCompleted(false)
             SettingsManager.shared.resetWalletScopedData(resetRuntimeServices: false)
+            guard UserDefaults.standard.synchronize() else { throw CocoaError(.fileWriteUnknown) }
+            try await Task.detached(priority: .userInitiated) {
+                try DurableWalletReplacement(storage: KeychainService(), urls: replacementURLs).commit()
+            }.value
         } catch {
-            SentryService.capture(error)
             resetRuntimeState()
-            let rollbackSucceeded: Bool
             do {
-                try restoreWalletFileBackups(
-                    fileBackups,
-                    beforeCommit: {
-                        try WalletMnemonicRollback.restore(
-                            previousMnemonic: previousMnemonic,
-                            secureStorage: keychainService
-                        )
-                    },
-                    onRollback: {
-                        try WalletMnemonicRollback.restore(
-                            previousMnemonic: newMnemonic,
-                            secureStorage: keychainService
-                        )
-                    }
-                )
-                rollbackSucceeded = true
+                try await recoverWalletReplacement()
+                let recoveredMnemonic = try keychainService.loadMnemonic()
+                mnemonic = recoveredMnemonic
+                if let recoveredMnemonic {
+                    try initializeWalletForLaunch(mnemonic: recoveredMnemonic)
+                    startDeferredStartupMaintenance()
+                    resumeCashuRequestListenerAfterWalletBoundaryRollback()
+                } else {
+                    needsOnboarding = true
+                    isRuntimeReady = true
+                }
             } catch {
-                rollbackSucceeded = false
-                AppLogger.wallet.error("Failed to restore the previous wallet transaction: \(error)")
+                AppLogger.wallet.error("Previous wallet recovery must be retried at launch: \(error)")
                 SentryService.capture(error)
             }
-
-            var reopenedPreviousWallet = false
-            if rollbackSucceeded {
-                restoreWalletBoundaryDefaults(defaultsSnapshot)
-                CashuRequestStore.shared.reloadFromDefaults()
-                mnemonic = previousMnemonic
-
-                if let previousMnemonic {
-                    do {
-                        try initializeWalletForLaunch(mnemonic: previousMnemonic)
-                        startDeferredStartupMaintenance()
-                        reopenedPreviousWallet = true
-                    } catch {
-                        AppLogger.wallet.error("Failed to reopen previous wallet after replacement error: \(error)")
-                    }
-                }
-            }
-
-            if reopenedPreviousWallet {
-                resumeCashuRequestListenerAfterWalletBoundaryRollback()
-            }
-
             throw error
         }
-
-        // The new seed/database pair is committed. Backup cleanup must never
-        // turn an otherwise successful replacement into a rollback after some
-        // of the only old-wallet backups have already been deleted.
-        do {
-            try removeWalletFileBackups(fileBackups)
-        } catch {
-            AppLogger.wallet.error("Failed to remove committed wallet replacement backups: \(error)")
-            SentryService.capture(error)
-        }
-
-        if !IntegrationTestConfig.shouldUseDeterministicUIRuntime {
-            performICloudBackup()
-        }
+        // Cleanup failure leaves a committed journal that startup can safely finish.
+        do { try await recoverWalletReplacement() }
+        catch { AppLogger.wallet.error("Committed wallet recovery cleanup deferred: \(error)") }
+        if !IntegrationTestConfig.shouldUseDeterministicUIRuntime { performICloudBackup() }
     }
 
     private func resumeCashuRequestListenerAfterWalletBoundaryRollback() {
@@ -1090,35 +1098,6 @@ extension WalletManager {
         }
 
         return [walletDirectoryURL, legacyDatabaseURL] + legacySidecars
-    }
-
-    private func backupWalletDatabaseFiles() throws -> [WalletFileBackup] {
-        let timestamp = Int(Date().timeIntervalSince1970)
-        return try WalletReplacementFiles.backup(urls: walletDatabaseBoundaryURLs()) { originalURL in
-            originalURL.deletingLastPathComponent()
-                .appendingPathComponent("\(originalURL.lastPathComponent).replacing.\(timestamp).\(UUID().uuidString)")
-        }
-    }
-
-    private func restoreWalletFileBackups(
-        _ backups: [WalletFileBackup],
-        beforeCommit: () throws -> Void,
-        onRollback: () throws -> Void
-    ) throws {
-        try WalletReplacementFiles.restore(
-            at: walletDatabaseBoundaryURLs(),
-            backups,
-            displacedURL: { originalURL in
-                originalURL.deletingLastPathComponent()
-                    .appendingPathComponent("\(originalURL.lastPathComponent).rollback.\(UUID().uuidString)")
-            },
-            beforeCommit: beforeCommit,
-            onRollback: onRollback
-        )
-    }
-
-    private func removeWalletFileBackups(_ backups: [WalletFileBackup]) throws {
-        try WalletReplacementFiles.removeBackups(backups)
     }
 
     private func removeWalletDatabaseFiles() throws {
@@ -1500,5 +1479,102 @@ extension WalletManager {
         let token = try tokenService.decodeToken(tokenString: tokenString)
         let tokenMintUrl = try token.mintUrl().url
         await mintService.ensureMintTracked(url: tokenMintUrl)
+    }
+}
+
+
+/// Crash recovery journal is kept in the device-only Keychain. Database backups remain
+/// intact throughout replay; even an interrupted rollback can be repeated on the next launch.
+struct DurableWalletReplacement {
+    static let key = "wallet_replacement_journal_v1"
+    private enum Phase: String, Codable { case preparing, installing, committed, restored }
+    private struct Record: Codable {
+        var phase: Phase
+        let existed: [Bool]
+        let state: Data
+    }
+    let storage: SecureStorageProtocol
+    let urls: [URL]
+    private var backups: [URL] { urls.map { URL(fileURLWithPath: $0.path + ".replacement-backup-v1") } }
+    private let fm = FileManager.default
+
+    private func read() throws -> Record? {
+        guard let value = try storage.loadSecret(forKey: Self.key) else { return nil }
+        guard let data = Data(base64Encoded: value) else { throw CocoaError(.fileReadCorruptFile) }
+        return try PropertyListDecoder().decode(Record.self, from: data)
+    }
+    private func write(_ record: Record) throws {
+        try storage.saveSecret(PropertyListEncoder().encode(record).base64EncodedString(), forKey: Self.key)
+    }
+    func begin(state: Data) throws {
+        guard try read() == nil, backups.allSatisfy({ !fm.fileExists(atPath: $0.path) }) else {
+            throw CocoaError(.fileWriteFileExists)
+        }
+        var record = Record(phase: .preparing, existed: urls.map { fm.fileExists(atPath: $0.path) }, state: state)
+        try write(record)
+        for i in urls.indices where record.existed[i] { try fm.copyItem(at: urls[i], to: backups[i]) }
+        record.phase = .installing
+        try write(record)
+        for url in urls { try remove(url) }
+    }
+    func commit() throws {
+        guard var record = try read(), record.phase == .installing else { throw CocoaError(.fileReadCorruptFile) }
+        record.phase = .committed
+        try write(record)
+    }
+    func recover(restoreState: (Data) throws -> Void) throws {
+        guard var record = try read() else { return }
+        guard record.existed.count == urls.count else { throw CocoaError(.fileReadCorruptFile) }
+        if record.phase == .installing {
+            guard urls.indices.allSatisfy({ !record.existed[$0] || fm.fileExists(atPath: backups[$0].path) }) else {
+                throw CocoaError(.fileReadNoSuchFile)
+            }
+            for i in urls.indices {
+                try remove(urls[i])
+                if record.existed[i] { try fm.copyItem(at: backups[i], to: urls[i]) }
+            }
+            try restoreState(record.state)
+            record.phase = .restored
+            try write(record)
+        }
+        for backup in backups { try remove(backup) }
+        try storage.deleteSecret(forKey: Self.key)
+    }
+    private func remove(_ url: URL) throws {
+        if fm.fileExists(atPath: url.path) { try fm.removeItem(at: url) }
+    }
+}
+
+/// Native FFI handles can be released asynchronously. A successful checkpoint
+/// establishes a stable database image before the replacement journal copies it.
+enum WalletReplacementCheckpoint {
+    static func flushDatabases(in urls: [URL]) throws {
+        for url in urls {
+            var directory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &directory) else { continue }
+            let candidates = directory.boolValue
+                ? try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
+                : [url]
+            for database in candidates where database.pathExtension == "db" || database.pathExtension == "sqlite" {
+                try flush(database)
+            }
+        }
+    }
+
+    private static func flush(_ url: URL) throws {
+        var connection: OpaquePointer?
+        guard sqlite3_open_v2(url.path, &connection, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK else {
+            if let connection { sqlite3_close(connection) }
+            throw CocoaError(.fileReadUnknown)
+        }
+        defer { sqlite3_close(connection) }
+        var statement: OpaquePointer?
+        guard sqlite3_prepare_v2(connection, "PRAGMA wal_checkpoint(TRUNCATE)", -1, &statement, nil) == SQLITE_OK else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        defer { sqlite3_finalize(statement) }
+        guard sqlite3_step(statement) == SQLITE_ROW, sqlite3_column_int(statement, 0) == 0 else {
+            throw WalletError.networkError("Wallet database is still busy. Try again in a moment.")
+        }
     }
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -729,31 +729,38 @@ extension WalletManager {
     func deleteWallet() async throws {
         isLoading = true
         defer { isLoading = false }
+        try lightningService.requireNoActiveMeltSettlement()
 
         // Stop accepting listener work and let an already-started token receive
         // finish all attribution/cache side effects before removing its wallet.
         await CashuRequestListener.shared.resetForWalletBoundary()
         await NWCManager.shared.stop()
-        try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
-            await self.operationCoordinator.cancelPendingOperations()
-            resetRuntimeState()
-            try await recoverWalletReplacement()
-            try keychainService.deleteMnemonic()
-            try? keychainService.deleteNostrPrivateKey()
-            OnboardingCompletionState.clear()
-            try removeWalletDatabaseFiles()
-            walletStore.removeAllWalletData()
-            SettingsManager.shared.resetWalletScopedData()
-            NWCManager.shared.resetForWalletBoundary()
-            CashuRequestStore.shared.resetForWalletBoundary()
-            MintLogoCache.shared.clear()
-            processedQuotes.removeAll()
-            // iCloud backup survives a local deletion — the user can restore it from
-            // Restore Wallet → Restore from iCloud.
-            needsOnboarding = true
-            isInitialized = true
-            isRuntimeReady = true
-            SentryService.breadcrumb("Wallet deleted", category: "wallet.lifecycle")
+        do {
+            try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
+                try lightningService.requireNoActiveMeltSettlement()
+                await self.operationCoordinator.cancelPendingOperations()
+                resetRuntimeState()
+                try await recoverWalletReplacement()
+                try keychainService.deleteMnemonic()
+                try? keychainService.deleteNostrPrivateKey()
+                OnboardingCompletionState.clear()
+                try removeWalletDatabaseFiles()
+                walletStore.removeAllWalletData()
+                SettingsManager.shared.resetWalletScopedData()
+                NWCManager.shared.resetForWalletBoundary()
+                CashuRequestStore.shared.resetForWalletBoundary()
+                MintLogoCache.shared.clear()
+                processedQuotes.removeAll()
+                // iCloud backup survives a local deletion — the user can restore it from
+                // Restore Wallet → Restore from iCloud.
+                needsOnboarding = true
+                isInitialized = true
+                isRuntimeReady = true
+                SentryService.breadcrumb("Wallet deleted", category: "wallet.lifecycle")
+            }
+        } catch {
+            await resumeServicesAfterWalletBoundaryFailure()
+            throw error
         }
     }
 
@@ -803,12 +810,27 @@ extension WalletManager {
     }
 
     private func installCleanWallet(mnemonic newMnemonic: String, restoring: Bool = false) async throws {
+        try lightningService.requireNoActiveMeltSettlement()
         await CashuRequestListener.shared.resetForWalletBoundary()
         await NWCManager.shared.stop()
-        try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
-            await self.operationCoordinator.cancelPendingOperations()
-            try await self.installCleanWalletAssumingLease(mnemonic: newMnemonic, restoring: restoring)
+        do {
+            try await operationCoordinator.perform(kind: .recovery, priority: .recovery) {
+                // Recheck with the lease held: a payment could have started while
+                // listener/NWC shutdown was suspended above.
+                try lightningService.requireNoActiveMeltSettlement()
+                await self.operationCoordinator.cancelPendingOperations()
+                try await self.installCleanWalletAssumingLease(mnemonic: newMnemonic, restoring: restoring)
+            }
+        } catch {
+            await resumeServicesAfterWalletBoundaryFailure()
+            throw error
         }
+    }
+
+    private func resumeServicesAfterWalletBoundaryFailure() async {
+        guard isRuntimeReady, walletRepository != nil else { return }
+        resumeCashuRequestListenerAfterWalletBoundaryRollback()
+        await NWCManager.shared.startIfEnabled()
     }
 
     private func installCleanWalletAssumingLease(mnemonic newMnemonic: String, restoring: Bool) async throws {

--- a/ios/CashuWalletTests/MeltSettlementWaitTests.swift
+++ b/ios/CashuWalletTests/MeltSettlementWaitTests.swift
@@ -77,4 +77,79 @@ final class MeltSettlementWaitTests: XCTestCase {
             XCTFail("unexpected failure: \(error)")
         }
     }
+
+    func testUncancellableResidualBlocksWalletBoundaryUntilNativeWaitReturns() async throws {
+        let service = makeService()
+        let (residual, finish) = await holdSettlement(service: service)
+
+        XCTAssertThrowsError(try service.requireNoActiveMeltSettlement())
+        service.clearState()
+        residual.cancel()
+        XCTAssertThrowsError(try service.requireNoActiveMeltSettlement(),
+                             "Clearing UI state or cancelling Swift must not hide a live native wait")
+
+        finish.resume(returning: finalized())
+        _ = try await residual.value
+        XCTAssertNoThrow(try service.requireNoActiveMeltSettlement())
+    }
+
+    func testWalletBoundaryWaitsForEveryNativeSettlement() async throws {
+        struct WaitError: Error {}
+        let service = makeService()
+        let (residual, finish) = await holdSettlement(service: service)
+        let (otherResidual, finishOther) = await holdSettlement(service: service)
+        XCTAssertThrowsError(try service.requireNoActiveMeltSettlement())
+
+        finish.resume(throwing: WaitError())
+        _ = await residual.result
+        XCTAssertThrowsError(try service.requireNoActiveMeltSettlement(),
+                             "A failed wait must not release another live settlement")
+
+        finishOther.resume(returning: finalized())
+        _ = try await otherResidual.value
+        XCTAssertNoThrow(try service.requireNoActiveMeltSettlement())
+    }
+
+    func testCreateAndDeleteRejectActiveSettlementBeforeTouchingWalletState() async throws {
+        let manager = WalletManager()
+        let (residual, finish) = await holdSettlement(service: manager.lightningService)
+
+        do {
+            try await manager.createNewWallet()
+            XCTFail("Creation must not replace files while a native settlement is active")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("still settling"))
+        }
+        do {
+            try await manager.deleteWallet()
+            XCTFail("Deletion must not remove files while a native settlement is active")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("still settling"))
+        }
+        XCTAssertNil(manager.walletRepository)
+        XCTAssertFalse(manager.isLoading)
+
+        finish.resume(returning: finalized())
+        _ = try await residual.value
+    }
+
+    private func holdSettlement(service: LightningService) async -> (
+        Task<FinalizedMelt, any Error>, CheckedContinuation<FinalizedMelt, any Error>
+    ) {
+        let started = expectation(description: "Native settlement started")
+        var finish: CheckedContinuation<FinalizedMelt, any Error>?
+        let race = Task {
+            await service.awaitMeltSettlementBounded(cap: .zero) {
+                try await withCheckedThrowingContinuation { continuation in
+                    finish = continuation
+                    started.fulfill()
+                }
+            }
+        }
+        await fulfillment(of: [started], timeout: 2)
+        guard case .capExpired(let residual) = await race.value, let finish else {
+            preconditionFailure("Held settlement must outlive the cap")
+        }
+        return (residual, finish)
+    }
 }

--- a/ios/CashuWalletTests/WalletAuditRegressionTests.swift
+++ b/ios/CashuWalletTests/WalletAuditRegressionTests.swift
@@ -1,10 +1,120 @@
 import Cdk
 import XCTest
+import SQLite3
 @testable import CashuWallet
 
 @MainActor
 final class WalletAuditRegressionTests: XCTestCase {
     private enum Failure: Error { case offline }
+
+    func testReplacementCheckpointPreservesSqliteWalContents() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let database = directory.appendingPathComponent("wallet.db")
+        var connection: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(database.path, &connection), SQLITE_OK)
+        defer { sqlite3_close(connection) }
+        XCTAssertEqual(sqlite3_exec(connection, "PRAGMA journal_mode=WAL; CREATE TABLE recovery_test(value TEXT); INSERT INTO recovery_test VALUES ('proofs before replacement');", nil, nil, nil), SQLITE_OK)
+        try WalletReplacementCheckpoint.flushDatabases(in: [directory])
+        let copy = directory.appendingPathComponent("snapshot.db")
+        try FileManager.default.copyItem(at: database, to: copy)
+        var reopened: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(copy.path, &reopened), SQLITE_OK)
+        defer { sqlite3_close(reopened) }
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(reopened, "SELECT value FROM recovery_test", -1, &statement, nil), SQLITE_OK)
+        defer { sqlite3_finalize(statement) }
+        XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
+        XCTAssertEqual(String(cString: sqlite3_column_text(statement, 0)), "proofs before replacement")
+    }
+
+    func testReplacementRelaunchRestoresSeedDefaultsAndDatabase() throws {
+        let storage = ReplacementJournalStorage()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = directory.appendingPathComponent("wallet.db")
+        try Data("old proofs".utf8).write(to: db)
+        let state = Data("old seed and preferences".utf8)
+        try DurableWalletReplacement(storage: storage, urls: [db]).begin(state: state)
+        try Data("new proofs".utf8).write(to: db)
+        var restored: Data?
+        try DurableWalletReplacement(storage: storage, urls: [db]).recover { restored = $0 }
+        XCTAssertEqual(restored, state)
+        XCTAssertEqual(try Data(contentsOf: db), Data("old proofs".utf8))
+        XCTAssertFalse(storage.hasSecret(forKey: DurableWalletReplacement.key))
+    }
+
+    func testReplacementRollbackCanBeInterruptedAndReplayed() throws {
+        let storage = ReplacementJournalStorage()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = directory.appendingPathComponent("wallet.db")
+        try Data("old".utf8).write(to: db)
+        try DurableWalletReplacement(storage: storage, urls: [db]).begin(state: Data())
+        XCTAssertThrowsError(try DurableWalletReplacement(storage: storage, urls: [db]).recover { _ in throw Failure.offline })
+        try Data("interrupted rollback".utf8).write(to: db)
+        try DurableWalletReplacement(storage: storage, urls: [db]).recover { _ in }
+        XCTAssertEqual(try Data(contentsOf: db), Data("old".utf8))
+    }
+
+    func testCommittedReplacementNeverRestoresPreviousSeed() throws {
+        let storage = ReplacementJournalStorage()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = directory.appendingPathComponent("wallet.db")
+        try Data("old".utf8).write(to: db)
+        let journal = DurableWalletReplacement(storage: storage, urls: [db])
+        try journal.begin(state: Data())
+        try Data("new".utf8).write(to: db)
+        try journal.commit()
+        try DurableWalletReplacement(storage: storage, urls: [db]).recover { _ in XCTFail("Committed replacement must not roll back") }
+        XCTAssertEqual(try Data(contentsOf: db), Data("new".utf8))
+    }
+
+    func testPreparingReplacementNeverTouchesOriginalFiles() throws {
+        let storage = ReplacementJournalStorage()
+        storage.failWrite = 2
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = directory.appendingPathComponent("wallet.db")
+        try Data("old".utf8).write(to: db)
+        XCTAssertThrowsError(try DurableWalletReplacement(storage: storage, urls: [db]).begin(state: Data()))
+        try DurableWalletReplacement(storage: storage, urls: [db]).recover { _ in XCTFail("Preferences are still untouched") }
+        XCTAssertEqual(try Data(contentsOf: db), Data("old".utf8))
+    }
+
+    func testMissingReplacementBackupBlocksRecoveryBeforeSeedChanges() throws {
+        let storage = ReplacementJournalStorage()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = directory.appendingPathComponent("wallet.db")
+        try Data("old".utf8).write(to: db)
+        try DurableWalletReplacement(storage: storage, urls: [db]).begin(state: Data())
+        try FileManager.default.removeItem(atPath: db.path + ".replacement-backup-v1")
+        try Data("new".utf8).write(to: db)
+        XCTAssertThrowsError(try DurableWalletReplacement(storage: storage, urls: [db]).recover { _ in XCTFail("Must not mismatch the seed") })
+        XCTAssertEqual(try Data(contentsOf: db), Data("new".utf8))
+        XCTAssertTrue(storage.hasSecret(forKey: DurableWalletReplacement.key))
+    }
+
+    func testManualRestoreBackupBarrierSurvivesDefaultsReload() throws {
+        let suite = "WalletRestoreBarrierTests-" + UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+        ICloudRestoreState.setIncomplete(true, defaults: defaults)
+        XCTAssertTrue(defaults.synchronize())
+        let reopened = try XCTUnwrap(UserDefaults(suiteName: suite))
+        XCTAssertFalse(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: ICloudRestoreState.isIncomplete(defaults: reopened)))
+        XCTAssertTrue(StorageKeys.walletBoundaryKeys.contains(ICloudRestoreState.incompleteKey))
+        ICloudRestoreState.setIncomplete(false, defaults: reopened)
+        XCTAssertTrue(ICloudRestorePolicy.shouldPerformBackup(restoreIncomplete: ICloudRestoreState.isIncomplete(defaults: reopened)))
+    }
 
     func testMeltAmountRejectsOverflowingFee() throws {
         XCTAssertEqual(try LightningService.requiredMeltAmount(amount: 10, feeReserve: 2), 12)
@@ -206,4 +316,18 @@ final class WalletAuditRegressionTests: XCTestCase {
             usedByOperation: reservation, version: 0
         )
     }
+}
+
+private final class ReplacementJournalStorage: SecureStorageProtocol {
+    private var values: [String: String] = [:]
+    var failWrite = 0
+    private var writes = 0
+    func saveSecret(_ secret: String, forKey key: String) throws {
+        writes += 1
+        if writes == failWrite { throw CocoaError(.fileWriteUnknown) }
+        values[key] = secret
+    }
+    func loadSecret(forKey key: String) throws -> String? { values[key] }
+    func deleteSecret(forKey key: String) throws { values.removeValue(forKey: key) }
+    func hasSecret(forKey key: String) -> Bool { values[key] != nil }
 }


### PR DESCRIPTION
Interrupted wallet replacement could leave the stored seed and database out of sync. Both platforms now keep an encrypted recovery journal and database backups until the replacement commits, replay unfinished recovery before opening the wallet, and checkpoint SQLite before copying it. Rollback can itself be interrupted and safely retried, including restoration of wallet settings and signing keys.

On iOS, replacement and deletion also reject attempts while a native Lightning settlement wait remains active after its UI timeout. The check runs before stopping services and again under the exclusive wallet-operation lease. Clearing UI state or cancelling the Swift task cannot release this protection; every native wait must actually return first. Services resume if a late check rejects the operation.

The related payment and backup fixes:

- Android deferred receipts use the complete token's hash for identity and compare complete tokens when saving, so different payments with the same encoded prefix cannot overwrite each other. Existing saved receipts remain compatible.
- Android foreign-mint NFC conversion first redeems the token through CDK's receive/swap operation, then melts owned proofs from the persistent source wallet. This prevents failed or interrupted melt compensation from crediting unverified or already-spent bearer proofs. The source mint remains visible, returned change survives restart, and the conversion budget includes receive and melt fees while excluding retained change.
- Android Lightning payment errors reconcile mint status and local reservations before reporting an outcome. Unknown status blocks an immediate retry; confirmed compensation requires a fresh quote.
- Manual seed restores and cloud restores retain a persistent backup-write barrier until explicit completion. This protects iCloud and Nostr mint-list backups from incomplete restores, including across relaunches. Legacy restore entry points also require explicit completion.

Validation:

- Android JVM suite: 720 passed, 6 existing skips, no failures.
- Focused iOS settlement and wallet-safety suite: 43 passed, no failures. Coverage includes uncancellable residual waits, overlapping settlements, and rejection of wallet creation/deletion before state changes.
- Two native Android NFC tests passed against synthetic local mints: conservation and spendability of retained change after reopening, and rejection of an already-spent token before and after saga recovery and reopening.
- The spent-token regression was also run against the original implementation: it failed with a false 1,000-sat balance; the fixed implementation passes with a zero balance.
- Debug Android app and instrumentation builds, the iOS simulator build, and `git diff --check` passed.

Payment tests used synthetic local-mint funds. Physical NFC hardware was not exercised.
