### PR TITLE
Android: display wallet-deletion failures

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -49,6 +49,7 @@ class FakeWalletGateway(
     private var repositoryOpen = false
 
     var nextFailure: Throwable? = null
+    var nextCloseFailure: Throwable? = null
     val latestMintQuoteId: String?
         get() = mintQuotes.keys.lastOrNull()
 
@@ -92,6 +93,10 @@ class FakeWalletGateway(
     }
 
     override suspend fun closeWalletRepository() {
+        nextCloseFailure?.let { failure ->
+            nextCloseFailure = null
+            throw failure
+        }
         repositoryOpen = false
     }
 

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/FunctionalWalletJourneyTest.kt
@@ -282,6 +282,25 @@ class FunctionalWalletJourneyTest {
     }
 
     @Test
+    fun failedWalletDeletionShowsFeedbackAndRequiresAnotherConfirmation() {
+        val fixture = launch(FixtureMode.SeededWithoutMint)
+        val failure = IllegalStateException("code=11001, errorMessage=private storage detail")
+        fixture.fakeGateway!!.nextCloseFailure = failure
+        robot.awaitTag(UiTestTags.WalletScreen)
+            .tapDescription("Settings")
+            .awaitTag(UiTestTags.SettingsScreen)
+            .scrollToText(UiTestTags.SettingsList, "Delete Wallet")
+            .tapText("Delete Wallet")
+            .awaitText("Delete wallet?")
+            .tapText("Delete")
+            .awaitText(com.cashu.me.Core.Wallet.WalletErrorMessages.classify(failure).text)
+            .tapText("Delete Wallet")
+            .awaitText("Delete wallet?")
+            .tapText("Cancel")
+            .awaitTag(UiTestTags.SettingsScreen)
+    }
+
+    @Test
     fun deleteWalletConfirmationReturnsToOnboarding() {
         launch(FixtureMode.SeededWithoutMint)
 

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDeletionAction.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletDeletionAction.kt
@@ -1,0 +1,36 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.Wallet.userFacingWalletMessage
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/** A destructive operation is owned by the wallet, independent of its sheet. */
+internal class WalletDeletionAction(
+    private val launch: (suspend CoroutineScope.() -> Unit) -> Unit,
+    private val delete: suspend () -> Unit,
+) {
+    private val mutableRunning = MutableStateFlow(false)
+    val running = mutableRunning.asStateFlow()
+    private val mutableError = MutableStateFlow<String?>(null)
+    val error = mutableError.asStateFlow()
+
+    fun submit() {
+        if (!mutableRunning.compareAndSet(false, true)) return
+        mutableError.value = null
+        launch {
+            try {
+                delete()
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                mutableError.value = error.userFacingWalletMessage
+            } finally {
+                mutableRunning.value = false
+            }
+        }
+    }
+
+    fun acknowledgeError(message: String) { mutableError.compareAndSet(message, null) }
+}

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -1691,6 +1691,10 @@ class WalletManager(
         }
     }
 
+    internal val deletionAction by lazy {
+        WalletDeletionAction(::launch, ::deleteWallet)
+    }
+
     fun launch(block: suspend CoroutineScope.() -> Unit) {
         scope.launch { block() }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/settings/SettingsScreen.kt
@@ -34,6 +34,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
@@ -77,10 +80,21 @@ fun SettingsScreen(
 ) {
     val context = LocalContext.current
     val settings by settingsManager.state.collectAsState()
+    val deletion = walletManager.deletionAction
+    val deleting by deletion.running.collectAsState()
+    val deletionError by deletion.error.collectAsState()
+    val snackbar = remember { SnackbarHostState() }
+    LaunchedEffect(deletionError) {
+        deletionError?.let { message ->
+            snackbar.showSnackbar(message)
+            deletion.acknowledgeError(message)
+        }
+    }
     var confirmDelete by remember { mutableStateOf(false) }
     var currencyPickerOpen by remember { mutableStateOf(false) }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbar) },
         modifier = Modifier
             .testTag(UiTestTags.SettingsScreen)
             .padding(contentPadding)
@@ -209,7 +223,8 @@ fun SettingsScreen(
                 NavRow(
                     title = "Delete Wallet",
                     leadingIcon = Icons.Outlined.DeleteOutline,
-                    onClick = { confirmDelete = true },
+                    onClick = { if (!deleting) confirmDelete = true },
+                    enabled = !deleting,
                     tint = MaterialTheme.colorScheme.error,
                     showChevron = false,
                 )
@@ -244,7 +259,7 @@ fun SettingsScreen(
             destructive = true,
             onConfirm = {
                 confirmDelete = false
-                walletManager.launch { walletManager.deleteWallet() }
+                deletion.submit()
             },
             onDismiss = { confirmDelete = false },
         )

--- a/android/app/src/test/java/com/cashu/me/Core/WalletDeletionActionTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletDeletionActionTest.kt
@@ -1,0 +1,42 @@
+package com.cashu.me.Core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+class WalletDeletionActionTest {
+    @Test fun rejectsDuplicateSubmissionsAndAllowsExplicitRetryAfterFailure() = runBlocking {
+        val jobs = mutableListOf<suspend CoroutineScope.() -> Unit>()
+        var calls = 0
+        val action = WalletDeletionAction({ jobs.add(it); Unit }) {
+            calls++
+            if (calls == 1) error("code=11001, errorMessage=private storage detail")
+        }
+        action.submit()
+        action.submit()
+        assertTrue(action.running.value)
+        assertEquals(1, jobs.size)
+        jobs.removeAt(0)(this)
+        assertFalse(action.running.value)
+        assertNotNull(action.error.value)
+        assertEquals("private storage detail", action.error.value)
+        action.submit()
+        assertNull(action.error.value)
+        jobs.removeAt(0)(this)
+        assertEquals(2, calls)
+        assertFalse(action.running.value)
+        assertNull(action.error.value)
+    }
+
+    @Test fun cancellationIsNotReportedAsDeletionFailure() = runBlocking {
+        val jobs = mutableListOf<suspend CoroutineScope.() -> Unit>()
+        val action = WalletDeletionAction({ jobs.add(it); Unit }) { throw CancellationException() }
+        action.submit()
+        try { jobs.removeAt(0)(this); fail("Expected cancellation") }
+        catch (_: CancellationException) { }
+        assertFalse(action.running.value)
+        assertNull(action.error.value)
+    }
+}

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -148,7 +148,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · iOS → Android] Explain unavailable App Lock and preserve access.** iOS detects the absence of a device passcode, gives setup guidance, and explains that seed reveal always authenticates; Android exposes no equivalent guidance. Android’s manager currently fails open, so this is not an established lockout bug. **Done when:** Android reports capability state, points to device security setup, states the seed-reveal guarantee, and never presents an unavailable lock as active.
 
-- [ ] **[P1 · iOS → Android] Show wallet-deletion failures.** iOS catches deletion errors and displays a banner; Android starts deletion without dedicated error feedback. **Done when:** Android reports failure and leaves the existing wallet state intact and understandable.
+- [ ] **[P1 · iOS → Android] Show wallet-deletion failures.** The wallet-owned deletion action suppresses duplicate submissions and presents mapped failures in a native snackbar. Every new attempt still requires confirmation. Regression tests cover failure, cancellation, and retry. **Verification:** implementation ready; final device review pending.
 
 - [x] **[P1 · Android → iOS] Read the app version from build metadata.** Android uses `BuildConfig.VERSION_NAME`; iOS hard-codes `1.0.0`. **Done when:** iOS displays the shipped bundle version and, if included, its build number from metadata.
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -148,7 +148,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · iOS → Android] Explain unavailable App Lock and preserve access.** iOS detects the absence of a device passcode, gives setup guidance, and explains that seed reveal always authenticates; Android exposes no equivalent guidance. Android’s manager currently fails open, so this is not an established lockout bug. **Done when:** Android reports capability state, points to device security setup, states the seed-reveal guarantee, and never presents an unavailable lock as active.
 
