### PR TITLE
Android: reject malformed Lightning invoices in Send

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/send/SendDestinationResolverTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/send/SendDestinationResolverTest.kt
@@ -59,6 +59,19 @@ class SendDestinationResolverTest {
         assertEquals(SendDestinationResolution.EcashToken(token), resolution)
     }
 
+    @Test
+    fun malformedBolt11DoesNotAdvanceAfterStrictDecodingFails() {
+        val inputs = listOf(
+            "lnbc10u1bogus", "lightning:lnbc10u1bogus", "LNBC10U1BOGUS",
+            Bolt11AmountfulCoffeeInvoice.dropLast(1),
+            Bolt11AmountfulCoffeeInvoice.dropLast(1) + "q",
+        )
+        inputs.forEach { input ->
+            assertEquals(SendDestinationResolution.Unrecognized,
+                resolveSendDestination(input, walletMints = emptyList()))
+        }
+    }
+
     private companion object {
         private const val AmountlessBolt12Offer =
             "lno1pgqpvggr25nht4nyqrgtnhxltctkdsfrf3myhj008f6fyulf4tplmarx8hxq"

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendDestinationResolver.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendDestinationResolver.kt
@@ -1,12 +1,10 @@
 package com.cashu.me.ui.send
 
-import com.cashu.me.Core.LightningRequestParser
 import com.cashu.me.Core.PaymentRequestDecodeResult
 import com.cashu.me.Core.PaymentRequestDecoder
 import com.cashu.me.Core.TokenParser
 import com.cashu.me.Core.compatibleMintsForCashuPaymentRequest
 import com.cashu.me.Models.MintInfo
-import com.cashu.me.Models.PaymentMethodKind
 
 internal const val AmountlessBolt11Hint =
     "This BOLT11 invoice doesn't include an amount. Ask for an amount-specific invoice before paying."
@@ -35,7 +33,7 @@ internal fun resolveSendDestination(
 ): SendDestinationResolution {
     val trimmed = raw.trim()
     if (trimmed.isEmpty()) return SendDestinationResolution.Unrecognized
-    var decoded = decodeSendDestination(
+    var decoded = PaymentRequestDecoder.decode(
         trimmed,
         includeCashuPaymentRequests = true,
         preferCashuPaymentRequests = true,
@@ -44,7 +42,7 @@ internal fun resolveSendDestination(
     if (decoded is PaymentRequestDecodeResult.CashuPaymentRequest &&
         compatibleMintsForCashuPaymentRequest(decoded.summary, walletMints).isEmpty()
     ) {
-        val fallback = decodeSendDestination(trimmed)
+        val fallback = PaymentRequestDecoder.decode(trimmed)
         if (fallback !is PaymentRequestDecodeResult.Unrecognized) {
             decoded = fallback
             request = PaymentRequestDecoder.encodedLightningRequest(trimmed) ?: trimmed
@@ -94,24 +92,5 @@ internal fun resolveSendDestination(
                 ?.let(SendDestinationResolution::EcashToken)
                 ?: SendDestinationResolution.Unrecognized
         }
-    }
-}
-
-private fun decodeSendDestination(
-    raw: String,
-    includeCashuPaymentRequests: Boolean = false,
-    preferCashuPaymentRequests: Boolean = false,
-): PaymentRequestDecodeResult {
-    val decoded = PaymentRequestDecoder.decode(
-        raw,
-        includeCashuPaymentRequests = includeCashuPaymentRequests,
-        preferCashuPaymentRequests = preferCashuPaymentRequests,
-    )
-    if (decoded !is PaymentRequestDecodeResult.Unrecognized) return decoded
-    val lightning = runCatching { LightningRequestParser.parse(raw) }.getOrNull() ?: return decoded
-    return when (lightning.method) {
-        PaymentMethodKind.Bolt11 -> PaymentRequestDecodeResult.Bolt11(lightning.amountSats, lightning.description)
-        PaymentMethodKind.Bolt12 -> PaymentRequestDecodeResult.Bolt12(lightning.amountSats, lightning.description)
-        PaymentMethodKind.Onchain -> decoded
     }
 }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -44,7 +44,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Send — unified destination and payment flow
 
-- [ ] **[P1 · iOS → Android] Reject malformed Lightning invoices at destination entry.** Send uses the central payment decoder without a prefix-only BOLT11 fallback. Valid and amountless BOLT11 invoices and the existing BOLT12 fallback retain their routing. **Verification:** native CDK regression tests added; device execution pending.
+- [x] **[P1 · iOS → Android] Reject malformed Lightning invoices at destination entry.** Send uses the central payment decoder without a prefix-only BOLT11 fallback. Valid and amountless BOLT11 invoices and the existing BOLT12 fallback retain their routing. **Verification:** All six destination tests passed with native CDK; Android unit/lint/build checks passed. Invalid destination entry was inspected on-device.
 
 
 - [x] **[P1 · iOS → Android] Support fiat-primary amount entry.** iOS converts keypad input according to the saved sats/fiat primary setting; Android’s unified Send amount step always interprets the input as sats. **Done when:** Android entry, Send Max, validation, and amount presentation honor the selected primary unit without changing the sat amount being paid.

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -44,6 +44,9 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Send — unified destination and payment flow
 
+- [ ] **[P1 · iOS → Android] Reject malformed Lightning invoices at destination entry.** Send uses the central payment decoder without a prefix-only BOLT11 fallback. Valid and amountless BOLT11 invoices and the existing BOLT12 fallback retain their routing. **Verification:** native CDK regression tests added; device execution pending.
+
+
 - [x] **[P1 · iOS → Android] Support fiat-primary amount entry.** iOS converts keypad input according to the saved sats/fiat primary setting; Android’s unified Send amount step always interprets the input as sats. **Done when:** Android entry, Send Max, validation, and amount presentation honor the selected primary unit without changing the sat amount being paid.
 
 - [x] **[P1 · iOS → Android] Honor the preferred unit on payment confirmation.** Android confirmation renders a fixed sat string; iOS keeps the saved primary value and alternate conversion available. **Done when:** Android confirmation leads with the persisted primary unit and makes the alternate value available visually and to accessibility services through a native Android presentation. An identical iOS flip control is not required.


### PR DESCRIPTION
Send now relies on the central payment decoder and removes its prefix-only BOLT11 fallback. Malformed invoices stay at destination entry; valid BOLT11, amountless guidance, and the existing BOLT12 fallback retain their routing.

Validation: All six destination tests pass against the native CDK library on Android, including malformed and truncated invoices. These tests moved from the host JVM to instrumentation because real invoice validation requires the native library. Android unit, lint, and debug build checks pass.

Limitations: Native decoding is covered by instrumentation rather than host JVM stubs.

The relevant parity checklist entry is updated. Visual evidence remains local.

Required GitHub Actions checks passed on this PR head. The existing workflow retry and opt-in test policies apply. Visual evidence remains local.
