### PR TITLE
iOS: show localized currency names

### DIFF
--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -152,7 +152,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · Android → iOS] Read the app version from build metadata.** Android uses `BuildConfig.VERSION_NAME`; iOS hard-codes `1.0.0`. **Done when:** iOS displays the shipped bundle version and, if included, its build number from metadata.
 
-- [ ] **[P2 · Android → iOS] Add localized currency names.** iOS currency rows show the localized name beneath the ISO code and include both in the accessibility label, falling back to the code. Names wrap at large text sizes; ordering, selection, and avatars remain native. **Verification:** implementation ready; final device review pending.
+- [x] **[P2 · Android → iOS] Add localized currency names.** iOS currency rows show the localized name beneath the ISO code and include both in the accessibility label, falling back to the code. Names wrap at large text sizes; ordering, selection, and avatars remain native. **Verification:** Native English/German accessibility-size tests and iOS builds passed; localized names were visually reviewed.
 
 - [x] **[P2 · iOS → Android] Show when the BTC price was last updated.** iOS includes a relative timestamp beside the price; Android omits it. **Done when:** Android exposes recency and handles never-loaded and stale states.
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -152,7 +152,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [x] **[P1 · Android → iOS] Read the app version from build metadata.** Android uses `BuildConfig.VERSION_NAME`; iOS hard-codes `1.0.0`. **Done when:** iOS displays the shipped bundle version and, if included, its build number from metadata.
 
-- [ ] **[P2 · Android → iOS] Add localized currency names.** Android shows the ISO code plus the localized currency name; iOS shows only the code. **Done when:** iOS rows are understandable without memorizing ISO-4217 codes.
+- [ ] **[P2 · Android → iOS] Add localized currency names.** iOS currency rows show the localized name beneath the ISO code and include both in the accessibility label, falling back to the code. Names wrap at large text sizes; ordering, selection, and avatars remain native. **Verification:** implementation ready; final device review pending.
 
 - [x] **[P2 · iOS → Android] Show when the BTC price was last updated.** iOS includes a relative timestamp beside the price; Android omits it. **Done when:** Android exposes recency and handles never-loaded and stale states.
 

--- a/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
@@ -106,8 +106,16 @@ struct CurrencyPickerSheet: View {
                     Button { select(code) } label: {
                         HStack(spacing: 12) {
                             CurrencyAvatar(glyph: .flag(CurrencyFlag.emoji(for: code)))
-                            Text(code)
-                                .font(.body.weight(.medium))
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(code)
+                                    .font(.body.weight(.medium))
+                                if let name = Locale.current.localizedString(forCurrencyCode: code), name != code {
+                                    Text(name)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
                             Spacer()
                             if isSelected(code) {
                                 Image(systemName: "checkmark")
@@ -118,7 +126,7 @@ struct CurrencyPickerSheet: View {
                     }
                     .listRowSeparator(.hidden)
                     .buttonStyle(.plain)
-                    .accessibilityLabel(code)
+                    .accessibilityLabel(currencyAccessibilityLabel(code))
                     .accessibilityAddTraits(isSelected(code) ? [.isSelected] : [])
                 }
             }
@@ -179,6 +187,11 @@ struct CurrencyPickerSheet: View {
     }
 
     // MARK: - Selection
+
+    private func currencyAccessibilityLabel(_ code: String) -> String {
+        guard let name = Locale.current.localizedString(forCurrencyCode: code), name != code else { return code }
+        return "\(code), \(name)"
+    }
 
     private func isSelected(_ code: String) -> Bool {
         settings.showFiatBalance && settings.bitcoinPriceCurrency == code

--- a/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
+++ b/ios/CashuWallet/Views/Settings/ThemeSettingsSection.swift
@@ -109,7 +109,7 @@ struct CurrencyPickerSheet: View {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(code)
                                     .font(.body.weight(.medium))
-                                if let name = Locale.current.localizedString(forCurrencyCode: code), name != code {
+                                if let name = currencyNameLocale.localizedString(forCurrencyCode: code), name != code {
                                     Text(name)
                                         .font(.subheadline)
                                         .foregroundStyle(.secondary)
@@ -188,8 +188,14 @@ struct CurrencyPickerSheet: View {
 
     // MARK: - Selection
 
+    // Currency names follow the user's language even before the app's other
+    // strings have a translation in that language.
+    private var currencyNameLocale: Locale {
+        Locale(identifier: Locale.preferredLanguages.first ?? Locale.current.identifier)
+    }
+
     private func currencyAccessibilityLabel(_ code: String) -> String {
-        guard let name = Locale.current.localizedString(forCurrencyCode: code), name != code else { return code }
+        guard let name = currencyNameLocale.localizedString(forCurrencyCode: code), name != code else { return code }
         return "\(code), \(name)"
     }
 

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -17,7 +17,7 @@ final class SettingsUITests: UITestBase {
     func testCurrencyNamesRemainAccessibleAtLargeTextSizes() {
         for (language, locale) in [("en", "en_US"), ("de", "de_DE")] {
             app.terminate()
-            app.launchArguments += ["-AppleLanguages", "(\(language))", "-AppleLocale", locale,
+            app.launchArguments = ["-AppleLanguages", "(\(language))", "-AppleLocale", locale,
                                     "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityL"]
             app.launch()
             navigateToSettings()

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -14,6 +14,27 @@ final class SettingsUITests: UITestBase {
 
     // MARK: - Tests
 
+    func testCurrencyNamesRemainAccessibleAtLargeTextSizes() {
+        for (language, locale) in [("en", "en_US"), ("de", "de_DE")] {
+            app.terminate()
+            app.launchArguments += ["-AppleLanguages", "(\(language))", "-AppleLocale", locale,
+                                    "-UIPreferredContentSizeCategoryName", "UICTContentSizeCategoryAccessibilityL"]
+            app.launch()
+            navigateToSettings()
+            tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch)
+            let name = Locale(identifier: locale).localizedString(forCurrencyCode: "USD") ?? "USD"
+            let row = app.buttons["USD, \(name)"]
+            XCTAssertTrue(row.waitForExistence(timeout: 5))
+            XCTAssertTrue(row.isHittable)
+            let attachment = XCTAttachment(screenshot: app.screenshot())
+            attachment.name = "currency-names-\(locale)-large-text"
+            attachment.lifetime = .keepAlways
+            add(attachment)
+            tapWhenReady(row)
+            XCTAssertTrue(screen("settings-screen").waitForExistence(timeout: 5))
+        }
+    }
+
     func testSettingsRoundTrip() throws {
         navigateToSettings()
 


### PR DESCRIPTION
Currency rows now show the localized name beneath each ISO code and announce both. Names follow the preferred language, wrap at large text sizes, and fall back to the code. Selection, ordering, and native avatars remain unchanged.

Validation: A native UI test passes for English and German at accessibility text sizes and verifies that the currency remains selectable. The iOS app and test bundles build successfully.

Limitations: Accessibility validation checks the native row labels and selection; no spoken VoiceOver session was recorded.

The relevant parity checklist entry is updated. Visual evidence remains local.

Required GitHub Actions checks passed on this PR head. The existing workflow retry and opt-in test policies apply. Visual evidence remains local.
