### PR TITLE
Accept delegated Lightning Address callbacks on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/Core/CDK/LightningAddressResolver.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/LightningAddressResolver.kt
@@ -76,7 +76,6 @@ internal class LightningAddressResolver(
 
         val callbackUrl = invoiceCallbackUrl(
             callback = callback,
-            expectedHost = endpoint.host,
             amountMsat = amountMsat,
         )
         val invoiceResponse = try {
@@ -153,16 +152,16 @@ internal class LightningAddressResolver(
 
     private fun invoiceCallbackUrl(
         callback: String,
-        expectedHost: String,
         amountMsat: Long,
     ): HttpUrl {
         val parsed = callback.toHttpUrlOrNull()
             ?: throw LightningAddressResolutionException.Invalid(
                 "Lightning address service returned an invalid payment callback.",
             )
+        val authority = runCatching { java.net.URI(callback).rawAuthority }.getOrNull()
         if (
+            authority == null || authority.contains('@') ||
             parsed.scheme != "https" ||
-            parsed.host != expectedHost ||
             parsed.username.isNotEmpty() ||
             parsed.password.isNotEmpty() ||
             parsed.fragment != null

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/LightningAddressResolverTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/LightningAddressResolverTest.kt
@@ -77,24 +77,55 @@ class LightningAddressResolverTest {
     }
 
     @Test
-    fun rejectsCallbackOnDifferentHost() = runBlocking {
+    fun acceptsDelegatedCallbackAndReplacesEveryAmountParameter() = runBlocking {
         val transport = RecordingTransport(
-            LnurlHttpResponse(
-                code = 200,
-                body = payRequestJson(callback = "https://attacker.example/lnurl/callback"),
-            ),
+            LnurlHttpResponse(200, payRequestJson("https://pay.example.net/invoice?amount=1&Amount=2&memo=coffee")),
+            LnurlHttpResponse(200, """{"pr":"$Bolt11AmountfulCoffeeInvoice"}"""),
         )
+        assertEquals(Bolt11AmountfulCoffeeInvoice, resolver(transport, InvoiceAmountMsat)
+            .resolveBolt11Invoice("alice@example.com", InvoiceAmountMsat))
+        val callback = transport.requestedUrls.last()
+        assertEquals("pay.example.net", callback.host)
+        assertEquals(listOf(InvoiceAmountMsat.toString()), callback.queryParameterValues("amount"))
+        assertEquals(emptyList<String>(), callback.queryParameterValues("Amount"))
+        assertEquals("coffee", callback.queryParameter("memo"))
+    }
 
-        val error = runCatching {
-            resolver(transport, decodedAmountMsat = InvoiceAmountMsat).resolveBolt11Invoice(
-                address = "alice@example.com",
-                amountMsat = InvoiceAmountMsat,
+    @Test
+    fun rejectsUnsafeCallbacksBeforeRequestingAnInvoice() = runBlocking {
+        listOf(
+            "http://pay.example.net/invoice",
+            "https://@pay.example.net/invoice",
+            "https:///invoice",
+            "https://bad host/invoice",
+            "https://user:pass@pay.example.net/invoice",
+            "https://pay.example.net/invoice#fragment",
+            "not a URL",
+        ).forEach { callback ->
+            val transport = RecordingTransport(LnurlHttpResponse(200, payRequestJson(callback)))
+            val error = runCatching {
+                resolver(transport, InvoiceAmountMsat).resolveBolt11Invoice("alice@example.com", InvoiceAmountMsat)
+            }.exceptionOrNull()
+            assertTrue(callback, error is LightningAddressResolutionException.Invalid)
+            assertEquals(1, transport.requestedUrls.size)
+        }
+    }
+
+    @Test
+    fun rejectsInvalidAndNonBolt11InvoicesFromDelegatedCallback() = runBlocking {
+        listOf<LightningInvoiceDecoder>(
+            LightningInvoiceDecoder { throw IllegalArgumentException("bad invoice") },
+            LightningInvoiceDecoder { LightningInvoiceMetadata(false, InvoiceAmountMsat.toULong()) },
+        ).forEach { decoder ->
+            val transport = RecordingTransport(
+                LnurlHttpResponse(200, payRequestJson("https://pay.example.net/invoice")),
+                LnurlHttpResponse(200, """{"pr":"invalid"}"""),
             )
-        }.exceptionOrNull()
-
-        assertTrue(error is LightningAddressResolutionException.Invalid)
-        assertTrue(error?.message.orEmpty().contains("unsafe payment callback"))
-        assertEquals(1, transport.requestedUrls.size)
+            val error = runCatching {
+                LightningAddressResolver(transport, decoder).resolveBolt11Invoice("alice@example.com", InvoiceAmountMsat)
+            }.exceptionOrNull()
+            assertTrue(error is LightningAddressResolutionException.Invalid)
+        }
     }
 
     private fun payRequestJson(

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		T2B0000000000013 /* AsciiFieldErosionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000013 /* AsciiFieldErosionTests.swift */; };
 		T2B0000000000014 /* MintQuoteDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000014 /* MintQuoteDomainTests.swift */; };
 		T2B0000000000100 /* ConnectMintContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000100 /* ConnectMintContextTests.swift */; };
+		6E771298AB0DD61628FCF572 /* LightningAddressResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +384,7 @@
 		T1B0000000000013 /* AsciiFieldErosionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsciiFieldErosionTests.swift; path = CashuWalletTests/AsciiFieldErosionTests.swift; sourceTree = "<group>"; };
 		T1B0000000000014 /* MintQuoteDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MintQuoteDomainTests.swift; path = CashuWalletTests/MintQuoteDomainTests.swift; sourceTree = "<group>"; };
 		T1B0000000000100 /* ConnectMintContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectMintContextTests.swift; path = CashuWalletTests/ConnectMintContextTests.swift; sourceTree = "<group>"; };
+		2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/LightningAddressResolverTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -445,6 +447,7 @@
 				AV00000000000012 /* AppVersionTests.swift */,
 				MW00000000000011 /* MeltSettlementWaitTests.swift */,
 				A09100000000000000000006 /* WalletAuditRegressionTests.swift */,
+				2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
 				AA9600000000000000000002 /* NPCServiceTests.swift */,
@@ -1048,6 +1051,7 @@
 				AV00000000000002 /* AppVersionTests.swift in Sources */,
 				MW00000000000001 /* MeltSettlementWaitTests.swift in Sources */,
 				A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */,
+				6E771298AB0DD61628FCF572 /* LightningAddressResolverTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
 				AA9600000000000000000001 /* NPCServiceTests.swift in Sources */,

--- a/ios/CashuWallet/Core/Services/LightningService.swift
+++ b/ios/CashuWallet/Core/Services/LightningService.swift
@@ -1487,10 +1487,14 @@ class LightningService: ObservableObject {
 
 }
 
-private enum LightningAddressResolver {
-    static func resolveBolt11Invoice(address: String, amountMsat: UInt64) async throws -> String {
+enum LightningAddressResolver {
+    static func resolveBolt11Invoice(
+        address: String,
+        amountMsat: UInt64,
+        load: (URLRequest) async throws -> (Data, URLResponse) = { try await URLSession.shared.data(for: $0) }
+    ) async throws -> String {
         let endpoint = try lightningAddressEndpoint(for: address)
-        let payRequest = try await fetchJSON(LnurlPayRequest.self, from: endpoint)
+        let payRequest = try await fetchJSON(LnurlPayRequest.self, from: endpoint, load: load)
 
         try throwIfServiceError(status: payRequest.status, reason: payRequest.reason)
 
@@ -1511,7 +1515,7 @@ private enum LightningAddressResolver {
         }
 
         let callbackURL = try invoiceCallbackURL(callback: callback, amountMsat: amountMsat)
-        let callbackResponse = try await fetchJSON(LnurlPayCallbackResponse.self, from: callbackURL)
+        let callbackResponse = try await fetchJSON(LnurlPayCallbackResponse.self, from: callbackURL, load: load)
 
         try throwIfServiceError(status: callbackResponse.status, reason: callbackResponse.reason)
 
@@ -1564,7 +1568,10 @@ private enum LightningAddressResolver {
     private static func invoiceCallbackURL(callback: String, amountMsat: UInt64) throws -> URL {
         guard var components = URLComponents(string: callback),
               components.scheme?.lowercased() == "https",
-              components.host?.isEmpty == false else {
+              components.host?.isEmpty == false,
+              components.user == nil,
+              components.password == nil,
+              components.fragment == nil else {
             throw LightningAddressResolverError.invalidCallback
         }
 
@@ -1580,11 +1587,14 @@ private enum LightningAddressResolver {
         return url
     }
 
-    private static func fetchJSON<T: Decodable>(_ type: T.Type, from url: URL) async throws -> T {
+    private static func fetchJSON<T: Decodable>(
+        _ type: T.Type, from url: URL,
+        load: (URLRequest) async throws -> (Data, URLResponse)
+    ) async throws -> T {
         var request = URLRequest(url: url, timeoutInterval: 20)
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await load(request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200..<300).contains(httpResponse.statusCode) else {
             throw LightningAddressResolverError.networkFailure
@@ -1625,7 +1635,7 @@ private struct LnurlPayCallbackResponse: Decodable {
     let reason: String?
 }
 
-private enum LightningAddressResolverError: LocalizedError {
+enum LightningAddressResolverError: LocalizedError {
     case invalidAddress
     case invalidCallback
     case invalidResponse(String)

--- a/ios/CashuWalletTests/LightningAddressResolverTests.swift
+++ b/ios/CashuWalletTests/LightningAddressResolverTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class LightningAddressResolverTests: XCTestCase {
+    private let amount: UInt64 = 250_000_000
+    private let invoice = "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh"
+
+    func testSameHostAndDelegatedCallbacksPreserveQueryAndReplaceAmounts() async throws {
+        for host in ["example.com", "pay.example.net"] {
+            var urls: [URL] = []
+            let resolved = try await resolve(callback: "https://\(host)/invoice?amount=1&Amount=2&memo=coffee") {
+                urls.append($0)
+            }
+            XCTAssertEqual(resolved, invoice)
+            let callback = try XCTUnwrap(URLComponents(url: XCTUnwrap(urls.last), resolvingAgainstBaseURL: false))
+            XCTAssertEqual(callback.host, host)
+            XCTAssertEqual(callback.queryItems?.filter { $0.name.lowercased() == "amount" }, [URLQueryItem(name: "amount", value: String(amount))])
+            XCTAssertTrue(callback.queryItems?.contains(URLQueryItem(name: "memo", value: "coffee")) == true)
+        }
+    }
+
+    func testUnsafeCallbacksAreRejectedBeforeRequestingInvoice() async {
+        for callback in ["http://pay.example.net/invoice", "https://@pay.example.net/invoice", "https:///invoice", "https://bad host/invoice", "https://user:pass@pay.example.net/invoice", "https://pay.example.net/invoice#fragment", "not a URL"] {
+            var requests = 0
+            do {
+                _ = try await resolve(callback: callback) { _ in requests += 1 }
+                XCTFail("Unsafe callback accepted")
+            } catch {
+                XCTAssertEqual(requests, 1)
+                XCTAssertFalse((error as? LightningAddressResolverError)?.indicatesNoLnurlPayEndpoint ?? true)
+            }
+        }
+    }
+
+    func testInvalidOrAmountMismatchedInvoiceCannotTriggerFallback() async {
+        for (response, requested) in [("invalid", amount), (invoice, amount - 1)] {
+            do {
+                _ = try await resolve(callback: "https://pay.example.net/invoice", responseInvoice: response, requested: requested)
+                XCTFail("Invalid invoice accepted")
+            } catch {
+                XCTAssertFalse((error as? LightningAddressResolverError)?.indicatesNoLnurlPayEndpoint ?? true)
+            }
+        }
+    }
+
+    func testMissingEndpointStillAllowsBip353Fallback() async {
+        do {
+            _ = try await LightningAddressResolver.resolveBolt11Invoice(address: "alice@example.com", amountMsat: amount) { request in
+                (Data(), HTTPURLResponse(url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!)
+            }
+            XCTFail("Missing endpoint accepted")
+        } catch {
+            XCTAssertTrue((error as? LightningAddressResolverError)?.indicatesNoLnurlPayEndpoint == true)
+        }
+    }
+
+    private func resolve(
+        callback: String, responseInvoice: String? = nil, requested: UInt64? = nil,
+        observe: (URL) -> Void = { _ in }
+    ) async throws -> String {
+        var calls = 0
+        return try await LightningAddressResolver.resolveBolt11Invoice(address: "alice@example.com", amountMsat: requested ?? amount) { request in
+            let url = try XCTUnwrap(request.url)
+            observe(url)
+            calls += 1
+            let body: [String: Any] = calls == 1
+                ? ["tag": "payRequest", "callback": callback, "minSendable": 1, "maxSendable": 1_000_000_000]
+                : ["pr": responseInvoice ?? self.invoice]
+            return (try JSONSerialization.data(withJSONObject: body), HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+    }
+}


### PR DESCRIPTION
Android rejected Lightning Addresses whose LNURL-pay service delegates invoice generation to a different host. Accept delegated HTTPS callbacks and align both native apps on rejecting embedded credentials and fragments. Preserve callback query parameters while replacing every supplied amount parameter, and retain BOLT11 type, exact-amount checks, and BIP-353 fallback behavior.

Validation:
- Android: 739 unit tests, 733 passed and 6 skipped; release assembly and release lint passed (0 errors, 36 existing warnings).
- iOS: all 4 callback regression tests passed on the iOS simulator; app and test targets built successfully.
- Coverage includes same-host/delegated callbacks, duplicate amounts, unsafe URLs, invalid invoices, amount mismatches, and missing LNURL endpoints.

Independent fix for release-review finding 6, based on main with CDK 0.18.0. Findings 3 and 4 are outside this PR.
