### PR TITLE
Explain Cashu Request removal on iOS and Android

### DIFF
--- a/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/history/HistoryScreen.kt
@@ -365,7 +365,7 @@ fun HistoryScreen(
     requestPendingDelete?.let { req ->
         ActionConfirmationSheet(
             title = "Remove from history?",
-            message = "Only this request is removed from history. Payments already received stay in your wallet, and the request can still receive payments.",
+            message = "Only this request is removed from history. Payments already received stay in your wallet. The QR code and any pending payment routing remain valid, so the request can still receive payments.",
             actionLabel = "Remove",
             destructive = true,
             onConfirm = {

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -106,7 +106,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
 
-- [ ] **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** iOS says the QR and pending payment routing remain valid; Android only says received payments stay in the wallet. **Done when:** Android states before deletion that previously received funds remain, the QR and payment routing remain valid, and only the History row is removed.
+- [ ] **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** Android confirmation states that received funds stay in the wallet, the QR and pending payment routing remain valid, and only the History entry is removed. Removal behavior is unchanged. **Verification:** implementation ready; final device review pending.
 
 - [ ] **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** Android already supports declining a held Cashu Request payment, but it has no equivalent removal for a normal unclaimed token. **Done when:** Android provides a discoverable removal action for ordinary parked tokens and warns that the ecash will be discarded and only the sender can reissue it.
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -106,7 +106,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
 
-- [ ] **[P1 · iOS → Android] Explain all consequences of removing a Cashu Request row.** Android confirmation states that received funds stay in the wallet, the QR and pending payment routing remain valid, and only the History entry is removed. Removal behavior is unchanged. **Verification:** implementation ready; final device review pending.
+- [ ] **[P1 · Converge] Explain all consequences of removing a Cashu Request row.** Both native confirmations state that received funds stay in the wallet, the QR and pending payment routing remain valid, and only the History entry is removed. Removal behavior is unchanged. **Verification:** implementation ready; final device review pending.
 
 - [ ] **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** Android already supports declining a held Cashu Request payment, but it has no equivalent removal for a normal unclaimed token. **Done when:** Android provides a discoverable removal action for ordinary parked tokens and warns that the ecash will be discarded and only the sender can reissue it.
 

--- a/docs/product/ios-android-parity-checklist.md
+++ b/docs/product/ios-android-parity-checklist.md
@@ -106,7 +106,7 @@ Platform-specific capabilities remain intentionally outside parity, including iC
 
 - [ ] **[P2 · iOS → Android] Search a Cashu Request’s Total received amount.** iOS includes the aggregate received value in search; Android only searches the requested amount. **Done when:** Android matches both configured and received totals using the same normalized amount formats as other History search.
 
-- [ ] **[P1 · Converge] Explain all consequences of removing a Cashu Request row.** Both native confirmations state that received funds stay in the wallet, the QR and pending payment routing remain valid, and only the History entry is removed. Removal behavior is unchanged. **Verification:** implementation ready; final device review pending.
+- [x] **[P1 · Converge] Explain all consequences of removing a Cashu Request row.** Both native confirmations state that received funds stay in the wallet, the QR and pending payment routing remain valid, and only the History entry is removed. Removal behavior is unchanged. **Verification:** Android unit/lint/build checks and native confirmation captures passed. The matching iOS build and native removal-sheet capture passed on iOS 26.5.
 
 - [ ] **[P1 · iOS → Android] Add removal for an ordinary parked incoming token.** Android already supports declining a held Cashu Request payment, but it has no equivalent removal for a normal unclaimed token. **Done when:** Android provides a discoverable removal action for ordinary parked tokens and warns that the ecash will be discarded and only the sender can reissue it.
 

--- a/ios/CashuWallet/Views/History/HistoryView.swift
+++ b/ios/CashuWallet/Views/History/HistoryView.swift
@@ -161,7 +161,7 @@ struct HistoryView: View {
             .backdropSheet(item: $requestPendingDeletion) { request in
                 ActionConfirmationSheet(
                     title: "Remove from history?",
-                    message: "Only this request is removed from history. Payments already received stay in your wallet, and the request can still receive payments.",
+                    message: "Only this request is removed from history. Payments already received stay in your wallet. The QR code and any pending payment routing remain valid, so the request can still receive payments.",
                     actionLabel: "Remove",
                     destructive: true
                 ) {


### PR DESCRIPTION
Both native removal confirmations now state that received funds remain, the QR and pending payment routing stay valid, and only the History entry is removed. Current main had shortened the warning on both platforms. The removal operations are unchanged.

Validation: Android unit, lint, and debug build checks pass. The iOS app and test bundles build, and the native removal-sheet UI test passes on iOS 26.5. Matched native confirmation captures were reviewed on both platforms.

The relevant parity checklist entry is updated. Visual evidence remains local.

Required GitHub Actions checks passed on this PR head. The existing workflow retry and opt-in test policies apply. Visual evidence remains local.
