### PR TITLE
iOS: retry Lightning-address setup

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -142,6 +142,9 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Settings — information architecture, display, and destructive actions
 
+- [ ] **[P1 · Android → iOS] Retry Lightning-address setup from Settings.** “Try setup again” recovers failed wallet initialization and initializes missing NPC keys from the stored seed. Existing identities, wallet data, and preferences are preserved. Loading and errors remain retryable. **Verification:** 13 NPC service tests pass, including recovery success, failure, and existing-identity preservation; device review pending.
+
+
 - [x] **[P2 · iOS → Android] Make App Lock discoverable in a security-oriented Settings location.** Android currently places the toggle under Privacy even though it controls local device access. **Done when:** App Lock is discoverable under a clear security or backup-and-security destination while privacy/background networking controls remain conceptually separate. The exact iOS hierarchy is not required.
 
 - [x] **[P0 · iOS → Android] Authenticate before enabling App Lock.** iOS verifies device-owner authentication and reverts with an error if enabling fails; Android directly persists the toggle. **Done when:** Android cannot enable App Lock until a device-owner challenge succeeds, and cancellation or failure leaves it disabled.

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -142,7 +142,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Settings — information architecture, display, and destructive actions
 
-- [x] **[P1 · Android → iOS] Retry Lightning-address setup from Settings.** “Try setup again” recovers failed wallet initialization and initializes missing NPC keys from the stored seed. Existing identities, wallet data, and preferences are preserved. Loading and errors remain retryable. **Verification:** All 13 NPC service tests and the native setup-state capture passed on iOS 26.5; the app and test bundles build.
+- [x] **[P1 · Android → iOS] Retry Lightning-address setup from Settings.** “Try setup again” recovers failed wallet initialization and initializes missing NPC keys from the stored seed. Startup and retries share the in-flight runtime load, and successful runtime recovery restarts the Cashu Request listener. Existing identities, wallet data, and preferences are preserved. Loading and errors remain retryable. **Verification:** The initial implementation passed all 13 NPC service tests, the native setup-state capture on iOS 26.5, and app/test-bundle builds. The follow-up concurrency and listener fixes received static review; tests were not rerun.
 
 
 - [x] **[P2 · iOS → Android] Make App Lock discoverable in a security-oriented Settings location.** Android currently places the toggle under Privacy even though it controls local device access. **Done when:** App Lock is discoverable under a clear security or backup-and-security destination while privacy/background networking controls remain conceptually separate. The exact iOS hierarchy is not required.

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -142,7 +142,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 ### Settings — information architecture, display, and destructive actions
 
-- [ ] **[P1 · Android → iOS] Retry Lightning-address setup from Settings.** “Try setup again” recovers failed wallet initialization and initializes missing NPC keys from the stored seed. Existing identities, wallet data, and preferences are preserved. Loading and errors remain retryable. **Verification:** 13 NPC service tests pass, including recovery success, failure, and existing-identity preservation; device review pending.
+- [x] **[P1 · Android → iOS] Retry Lightning-address setup from Settings.** “Try setup again” recovers failed wallet initialization and initializes missing NPC keys from the stored seed. Existing identities, wallet data, and preferences are preserved. Loading and errors remain retryable. **Verification:** All 13 NPC service tests and the native setup-state capture passed on iOS 26.5; the app and test bundles build.
 
 
 - [x] **[P2 · iOS → Android] Make App Lock discoverable in a security-oriented Settings location.** Android currently places the toggle under Privacy even though it controls local device access. **Done when:** App Lock is discoverable under a clear security or backup-and-security destination while privacy/background networking controls remain conceptually separate. The exact iOS hierarchy is not required.

--- a/ios/CashuWallet/Core/NPCService.swift
+++ b/ios/CashuWallet/Core/NPCService.swift
@@ -465,3 +465,20 @@ private extension NpubCashQuote {
         state?.caseInsensitiveCompare("PAID") == .orderedSame
     }
 }
+
+/// Retry orchestration with injectable boundaries; identity derivation stays in NPCService.
+@MainActor
+enum LightningAddressSetupRecovery {
+    static func retry(
+        isRuntimeReady: () -> Bool,
+        initializeRuntime: () async -> Void,
+        isAddressInitialized: () -> Bool,
+        loadSeed: () throws -> Data,
+        initializeAddress: (Data) throws -> Void
+    ) async throws {
+        if !isRuntimeReady() { await initializeRuntime() }
+        guard isRuntimeReady() else { throw WalletError.notInitialized }
+        guard !isAddressInitialized() else { return }
+        try initializeAddress(loadSeed())
+    }
+}

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -494,6 +494,22 @@ extension WalletManager {
         await loadWalletState()
     }
 
