### PR TITLE
iOS: verify live and reopened Cashu Request totals

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -98,7 +98,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · Android → iOS] Correlate an open Cashu Request success to a new payment record.** Android watches the request’s received-payment IDs; iOS has a fallback that treats any balance increase while the receive sheet is open as payment for that request. **Done when:** iOS cannot show request success for an unrelated balance increase, with regression coverage for concurrent balance changes.
 
-- [ ] **[P2 · Android → iOS] Show Total received in Cashu Request details.** The total row landed in #344. Regression coverage now checks cumulative mint-unit totals across live payments, duplicate delivery, and reopening from persisted History. Requested amounts and payment counts remain separate. **Verification:** implementation ready; final device review pending.
+- [x] **[P2 · Android → iOS] Show Total received in Cashu Request details.** The total row landed in #344. Regression coverage now checks cumulative mint-unit totals across live payments, duplicate delivery, and reopening from persisted History. Requested amounts and payment counts remain separate. **Verification:** Six payment-observation tests passed, including cumulative totals and reopening. Native sat/USD receipt captures and iOS builds passed.
 
 ### History and transaction details
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -98,7 +98,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · Android → iOS] Correlate an open Cashu Request success to a new payment record.** Android watches the request’s received-payment IDs; iOS has a fallback that treats any balance increase while the receive sheet is open as payment for that request. **Done when:** iOS cannot show request success for an unrelated balance increase, with regression coverage for concurrent balance changes.
 
-- [ ] **[P2 · Android → iOS] Show Total received in Cashu Request details.** Android adds the aggregate after one or more payments; iOS shows only the status count and original request amount. **Done when:** iOS includes a unit-correct aggregate row without confusing it with the requested amount.
+- [ ] **[P2 · Android → iOS] Show Total received in Cashu Request details.** The total row landed in #344. Regression coverage now checks cumulative mint-unit totals across live payments, duplicate delivery, and reopening from persisted History. Requested amounts and payment counts remain separate. **Verification:** implementation ready; final device review pending.
 
 ### History and transaction details
 

--- a/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
+++ b/ios/CashuWalletTests/CashuRequestPaymentObservationTests.swift
@@ -23,6 +23,21 @@ final class CashuRequestPaymentObservationTests: XCTestCase {
         super.tearDown()
     }
 
+    func testCumulativeTotalSurvivesReopeningAndDuplicateDelivery() throws {
+        let request = store.createNew(id: "total-request", unit: "usd", encoded: "creqAtotal")
+        XCTAssertEqual(request.totalReceived, 0)
+        store.attachPayment(requestId: request.id, transactionId: "first", amount: 1234)
+        XCTAssertEqual(store.request(withId: request.id)?.totalReceived, 1234)
+        store.attachPayment(requestId: request.id, transactionId: "second", amount: 66)
+        store.attachPayment(requestId: request.id, transactionId: "second", amount: 66)
+        let reopened = CashuRequestStore(userDefaults: defaults)
+        let saved = try XCTUnwrap(reopened.request(withId: request.id))
+        XCTAssertEqual(saved.totalReceived, 1300)
+        XCTAssertEqual(saved.receivedPayments.count, 2)
+        XCTAssertEqual(saved.unit, "usd")
+        XCTAssertNil(saved.amount, "Received totals must not become the requested amount")
+    }
+
     func testUnrelatedConcurrentBalanceIncreaseDoesNotProduceRequestSuccess() throws {
         let watchedRequest = store.createNew(id: "watched-request", encoded: "creqAwatched")
         _ = store.createNew(id: "unrelated-request", encoded: "creqAunrelated")


### PR DESCRIPTION
The requested Total received row already landed in #344. This independent follow-up adds regression coverage for cumulative totals, duplicate delivery, stored mint units, and reopening requests, and corrects the parity checklist.

Validation: All six Cashu Request payment observation tests pass on iOS 26.5. The iOS app and test bundles build successfully.

Limitations: The production total row was already present in main; this PR adds regression coverage and the checklist correction.

The relevant parity checklist entry is updated. Visual evidence remains local.

Required GitHub Actions checks passed on this PR head. The existing workflow retry and opt-in test policies apply. Visual evidence remains local.
