### PR TITLE
Preserve stored currency balances and history across mint metadata changes

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
@@ -3,7 +3,16 @@ package com.cashu.me.Core
 import androidx.test.platform.app.InstrumentationRegistry
 import com.cashu.me.Core.CDK.CdkWalletGateway
 import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
+import com.cashu.me.Core.CDK.WalletAccountReference
 import com.cashu.me.Models.MintInfo
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.Models.PendingReceiveToken
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.Models.WalletTransaction
+import com.cashu.me.Models.TransactionStatus as AppTransactionStatus
 import com.cashu.me.test.fixtures.FakeWalletGateway
 import java.io.File
 import java.util.UUID
@@ -18,7 +27,7 @@ class StoredAccountProjectionInstrumentedTest {
     @Test fun discontinuedCurrencyHistorySurvivesDatabaseReopenWithoutAnAdvertisedWallet() = runBlocking {
         val directory = File(context.cacheDir, UUID.randomUUID().toString()).apply { mkdirs() }
         val path = File(directory, "wallet.db").path
-        val mint = MintUrl("https://offline.example")
+        val mint = MintUrl("https://offline.example:443")
         val gateway = CdkWalletGatewayImpl()
         try {
             val mnemonic = gateway.generateMnemonic()
@@ -72,5 +81,80 @@ class StoredAccountProjectionInstrumentedTest {
         }
         val result = WalletTransactionLoader(store, failing).load(mints, false)
         assertEquals(setOf("usd-old", "sat-new"), result.transactions.map { it.id }.toSet())
+    }
+
+    @Test fun accountAndDiscoveryFailuresDoNotSuppressFreshQuotes() = runBlocking {
+        val fake = FakeWalletGateway()
+        fake.openWalletRepository("fixture", "unused")
+        val mint = "https://offline.example"
+        fake.ensureWallet(mint, "sat")
+        val quote = MintQuoteInfo(
+            id = "invoice", request = "invoice-request", amount = 8,
+            paymentMethod = PaymentMethodKind.Bolt11, state = MintQuoteState.Unpaid,
+            expiryEpochSeconds = 1, mintUrl = mint,
+        )
+        val staleInvoice = WalletTransaction(
+            id = quote.id, quoteId = quote.id, amount = 8, type = TransactionType.Incoming,
+            kind = TransactionKind.Lightning, dateEpochMillis = 1,
+            status = AppTransactionStatus.Pending, mintUrl = mint,
+        )
+        val completed = staleInvoice.copy(
+            id = "cdk-transaction", quoteId = "settled-quote", status = AppTransactionStatus.Completed,
+        )
+        var failDiscovery = false
+        var failQuotes = false
+        val failing = object : CdkWalletGateway by fake {
+            override suspend fun storedAccounts(): List<WalletAccountReference> {
+                if (failDiscovery) error("Discovery unavailable")
+                return fake.storedAccounts()
+            }
+            override suspend fun listTransactions(unitsByMint: Map<String, List<String>>): List<WalletTransaction> =
+                error("Account unavailable")
+            override suspend fun listUnissuedMintQuotes(): List<MintQuoteInfo> {
+                if (failQuotes) error("Quotes unavailable")
+                return listOf(quote)
+            }
+        }
+        val store = WalletStore(context, "quote_failure_" + UUID.randomUUID())
+        val loader = WalletTransactionLoader(store, failing)
+        for (discoveryFails in listOf(false, true)) {
+            failDiscovery = discoveryFails
+            failQuotes = false
+            store.saveTransactions(listOf(staleInvoice, completed))
+            val refreshed = loader.load(listOf(MintInfo(mint)), false).transactions
+            assertEquals(AppTransactionStatus.Expired, refreshed.single { it.id == quote.id }.status)
+            assertEquals(AppTransactionStatus.Completed, refreshed.single { it.id == completed.id }.status)
+            assertEquals(2, refreshed.size)
+
+            failQuotes = true
+            store.saveTransactions(listOf(staleInvoice, completed))
+            val retained = loader.load(listOf(MintInfo(mint)), false).transactions
+            assertEquals(AppTransactionStatus.Pending, retained.single { it.id == quote.id }.status)
+            assertEquals(2, retained.size)
+        }
+    }
+
+    @Test fun discoveryFailureStillRebuildsLocallyParkedTokensAfterRelaunch() = runBlocking {
+        val fake = FakeWalletGateway()
+        fake.openWalletRepository("fixture", "unused")
+        val failing = object : CdkWalletGateway by fake {
+            override suspend fun storedAccounts(): List<WalletAccountReference> = error("Discovery unavailable")
+        }
+        val storeName = "pending_failure_" + UUID.randomUUID()
+        val store = WalletStore(context, storeName)
+        val pending = PendingReceiveToken(
+            tokenId = "parked", token = "cashuAparked", amount = 8,
+            dateEpochMillis = 1, mintUrl = "https://offline.example",
+        )
+        store.savePendingReceiveTokens(listOf(pending))
+        val first = WalletTransactionLoader(store, failing).load(emptyList(), false).transactions
+        assertEquals(listOf(pending.tokenId), first.map { it.id })
+        assertTrue(first.single().isPendingReceiveToken)
+
+        val reopenedStore = WalletStore(context, storeName)
+        val relaunched = WalletTransactionLoader(reopenedStore, failing)
+        assertEquals(listOf(pending.tokenId), relaunched.load(emptyList(), false).transactions.map { it.id })
+        reopenedStore.savePendingReceiveTokens(emptyList())
+        assertTrue(relaunched.load(emptyList(), false).transactions.isEmpty())
     }
 }

--- a/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
@@ -1,0 +1,75 @@
+package com.cashu.me.Core
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.cashu.me.Core.CDK.CdkWalletGateway
+import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
+import com.cashu.me.Models.MintInfo
+import com.cashu.me.test.fixtures.FakeWalletGateway
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.runBlocking
+import org.cashudevkit.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class StoredAccountProjectionInstrumentedTest {
+    private val context get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test fun discontinuedCurrencyHistorySurvivesDatabaseReopenWithoutAnAdvertisedWallet() = runBlocking {
+        val directory = File(context.cacheDir, UUID.randomUUID().toString()).apply { mkdirs() }
+        val path = File(directory, "wallet.db").path
+        val mint = MintUrl("https://offline.example")
+        val gateway = CdkWalletGatewayImpl()
+        try {
+            val mnemonic = gateway.generateMnemonic()
+            WalletSqliteDatabase(path).use { db ->
+                db.addMint(mint, null)
+                db.addTransaction(Transaction(
+                    id = TransactionId("a".repeat(64)), mintUrl = mint,
+                    direction = TransactionDirection.INCOMING, amount = Amount(250u), fee = Amount(0u),
+                    unit = CurrencyUnit.Usd, ys = emptyList(), timestamp = 1u, memo = null,
+                    metadata = emptyMap(), quoteId = null, paymentRequest = null, paymentProof = null,
+                    paymentMethod = null, sagaId = null, status = TransactionStatus.COMPLETED,
+                ))
+            }
+            gateway.openWalletRepository(mnemonic, path)
+            val account = gateway.storedAccounts().single { it.unit == "usd" }
+            assertEquals(0L, gateway.storedAccountBalance(account))
+            val store = WalletStore(context, "stored_accounts_" + UUID.randomUUID())
+            val loader = WalletTransactionLoader(store, gateway)
+            val mints = listOf(MintInfo(url = mint.url, units = listOf("sat")))
+            assertEquals(listOf("usd"), loader.load(mints, false).transactions.map { it.unit })
+            gateway.closeWalletRepository()
+            gateway.openWalletRepository(mnemonic, path)
+            assertEquals(listOf("usd"), loader.load(mints, false).transactions.map { it.unit })
+        } finally {
+            gateway.closeWalletRepository()
+            directory.deleteRecursively()
+        }
+    }
+
+    @Test fun failedHistoryReadPreservesAffectedAccountWhileRefreshingOthers() = runBlocking {
+        val fake = FakeWalletGateway()
+        fake.openWalletRepository("fixture", "unused")
+        fake.ensureWallet("https://a.example", "usd")
+        fake.ensureWallet("https://b.example", "sat")
+        fun tx(id: String, mint: String, unit: String) = com.cashu.me.Models.WalletTransaction(
+            id = id, amount = 10, type = com.cashu.me.Models.TransactionType.Incoming,
+            kind = com.cashu.me.Models.TransactionKind.Ecash, dateEpochMillis = 1,
+            status = com.cashu.me.Models.TransactionStatus.Completed, mintUrl = mint, unit = unit,
+        )
+        fake.addTransaction(tx("usd-old", "https://a.example", "usd"))
+        val store = WalletStore(context, "history_failure_" + UUID.randomUUID())
+        val mints = listOf(MintInfo("https://a.example"), MintInfo("https://b.example"))
+        WalletTransactionLoader(store, fake).load(mints, false)
+        fake.addTransaction(tx("sat-new", "https://b.example", "sat"))
+        val failing = object : CdkWalletGateway by fake {
+            override suspend fun listTransactions(unitsByMint: Map<String, List<String>>): List<com.cashu.me.Models.WalletTransaction> {
+                if (unitsByMint.containsKey("https://a.example")) error("Storage unavailable")
+                return fake.listTransactions(unitsByMint)
+            }
+        }
+        val result = WalletTransactionLoader(store, failing).load(mints, false)
+        assertEquals(setOf("usd-old", "sat-new"), result.transactions.map { it.id }.toSet())
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StoredAccountProjectionInstrumentedTest.kt
@@ -35,6 +35,7 @@ class StoredAccountProjectionInstrumentedTest {
             gateway.openWalletRepository(mnemonic, path)
             val account = gateway.storedAccounts().single { it.unit == "usd" }
             assertEquals(0L, gateway.storedAccountBalance(account))
+            assertEquals(0L, gateway.unitBalance(mint.url, "usd"))
             val store = WalletStore(context, "stored_accounts_" + UUID.randomUUID())
             val loader = WalletTransactionLoader(store, gateway)
             val mints = listOf(MintInfo(url = mint.url, units = listOf("sat")))

--- a/android/app/src/androidTest/java/com/cashu/me/Core/StoredCurrencyVisibilityInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StoredCurrencyVisibilityInstrumentedTest.kt
@@ -1,0 +1,47 @@
+package com.cashu.me.Core
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import com.cashu.me.Core.Protocols.CurrencyAmount
+import com.cashu.me.Core.Protocols.CurrencyRegistry
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FakeWalletGateway
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+class StoredCurrencyVisibilityInstrumentedTest {
+    @Test fun storedCurrencyRemainsVisibleWithSatOnlyMintMetadata() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        AppTestFixture.launch(FixtureMode.FundedWithHistory).use { fixture ->
+            val fake = checkNotNull(fixture.fakeGateway)
+            val manager = fixture.container.walletManager
+            runBlocking {
+                fake.setUnitBalance(FakeWalletGateway.TestMintUrl, "usd", 500)
+                manager.refreshBalance()
+            }
+            assertEquals(listOf("sat"), manager.state.value.activeMint?.units)
+            assertEquals(listOf("sat", "usd"), runBlocking { manager.storedAccountUnits(FakeWalletGateway.TestMintUrl) })
+            assertTrue(device.wait(Until.hasObject(By.text("Mints")), 5_000))
+            device.waitForIdle(5_000)
+            // Derive the swipe from the displayed balance's actual bounds.
+            val hero = device.wait(Until.findObject(By.descContains("500")), 5_000)
+            assertNotNull(hero)
+            val heroY = hero.visibleBounds.centerY()
+            device.swipe(device.displayWidth * 4 / 5, heroY,
+                device.displayWidth / 5, heroY, 20)
+            val amount = CurrencyAmount(500, CurrencyRegistry.currencyForMintUnit("usd")).formatted()
+            assertTrue(device.wait(Until.hasObject(By.descContains(amount)), 5_000))
+            device.findObject(By.text("Mints")).click()
+            val row = device.wait(Until.findObject(By.res(UiTestTags.mintRow(FakeWalletGateway.TestMintUrl))), 5_000)
+            assertNotNull(row)
+            row.click()
+            assertTrue(device.wait(Until.hasObject(By.text("Balance (USD)")), 5_000))
+            assertTrue(device.hasObject(By.text(amount)))
+        }
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -141,6 +141,13 @@ class FakeWalletGateway(
         )
     }
 
+    override suspend fun storedAccounts() = walletUnits.flatMap { (url, units) ->
+        units.map { com.cashu.me.Core.CDK.WalletAccountReference(url, it) }
+    } + transactions.mapNotNull { tx -> tx.mintUrl?.let { com.cashu.me.Core.CDK.WalletAccountReference(it, tx.unit) } }
+
+    override suspend fun storedAccountBalance(account: com.cashu.me.Core.CDK.WalletAccountReference): Long =
+        unitBalance(account.mintUrl, account.unit)
+
     override suspend fun totalBalance(mintUrl: String): Long =
         balances[normalize(mintUrl)] ?: 0
 

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -43,6 +43,7 @@ class FakeWalletGateway(
     private val walletUnits = linkedMapOf<String, MutableSet<String>>()
     private val mintInfo = linkedMapOf<String, MintInfo>()
     private val balances = initialBalances.toMutableMap()
+    private val nonSatBalances = mutableMapOf<Pair<String, String>, Long>()
     private val transactions = initialTransactions.toMutableList()
     private val mintQuotes = linkedMapOf<String, MutableStateFlow<MintQuoteInfo>>()
     private val meltQuotes = linkedMapOf<String, MeltQuoteInfo>()
@@ -51,6 +52,11 @@ class FakeWalletGateway(
     var nextFailure: Throwable? = null
     val latestMintQuoteId: String?
         get() = mintQuotes.keys.lastOrNull()
+
+    suspend fun setUnitBalance(mintUrl: String, unit: String, amount: Long) {
+        ensureWallet(mintUrl, unit)
+        nonSatBalances[normalize(mintUrl) to unit] = amount
+    }
 
     fun setBalance(mintUrl: String, amount: Long) {
         balances[normalize(mintUrl)] = amount
@@ -152,7 +158,7 @@ class FakeWalletGateway(
         balances[normalize(mintUrl)] ?: 0
 
     override suspend fun unitBalance(mintUrl: String, unit: String): Long =
-        if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else 0
+        if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else nonSatBalances[normalize(mintUrl) to unit] ?: 0
 
     override suspend fun unitBalanceIfExists(mintUrl: String, unit: String): Long? =
         if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else null

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -40,6 +40,9 @@ interface CdkWalletGateway {
     suspend fun removeWalletIfSingleUnit(mintUrl: String): Boolean
     suspend fun fetchMintInfo(mintUrl: String): MintInfo?
     suspend fun restoreMint(mintUrl: String): RestoreMintResult
+    /** Local CDK accounts, independent of the mint's current advertisements. */
+    suspend fun storedAccounts(): List<WalletAccountReference>
+    suspend fun storedAccountBalance(account: WalletAccountReference): Long
     suspend fun totalBalance(mintUrl: String): Long
 
     /** Balance of the (mint, unit) wallet, registering the unit wallet if needed. */
@@ -197,3 +200,6 @@ data class NfcReceiveReceipt(
 )
 
 class CdkGatewayUnavailable(message: String) : IllegalStateException(message)
+
+/** App-internal account identity. This does not alter any payment protocol. */
+data class WalletAccountReference(val mintUrl: String, val unit: String)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -284,9 +284,7 @@ class CdkWalletGatewayImpl : WalletGateway {
     }
 
     override suspend fun unitBalance(mintUrl: String, unit: String): Long = cdkCall {
-        val cdkUnit = cdkUnit(unit)
-        ensureWalletUnlocked(mintUrl, cdkUnit)
-        walletFor(mintUrl, cdkUnit).totalBalance().value.toLong()
+        checkNotNull(database).getBalance(CdkMintUrl(mintUrl), cdkUnit(unit), listOf(org.cashudevkit.ProofState.UNSPENT)).toLong()
     }
 
     override suspend fun unitBalanceIfExists(mintUrl: String, unit: String): Long? = cdkCall {

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -262,6 +262,23 @@ class CdkWalletGatewayImpl : WalletGateway {
         )
     }
 
+    override suspend fun storedAccounts(): List<WalletAccountReference> = cdkCall {
+        val db = checkNotNull(database)
+        // Do not suppress discovery failures: callers must retain their last
+        // complete projection instead of interpreting an incomplete scan as zero.
+        buildList {
+            addAll(requireRepository().getWallets().map { WalletAccountReference(it.mintUrl().url, it.unit().toDomainUnit()) })
+            addAll(db.getProofs(null, null, null, null).map { WalletAccountReference(it.mintUrl.url, it.unit.toDomainUnit()) })
+            addAll(db.listTransactions(null, null, null).map { WalletAccountReference(it.mintUrl.url, it.unit.toDomainUnit()) })
+            addAll(db.getMintQuotes().map { WalletAccountReference(it.mintUrl.url, it.unit.toDomainUnit()) })
+            addAll(db.getMeltQuotes().mapNotNull { quote -> quote.mintUrl?.let { WalletAccountReference(it.url, quote.unit.toDomainUnit()) } })
+        }.distinct()
+    }
+
+    override suspend fun storedAccountBalance(account: WalletAccountReference): Long = cdkCall {
+        checkNotNull(database).getBalance(CdkMintUrl(account.mintUrl), cdkUnit(account.unit), listOf(org.cashudevkit.ProofState.UNSPENT)).toLong()
+    }
+
     override suspend fun totalBalance(mintUrl: String): Long = cdkCall {
         walletFor(mintUrl).totalBalance().value.toLong()
     }
@@ -804,14 +821,9 @@ class CdkWalletGatewayImpl : WalletGateway {
 
     override suspend fun listTransactions(unitsByMint: Map<String, List<String>>): List<WalletTransaction> = cdkCall {
         unitsByMint.flatMap { (mintUrl, units) ->
-            units.flatMap units@{ unit ->
-                val wallet = runCatching { walletFor(mintUrl, cdkUnit(unit)) }
-                    .getOrNull() ?: return@units emptyList()
-                val incoming = runCatching { wallet.listTransactions(CdkTransactionDirection.INCOMING) }
-                    .getOrDefault(emptyList())
-                val outgoing = runCatching { wallet.listTransactions(CdkTransactionDirection.OUTGOING) }
-                    .getOrDefault(emptyList())
-                (incoming + outgoing).map { it.toDomain(unit) }
+            units.flatMap { unit ->
+                checkNotNull(database).listTransactions(CdkMintUrl(mintUrl), null, cdkUnit(unit))
+                    .map { it.toDomain(it.unit.toDomainUnit()) }
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/Core/HomeBalance.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/HomeBalance.kt
@@ -3,10 +3,7 @@ package com.cashu.me.Core
 /**
  * Pure logic for the home balance unit pager (port of iOS HomeBalance).
  *
- * The pager appears only when the active (default) mint advertises multiple
- * units AND a non-sat balance is actually held; a sat-only default mint renders
- * the single hero even if a non-sat balance exists at another mint (that
- * balance still shows on Send + Mint Detail).
+ * Held balances determine visibility independently of advertised payment units.
  */
 object HomeBalance {
     /** Pager page order: sat first, then held non-sat units sorted. */
@@ -24,7 +21,6 @@ object HomeBalance {
         if (units.contains(unit)) unit else "sat"
 
     fun showsUnitPager(
-        activeMintSupportsMultipleUnits: Boolean,
         balancesByUnit: Map<String, Long>,
-    ): Boolean = activeMintSupportsMultipleUnits && homeBalanceUnits(balancesByUnit).size > 1
+    ): Boolean = homeBalanceUnits(balancesByUnit).size > 1
 }

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/StoredAccountProjection.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/StoredAccountProjection.kt
@@ -1,0 +1,36 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.CDK.WalletAccountReference
+import kotlinx.coroutines.CancellationException
+
+internal data class StoredBalanceProjection(
+    val totals: Map<String, Long>,
+    val balances: Map<WalletAccountReference, Long>,
+)
+
+/** Commit each currency only when every contributing account was read. */
+internal suspend fun projectStoredBalances(
+    accounts: List<WalletAccountReference>,
+    previousTotals: Map<String, Long>,
+    read: suspend (WalletAccountReference) -> Long,
+): StoredBalanceProjection {
+    val balances = mutableMapOf<WalletAccountReference, Long>()
+    val totals = mutableMapOf<String, Long>()
+    for ((unit, group) in accounts.distinct().groupBy { it.unit }) {
+        var complete = true
+        var total = 0L
+        for (account in group) {
+            try {
+                val amount = read(account)
+                balances[account] = amount
+                total += amount
+            } catch (error: Exception) {
+                if (error is CancellationException) throw error
+                complete = false
+            }
+        }
+        if (complete) totals[unit] = total
+        else previousTotals[unit]?.let { totals[unit] = it }
+    }
+    return StoredBalanceProjection(totals, balances)
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -468,21 +468,22 @@ class WalletManager(
 
     suspend fun refreshBalance() {
         val mints = mutableState.value.mints
-        var total = 0L
-        val unitTotals = mutableMapOf<String, Long>()
-        val updated = mints.map { mint ->
-            val balance = runCatching { gateway.totalBalance(mint.url) }.getOrDefault(mint.balance)
-            total += balance
-            // Only sum unit wallets that already exist — never register a unit
-            // wallet just because the mint advertises the unit.
-            mint.units.filter { !it.equals("sat", ignoreCase = true) }.forEach { unit ->
-                runCatching { gateway.unitBalanceIfExists(mint.url, unit) }.getOrNull()?.let {
-                    unitTotals[unit] = (unitTotals[unit] ?: 0L) + it
-                }
-            }
-            mint.copy(balance = balance)
+        val accounts = try { gateway.storedAccounts() } catch (error: Exception) {
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            AppLogger.wallet.error("Unable to discover stored currency accounts", error)
+            return
         }
-        unitTotals["sat"] = total
+        val projection = projectStoredBalances(
+            accounts = accounts.filter { account -> mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, account.mintUrl) } },
+            previousTotals = mutableState.value.balancesByUnit,
+            read = gateway::storedAccountBalance,
+        )
+        val unitTotals = projection.totals
+        val total = unitTotals["sat"] ?: 0L
+        val updated = mints.map { mint ->
+            val account = accounts.firstOrNull { it.unit == "sat" && com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.mintUrl, mint.url) }
+            mint.copy(balance = if (account == null) 0L else projection.balances[account] ?: mint.balance)
+        }
         walletStore.saveMints(updated)
         walletStore.saveBalancesByUnit(unitTotals)
         update {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -550,10 +550,12 @@ class WalletManager(
         }
     }
 
-    /**
-     * Balance of one (mint, unit). Sat answers from the cached mint balance;
-     * non-sat registers the unit wallet on demand. Null when unavailable.
-     */
+    /** Existing units for balance displays; payment options still use metadata. */
+    suspend fun storedAccountUnits(mintUrl: String): List<String> = withContext(Dispatchers.IO) {
+        gateway.storedAccounts().filter { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.mintUrl, mintUrl) }.map { it.unit }.distinct().sorted()
+    }
+
+    /** Balance of one durable account. Null when storage is unavailable. */
     suspend fun unitBalance(mintUrl: String, unit: String): Long? {
         if (unit.equals("sat", ignoreCase = true)) {
             return mutableState.value.mints.firstOrNull { it.url == mintUrl }?.balance

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -37,6 +37,9 @@ internal class WalletTransactionLoader(
         val savedTokens = walletStore.loadSavedTokens()
         val pendingReceiveTokens = walletStore.loadPendingReceiveTokens()
         val previous = walletStore.loadTransactions().filter { !it.isPendingReceiveToken }
+        // Synthesized invoice rows use the quote id as their row id; CDK rows
+        // use transaction ids. Only CDK rows may suppress a fresh quote read.
+        val previousAccountTransactions = previous.filter { it.id != it.quoteId }
         val remote = try {
             gateway.storedAccounts().filter { account ->
                 mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, account.mintUrl) }
@@ -45,12 +48,12 @@ internal class WalletTransactionLoader(
                     gateway.listTransactions(mapOf(account.mintUrl to listOf(account.unit)))
                 } catch (error: Exception) {
                     if (error is kotlinx.coroutines.CancellationException) throw error
-                    previous.filter { it.unit == account.unit && com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.mintUrl.orEmpty(), account.mintUrl) }
+                    previousAccountTransactions.filter { it.unit == account.unit && com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.mintUrl.orEmpty(), account.mintUrl) }
                 }
             }
         } catch (error: Exception) {
             if (error is kotlinx.coroutines.CancellationException) throw error
-            previous.filter { tx -> mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, tx.mintUrl.orEmpty()) } }
+            previousAccountTransactions.filter { tx -> mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, tx.mintUrl.orEmpty()) } }
         }
         val remoteWithSavedTokens = remote
             .map { transaction ->
@@ -86,9 +89,10 @@ internal class WalletTransactionLoader(
         val quoteIdsWithTransactions = remoteWithTokens.mapNotNull { it.quoteId }.toSet()
         val mintQuoteTimestamps = walletStore.loadMintQuoteTimestamps().toMutableMap()
         val quoteRead = runCatching { gateway.listUnissuedMintQuotes() }
+        quoteRead.exceptionOrNull()?.let { if (it is kotlinx.coroutines.CancellationException) throw it }
         val unissuedMintQuotes = quoteRead.getOrDefault(emptyList())
         val retainedQuotes = if (quoteRead.isFailure) previous.filter {
-            it.quoteId != null && it.quoteId !in quoteIdsWithTransactions && it.mintUrl in trackedMintUrls
+            it.id == it.quoteId && it.id !in quoteIdsWithTransactions && it.mintUrl in trackedMintUrls
         } else emptyList()
         val pendingQuotes = pendingMintQuoteTransactions(
             quotes = unissuedMintQuotes,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletTransactionLoader.kt
@@ -36,8 +36,23 @@ internal class WalletTransactionLoader(
         val trackedMintUrls = mints.map { it.url }.toSet()
         val savedTokens = walletStore.loadSavedTokens()
         val pendingReceiveTokens = walletStore.loadPendingReceiveTokens()
-        val remote = runCatching { gateway.listTransactions(transactionUnitsByMint(mints)) }
-            .getOrDefault(emptyList())
+        val previous = walletStore.loadTransactions().filter { !it.isPendingReceiveToken }
+        val remote = try {
+            gateway.storedAccounts().filter { account ->
+                mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, account.mintUrl) }
+            }.flatMap { account ->
+                try {
+                    gateway.listTransactions(mapOf(account.mintUrl to listOf(account.unit)))
+                } catch (error: Exception) {
+                    if (error is kotlinx.coroutines.CancellationException) throw error
+                    previous.filter { it.unit == account.unit && com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.mintUrl.orEmpty(), account.mintUrl) }
+                }
+            }
+        } catch (error: Exception) {
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            previous.filter { tx -> mints.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, tx.mintUrl.orEmpty()) } }
+        }
+        val remoteWithSavedTokens = remote
             .map { transaction ->
                 if (transaction.kind == TransactionKind.Ecash && transaction.token == null) {
                     transaction.copy(token = savedTokens[transaction.id])
@@ -48,7 +63,7 @@ internal class WalletTransactionLoader(
         // A sent token's string survives in the send saga until the token is
         // claimed. Backfill rows that predate the transaction-id-keyed token
         // store (e.g. sends recorded by an older app version) from the saga.
-        val remoteWithTokens = remote.map { transaction ->
+        val remoteWithTokens = remoteWithSavedTokens.map { transaction ->
             if (
                 transaction.kind == TransactionKind.Ecash &&
                 transaction.type == TransactionType.Outgoing &&
@@ -70,8 +85,11 @@ internal class WalletTransactionLoader(
         }
         val quoteIdsWithTransactions = remoteWithTokens.mapNotNull { it.quoteId }.toSet()
         val mintQuoteTimestamps = walletStore.loadMintQuoteTimestamps().toMutableMap()
-        val unissuedMintQuotes = runCatching { gateway.listUnissuedMintQuotes() }
-            .getOrDefault(emptyList())
+        val quoteRead = runCatching { gateway.listUnissuedMintQuotes() }
+        val unissuedMintQuotes = quoteRead.getOrDefault(emptyList())
+        val retainedQuotes = if (quoteRead.isFailure) previous.filter {
+            it.quoteId != null && it.quoteId !in quoteIdsWithTransactions && it.mintUrl in trackedMintUrls
+        } else emptyList()
         val pendingQuotes = pendingMintQuoteTransactions(
             quotes = unissuedMintQuotes,
             trackedMintUrls = trackedMintUrls,
@@ -90,7 +108,7 @@ internal class WalletTransactionLoader(
         // mint-issued quote ids, random pending-receive ids) and quote-backed
         // rows are skipped once CDK owns a transaction for the quote, so a
         // plain id dedupe is sufficient.
-        val merged = (remoteWithTokens + pendingQuoteTransactions + receiveTokenTransactions)
+        val merged = (remoteWithTokens + pendingQuoteTransactions + retainedQuotes + receiveTokenTransactions)
             .map { it.restoringDescription(requests) }
             .distinctBy { it.id }
             .sortedByDescending { it.dateEpochMillis }

--- a/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/home/HomeScreen.kt
@@ -242,7 +242,6 @@ fun HomeScreen(
                 balance = {
                     HomeBalanceHero(
                         showsPager = HomeBalance.showsUnitPager(
-                            activeMintSupportsMultipleUnits = walletState.activeMint?.supportsMultipleUnits == true,
                             balancesByUnit = walletState.balancesByUnit,
                         ),
                         balancesByUnit = walletState.balancesByUnit,

--- a/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/mints/MintDetailScreen.kt
@@ -154,9 +154,12 @@ fun MintDetailScreen(
 
             // Stats block (unlabeled), matching iOS's identity rows under the
             // header: Balance [+ per-unit balances] then Connection.
-            val nonSatUnits = remember(mint.units) {
-                mint.units.filter { !it.equals("sat", ignoreCase = true) }.sorted()
+            var storedUnits by remember(mint.url) { mutableStateOf(emptyList<String>()) }
+            LaunchedEffect(mint.url, walletState.balancesByUnit, mint.units) {
+                try { storedUnits = walletManager.storedAccountUnits(mint.url) }
+                catch (error: Exception) { if (error is CancellationException) throw error }
             }
+            val nonSatUnits = (mint.units + storedUnits).distinct().filter { !it.equals("sat", ignoreCase = true) }.sorted()
             var unitBalances by remember(mint.url) { mutableStateOf<Map<String, Long>>(emptyMap()) }
             LaunchedEffect(mint.url, nonSatUnits) {
                 nonSatUnits.forEach { unit ->

--- a/android/app/src/test/java/com/cashu/me/Core/HomeBalanceTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/HomeBalanceTest.kt
@@ -28,15 +28,12 @@ class HomeBalanceTest {
     }
 
     @Test
-    fun pagerRequiresMultiUnitActiveMintAndHeldNonSatBalance() {
+    fun pagerShowsHeldCurrenciesIndependentlyOfMintAdvertisements() {
         val held = mapOf("sat" to 100L, "eur" to 200L)
-        assertTrue(HomeBalance.showsUnitPager(activeMintSupportsMultipleUnits = true, balancesByUnit = held))
-        // Sat-only default mint stays a single hero even when eur is held elsewhere.
-        assertFalse(HomeBalance.showsUnitPager(activeMintSupportsMultipleUnits = false, balancesByUnit = held))
-        // Multi-unit mint with no non-sat balance stays a single hero.
+        assertTrue(HomeBalance.showsUnitPager(balancesByUnit = held))
+        // No held non-sat balance means there is only one page.
         assertFalse(
             HomeBalance.showsUnitPager(
-                activeMintSupportsMultipleUnits = true,
                 balancesByUnit = mapOf("sat" to 100L, "eur" to 0L),
             ),
         )

--- a/android/app/src/test/java/com/cashu/me/Core/StoredAccountProjectionTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/StoredAccountProjectionTest.kt
@@ -1,0 +1,37 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.CDK.WalletAccountReference
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StoredAccountProjectionTest {
+    private val a = WalletAccountReference("https://a.example", "usd")
+    private val b = WalletAccountReference("https://b.example", "usd")
+    private val sat = WalletAccountReference(a.mintUrl, "sat")
+
+    @Test fun failedAccountKeepsTheWholePreviousCurrencyTotal() = runBlocking {
+        val result = projectStoredBalances(listOf(a, b, sat), mapOf("usd" to 500L, "sat" to 1L)) {
+            when (it) { a -> 200L; b -> error("Storage unavailable"); else -> 30L }
+        }
+        assertEquals(mapOf("usd" to 500L, "sat" to 30L), result.totals)
+        assertEquals(200L, result.balances[a])
+    }
+
+    @Test fun successfulRetryReplacesPreviousTotalAndDeduplicatesAccounts() = runBlocking {
+        val result = projectStoredBalances(listOf(a, b, a), mapOf("usd" to 500L)) { 200L }
+        assertEquals(mapOf("usd" to 400L), result.totals)
+    }
+
+    @Test fun zeroBalanceHistoricalAccountRemainsRepresented() = runBlocking {
+        val result = projectStoredBalances(listOf(a), mapOf("usd" to 500L)) { 0L }
+        assertEquals(mapOf("usd" to 0L), result.totals)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun cancellationDoesNotPublishAPartialRefresh() = runBlocking {
+        projectStoredBalances(listOf(a), emptyMap()) { throw CancellationException() }
+        Unit
+    }
+}

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -186,6 +186,8 @@
 		T2B0000000000013 /* AsciiFieldErosionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000013 /* AsciiFieldErosionTests.swift */; };
 		T2B0000000000014 /* MintQuoteDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000014 /* MintQuoteDomainTests.swift */; };
 		T2B0000000000100 /* ConnectMintContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000100 /* ConnectMintContextTests.swift */; };
+		F9B9C2789923138C562B8CBF /* StoredWalletAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDA5FB4E01D8EAEC9BB97FA /* StoredWalletAccount.swift */; };
+		881794875F3E0162F335D0D7 /* StoredWalletAccountTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9804DC8F57E0384EDE3B390B /* StoredWalletAccountTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +385,8 @@
 		T1B0000000000013 /* AsciiFieldErosionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsciiFieldErosionTests.swift; path = CashuWalletTests/AsciiFieldErosionTests.swift; sourceTree = "<group>"; };
 		T1B0000000000014 /* MintQuoteDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MintQuoteDomainTests.swift; path = CashuWalletTests/MintQuoteDomainTests.swift; sourceTree = "<group>"; };
 		T1B0000000000100 /* ConnectMintContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectMintContextTests.swift; path = CashuWalletTests/ConnectMintContextTests.swift; sourceTree = "<group>"; };
+		5DDA5FB4E01D8EAEC9BB97FA /* StoredWalletAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoredWalletAccount.swift; sourceTree = "<group>"; };
+		9804DC8F57E0384EDE3B390B /* StoredWalletAccountTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/StoredWalletAccountTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -445,6 +449,7 @@
 				AV00000000000012 /* AppVersionTests.swift */,
 				MW00000000000011 /* MeltSettlementWaitTests.swift */,
 				A09100000000000000000006 /* WalletAuditRegressionTests.swift */,
+				9804DC8F57E0384EDE3B390B /* StoredWalletAccountTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
 				AA9600000000000000000002 /* NPCServiceTests.swift */,
@@ -754,6 +759,7 @@
 			isa = PBXGroup;
 			children = (
 				2100000000000004 /* WalletManager.swift */,
+				5DDA5FB4E01D8EAEC9BB97FA /* StoredWalletAccount.swift */,
 				D100000000000101 /* WalletManager+Lifecycle.swift */,
 				D100000000000102 /* WalletManager+NPC.swift */,
 				D100000000000103 /* WalletManager+Mints.swift */,
@@ -1048,6 +1054,7 @@
 				AV00000000000002 /* AppVersionTests.swift in Sources */,
 				MW00000000000001 /* MeltSettlementWaitTests.swift in Sources */,
 				A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */,
+				881794875F3E0162F335D0D7 /* StoredWalletAccountTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
 				AA9600000000000000000001 /* NPCServiceTests.swift in Sources */,
@@ -1070,6 +1077,7 @@
 				1100000000000002 /* ContentView.swift in Sources */,
 				6A8EC9362F244C8C0058C21B /* TransactionDetailView.swift in Sources */,
 				1100000000000004 /* WalletManager.swift in Sources */,
+				F9B9C2789923138C562B8CBF /* StoredWalletAccount.swift in Sources */,
 				D200000000000101 /* WalletManager+Lifecycle.swift in Sources */,
 				D200000000000102 /* WalletManager+NPC.swift in Sources */,
 				D200000000000103 /* WalletManager+Mints.swift in Sources */,

--- a/ios/CashuWallet/Core/Protocols/CurrencyProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/CurrencyProtocol.swift
@@ -169,13 +169,9 @@ enum HomeBalance {
         units.contains(unit) ? unit : "sat"
     }
 
-    /// The home hero pages (swipe/dots) only when the active/default mint is
-    /// multi-unit AND the wallet holds a non-sat balance. A single-unit default
-    /// mint keeps the single sat hero even if a non-sat balance exists at another
-    /// mint (that balance stays visible on Send + Mint Detail).
-    static func showsUnitPager(activeMintSupportsMultipleUnits: Bool,
-                               balancesByUnit: [String: UInt64]) -> Bool {
-        activeMintSupportsMultipleUnits && homeBalanceUnits(balancesByUnit).count > 1
+    /// Held funds stay visible when the active mint's payment options change.
+    static func showsUnitPager(balancesByUnit: [String: UInt64]) -> Bool {
+        homeBalanceUnits(balancesByUnit).count > 1
     }
 }
 

--- a/ios/CashuWallet/Core/Services/TransactionService.swift
+++ b/ios/CashuWallet/Core/Services/TransactionService.swift
@@ -50,7 +50,7 @@ class TransactionService: ObservableObject {
         includeRemoteObservations: Bool = true,
         observingQuoteID: String? = nil
     ) async {
-        guard let repo = walletRepository() else { return }
+        guard let repo = walletRepository(), let database = walletDatabase() else { return }
 
         loadPendingReceiveTokens()
         var mintQuoteTimestamps = loadMintQuoteTimestamps()
@@ -62,13 +62,21 @@ class TransactionService: ObservableObject {
         var quoteIdsWithTransactions: Set<String> = []
         let trackedMintUrls = Set(getTrackedMintUrls().filter { !$0.isEmpty })
 
-        let registeredWallets = await repo.getWallets()
-        for mintUrlString in trackedMintUrls {
-            for wallet in registeredWallets where MintURLIdentity.normalized(wallet.mintUrl().url) == MintURLIdentity.normalized(mintUrlString) {
-                let currencyUnit = wallet.unit()
-                let unitString = PaymentRequestDecoder.unitDescription(currencyUnit)
+        let accounts: [StoredWalletAccount]
+        do {
+            accounts = try await StoredWalletAccount.discover(database: database, repository: repo)
+                .filter { account in trackedMintUrls.contains { MintURLIdentity.normalized($0) == account.mintURL } }
+        } catch {
+            // Preserve existing history when discovery could only be partial.
+            AppLogger.wallet.error("Unable to discover stored transaction accounts")
+            return
+        }
+        for account in accounts {
+                let mintUrlString = account.mintURL
+                let currencyUnit = account.unit
+                let unitString = account.unitName
                 do {
-                    let txs = try await wallet.listTransactions(direction: nil)
+                    let txs = try await database.listTransactions(mintUrl: MintUrl(url: mintUrlString), direction: nil, unit: currencyUnit)
                     var walletTxs: [WalletTransaction] = txs.map { tx in
                         if let quoteId = tx.quoteId {
                             quoteIdsWithTransactions.insert(quoteId)
@@ -105,7 +113,7 @@ class TransactionService: ObservableObject {
                         walletTransaction.fee = tx.fee.value
                         walletTransaction.quoteId = tx.quoteId
                         walletTransaction.sagaId = tx.sagaId
-                        walletTransaction.unit = PaymentRequestDecoder.unitDescription(currencyUnit)
+                        walletTransaction.unit = PaymentRequestDecoder.unitDescription(tx.unit)
                         return walletTransaction
                     }
                     // A sent token's string survives in the send saga until the
@@ -124,12 +132,16 @@ class TransactionService: ObservableObject {
                     }
                     allTransactions.append(contentsOf: walletTxs)
                 } catch {
-                    // Keep the other registered accounts visible if this read fails.
+                    let retained = transactions.filter {
+                        !$0.isPendingReceiveToken && $0.unit == unitString
+                            && $0.mintUrl.map(MintURLIdentity.normalized) == mintUrlString
+                    }
+                    allTransactions.append(contentsOf: retained)
+                    quoteIdsWithTransactions.formUnion(retained.compactMap(\.quoteId))
                     AppLogger.wallet.error(
                         "Failed to load transactions for mint \(mintUrlString), unit \(unitString): \(error)"
                     )
                 }
-            }
         }
 
         if let walletDatabase = walletDatabase() {
@@ -149,6 +161,11 @@ class TransactionService: ObservableObject {
                 )
                 allTransactions.append(contentsOf: pendingQuoteTransactions)
             } catch {
+                allTransactions.append(contentsOf: transactions.filter {
+                    !$0.isPendingReceiveToken && $0.quoteId != nil
+                        && !quoteIdsWithTransactions.contains($0.quoteId!)
+                        && $0.mintUrl.map(trackedMintUrls.contains) == true
+                })
                 AppLogger.wallet.error("Failed to load stored payment quotes: \(error)")
             }
         }

--- a/ios/CashuWallet/Core/Services/TransactionService.swift
+++ b/ios/CashuWallet/Core/Services/TransactionService.swift
@@ -60,16 +60,27 @@ class TransactionService: ObservableObject {
         // lifecycle status, so rows map one-to-one without local merging.
         var allTransactions: [WalletTransaction] = []
         var quoteIdsWithTransactions: Set<String> = []
-        let trackedMintUrls = Set(getTrackedMintUrls().filter { !$0.isEmpty })
+        let trackedMintUrls = Set(getTrackedMintUrls().filter { !$0.isEmpty }.map(MintURLIdentity.normalized))
+        let previous = transactions.filter {
+            !$0.isPendingReceiveToken && $0.mintUrl.map { trackedMintUrls.contains(MintURLIdentity.normalized($0)) } == true
+        }
+        // Synthesized invoice rows use their quote id as the row id. They must
+        // not suppress fresh quote reads when a CDK account read fails.
+        let previousAccountTransactions = previous.filter { $0.id != $0.quoteId }
 
         let accounts: [StoredWalletAccount]
         do {
             accounts = try await StoredWalletAccount.discover(database: database, repository: repo)
-                .filter { account in trackedMintUrls.contains { MintURLIdentity.normalized($0) == account.mintURL } }
-        } catch {
-            // Preserve existing history when discovery could only be partial.
-            AppLogger.wallet.error("Unable to discover stored transaction accounts")
+                .filter { trackedMintUrls.contains(MintURLIdentity.normalized($0.mintURL)) }
+        } catch is CancellationError {
             return
+        } catch {
+            // Preserve CDK rows, but still refresh quotes and locally parked
+            // tokens, whose stores may be available even when discovery fails.
+            accounts = []
+            allTransactions = previousAccountTransactions
+            quoteIdsWithTransactions.formUnion(previousAccountTransactions.compactMap(\.quoteId))
+            AppLogger.wallet.error("Unable to discover stored transaction accounts")
         }
         for account in accounts {
                 let mintUrlString = account.mintURL
@@ -131,10 +142,11 @@ class TransactionService: ObservableObject {
                         self.saveToken(txId: walletTxs[index].id, token: token)
                     }
                     allTransactions.append(contentsOf: walletTxs)
+                } catch is CancellationError {
+                    return
                 } catch {
-                    let retained = transactions.filter {
-                        !$0.isPendingReceiveToken && $0.unit == unitString
-                            && $0.mintUrl.map(MintURLIdentity.normalized) == mintUrlString
+                    let retained = previousAccountTransactions.filter {
+                        $0.unit == unitString && $0.mintUrl == mintUrlString
                     }
                     allTransactions.append(contentsOf: retained)
                     quoteIdsWithTransactions.formUnion(retained.compactMap(\.quoteId))
@@ -160,11 +172,11 @@ class TransactionService: ObservableObject {
                     observingQuoteID: observingQuoteID
                 )
                 allTransactions.append(contentsOf: pendingQuoteTransactions)
+            } catch is CancellationError {
+                return
             } catch {
-                allTransactions.append(contentsOf: transactions.filter {
-                    !$0.isPendingReceiveToken && $0.quoteId != nil
-                        && !quoteIdsWithTransactions.contains($0.quoteId!)
-                        && $0.mintUrl.map(trackedMintUrls.contains) == true
+                allTransactions.append(contentsOf: previous.filter {
+                    $0.id == $0.quoteId && !quoteIdsWithTransactions.contains($0.id)
                 })
                 AppLogger.wallet.error("Failed to load stored payment quotes: \(error)")
             }
@@ -193,6 +205,7 @@ class TransactionService: ObservableObject {
             return tx
         })
 
+        guard !Task.isCancelled else { return }
         persistMintQuoteTimestamps(for: allTransactions, using: mintQuoteTimestamps)
 
         // Restore from durable request metadata each load, even after payment/relaunch.
@@ -326,7 +339,7 @@ class TransactionService: ObservableObject {
         var transactions: [WalletTransaction] = []
 
         for quote in quotes {
-            guard trackedMintUrls.contains(quote.mintUrl.url) else {
+            guard trackedMintUrls.contains(MintURLIdentity.normalized(quote.mintUrl.url)) else {
                 continue
             }
 

--- a/ios/CashuWallet/Core/Wallet/StoredWalletAccount.swift
+++ b/ios/CashuWallet/Core/Wallet/StoredWalletAccount.swift
@@ -1,0 +1,65 @@
+import Cdk
+import Foundation
+
+/// Local account identity, independent of a mint's advertised payment options.
+struct StoredWalletAccount: Hashable {
+    let mintURL: String
+    let unit: CurrencyUnit
+
+    init(mintURL: String, unit: CurrencyUnit) {
+        self.mintURL = MintURLIdentity.normalized(mintURL)
+        self.unit = unit
+    }
+
+    var unitName: String { PaymentRequestDecoder.unitDescription(unit) }
+
+    static func discover(database: WalletSqliteDatabase, repository: WalletRepository) async throws -> [Self] {
+        // A failed scan must not become a successful, incomplete projection.
+        var accounts = Set(await repository.getWallets().map { Self(mintURL: $0.mintUrl().url, unit: $0.unit()) })
+        for proof in try await database.getProofs(mintUrl: nil, unit: nil, state: nil, spendingConditions: nil) {
+            accounts.insert(Self(mintURL: proof.mintUrl.url, unit: proof.unit))
+        }
+        for transaction in try await database.listTransactions(mintUrl: nil, direction: nil, unit: nil) {
+            accounts.insert(Self(mintURL: transaction.mintUrl.url, unit: transaction.unit))
+        }
+        for quote in try await database.getMintQuotes() {
+            accounts.insert(Self(mintURL: quote.mintUrl.url, unit: quote.unit))
+        }
+        for quote in try await database.getMeltQuotes() {
+            if let url = quote.mintUrl { accounts.insert(Self(mintURL: url.url, unit: quote.unit)) }
+        }
+        return accounts.sorted { ($0.mintURL, $0.unitName) < ($1.mintURL, $1.unitName) }
+    }
+}
+
+struct StoredBalanceProjection {
+    let totals: [String: UInt64]
+    let balances: [StoredWalletAccount: UInt64]
+
+    /// Retain the previous complete total if any account in a currency fails.
+    static func load(
+        accounts: [StoredWalletAccount],
+        previousTotals: [String: UInt64],
+        read: (StoredWalletAccount) async throws -> UInt64
+    ) async throws -> Self {
+        var balances: [StoredWalletAccount: UInt64] = [:]
+        var totals: [String: UInt64] = [:]
+        for (unit, group) in Dictionary(grouping: Set(accounts), by: \.unitName) {
+            var complete = true
+            var total: UInt64 = 0
+            for account in group {
+                do {
+                    let amount = try await read(account)
+                    balances[account] = amount
+                    total += amount
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    complete = false
+                }
+            }
+            totals[unit] = complete ? total : previousTotals[unit]
+        }
+        return Self(totals: totals, balances: balances)
+    }
+}

--- a/ios/CashuWallet/Core/Wallet/StoredWalletAccount.swift
+++ b/ios/CashuWallet/Core/Wallet/StoredWalletAccount.swift
@@ -7,11 +7,17 @@ struct StoredWalletAccount: Hashable {
     let unit: CurrencyUnit
 
     init(mintURL: String, unit: CurrencyUnit) {
-        self.mintURL = MintURLIdentity.normalized(mintURL)
+        // CDK preserves default ports in its storage keys. Keep that exact URL
+        // for reads, even when the app tracks an equivalent URL without a port.
+        self.mintURL = mintURL
         self.unit = unit
     }
 
     var unitName: String { PaymentRequestDecoder.unitDescription(unit) }
+
+    func matches(mintURL: String) -> Bool {
+        MintURLIdentity.normalized(self.mintURL) == MintURLIdentity.normalized(mintURL)
+    }
 
     static func discover(database: WalletSqliteDatabase, repository: WalletRepository) async throws -> [Self] {
         // A failed scan must not become a successful, incomplete projection.
@@ -35,6 +41,16 @@ struct StoredWalletAccount: Hashable {
 struct StoredBalanceProjection {
     let totals: [String: UInt64]
     let balances: [StoredWalletAccount: UInt64]
+    let failedAccounts: Set<StoredWalletAccount>
+
+    /// A tracked mint may have multiple CDK storage URLs for the same endpoint.
+    func balance(mintURL: String, unit: CurrencyUnit) -> UInt64? {
+        guard !failedAccounts.contains(where: { $0.unit == unit && $0.matches(mintURL: mintURL) }) else {
+            return nil
+        }
+        return balances.filter { $0.key.unit == unit && $0.key.matches(mintURL: mintURL) }
+            .values.reduce(0, +)
+    }
 
     /// Retain the previous complete total if any account in a currency fails.
     static func load(
@@ -44,6 +60,7 @@ struct StoredBalanceProjection {
     ) async throws -> Self {
         var balances: [StoredWalletAccount: UInt64] = [:]
         var totals: [String: UInt64] = [:]
+        var failedAccounts: Set<StoredWalletAccount> = []
         for (unit, group) in Dictionary(grouping: Set(accounts), by: \.unitName) {
             var complete = true
             var total: UInt64 = 0
@@ -56,10 +73,11 @@ struct StoredBalanceProjection {
                     throw CancellationError()
                 } catch {
                     complete = false
+                    failedAccounts.insert(account)
                 }
             }
             totals[unit] = complete ? total : previousTotals[unit]
         }
-        return Self(totals: totals, balances: balances)
+        return Self(totals: totals, balances: balances, failedAccounts: failedAccounts)
     }
 }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -201,33 +201,24 @@ extension WalletManager {
             return
         }
 
-        var balancesByMintURL = Dictionary(uniqueKeysWithValues: mintUrls.map { ($0, UInt64(0)) })
-        var unitTotals: [String: UInt64] = [:]
-        var failedUnits: Set<String> = []
-        let wallets = await walletRepository.getWallets()
-
-        for mintURL in mintUrls {
-            for wallet in wallets where MintURLIdentity.normalized(wallet.mintUrl().url) == MintURLIdentity.normalized(mintURL) {
-                let unit = PaymentRequestDecoder.unitDescription(wallet.unit())
-                do {
-                    let amount = try await wallet.totalBalance().value
-                    unitTotals[unit, default: 0] += amount
-                    if unit == "sat" { balancesByMintURL[mintURL] = amount }
-                } catch {
-                    failedUnits.insert(unit)
-                    if unit == "sat" {
-                        balancesByMintURL[mintURL] = mints.first { $0.url == mintURL }?.balance ?? 0
-                    }
-                    AppLogger.wallet.error(
-                        "balance refresh failed resource=\(WalletOperationCoordinator.privacySafeIdentifier(mintURL), privacy: .public) error_type=\(String(reflecting: type(of: error)), privacy: .public)"
-                    )
-                }
+        guard let db else { return }
+        let projection: StoredBalanceProjection
+        do {
+            let accounts = try await StoredWalletAccount.discover(database: db, repository: walletRepository)
+                .filter { account in mintUrls.contains { MintURLIdentity.normalized($0) == account.mintURL } }
+            projection = try await StoredBalanceProjection.load(accounts: accounts, previousTotals: balancesByUnit) { account in
+                try await db.getBalance(mintUrl: MintUrl(url: account.mintURL), unit: account.unit, state: [.unspent])
             }
+        } catch {
+            AppLogger.wallet.error("Unable to discover stored currency accounts")
+            return
         }
         guard !Task.isCancelled else { return }
-        // A failed read is not a zero balance. Keep that unit's last complete
-        // total until all of its accounts can be read successfully.
-        for unit in failedUnits { unitTotals[unit] = balancesByUnit[unit] }
+        let unitTotals = projection.totals
+        let balancesByMintURL = Dictionary(uniqueKeysWithValues: mintUrls.map { url in
+            let account = StoredWalletAccount(mintURL: url, unit: .sat)
+            return (url, projection.balances[account] ?? mints.first { $0.url == url }?.balance ?? 0)
+        })
         mintService.updateMintBalances(balancesByMintURL)
         balance = unitTotals["sat"] ?? 0
         balancesByUnit = unitTotals

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Mints.swift
@@ -205,7 +205,7 @@ extension WalletManager {
         let projection: StoredBalanceProjection
         do {
             let accounts = try await StoredWalletAccount.discover(database: db, repository: walletRepository)
-                .filter { account in mintUrls.contains { MintURLIdentity.normalized($0) == account.mintURL } }
+                .filter { account in mintUrls.contains { account.matches(mintURL: $0) } }
             projection = try await StoredBalanceProjection.load(accounts: accounts, previousTotals: balancesByUnit) { account in
                 try await db.getBalance(mintUrl: MintUrl(url: account.mintURL), unit: account.unit, state: [.unspent])
             }
@@ -216,8 +216,7 @@ extension WalletManager {
         guard !Task.isCancelled else { return }
         let unitTotals = projection.totals
         let balancesByMintURL = Dictionary(uniqueKeysWithValues: mintUrls.map { url in
-            let account = StoredWalletAccount(mintURL: url, unit: .sat)
-            return (url, projection.balances[account] ?? mints.first { $0.url == url }?.balance ?? 0)
+            (url, projection.balance(mintURL: url, unit: .sat) ?? mints.first { $0.url == url }?.balance ?? 0)
         })
         mintService.updateMintBalances(balancesByMintURL)
         balance = unitTotals["sat"] ?? 0

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -59,8 +59,8 @@ extension WalletManager {
     func storedAccountUnits(mintURL: String) async -> [String]? {
         guard let db, let repo = walletRepository else { return nil }
         return try? await operationCoordinator.perform(kind: .balance, resourceID: mintURL) {
-            try await StoredWalletAccount.discover(database: db, repository: repo)
-                .filter { MintRemovalPolicy.matches($0.mintURL, mintURL) }.map(\.unitName).sorted()
+            let accounts = try await StoredWalletAccount.discover(database: db, repository: repo)
+            return Set(accounts.filter { $0.matches(mintURL: mintURL) }.map(\.unitName)).sorted()
         }
     }
 
@@ -69,15 +69,20 @@ extension WalletManager {
         if unit.lowercased() == "sat" {
             return mints.first(where: { $0.url == mintURL })?.balance
         }
-        guard let db else { return nil }
+        guard let db, let repo = walletRepository else { return nil }
         do {
             return try await operationCoordinator.perform(
                 kind: .balance,
                 resourceID: mintURL
             ) {
-                let mintUrl = MintUrl(url: mintURL)
                 let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
-                return try await db.getBalance(mintUrl: mintUrl, unit: currencyUnit, state: [.unspent])
+                let accounts = try await StoredWalletAccount.discover(database: db, repository: repo)
+                    .filter { $0.unit == currencyUnit && $0.matches(mintURL: mintURL) }
+                var total: UInt64 = 0
+                for account in accounts {
+                    total += try await db.getBalance(mintUrl: MintUrl(url: account.mintURL), unit: account.unit, state: [.unspent])
+                }
+                return total
             }
         } catch {
             AppLogger.wallet.debug(

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -55,15 +55,21 @@ extension WalletManager {
         return result
     }
 
-    /// Balance of a specific (mint, unit) wallet, in that unit's base units.
-    /// "sat" resolves from the cached per-mint balance; other units query CDK
-    /// directly since the app doesn't cache non-sat balances. Returns nil on any
-    /// failure (e.g. a mint that doesn't actually support the unit).
+    /// Existing units for balance displays; payment options still use metadata.
+    func storedAccountUnits(mintURL: String) async -> [String]? {
+        guard let db, let repo = walletRepository else { return nil }
+        return try? await operationCoordinator.perform(kind: .balance, resourceID: mintURL) {
+            try await StoredWalletAccount.discover(database: db, repository: repo)
+                .filter { MintRemovalPolicy.matches($0.mintURL, mintURL) }.map(\.unitName).sorted()
+        }
+    }
+
+    /// Balance of a durable account. Returns nil when storage is unavailable.
     func unitBalance(mintURL: String, unit: String) async -> UInt64? {
         if unit.lowercased() == "sat" {
             return mints.first(where: { $0.url == mintURL })?.balance
         }
-        guard let repo = walletRepository else { return nil }
+        guard let db else { return nil }
         do {
             return try await operationCoordinator.perform(
                 kind: .balance,
@@ -71,9 +77,7 @@ extension WalletManager {
             ) {
                 let mintUrl = MintUrl(url: mintURL)
                 let currencyUnit = PaymentRequestDecoder.currencyUnit(from: unit)
-                try await repo.createWallet(mintUrl: mintUrl, unit: currencyUnit, targetProofCount: nil)
-                let wallet = try await repo.getWallet(mintUrl: mintUrl, unit: currencyUnit)
-                return try await wallet.totalBalance().value
+                return try await db.getBalance(mintUrl: mintUrl, unit: currencyUnit, state: [.unspent])
             }
         } catch {
             AppLogger.wallet.debug(

--- a/ios/CashuWallet/Views/Main/MainWalletView.swift
+++ b/ios/CashuWallet/Views/Main/MainWalletView.swift
@@ -73,12 +73,9 @@ struct MainWalletView: View {
         HomeBalance.homeBalanceUnits(walletManager.balancesByUnit)
     }
 
-    /// Whether to show the swipe/dots pager: only when the active (default) mint
-    /// is multi-unit AND a non-sat balance is held. A single-unit default mint
-    /// keeps the single sat hero.
+    /// Page through every held currency, independently of mint advertisements.
     private var showsUnitPager: Bool {
         HomeBalance.showsUnitPager(
-            activeMintSupportsMultipleUnits: walletManager.activeMint?.supportsMultipleUnits ?? false,
             balancesByUnit: walletManager.balancesByUnit
         )
     }

--- a/ios/CashuWallet/Views/Mints/MintDetailView.swift
+++ b/ios/CashuWallet/Views/Mints/MintDetailView.swift
@@ -29,6 +29,7 @@ struct MintDetailView: View {
     /// Balances for the mint's non-sat units, loaded on demand (the sat balance
     /// is the cached `mint.balance`). Where a freshly-minted eur/usd shows up.
     @State private var unitBalances: [String: UInt64] = [:]
+    @State private var storedUnits: [String] = []
 
     private var cdkInfo: Cdk.MintInfo? { infoLoader.info }
     private var isLoading: Bool { infoLoader.isLoading }
@@ -36,7 +37,7 @@ struct MintDetailView: View {
 
     /// The mint's non-sat units (sat is shown by `balanceRow`).
     private var nonSatUnits: [String] {
-        liveMint.units.filter { $0.lowercased() != "sat" }.sorted()
+        Set(liveMint.units + storedUnits).filter { $0.lowercased() != "sat" }.sorted()
     }
 
     private var isDefaultMint: Bool {
@@ -745,9 +746,9 @@ struct MintDetailView: View {
         }
     }
 
-    /// Fetch each non-sat unit's balance so a minted eur/usd is visible here
-    /// (the app's aggregate balance is sat-only).
+    /// Durable account units remain visible when metadata removes a payment unit.
     private func loadUnitBalances() async {
+        if let units = await walletManager.storedAccountUnits(mintURL: liveMint.url) { storedUnits = units }
         for unit in nonSatUnits {
             if let balance = await walletManager.unitBalance(mintURL: liveMint.url, unit: unit) {
                 unitBalances[unit] = balance

--- a/ios/CashuWalletTests/MintServiceTests.swift
+++ b/ios/CashuWalletTests/MintServiceTests.swift
@@ -501,33 +501,29 @@ final class MultiUnitSupportTests: XCTestCase {
         XCTAssertEqual(HomeBalance.resolvedUnit("eur", in: ["sat"]), "sat")
     }
 
-    // MARK: - Pager gate (active/default mint)
+    // MARK: - Pager visibility (held funds)
 
-    func testShowsPagerWhenMultiUnitDefaultAndNonSatHeld() {
+    func testShowsPagerWhenNonSatHeld() {
         XCTAssertTrue(HomeBalance.showsUnitPager(
-            activeMintSupportsMultipleUnits: true,
             balancesByUnit: ["sat": 100, "eur": 5]
         ))
     }
 
-    func testNoPagerWhenDefaultMintIsSingleUnit() {
-        // Non-sat balance held elsewhere, but the default mint is single-unit.
-        XCTAssertFalse(HomeBalance.showsUnitPager(
-            activeMintSupportsMultipleUnits: false,
-            balancesByUnit: ["sat": 100, "eur": 5]
+    func testShowsPagerWithDiscontinuedCurrencyBalance() {
+        // USD remains visible after its mint stops advertising that unit.
+        XCTAssertTrue(HomeBalance.showsUnitPager(
+            balancesByUnit: ["sat": 100, "usd": 5]
         ))
     }
 
     func testNoPagerWhenNoNonSatBalance() {
         XCTAssertFalse(HomeBalance.showsUnitPager(
-            activeMintSupportsMultipleUnits: true,
             balancesByUnit: ["sat": 100]
         ))
     }
 
     func testNoPagerWhenNonSatBalanceIsZero() {
         XCTAssertFalse(HomeBalance.showsUnitPager(
-            activeMintSupportsMultipleUnits: true,
             balancesByUnit: ["sat": 100, "eur": 0]
         ))
     }

--- a/ios/CashuWalletTests/StoredWalletAccountTests.swift
+++ b/ios/CashuWalletTests/StoredWalletAccountTests.swift
@@ -60,11 +60,126 @@ final class StoredWalletAccountTests: XCTestCase {
         await service.loadTransactions(includeRemoteObservations: false)
         XCTAssertEqual(service.transactions.count, 1)
     }
+
+    func testDefaultPortAccountsKeepTheirStorageKeysAndBothBalances() async throws {
+        try await withHistoryService { db, repo, service, _ in
+            let urls = ["https://offline.example:443", "https://offline.example"]
+            let keys = ["02", "03"].map { $0 + "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798" }
+            for (index, url) in urls.enumerated() {
+                let mint = MintUrl(url: url)
+                try await db.addMint(mintUrl: mint, mintInfo: nil)
+                try await db.updateProofs(added: [ProofInfo(
+                    proof: Proof(amount: Amount(value: UInt64(8 << index)), secret: "stored-account-\(index)",
+                        c: keys[index], keysetId: "001234567890abcd", witness: nil, dleq: nil, p2pkE: nil),
+                    y: PublicKey(hex: keys[index]), mintUrl: mint, state: .unspent,
+                    spendingCondition: nil, unit: .usd, derivationIndex: nil,
+                    usedByOperation: nil, createdByOperation: nil
+                )], removedYs: [])
+                try await db.addTransaction(transaction: Cdk.Transaction(
+                    id: TransactionId(hex: String(repeating: index == 0 ? "a" : "b", count: 64)),
+                    mintUrl: mint, direction: .incoming, amount: Amount(value: 8), fee: Amount(value: 0),
+                    unit: .usd, ys: [], timestamp: 1, memo: nil, metadata: [:], quoteId: nil,
+                    paymentRequest: nil, paymentProof: nil, paymentMethod: nil, sagaId: nil, status: .completed
+                ))
+            }
+            let accounts = try await StoredWalletAccount.discover(database: db, repository: repo)
+                .filter { $0.unit == .usd && $0.matches(mintURL: urls[1]) }
+            XCTAssertEqual(Set(accounts.map(\.mintURL)), Set(urls))
+            let projection = try await StoredBalanceProjection.load(accounts: accounts, previousTotals: [:]) {
+                try await db.getBalance(mintUrl: MintUrl(url: $0.mintURL), unit: $0.unit, state: [.unspent])
+            }
+            XCTAssertEqual(projection.totals["usd"], 24)
+            XCTAssertEqual(projection.balance(mintURL: urls[1], unit: .usd), 24)
+            let partial = try await StoredBalanceProjection.load(accounts: accounts, previousTotals: ["usd": 24]) {
+                if $0.mintURL == urls[0] { throw Failure.storage }
+                return 16
+            }
+            XCTAssertEqual(partial.totals["usd"], 24)
+            XCTAssertNil(partial.balance(mintURL: urls[1], unit: .usd))
+            await service.loadTransactions(includeRemoteObservations: false)
+            XCTAssertEqual(Set(service.transactions.compactMap(\.mintUrl)), Set(urls))
+            db.failAccountReads = true
+            await service.loadTransactions(includeRemoteObservations: false)
+            XCTAssertEqual(service.transactions.count, 2)
+        }
+    }
+
+    func testAccountAndDiscoveryFailuresDoNotSuppressFreshQuotes() async throws {
+        try await withHistoryService { db, _, service, _ in
+            try await db.addMintQuote(quote: MintQuote(
+                id: "invoice", amount: Amount(value: 8), unit: .sat, request: "invoice-request",
+                state: .unpaid, expiry: 1, mintUrl: MintUrl(url: "https://offline.example"),
+                amountIssued: Amount(value: 0), amountPaid: Amount(value: 0), updatedAt: 1,
+                estimatedBlocks: nil, paymentMethod: .bolt11, secretKey: nil, usedByOperation: nil, version: 0
+            ))
+            let staleInvoice = WalletTransaction(
+                id: "invoice", amount: 8, type: .incoming, kind: .lightning, date: Date(), memo: nil,
+                status: .pending, mintUrl: "https://offline.example", quoteId: "invoice"
+            )
+            let completed = WalletTransaction(
+                id: "cdk-transaction", amount: 8, type: .incoming, kind: .lightning, date: Date(), memo: nil,
+                status: .completed, mintUrl: "https://offline.example", quoteId: "settled-quote"
+            )
+            for discoveryFails in [false, true] {
+                db.failAccountReads = true
+                db.failDiscoveryReads = discoveryFails
+                db.failQuoteReads = false
+                service.transactions = [staleInvoice, completed]
+                await service.loadTransactions(includeRemoteObservations: false)
+                XCTAssertEqual(service.transactions.first { $0.id == "invoice" }?.status, .expired)
+                XCTAssertEqual(service.transactions.count, 2)
+                XCTAssertEqual(service.transactions.first { $0.id == completed.id }?.status, .completed)
+
+                db.failQuoteReads = true
+                service.transactions = [staleInvoice, completed]
+                await service.loadTransactions(includeRemoteObservations: false)
+                XCTAssertEqual(service.transactions.first { $0.id == "invoice" }?.status, .pending)
+                XCTAssertEqual(service.transactions.count, 2)
+            }
+        }
+    }
+
+    func testDiscoveryFailureStillRebuildsLocallyParkedTokensAfterRelaunch() async throws {
+        try await withHistoryService { db, repo, service, store in
+            db.failDiscoveryReads = true
+            let pending = PendingReceiveToken(tokenId: "parked", token: "cashuAparked", amount: 8,
+                date: Date(), mintUrl: "https://offline.example")
+            service.savePendingReceiveToken(pending)
+            await service.loadTransactions(includeRemoteObservations: false)
+            XCTAssertEqual(service.transactions.map(\.id), [pending.tokenId])
+            XCTAssertTrue(service.transactions.first?.isPendingReceiveToken == true)
+
+            let relaunched = TransactionService(walletRepository: { repo }, walletDatabase: { db },
+                getTrackedMintUrls: { ["https://offline.example"] }, walletStore: store)
+            await relaunched.loadTransactions(includeRemoteObservations: false)
+            XCTAssertEqual(relaunched.transactions.map(\.id), [pending.tokenId])
+            relaunched.removePendingReceiveToken(tokenId: pending.tokenId)
+            await relaunched.loadTransactions(includeRemoteObservations: false)
+            XCTAssertTrue(relaunched.transactions.isEmpty)
+        }
+    }
+
+    private func withHistoryService(
+        _ body: (FailingAccountHistoryDatabase, WalletRepository, TransactionService, WalletStore) async throws -> Void
+    ) async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let database = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("wallet.sqlite").path)
+        let reader = FailingAccountHistoryDatabase(database: database)
+        let repo = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: database))
+        let store = WalletStore(storage: InMemoryStorage())
+        let service = TransactionService(walletRepository: { repo }, walletDatabase: { reader },
+            getTrackedMintUrls: { ["https://offline.example"] }, walletStore: store)
+        try await body(reader, repo, service, store)
+    }
 }
 
 private final class FailingAccountHistoryDatabase: WalletSqliteDatabase, @unchecked Sendable {
     private var retainedDatabase: WalletSqliteDatabase?
     var failAccountReads = false
+    var failDiscoveryReads = false
+    var failQuoteReads = false
     required init(unsafeFromHandle handle: UInt64) { super.init(unsafeFromHandle: handle) }
     convenience init(database: WalletSqliteDatabase) {
         self.init(unsafeFromHandle: database.uniffiCloneHandle())
@@ -73,5 +188,13 @@ private final class FailingAccountHistoryDatabase: WalletSqliteDatabase, @unchec
     override func listTransactions(mintUrl: MintUrl?, direction: TransactionDirection?, unit: CurrencyUnit?) async throws -> [Cdk.Transaction] {
         if failAccountReads && unit != nil { throw NSError(domain: "TestStorage", code: 1) }
         return try await super.listTransactions(mintUrl: mintUrl, direction: direction, unit: unit)
+    }
+    override func getMintQuotes() async throws -> [MintQuote] {
+        if failDiscoveryReads { throw NSError(domain: "TestStorage", code: 2) }
+        return try await super.getMintQuotes()
+    }
+    override func getUnissuedMintQuotes() async throws -> [MintQuote] {
+        if failQuoteReads { throw NSError(domain: "TestStorage", code: 3) }
+        return try await super.getUnissuedMintQuotes()
     }
 }

--- a/ios/CashuWalletTests/StoredWalletAccountTests.swift
+++ b/ios/CashuWalletTests/StoredWalletAccountTests.swift
@@ -1,0 +1,77 @@
+import Cdk
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class StoredWalletAccountTests: XCTestCase {
+    private enum Failure: Error { case storage }
+
+    func testFailedAccountPreservesWholeCurrencyTotalAndRetryReplacesIt() async throws {
+        let a = StoredWalletAccount(mintURL: "https://a.example", unit: .usd)
+        let b = StoredWalletAccount(mintURL: "https://b.example", unit: .usd)
+        let sat = StoredWalletAccount(mintURL: a.mintURL, unit: .sat)
+        let first = try await StoredBalanceProjection.load(accounts: [a, b, sat], previousTotals: ["usd": 500, "sat": 1]) {
+            if $0 == b { throw Failure.storage }
+            return $0 == sat ? 30 : 200
+        }
+        XCTAssertEqual(first.totals, ["usd": 500, "sat": 30])
+        let retry = try await StoredBalanceProjection.load(accounts: [a, b, a], previousTotals: first.totals) { _ in 200 }
+        XCTAssertEqual(retry.totals, ["usd": 400])
+    }
+
+    func testDiscontinuedZeroBalanceCurrencyAndHistorySurviveOfflineRelaunch() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let path = directory.appendingPathComponent("wallet.sqlite").path
+        let mnemonic = try generateMnemonic()
+        let mint = MintUrl(url: "https://offline.example")
+        let id = String(repeating: "a", count: 64)
+        do {
+            let db = try LifecycleSafeWalletDatabase(filePath: path)
+            // No USD advertisement remains, but the historical account does.
+            try await db.addMint(mintUrl: mint, mintInfo: nil)
+            try await db.addTransaction(transaction: Cdk.Transaction(
+                id: TransactionId(hex: id), mintUrl: mint, direction: .incoming,
+                amount: Amount(value: 250), fee: Amount(value: 0), unit: .usd,
+                ys: [], timestamp: 1, memo: nil, metadata: [:], quoteId: nil,
+                paymentRequest: nil, paymentProof: nil, paymentMethod: nil, sagaId: nil, status: .completed
+            ))
+        }
+        let db = try LifecycleSafeWalletDatabase(filePath: path)
+        let repo = try WalletRepository(mnemonic: mnemonic, store: customWalletStore(db: db))
+        let wallets = await repo.getWallets()
+        XCTAssertFalse(wallets.contains { $0.unit() == .usd })
+        let accounts = try await StoredWalletAccount.discover(database: db, repository: repo)
+        let usd = StoredWalletAccount(mintURL: mint.url, unit: .usd)
+        XCTAssertTrue(accounts.contains(usd))
+        let projection = try await StoredBalanceProjection.load(accounts: accounts, previousTotals: [:]) {
+            try await db.getBalance(mintUrl: MintUrl(url: $0.mintURL), unit: $0.unit, state: [.unspent])
+        }
+        XCTAssertEqual(projection.totals["usd"], 0)
+        let reader = FailingAccountHistoryDatabase(database: db)
+        let service = TransactionService(walletRepository: { repo }, walletDatabase: { reader }, getTrackedMintUrls: { [mint.url] })
+        await service.loadTransactions(includeRemoteObservations: false)
+        XCTAssertEqual(service.transactions.map(\.unit), ["usd"])
+        reader.failAccountReads = true
+        await service.loadTransactions(includeRemoteObservations: false)
+        XCTAssertEqual(service.transactions.map(\.unit), ["usd"])
+        reader.failAccountReads = false
+        await service.loadTransactions(includeRemoteObservations: false)
+        XCTAssertEqual(service.transactions.count, 1)
+    }
+}
+
+private final class FailingAccountHistoryDatabase: WalletSqliteDatabase, @unchecked Sendable {
+    private var retainedDatabase: WalletSqliteDatabase?
+    var failAccountReads = false
+    required init(unsafeFromHandle handle: UInt64) { super.init(unsafeFromHandle: handle) }
+    convenience init(database: WalletSqliteDatabase) {
+        self.init(unsafeFromHandle: database.uniffiCloneHandle())
+        retainedDatabase = database
+    }
+    override func listTransactions(mintUrl: MintUrl?, direction: TransactionDirection?, unit: CurrencyUnit?) async throws -> [Cdk.Transaction] {
+        if failAccountReads && unit != nil { throw NSError(domain: "TestStorage", code: 1) }
+        return try await super.listTransactions(mintUrl: mintUrl, direction: direction, unit: unit)
+    }
+}

--- a/ios/CashuWalletTests/StoredWalletAccountTests.swift
+++ b/ios/CashuWalletTests/StoredWalletAccountTests.swift
@@ -160,7 +160,7 @@ final class StoredWalletAccountTests: XCTestCase {
     }
 
     private func withHistoryService(
-        _ body: (FailingAccountHistoryDatabase, WalletRepository, TransactionService, WalletStore) async throws -> Void
+        _ body: (FailingAccountHistoryDatabase, WalletRepository, TransactionService, CashuWallet.WalletStore) async throws -> Void
     ) async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)


### PR DESCRIPTION
When a mint stops advertising a currency, both apps keep its stored funds and history visible, including after relaunch when CDK has not recreated that unit's wallet. Discover local account references from CDK proofs, transactions, quotes, and registered wallets. Keep advertised payment options separate from those account projections.

The home currency pager follows held balances regardless of the active mint's advertisements. Mint Detail includes durable account units and reads their balances directly from storage without registering wallets. On iOS, database reads preserve CDK's original mint URL, including explicit default ports, while tracked-mint matching uses normalized URLs. Distinct stored accounts for an equivalent mint endpoint contribute to its displayed balance.

Balance refresh preserves the previous complete currency total if any contributing account fails. History retains cached CDK transactions separately from synthesized invoice rows, so account-read failures do not suppress fresh quote statuses. Quote rows are retained when the quote read itself fails. Locally parked receive tokens continue to appear, refresh, and disappear after removal even when account discovery fails.

Validation for the latest commit:
- CI passed at `a722d207`: [iOS unit, mint integration, and UI tests](https://github.com/cashubtc/wallet/actions/runs/34230698277), [Android Gradle checks](https://github.com/cashubtc/wallet/actions/runs/34230698245), and [Android screenshot and managed-device checks](https://github.com/cashubtc/wallet/actions/runs/34230698262). The optional Android compatibility matrix was skipped by the workflow.
- The default-port fixture uses distinct saga IDs, matching CDK's stored transaction identity rules, and verifies that both transaction rows exist before projecting history.
- Added iOS regressions for distinct default-port storage accounts, balance aggregation and partial failures, quote refreshes during account/discovery failures, quote-read fallback, and parked tokens across service recreation.
- Added Android regressions for quote refreshes and fallback during account/discovery failures, and parked tokens across store recreation. The existing database-reopen regression now uses an explicit default port.
- iOS `build-for-testing` passed for arm64 and x86_64 simulator targets with Xcode 26.6 and code signing disabled, compiling the app, unit-test bundle, and UI-test bundle. The test helper explicitly names `CashuWallet.WalletStore` to avoid a collision with CDK's type.
- `git diff --check` passed. No tests were executed locally, as requested; Android builds were not rerun for the iOS compilation fix.

Earlier validation at `b48bdf6f` (before these follow-up changes):
- Android: 741 unit tests, 735 passed and 6 skipped; release lint passed with 0 errors and 36 existing warnings; release assembly passed.
- Android emulator: 3 native regressions passed, including a discontinued currency after database reopen, failed account history reads, and USD visible in the production home pager and Mint Detail while metadata advertises only sat.
- iOS simulator: all 110 relevant stored-account, transaction-service, mint-service, and multi-currency tests passed; app and test targets built successfully. Included offline relaunch with a missing registered USD wallet, zero-balance historical accounts, repeated reads, and storage failures.
- Both platforms covered multiple accounts sharing a currency and preservation of the previous complete total.

Independent fix for release-review finding 5, based on main with CDK 0.18.0. No external protocol changes. Release-review finding 3 and the broader crash-recovery work in release-review finding 4 remain outside this PR.