+    /// Recover only missing Lightning-address prerequisites using the existing wallet.
+    func retryLightningAddressSetup() async throws {
+        try await LightningAddressSetupRecovery.retry(
+            isRuntimeReady: { self.isRuntimeReady },
+            initializeRuntime: { await self.loadWalletState() },
+            isAddressInitialized: { NPCService.shared.isInitialized },
+            loadSeed: {
+                guard let mnemonic = try self.keychainService.loadMnemonic() else {
+                    throw WalletError.notInitialized
+                }
+                return try Self.bip39Seed(mnemonic: mnemonic)
+            },
+            initializeAddress: { try NPCService.shared.initializeWithSeed($0) }
+        )
+    }
+
     private func loadWalletState() async {
         let signpostID = WalletStartupInstrumentation.signposter.makeSignpostID()
         let interval = WalletStartupInstrumentation.signposter.beginInterval(

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -511,6 +511,23 @@ extension WalletManager {
     }
 
     private func loadWalletState() async {
+        // Settings can be opened from the cached home before startup finishes.
+        // Join that load instead of opening a second repository over the same DB.
+        if let walletStateLoadTask {
+            await walletStateLoadTask.value
+            return
+        }
+        guard !isRuntimeReady else { return }
+
+        let task = Task { await self.performWalletStateLoad() }
+        walletStateLoadTask = task
+        // Only the caller that installed this task clears it; joined callers
+        // must not clear a newer retry after a failed attempt completes.
+        defer { walletStateLoadTask = nil }
+        await task.value
+    }
+
+    private func performWalletStateLoad() async {
         let signpostID = WalletStartupInstrumentation.signposter.makeSignpostID()
         let interval = WalletStartupInstrumentation.signposter.beginInterval(
             "WalletInitialize",
@@ -577,6 +594,9 @@ extension WalletManager {
                 }.value
 
                 installLaunchRuntime(runtime, mnemonic: storedMnemonic)
+                // The app's initial listener start may have already returned
+                // without Nostr keys after a failed launch. Recover it here too.
+                resumeCashuRequestListener()
                 startDeferredStartupMaintenance()
                 SentryService.breadcrumb("Wallet loaded", category: "wallet.lifecycle")
             } else {
@@ -845,7 +865,7 @@ extension WalletManager {
 
     private func resumeServicesAfterWalletBoundaryFailure() async {
         guard isRuntimeReady, walletRepository != nil else { return }
-        resumeCashuRequestListenerAfterWalletBoundaryRollback()
+        resumeCashuRequestListener()
         await NWCManager.shared.startIfEnabled()
     }
 
@@ -902,7 +922,7 @@ extension WalletManager {
                 if let recoveredMnemonic {
                     try initializeWalletForLaunch(mnemonic: recoveredMnemonic)
                     startDeferredStartupMaintenance()
-                    resumeCashuRequestListenerAfterWalletBoundaryRollback()
+                    resumeCashuRequestListener()
                 } else {
                     needsOnboarding = true
                     isRuntimeReady = true
@@ -919,7 +939,7 @@ extension WalletManager {
         if !IntegrationTestConfig.shouldUseDeterministicUIRuntime { performICloudBackup() }
     }
 
-    private func resumeCashuRequestListenerAfterWalletBoundaryRollback() {
+    private func resumeCashuRequestListener() {
         guard walletRepository != nil else { return }
         CashuRequestListener.shared.attach(walletManager: self)
         guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+NPC.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+NPC.swift
@@ -28,7 +28,7 @@ extension WalletManager {
 
     /// BIP39 seed (PBKDF2-HMAC-SHA512, 2048 rounds, empty passphrase),
     /// matching cdk's `Mnemonic::to_seed_normalized("")`.
-    private static func bip39Seed(mnemonic: String, passphrase: String = "") throws -> Data {
+    static func bip39Seed(mnemonic: String, passphrase: String = "") throws -> Data {
         let password = Array(mnemonic.decomposedStringWithCompatibilityMapping.utf8)
         let salt = Array(("mnemonic" + passphrase).decomposedStringWithCompatibilityMapping.utf8)
         var seed = [UInt8](repeating: 0, count: 64)

--- a/ios/CashuWallet/Core/Wallet/WalletManager.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager.swift
@@ -140,6 +140,8 @@ class WalletManager: ObservableObject {
     let keychainService = KeychainService()
     var mnemonic: String?
     var hasInitialized = false
+    /// Cold startup and Settings recovery share one database-open attempt.
+    var walletStateLoadTask: Task<Void, Never>?
     /// Per-mint launch reconciliation. The usable wallet state is published
     /// before this task starts, and wallet-boundary resets cancel it.
     var startupMaintenanceTask: Task<Void, Never>?

--- a/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
@@ -128,7 +128,7 @@ struct LightningAddressSettingsSection: View {
             SettingsSectionFooter {
                 InlineNotice(message: error, severity: .error)
             }
-        } else if !npcService.isInitialized {
+        } else if !npcService.isInitialized && retryingSetup {
             SettingsSectionFooter {
                 Text("Setting up Lightning address…")
             }

--- a/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/LightningAddressSettingsSection.swift
@@ -10,6 +10,8 @@ struct LightningAddressSettingsSection: View {
     @Binding var showMintPicker: Bool
 
     @State private var showAddressQR = false
+    @State private var retryingSetup = false
+    @State private var setupError: String?
 
     var body: some View {
         LazyVStack(spacing: 0) {
@@ -51,12 +53,31 @@ struct LightningAddressSettingsSection: View {
                 }
             } else if npcService.isEnabled && !npcService.isInitialized {
                 SettingsSectionGroup(nil) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
-                        Text("Wallet not fully initialized. Please restart the app.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                    VStack(spacing: 12) {
+                        InlineNotice(
+                            message: setupError ?? "Wallet not fully initialized. Try setup again to finish your Lightning address.",
+                            severity: .error
+                        )
+                        Button {
+                            guard !retryingSetup else { return }
+                            retryingSetup = true
+                            setupError = nil
+                            Task { @MainActor in
+                                defer { retryingSetup = false }
+                                do {
+                                    try await walletManager.retryLightningAddressSetup()
+                                } catch {
+                                    setupError = "Lightning address setup couldn't finish. Try again or restart the app."
+                                }
+                            }
+                        } label: {
+                            HStack {
+                                if retryingSetup { ProgressView() }
+                                Text("Try setup again")
+                            }
+                        }
+                        .glassButton(prominent: true)
+                        .disabled(retryingSetup)
                     }
                     .padding(.horizontal, 4)
                     .padding(.vertical, 14)

--- a/ios/CashuWalletTests/NPCServiceTests.swift
+++ b/ios/CashuWalletTests/NPCServiceTests.swift
@@ -4,6 +4,39 @@ import Cdk
 
 @MainActor
 final class NPCServiceTests: XCTestCase {
+    func testSetupRetryRecoversRuntimeAndUsesStoredSeed() async throws {
+        var ready = false
+        var initializedSeed: Data?
+        let seed = Data(repeating: 7, count: 64)
+        try await LightningAddressSetupRecovery.retry(
+            isRuntimeReady: { ready }, initializeRuntime: { ready = true },
+            isAddressInitialized: { false }, loadSeed: { seed },
+            initializeAddress: { initializedSeed = $0 }
+        )
+        XCTAssertEqual(initializedSeed, seed)
+    }
+
+    func testSetupRetryDoesNotReplaceAnExistingIdentity() async throws {
+        try await LightningAddressSetupRecovery.retry(
+            isRuntimeReady: { true }, initializeRuntime: { XCTFail("Must not reopen a healthy wallet") },
+            isAddressInitialized: { true }, loadSeed: { XCTFail("Must not reload keys"); return Data() },
+            initializeAddress: { _ in XCTFail("Must not replace identity") }
+        )
+    }
+
+    func testSetupRetryStopsWhenRuntimeOrSeedRecoveryFails() async {
+        for runtimeReady in [false, true] {
+            do {
+                try await LightningAddressSetupRecovery.retry(
+                    isRuntimeReady: { runtimeReady }, initializeRuntime: {},
+                    isAddressInitialized: { false }, loadSeed: { throw WalletError.notInitialized },
+                    initializeAddress: { _ in XCTFail("Must not initialize without prerequisites") }
+                )
+                XCTFail("Expected recovery failure")
+            } catch { }
+        }
+    }
+
     func testRestoredEnabledAddressConnectsWhenSeedBecomesAvailable() async throws {
         let client = ControlledNPCClient()
         let service = makeService(client: client)


### PR DESCRIPTION
Settings offers “Try setup again” with progress and retryable error feedback. WalletManager retries failed runtime initialization when needed and initializes missing NPC keys from the stored seed, preserving existing identities, wallet data, and preferences.

Cold startup and Settings retries share one in-flight runtime load, preventing overlapping database opens and stale startup results from disabling a recovered wallet. Successful runtime loading also reattaches and starts the Cashu Request listener, so incoming request payments resume without waiting for the app to return to the foreground.

Validation for the latest revision:
- Swift syntax parsing passed for both changed Swift files.
- Whitespace checks and static review passed.
- Tests were not run, and CI was skipped for this update, as requested.

The parity checklist documents the recovery behavior and distinguishes the initial implementation's verification from this follow-up. Live relay connectivity and hardware-backed storage were not exercised.