-- [ ] **[P1 · iOS → Android] Show wallet-deletion failures.** The wallet-owned deletion action suppresses duplicate submissions and presents mapped failures in a native snackbar. Every new attempt still requires confirmation. Regression tests cover failure, cancellation, and retry. **Verification:** implementation ready; final device review pending.
+- [x] **[P1 · iOS → Android] Show wallet-deletion failures.** The wallet-owned deletion action suppresses duplicate submissions and presents mapped failures in a native snackbar. Every new attempt still requires confirmation. Regression tests cover failure, cancellation, and retry. **Verification:** Unit/lint/build checks and native deletion failure/reconfirmation tests passed; matched failure captures show the snackbar.
 
 - [x] **[P1 · Android → iOS] Read the app version from build metadata.** Android uses `BuildConfig.VERSION_NAME`; iOS hard-codes `1.0.0`. **Done when:** iOS displays the shipped bundle version and, if included, its build number from metadata.
 


### PR DESCRIPTION
Wallet deletion failures now appear through the wallet error mapper in a native snackbar. A wallet-owned action rejects duplicate submissions, and each fresh attempt requires confirmation.

Validation: JVM tests cover duplicate submission, failure, cancellation, and explicit retry. A native journey verifies error feedback and a fresh confirmation after failure. Android unit, lint, debug build, and instrumentation checks pass.

The relevant parity checklist entry is updated. Visual evidence remains local.

Required GitHub Actions checks passed on this PR head. The existing workflow retry and opt-in test policies apply. Visual evidence remains local.
