### PR TITLE
Android: animate restore progress

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/restore/RestoreProgressMotionTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/restore/RestoreProgressMotionTest.kt
@@ -1,0 +1,48 @@
+package com.cashu.me.ui.restore
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.ui.setCashuContent
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RestoreProgressMotionTest {
+    private val duration = object : MotionDurationScale { override val scaleFactor = 1f }
+    @get:Rule val compose = createComposeRule(effectContext = duration)
+
+    @Test fun interruptedPhaseTransitionSettlesOnLatestValue() {
+        val phase = mutableStateOf("Restoring")
+        compose.setCashuContent {
+            RestoreProgressTransition(phase.value, reducedMotion = false) { Text(it) }
+        }
+        compose.mainClock.autoAdvance = false
+        compose.runOnIdle { phase.value = "Retry" }
+        compose.mainClock.advanceTimeBy(32)
+        compose.runOnIdle { phase.value = "21 sats" }
+        compose.mainClock.advanceTimeBy(2000)
+        compose.onNodeWithText("21 sats").assertIsDisplayed()
+        compose.onNodeWithText("Retry").assertDoesNotExist()
+        compose.onNodeWithText("Restoring").assertDoesNotExist()
+    }
+
+    @Test fun reducedMotionReplacesValueWithoutOutgoingContent() {
+        val total = mutableStateOf(21L)
+        compose.setCashuContent {
+            RestoreProgressTransition(total.value, direction = { _, _ -> 1 }, reducedMotion = true) {
+                Text("Recovered: $it sats")
+            }
+        }
+        compose.mainClock.autoAdvance = false
+        compose.runOnIdle { total.value = 55L }
+        compose.mainClock.advanceTimeByFrame()
+        compose.onNodeWithText("Recovered: 55 sats").assertIsDisplayed()
+        compose.onNodeWithText("Recovered: 21 sats").assertDoesNotExist()
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/restore/RestoreProgressTransition.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/restore/RestoreProgressTransition.kt
@@ -1,0 +1,54 @@
+package com.cashu.me.ui.restore
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import com.cashu.me.ui.theme.rememberReducedMotion
+
+/** Shared by onboarding and Settings restore, with no delayed or queued values. */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun <T> RestoreProgressTransition(
+    value: T,
+    direction: (T, T) -> Int = { _, _ -> 0 },
+    reducedMotion: Boolean = rememberReducedMotion(),
+    content: @Composable (T) -> Unit,
+) {
+    if (reducedMotion || LocalInspectionMode.current) {
+        content(value)
+        return
+    }
+    val enter = MaterialTheme.motionScheme.defaultEffectsSpec<Float>()
+    val exit = MaterialTheme.motionScheme.fastEffectsSpec<Float>()
+    val spatial = MaterialTheme.motionScheme.defaultSpatialSpec<Float>()
+    val slide = MaterialTheme.motionScheme.defaultSpatialSpec<IntOffset>()
+    val size = MaterialTheme.motionScheme.defaultSpatialSpec<IntSize>()
+    AnimatedContent(
+        targetState = value,
+        contentAlignment = Alignment.CenterEnd,
+        transitionSpec = {
+            val roll = direction(initialState, targetState)
+            val transition = if (roll != 0) {
+                (fadeIn(enter) + slideInVertically(slide) { roll * it / 3 })
+                    .togetherWith(fadeOut(exit) + slideOutVertically(slide) { -roll * it / 3 })
+            } else {
+                (fadeIn(enter) + scaleIn(spatial, initialScale = 0.92f))
+                    .togetherWith(fadeOut(exit))
+            }
+            transition.using(SizeTransform(clip = false) { _, _ -> size })
+        },
+        label = "restore-progress",
+    ) { current -> content(current) }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
@@ -1092,13 +1092,15 @@ fun RestoreRecoveredTotal(
             tint = CashuTheme.colors.onReceivedContainer,
             modifier = Modifier.size(18.dp),
         )
-        Text(
-            text = "Recovered: $totalRecovered sats",
-            style = MaterialTheme.typography.bodyMedium
-                .copy(fontWeight = FontWeight.SemiBold)
-                .withMonoDigits(),
-            color = CashuTheme.colors.onReceivedContainer,
-        )
+        RestoreProgressTransition(value = totalRecovered, direction = { from, to -> if (to >= from) 1 else -1 }) { total ->
+            Text(
+                text = "Recovered: $total sats",
+                style = MaterialTheme.typography.bodyMedium
+                    .copy(fontWeight = FontWeight.SemiBold)
+                    .withMonoDigits(),
+                color = CashuTheme.colors.onReceivedContainer,
+            )
+        }
         if (centered) {
             Spacer(Modifier.weight(1f))
         }
@@ -1293,55 +1295,57 @@ private fun RestoreProgressRow(
             }
         }
 
-        when (phase) {
-            RestoreMintPhase.Pending, RestoreMintPhase.Restoring -> {
-                // Expressive loader per DESIGN-ANDROID.md §1 — the classic
-                // circular spinner is reserved for nothing.
-                LoadingIndicator(
-                    modifier = Modifier.size(ProgressSpinnerSize),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-            is RestoreMintPhase.Recovered -> {
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        imageVector = if (phase.result.totalRecovered > 0) {
-                            Icons.Filled.CheckCircle
-                        } else {
-                            Icons.Filled.RemoveCircleOutline
-                        },
-                        contentDescription = null,
-                        tint = if (phase.result.totalRecovered > 0) {
-                            CashuTheme.colors.onReceivedContainer
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Text(
-                        text = "${phase.result.unspent} sats",
-                        style = MaterialTheme.typography.bodyMedium
-                            .copy(
-                                fontWeight = if (phase.result.unspent > 0) {
-                                    FontWeight.SemiBold
-                                } else {
-                                    FontWeight.Normal
-                                },
-                            )
-                            .withMonoDigits(),
-                        color = if (phase.result.unspent > 0) {
-                            MaterialTheme.colorScheme.onSurface
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
+        RestoreProgressTransition(value = phase) { displayPhase ->
+            when (displayPhase) {
+                RestoreMintPhase.Pending, RestoreMintPhase.Restoring -> {
+                    // Expressive loader per DESIGN-ANDROID.md §1 — the classic
+                    // circular spinner is reserved for nothing.
+                    LoadingIndicator(
+                        modifier = Modifier.size(ProgressSpinnerSize),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-            }
-            is RestoreMintPhase.Failed -> {
-                GhostButton(context = TextButtonContext.Compact, text = "Retry", onClick = onRetry)
+                is RestoreMintPhase.Recovered -> {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(CashuTheme.spacing.micro),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = if (displayPhase.result.totalRecovered > 0) {
+                                Icons.Filled.CheckCircle
+                            } else {
+                                Icons.Filled.RemoveCircleOutline
+                            },
+                            contentDescription = null,
+                            tint = if (displayPhase.result.totalRecovered > 0) {
+                                CashuTheme.colors.onReceivedContainer
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                            modifier = Modifier.size(18.dp),
+                        )
+                        Text(
+                            text = "${displayPhase.result.unspent} sats",
+                            style = MaterialTheme.typography.bodyMedium
+                                .copy(
+                                    fontWeight = if (displayPhase.result.unspent > 0) {
+                                        FontWeight.SemiBold
+                                    } else {
+                                        FontWeight.Normal
+                                    },
+                                )
+                                .withMonoDigits(),
+                            color = if (displayPhase.result.unspent > 0) {
+                                MaterialTheme.colorScheme.onSurface
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                    }
+                }
+                is RestoreMintPhase.Failed -> {
+                    GhostButton(context = TextButtonContext.Compact, text = "Retry", onClick = onRetry)
+                }
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/restore/RestoreWalletFlow.kt
@@ -1054,6 +1054,9 @@ class RestoreProgressState internal constructor(
     }
 
     fun retry(url: String) {
+        if (phases[url] !is RestoreMintPhase.Failed) return
+        // Claim the retry before launching so repeated taps cannot queue another restore.
+        phases[url] = RestoreMintPhase.Restoring
         scope.launch { restoreMint(url) }
     }
 }
@@ -1344,7 +1347,13 @@ private fun RestoreProgressRow(
                     }
                 }
                 is RestoreMintPhase.Failed -> {
-                    GhostButton(context = TextButtonContext.Compact, text = "Retry", onClick = onRetry)
+                    GhostButton(
+                        context = TextButtonContext.Compact,
+                        text = "Retry",
+                        onClick = onRetry,
+                        // The outgoing button can outlive the failure during its exit animation.
+                        enabled = phase is RestoreMintPhase.Failed,
+                    )
                 }
             }
         }

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -275,7 +275,7 @@ These are important, but they belong in dedicated security/privacy, design-syste
 - [ ] **[P2 · Design system] Retire the hand-rolled inline errors.** Highest priority: `SendView.swift:294` (`sendInputNotice`, a clone of the shared component that drops the VoiceOver severity prefix), the two scanner overlays, and `SendEcashScreen.kt:957` (bare red text under an already-`isError` field). **Done when:** no screen renders raw error-coloured text, which is the contract `InlineNotice`'s own KDoc already claims.
 
 
-- [ ] **[P2 · iOS → Android] Animate restore progress in shared restore components.** Material motion animates per-mint state changes and the recovered total, preserves trailing alignment, and can be interrupted. Reduced motion replaces values immediately. **Verification:** Compose regressions added for interruption and reduced motion; device review pending.
+- [x] **[P2 · iOS → Android] Animate restore progress in shared restore components.** Material motion animates per-mint state changes and the recovered total, preserves trailing alignment, and can be interrupted. Reduced motion replaces values immediately. **Verification:** Native interruption and reduced-motion regressions, Android unit/lint/build checks, and local transition-recording review passed.
 
 ## Completed and verified in the baseline
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -274,6 +274,9 @@ These are important, but they belong in dedicated security/privacy, design-syste
 
 - [ ] **[P2 · Design system] Retire the hand-rolled inline errors.** Highest priority: `SendView.swift:294` (`sendInputNotice`, a clone of the shared component that drops the VoiceOver severity prefix), the two scanner overlays, and `SendEcashScreen.kt:957` (bare red text under an already-`isError` field). **Done when:** no screen renders raw error-coloured text, which is the contract `InlineNotice`'s own KDoc already claims.
 
+
+- [ ] **[P2 · iOS → Android] Animate restore progress in shared restore components.** Material motion animates per-mint state changes and the recovered total, preserves trailing alignment, and can be interrupted. Reduced motion replaces values immediately. **Verification:** Compose regressions added for interruption and reduced motion; device review pending.
+
 ## Completed and verified in the baseline
 
 - [x] **[P1 · iOS → Android] Surface wallet startup failures on onboarding.** Android presents initialization failures with user-facing recovery.


### PR DESCRIPTION
Shared Android restore components now animate per-mint status and recovered totals using the existing Material motion specifications. Transitions preserve trailing alignment and can be interrupted; reduced motion replaces values immediately. Both onboarding and Settings use these components.

Retry becomes disabled as soon as the mint leaves the failed phase, including while the outgoing button fades away. The state holder marks the mint as restoring before launching its coroutine and ignores retries outside the failed phase, preventing repeated taps from queuing duplicate restores.

Validation: The original animation commits passed native Compose regressions for interrupted transitions and reduced-motion replacement, Android unit/lint/debug-build checks, and the required GitHub Actions checks. Local recordings were reviewed using synthetic state in the shared restore components. The retry follow-up received static code review and passed `git diff --check`; tests and builds were not rerun for this fix, as requested.

Limitations: The recording drives synthetic state through the shared components; it does not perform a live mint restore. The relevant parity checklist entry is updated. Visual evidence remains local. The existing workflow retry and opt-in test policies apply.
