### PR TITLE
Recover interrupted receipts from untracked mints

### DIFF
--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -170,6 +170,8 @@ jobs:
       run: |
         chmod +x CI/start-nutshell.sh CI/start-cdk.sh
         ./CI/start-nutshell.sh 3338
+        python3 CI/receipt-recovery-proxy.py > "$RUNNER_TEMP/receipt-proxy.log" 2>&1 &
+        echo $! > "$RUNNER_TEMP/receipt-proxy.pid"
         ./CI/start-cdk.sh
 
     - name: Run required Android UI suite
@@ -185,6 +187,7 @@ jobs:
           -Pandroid.testInstrumentationRunnerArguments.cashu.liveUiLocalMintEnabled=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nativeWalletLocalMintIntegration=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338 \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.receiptRecoveryMintUrl=http://10.0.2.2:3340 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.cdkMintUrl=http://10.0.2.2:3339
 
     - name: Run full Android UI and native suite
@@ -199,6 +202,7 @@ jobs:
           -Pandroid.testInstrumentationRunnerArguments.cashu.liveUiLocalMintEnabled=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nativeWalletLocalMintIntegration=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338 \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.receiptRecoveryMintUrl=http://10.0.2.2:3340 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.cdkMintUrl=http://10.0.2.2:3339
 
     - name: Stop local test mints
@@ -206,6 +210,7 @@ jobs:
       working-directory: .
       run: |
         chmod +x CI/stop-nutshell.sh CI/stop-cdk.sh
+        if [ -f "$RUNNER_TEMP/receipt-proxy.pid" ]; then kill "$(cat "$RUNNER_TEMP/receipt-proxy.pid")" || true; fi
         ./CI/stop-nutshell.sh
         ./CI/stop-cdk.sh
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -114,6 +114,8 @@ jobs:
         ./CI/start-cdk.sh &
         CDK_START_PID=$!
 
+        python3 CI/receipt-recovery-proxy.py > "$RUNNER_TEMP/receipt-proxy.log" 2>&1 &
+        echo $! > "$RUNNER_TEMP/receipt-proxy.pid"
         STATUS=0
         wait "$NUTSHELL_START_PID" || STATUS=$?
         wait "$CDK_START_PID" || STATUS=$?
@@ -169,6 +171,7 @@ jobs:
       if: always()
       run: |
         chmod +x CI/stop-nutshell.sh CI/stop-cdk.sh
+        if [ -f "$RUNNER_TEMP/receipt-proxy.pid" ]; then kill "$(cat "$RUNNER_TEMP/receipt-proxy.pid")" || true; fi
         ./CI/stop-nutshell.sh &
         NUTSHELL_STOP_PID=$!
         ./CI/stop-cdk.sh &

--- a/CI/README.md
+++ b/CI/README.md
@@ -269,3 +269,16 @@ This isn't just "does the app work" — this tests **CDK-Swift ↔ real Cashu mi
 - ✅ Multi-mint management
 
 **This catches real integration bugs** that unit tests can't find!
+
+### Interrupted receipt recovery
+
+`python3 CI/receipt-recovery-proxy.py` starts a loopback-only proxy on port 3340
+in front of the Nutshell test mint on port 3338. The iOS `ReceiveRecoveryTests`
+and Android `ReceiptRecoveryInstrumentedTest` exercise a completed receipt before
+app tracking, an accepted swap whose response is interrupted, an offline database
+reopen, and repeated CDK reconciliation. They never redeem the original token a
+second time. Run these tests serially because they share the proxy's fault state.
+The native CI jobs start and stop the proxy automatically. Android uses
+`cashu.nativeWalletLocalMintIntegration=true` and
+`cashu.receiptRecoveryMintUrl=http://10.0.2.2:3340` on hosted emulators; use an ADB
+reverse mapping and the emulator loopback address for a local run.

--- a/CI/receipt-recovery-proxy.py
+++ b/CI/receipt-recovery-proxy.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Loopback-only fault proxy for interrupted receipt integration tests.
+
+Run after start-nutshell.sh: python3 CI/receipt-recovery-proxy.py
+POST /__receipt_test/interrupt-next-swap forwards the next swap, discards
+its successful response, then keeps the client offline until POST reset.
+POST /__receipt_test/offline blocks requests before they reach the mint.
+"""
+import argparse
+import http.client
+import http.server
+import threading
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("--port", type=int, default=3340)
+parser.add_argument("--mint-port", type=int, default=3338)
+args = parser.parse_args()
+lock = threading.Lock()
+state = {"armed": False, "offline": False}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass  # Tokens and payment payloads must never appear in proxy logs.
+
+    def respond(self, code, body=b"{}", content_type="application/json"):
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self):
+        self.handle_request()
+
+    def do_GET(self):
+        self.handle_request()
+
+    def handle_request(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        if self.command == "POST" and self.path.startswith("/__receipt_test/"):
+            action = self.path.rsplit("/", 1)[-1]
+            with lock:
+                if action == "reset":
+                    state.update(armed=False, offline=False)
+                elif action == "interrupt-next-swap":
+                    state.update(armed=True, offline=False)
+                elif action == "offline":
+                    state.update(armed=False, offline=True)
+                else:
+                    return self.respond(404)
+            return self.respond(200)
+        with lock:
+            if state["offline"]:
+                return self.respond(503)
+            interrupt = state["armed"] and self.path == "/v1/swap" and self.command == "POST"
+            if interrupt:
+                state["armed"] = False
+        connection = http.client.HTTPConnection("127.0.0.1", args.mint_port, timeout=20)
+        try:
+            connection.request(self.command, self.path, body, {"Content-Type": "application/json"})
+            response = connection.getresponse()
+            result = response.read()
+            if interrupt and 200 <= response.status < 300:
+                with lock:
+                    state["offline"] = True
+                return self.respond(503)
+            self.respond(response.status, result, response.getheader("Content-Type", "application/json"))
+        except OSError:
+            self.respond(503)
+        finally:
+            connection.close()
+
+
+http.server.ThreadingHTTPServer(("127.0.0.1", args.port), Handler).serve_forever()

--- a/android/app/src/androidTest/java/com/cashu/me/Core/ReceivedAccountReconciliationTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/ReceivedAccountReconciliationTest.kt
@@ -2,7 +2,9 @@ package com.cashu.me.Core
 
 import com.cashu.me.Core.CDK.ReceiveRecoveryCandidate
 import com.cashu.me.Models.PendingReceiveToken
+import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FakeWalletGateway
 import com.cashu.me.test.fixtures.FixtureMode
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
@@ -11,6 +13,100 @@ import org.junit.Assert.*
 import org.junit.Test
 
 class ReceivedAccountReconciliationTest {
+    @Test fun removalSkipsRetainedProofsUntilTheMintIsAddedAgain() {
+        AppTestFixture.launch(FixtureMode.SeededWithMint).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            val mint = store.loadMints().single()
+            fake.receiveCandidates = listOf(ReceiveRecoveryCandidate(mint.url, "sat"))
+            runBlocking {
+                manager.removeMint(mint)
+                manager.reconcileReceivedAccounts()
+                manager.reconcileReceivedAccounts()
+                assertTrue(store.isMintRemoved(mint.url))
+                assertTrue(store.loadMints().isEmpty())
+                assertEquals(0, fake.receiveRecoveryCalls)
+
+                manager.addMint(mint.url)
+                manager.reconcileReceivedAccounts()
+                assertFalse(store.isMintRemoved(mint.url))
+                assertEquals(listOf(mint.url), store.loadMints().map { it.url })
+                assertEquals(1, fake.receiveRecoveryCalls)
+            }
+        }
+    }
+
+    @Test fun failedNativeRemovalDoesNotExcludeTheMint() {
+        AppTestFixture.launch(FixtureMode.SeededWithMint).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            val mint = store.loadMints().single()
+            runBlocking {
+                fake.ensureWallet(mint.url, "usd")
+                assertTrue(runCatching { manager.removeMint(mint) }.isFailure)
+            }
+            assertFalse(store.isMintRemoved(mint.url))
+            assertEquals(listOf(mint.url), store.loadMints().map { it.url })
+        }
+    }
+
+    @Test fun approvedReceiveAllowsRecoveryAfterALostResponseFromARemovedMint() {
+        AppTestFixture.launch(FixtureMode.SeededWithMint).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            runBlocking {
+                manager.removeMint(store.loadMints().single())
+                fake.receiveCandidates = listOf(ReceiveRecoveryCandidate(FakeWalletGateway.TestMintUrl, "sat"))
+                fake.nextFailure = IllegalStateException("Swap response lost")
+                assertTrue(runCatching { manager.receiveTokens(FakeWalletGateway.DeterministicToken) }.isFailure)
+            }
+            assertFalse(store.isMintRemoved(FakeWalletGateway.TestMintUrl))
+            assertEquals(listOf(FakeWalletGateway.TestMintUrl), store.loadMints().map { it.url })
+            assertEquals(1, fake.receiveRecoveryCalls)
+        }
+    }
+
+    @Test fun successfulReceiveEnrichesTheDurablePlaceholderWithoutLosingCurrencies() {
+        val methods = listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Bolt12, PaymentMethodKind.Onchain)
+        AppTestFixture.launch(FixtureMode.SeededWithoutMint, supportedMintMethods = methods).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            fake.receiveCandidates = listOf(ReceiveRecoveryCandidate(FakeWalletGateway.TestMintUrl, "usd"))
+            runBlocking { manager.reconcileReceivedAccounts() }
+            fake.onMetadataFetch = {
+                val placeholder = store.loadMints().single()
+                assertEquals("Unknown Mint", placeholder.name)
+                assertEquals(setOf("sat", "usd"), placeholder.units.toSet())
+            }
+            val amount = runBlocking { manager.receiveTokens(FakeWalletGateway.DeterministicToken) }
+            val enriched = store.loadMints().single()
+            assertEquals(25L, amount)
+            assertEquals("Nutshell UI Test Mint", enriched.name)
+            assertEquals(methods, enriched.supportedMintMethods)
+            assertEquals(setOf("sat", "usd"), enriched.units.toSet())
+            assertEquals(25L, manager.state.value.balance)
+            assertEquals(enriched, manager.state.value.activeMint)
+        }
+    }
+
+    @Test fun metadataFailureKeepsASuccessfulReceiveAndItsPlaceholder() {
+        AppTestFixture.launch(FixtureMode.SeededWithoutMint).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            fake.metadataFailure = IllegalStateException("Metadata offline")
+            val amount = runBlocking { manager.receiveTokens(FakeWalletGateway.DeterministicToken) }
+            assertEquals(25L, amount)
+            assertEquals("Unknown Mint", store.loadMints().single().name)
+            assertEquals(25L, manager.state.value.balance)
+            assertTrue(fake.metadataFetches > 0)
+        }
+    }
+
     @Test fun offlineRecoveryTracksOnceWithoutMetadataRedemptionOrAnotherAnnouncement() {
         AppTestFixture.launch(FixtureMode.SeededWithoutMint).use { fixture ->
             val manager = fixture.container.walletManager

--- a/android/app/src/androidTest/java/com/cashu/me/Core/ReceivedAccountReconciliationTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/ReceivedAccountReconciliationTest.kt
@@ -1,0 +1,40 @@
+package com.cashu.me.Core
+
+import com.cashu.me.Core.CDK.ReceiveRecoveryCandidate
+import com.cashu.me.Models.PendingReceiveToken
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FixtureMode
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+
+class ReceivedAccountReconciliationTest {
+    @Test fun offlineRecoveryTracksOnceWithoutMetadataRedemptionOrAnotherAnnouncement() {
+        AppTestFixture.launch(FixtureMode.SeededWithoutMint).use { fixture ->
+            val manager = fixture.container.walletManager
+            val fake = checkNotNull(fixture.fakeGateway)
+            val store = fixture.container.walletStore
+            runBlocking { manager.initialize() }
+            val pending = PendingReceiveToken("approval", "cashu-awaiting-approval", 21, 1, "https://unapproved.example")
+            store.savePendingReceiveTokens(listOf(pending))
+            val fetchesBefore = fake.metadataFetches
+            fake.receiveCandidates = listOf(ReceiveRecoveryCandidate("https://received.example", "sat"), ReceiveRecoveryCandidate("https://received.example", "usd"))
+            fake.nextFailure = IllegalStateException("Offline")
+            var announcements = 0
+            runBlocking {
+                val observer = launch(start = CoroutineStart.UNDISPATCHED) { manager.receivedPayments.collect { announcements++ } }
+                manager.reconcileReceivedAccounts()
+                manager.reconcileReceivedAccounts()
+                observer.cancel()
+            }
+            assertEquals(listOf("https://received.example"), store.loadMints().map { it.url })
+            assertEquals(fetchesBefore, fake.metadataFetches)
+            assertEquals(0, announcements)
+            assertEquals(listOf(pending), store.loadPendingReceiveTokens())
+            assertEquals(setOf("sat", "usd"), store.loadMints().single().units.toSet())
+            assertEquals(4, fake.receiveRecoveryCalls)
+        }
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/Core/StorageDataStoreInstrumentedTest.kt
@@ -29,6 +29,28 @@ class StorageDataStoreInstrumentedTest {
     private val json = Json { encodeDefaults = true }
 
     @Test
+    fun mintRemovalSurvivesReloadAndWalletRollbackButNotWalletDeletion() {
+        val storeName = uniqueStoreName("removed_mints")
+        val store = WalletStore(context, storeName)
+        val mint = MintInfo(url = "https://mint.example/Mint", balance = 21)
+        store.saveMints(listOf(mint))
+        // Model interruption after recording removal but before deleting the
+        // old metadata. Reload must still hide the retained mint and proofs.
+        store.setMintRemoved("https://MINT.example/Mint/", removed = true)
+        val reloaded = WalletStore(context, storeName)
+        assertTrue(reloaded.isMintRemoved(mint.url))
+        assertFalse(reloaded.isMintRemoved("https://mint.example/mint"))
+        assertTrue(reloaded.loadMints().isEmpty())
+        val snapshot = reloaded.snapshotWalletScopedData()
+        reloaded.removeAllWalletData()
+        assertFalse(reloaded.isMintRemoved(mint.url))
+        reloaded.restoreWalletScopedData(snapshot)
+        assertTrue(reloaded.isMintRemoved(mint.url))
+        assertTrue(reloaded.loadMints().isEmpty())
+        reloaded.removeAllWalletData()
+    }
+
+    @Test
     fun restoreBackupBarrierSurvivesReloadAndWalletRollback() {
         val storeName = uniqueStoreName("restore_barrier")
         val store = SettingsStore(context, storeName)

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/ReceiptRecoveryInstrumentedTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/ReceiptRecoveryInstrumentedTest.kt
@@ -1,0 +1,80 @@
+package com.cashu.me.liveintegration
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
+import com.cashu.me.Core.CDK.ReceiveRecoveryCandidate
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.UUID
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+class ReceiptRecoveryInstrumentedTest {
+    private val args get() = InstrumentationRegistry.getArguments()
+    private val mint get() = args.getString("cashu.receiptRecoveryMintUrl") ?: "http://127.0.0.1:3340"
+
+    @Test fun completedReceiptBeforeTrackingSurvivesOfflineReopen() = runBlocking { exerciseReceipt(false) }
+    @Test fun acceptedSwapWithLostResponseRecoversAfterReopenExactlyOnce() = runBlocking { exerciseReceipt(true) }
+
+    private suspend fun exerciseReceipt(interrupt: Boolean) {
+        assumeTrue(args.getString("cashu.nativeWalletLocalMintIntegration") == "true")
+        control("reset")
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val directory = File(context.cacheDir, UUID.randomUUID().toString()).apply { mkdirs() }
+        val sender = CdkWalletGatewayImpl()
+        val receiver = CdkWalletGatewayImpl()
+        try {
+            sender.openWalletRepository(sender.generateMnemonic(), File(directory, "sender.db").path)
+            sender.ensureWallet(mint)
+            val quote = sender.createMintQuote(16, PaymentMethodKind.Bolt11, mint)
+            for (attempt in 0..<40) {
+                if (sender.checkMintQuote(quote.id).state == MintQuoteState.Paid) break
+                delay(100)
+            }
+            sender.mintTokens(quote.id)
+            val token = sender.sendEcashToken(16, null, null, mint).token
+            val seed = receiver.generateMnemonic()
+            val path = File(directory, "receiver.db").path
+            receiver.openWalletRepository(seed, path)
+            receiver.ensureWallet(mint)
+            assertTrue("Preview and unapproved tokens provide no recovery evidence", receiver.receiveRecoveryCandidates().isEmpty())
+            if (interrupt) control("interrupt-next-swap")
+            val result = runCatching { receiver.receiveEcashToken(token) }
+            assertEquals(interrupt, result.isFailure)
+            if (!interrupt) assertEquals(16L, result.getOrThrow())
+            receiver.closeWalletRepository()
+            control("offline")
+            receiver.openWalletRepository(seed, path)
+            val candidates = receiver.receiveRecoveryCandidates()
+            assertEquals(listOf(ReceiveRecoveryCandidate(mint, "sat")), candidates)
+            if (!interrupt) assertEquals(16L, receiver.totalBalance(mint))
+            control("reset")
+            candidates.forEach { receiver.recoverReceiveAccount(it) }
+            candidates.forEach { receiver.recoverReceiveAccount(it) }
+            assertEquals(16L, receiver.totalBalance(mint))
+            val transactions = receiver.listTransactions(mapOf(mint to listOf("sat")))
+            assertEquals(1, transactions.size)
+            assertEquals(com.cashu.me.Models.TransactionStatus.Completed, transactions.single().status)
+        } finally {
+            control("reset")
+            sender.closeWalletRepository()
+            receiver.closeWalletRepository()
+            directory.deleteRecursively()
+        }
+    }
+
+    private fun control(action: String) {
+        val connection = (URL("$mint/__receipt_test/$action").openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 5_000
+            readTimeout = 5_000
+        }
+        try { assertEquals(200, connection.responseCode) } finally { connection.disconnect() }
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -52,6 +52,8 @@ class FakeWalletGateway(
     var receiveCandidates = emptyList<com.cashu.me.Core.CDK.ReceiveRecoveryCandidate>()
     var receiveRecoveryCalls = 0
     var metadataFetches = 0
+    var metadataFailure: Throwable? = null
+    var onMetadataFetch: (() -> Unit)? = null
     var nextFailure: Throwable? = null
     var nextCloseFailure: Throwable? = null
     val latestMintQuoteId: String?
@@ -139,6 +141,8 @@ class FakeWalletGateway(
 
     override suspend fun fetchMintInfo(mintUrl: String): MintInfo? {
         metadataFetches++
+        onMetadataFetch?.invoke()
+        metadataFailure?.let { throw it }
         failIfRequested()
         check(repositoryOpen) { "Fake wallet repository is not open." }
         val normalized = normalize(mintUrl)

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -49,6 +49,9 @@ class FakeWalletGateway(
     private val meltQuotes = linkedMapOf<String, MeltQuoteInfo>()
     private var repositoryOpen = false
 
+    var receiveCandidates = emptyList<com.cashu.me.Core.CDK.ReceiveRecoveryCandidate>()
+    var receiveRecoveryCalls = 0
+    var metadataFetches = 0
     var nextFailure: Throwable? = null
     var nextCloseFailure: Throwable? = null
     val latestMintQuoteId: String?
@@ -135,6 +138,7 @@ class FakeWalletGateway(
     }
 
     override suspend fun fetchMintInfo(mintUrl: String): MintInfo? {
+        metadataFetches++
         failIfRequested()
         check(repositoryOpen) { "Fake wallet repository is not open." }
         val normalized = normalize(mintUrl)
@@ -308,6 +312,13 @@ class FakeWalletGateway(
 
     override suspend fun checkMeltQuoteStatus(quoteId: String, mintUrl: String?): MeltQuoteInfo =
         checkNotNull(meltQuotes[quoteId]) { "Unknown fake melt quote $quoteId" }
+
+    override suspend fun receiveRecoveryCandidates() = receiveCandidates
+    override suspend fun recoverReceiveAccount(candidate: com.cashu.me.Core.CDK.ReceiveRecoveryCandidate): SagaRecoveryReport {
+        receiveRecoveryCalls++
+        failIfRequested()
+        return SagaRecoveryReport(0, 0, 0, 0)
+    }
 
     override suspend fun recoverIncompleteSagas(mintUrl: String): SagaRecoveryReport =
         SagaRecoveryReport(recovered = 0, compensated = 0, skipped = 0, failed = 0)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGateway.kt
@@ -79,6 +79,10 @@ interface CdkWalletGateway {
      * maintenance parity.
      */
     suspend fun recoverIncompleteSagas(mintUrl: String): SagaRecoveryReport
+
+    /** Durable receive evidence only; never includes preview-only wallets. */
+    suspend fun receiveRecoveryCandidates(): List<ReceiveRecoveryCandidate>
+    suspend fun recoverReceiveAccount(candidate: ReceiveRecoveryCandidate): SagaRecoveryReport
     suspend fun sendEcashToken(amount: Long, memo: String?, p2pkPubkey: String?, mintUrl: String, unit: String = "sat", p2pkSigningKeys: List<String> = emptyList()): SendTokenResult
     suspend fun receiveEcashToken(tokenString: String, p2pkSigningKeys: List<String> = emptyList()): Long
     suspend fun receiveNfcEcashToken(
@@ -203,3 +207,6 @@ class CdkGatewayUnavailable(message: String) : IllegalStateException(message)
 
 /** App-internal account identity. This does not alter any payment protocol. */
 data class WalletAccountReference(val mintUrl: String, val unit: String)
+
+/** Internal receive-recovery account reference; no bearer token is copied out of CDK. */
+data class ReceiveRecoveryCandidate(val mintUrl: String, val unit: String)

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/CdkWalletGatewayImpl.kt
@@ -635,6 +635,27 @@ class CdkWalletGatewayImpl : WalletGateway {
         quote.toDomain(fallbackMethod = stored?.paymentMethod?.toDomain() ?: quote.paymentMethod.toDomain())
     }
 
+    override suspend fun receiveRecoveryCandidates(): List<ReceiveRecoveryCandidate> = cdkCall {
+        val db = checkNotNull(database)
+        val states = listOf(org.cashudevkit.ProofState.UNSPENT, org.cashudevkit.ProofState.RESERVED, org.cashudevkit.ProofState.PENDING)
+        val proofs = db.getProofs(null, null, states, null).map {
+            ReceiveRecoveryCandidate(it.mintUrl.url, it.unit.toDomainUnit())
+        }
+        (proofs + db.getIncompleteSagas().mapNotNull(::receiveRecoveryCandidate)).distinct()
+    }
+
+    override suspend fun recoverReceiveAccount(candidate: ReceiveRecoveryCandidate): SagaRecoveryReport = cdkCall {
+        val unit = cdkUnit(candidate.unit)
+        // Reconstruct a missing account locally. Do not fetch mint metadata or
+        // replace an existing wallet/keyset counter before resuming its saga.
+        val repo = requireRepository()
+        if (!repo.getWallets().any { mintRemovalUrlsMatch(it.mintUrl().url, candidate.mintUrl) && it.unit() == unit }) {
+            repo.createWallet(CdkMintUrl(candidate.mintUrl), unit, null)
+        }
+        val report = walletFor(candidate.mintUrl, unit).recoverIncompleteSagas()
+        SagaRecoveryReport(report.recovered.toLong(), report.compensated.toLong(), report.skipped.toLong(), report.failed.toLong())
+    }
+
     override suspend fun recoverIncompleteSagas(mintUrl: String): SagaRecoveryReport = cdkCall {
         val report = walletFor(mintUrl, CdkCurrencyUnit.Sat).recoverIncompleteSagas()
         SagaRecoveryReport(

--- a/android/app/src/main/java/com/cashu/me/Core/CDK/ReceiveRecoveryCandidate.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/CDK/ReceiveRecoveryCandidate.kt
@@ -1,0 +1,14 @@
+package com.cashu.me.Core.CDK
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/** CDK 0.18 returns JSON-serialized incomplete sagas. Read only account identity. */
+internal fun receiveRecoveryCandidate(saga: String): ReceiveRecoveryCandidate? = runCatching {
+    val payload = Json.parseToJsonElement(saga).jsonObject
+    if (payload["kind"]?.jsonPrimitive?.content != "receive") return@runCatching null
+    val mint = payload["mint_url"]?.jsonPrimitive?.content ?: return@runCatching null
+    val unit = payload["unit"]?.jsonPrimitive?.content ?: return@runCatching null
+    ReceiveRecoveryCandidate(mint, unit.lowercase())
+}.getOrNull()

--- a/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Protocols/StorageProtocol.kt
@@ -47,6 +47,7 @@ object StorageKeys {
     const val priceDataPrefix = "price."
 
     const val walletMints = "wallet.mints"
+    const val walletRemovedMintUrls = "wallet.removedMintUrls"
     const val walletActiveMintUrl = "wallet.activeMintUrl"
     const val walletBalancesByUnit = "wallet.balancesByUnit"
     const val walletPendingReceiveTokens = "wallet.pendingReceiveTokens"
@@ -139,6 +140,7 @@ object StorageKeys {
 
     val walletBoundaryKeys = setOf(
         walletMints,
+        walletRemovedMintUrls,
         walletActiveMintUrl,
         walletBalancesByUnit,
         walletPendingReceiveTokens,

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -399,6 +399,7 @@ class WalletManager(
             val fetched = gateway.fetchMintInfo(normalized)
                 ?: throw IllegalStateException("Mint did not return info via CDK.")
             val updated = mutableState.value.mints + fetched
+            walletStore.setMintRemoved(normalized, removed = false)
             walletStore.saveMints(updated)
             if (mutableState.value.activeMint == null) walletStore.activeMintURL = fetched.url
             loadCachedState(needsOnboarding = false)
@@ -437,6 +438,9 @@ class WalletManager(
                 mintUrl = trackedMint.url,
                 removeWalletIfSingleUnit = gateway::removeWalletIfSingleUnit,
             ) {
+                // Persist the exclusion before deleting metadata so retained
+                // CDK proofs cannot reconnect this mint after a relaunch.
+                walletStore.setMintRemoved(trackedMint.url, removed = true)
                 val updated = mutableState.value.mints.filterNot { it.url == trackedMint.url }
                 walletStore.saveMints(updated)
                 if (walletStore.activeMintURL == trackedMint.url) {
@@ -1030,10 +1034,14 @@ class WalletManager(
         tokenString: String,
         confirmationOwner: ReceiveConfirmationOwner?,
     ): Long {
-        val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
+        val tokenInfo = com.cashu.me.Models.TokenInfo.parse(tokenString)
+        val unit = tokenInfo?.unit ?: "sat"
         val amount = withLoadingResult {
             val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
             val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
+            // This receive has passed approval. Its receipt may reconnect a
+            // removed mint, including when the swap response is lost.
+            tokenInfo?.mint?.let { walletStore.setMintRemoved(it, removed = false) }
             val received = try {
                 gateway.receiveEcashToken(tokenString, signingKeys)
             } catch (error: Exception) {
@@ -1055,7 +1063,10 @@ class WalletManager(
                     onTrackingFailed = {
                         AppLogger.wallet.error("Failed to track mint for received token", it)
                     },
-                    ensureMintTracked = { trackReceivedMintLocally(it, unit) },
+                    ensureMintTracked = {
+                        trackReceivedMintLocally(it, unit)
+                        ensureMintTracked(it)
+                    },
                 )
                 refreshBalance()
                 loadTransactions()
@@ -1093,11 +1104,13 @@ class WalletManager(
         tokenString: String,
         processedId: String,
     ): com.cashu.me.Core.CDK.NfcReceiveReceipt {
-        val unit = com.cashu.me.Models.TokenInfo.parse(tokenString)?.unit ?: "sat"
+        val tokenInfo = com.cashu.me.Models.TokenInfo.parse(tokenString)
+        val unit = tokenInfo?.unit ?: "sat"
         val receipt = withLoadingResult {
             require(processedId !in walletStore.loadProcessedCashuRequests()) { "This payment was already received." }
             val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
             val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
+            tokenInfo?.mint?.let { walletStore.setMintRemoved(it, removed = false) }
             gateway.receiveNfcEcashToken(tokenString, signingKeys).also {
                 p2pkPubkeys.forEach(settingsManager::markP2PKKeyUsed)
                 trackMintForReceivedToken(
@@ -1619,6 +1632,7 @@ class WalletManager(
     /** Publish the durable mint before any online reconciliation can fail. */
     private fun trackReceivedMintLocally(url: String, unit: String) {
         val normalized = mintMetadataFetcher.normalizeMintUrl(url)
+        if (walletStore.isMintRemoved(normalized)) return
         val current = walletStore.loadMints()
         val existing = current.firstOrNull { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, normalized) }
         if (existing != null && (existing.name != "Unknown Mint" || unit in existing.units)) return
@@ -1633,7 +1647,9 @@ class WalletManager(
     }
 
     internal suspend fun reconcileReceivedAccounts() {
-        val candidates = try { gateway.receiveRecoveryCandidates() } catch (error: Exception) {
+        val candidates = try {
+            gateway.receiveRecoveryCandidates().filterNot { walletStore.isMintRemoved(it.mintUrl) }
+        } catch (error: Exception) {
             if (error is kotlinx.coroutines.CancellationException) throw error
             AppLogger.wallet.error("Unable to discover interrupted receipts", error)
             return
@@ -1641,6 +1657,7 @@ class WalletManager(
         // Track every candidate before network recovery of any one account.
         candidates.forEach { trackReceivedMintLocally(it.mintUrl, it.unit) }
         for (candidate in candidates) {
+            if (walletStore.isMintRemoved(candidate.mintUrl)) continue
             try { gateway.recoverReceiveAccount(candidate) } catch (error: Exception) {
                 if (error is kotlinx.coroutines.CancellationException) throw error
                 AppLogger.wallet.error("Receipt recovery remains pending", error)
@@ -1655,23 +1672,37 @@ class WalletManager(
 
     private suspend fun ensureMintTracked(url: String): String {
         val normalized = mintMetadataFetcher.normalizeMintUrl(url)
+        walletStore.setMintRemoved(normalized, removed = false)
         runCatching { gateway.ensureWallet(normalized) }
             .onFailure { AppLogger.wallet.error("CDK wallet preparation is not available yet for $normalized", it) }
-        if (walletStore.loadMints().any { it.url == normalized }) return normalized
+        val existing = walletStore.loadMints().firstOrNull {
+            com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, normalized)
+        }
+        if (existing != null && existing.name != "Unknown Mint") return existing.url
 
-        val fetched = runCatching { gateway.fetchMintInfo(normalized) }.getOrElse {
+        val fetched = runCatching { gateway.fetchMintInfo(normalized) }.onFailure {
             AppLogger.wallet.error("Failed to fetch CDK mint info for $normalized", it)
-            MintInfo(
-                url = normalized,
-                name = runCatching { URL(normalized).host }.getOrNull() ?: "Unknown Mint",
-            )
-        } ?: MintInfo(
+        }.getOrNull()
+        // Re-read after the network suspension so enrichment preserves balances
+        // and every currency recovered into the locally persisted placeholder.
+        val current = walletStore.loadMints()
+        val placeholder = current.firstOrNull {
+            com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, normalized)
+        }
+        if (walletStore.isMintRemoved(normalized)) return normalized
+        val enriched = fetched?.copy(
+            url = placeholder?.url ?: normalized,
+            units = (placeholder?.units.orEmpty() + fetched.units).distinct(),
+            balance = placeholder?.balance ?: 0,
+            isActive = placeholder?.isActive ?: fetched.isActive,
+        ) ?: placeholder ?: MintInfo(
             url = normalized,
             name = runCatching { URL(normalized).host }.getOrNull() ?: "Unknown Mint",
         )
-        val updated = walletStore.loadMints().filterNot { it.url == normalized } + fetched
+        val updated = if (placeholder == null) current + enriched else
+            current.map { if (it == placeholder) enriched else it }
         walletStore.saveMints(updated)
-        if (walletStore.activeMintURL == null) walletStore.activeMintURL = fetched.url
+        if (walletStore.activeMintURL == null) walletStore.activeMintURL = enriched.url
         update {
             copy(
                 mints = updated,
@@ -1679,7 +1710,7 @@ class WalletManager(
                 balance = updated.sumOf { it.balance },
             )
         }
-        return normalized
+        return enriched.url
     }
 
     private suspend fun deriveNostrKey(mnemonic: String) {

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletManager.kt
@@ -235,6 +235,7 @@ class WalletManager(
             // background maintenance contends for CDK's operation mutex.
             kotlinx.coroutines.yield()
             if (hasStoredWallet) {
+                reconcileReceivedAccounts()
                 runCatching { refreshBalance() }
                     .onFailure { AppLogger.wallet.error("Deferred balance refresh failed", it) }
 
@@ -1033,7 +1034,16 @@ class WalletManager(
         val amount = withLoadingResult {
             val p2pkPubkeys = TokenParser.p2pkPubkeys(tokenString)
             val signingKeys = settingsManager.p2pkSigningKeysFor(p2pkPubkeys)
-            gateway.receiveEcashToken(tokenString, signingKeys).also {
+            val received = try {
+                gateway.receiveEcashToken(tokenString, signingKeys)
+            } catch (error: Exception) {
+                if (error is kotlinx.coroutines.CancellationException) throw error
+                // The mint may have accepted the swap before the response was
+                // lost. Resume CDK's saga; never submit the original token again.
+                reconcileReceivedAccounts()
+                throw error
+            }
+            received.also {
                 p2pkPubkeys.forEach(settingsManager::markP2PKKeyUsed)
                 // iOS parity (WalletManager+Tokens.receiveTokens): track the
                 // token's mint only after a successful receive, so an
@@ -1045,7 +1055,7 @@ class WalletManager(
                     onTrackingFailed = {
                         AppLogger.wallet.error("Failed to track mint for received token", it)
                     },
-                    ensureMintTracked = { ensureMintTracked(it) },
+                    ensureMintTracked = { trackReceivedMintLocally(it, unit) },
                 )
                 refreshBalance()
                 loadTransactions()
@@ -1604,6 +1614,43 @@ class WalletManager(
     private fun activeMintFrom(mints: List<MintInfo>): MintInfo? {
         val saved = walletStore.activeMintURL
         return mints.firstOrNull { it.url == saved } ?: mints.firstOrNull()
+    }
+
+    /** Publish the durable mint before any online reconciliation can fail. */
+    private fun trackReceivedMintLocally(url: String, unit: String) {
+        val normalized = mintMetadataFetcher.normalizeMintUrl(url)
+        val current = walletStore.loadMints()
+        val existing = current.firstOrNull { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it.url, normalized) }
+        if (existing != null && (existing.name != "Unknown Mint" || unit in existing.units)) return
+        val updated = if (existing == null) {
+            current + MintInfo(url = normalized, name = "Unknown Mint", units = listOf(unit))
+        } else {
+            current.map { if (it == existing) it.copy(units = (it.units + unit).distinct()) else it }
+        }
+        walletStore.saveMints(updated)
+        if (walletStore.activeMintURL == null) walletStore.activeMintURL = normalized
+        update { copy(mints = updated, activeMint = activeMintFrom(updated)) }
+    }
+
+    internal suspend fun reconcileReceivedAccounts() {
+        val candidates = try { gateway.receiveRecoveryCandidates() } catch (error: Exception) {
+            if (error is kotlinx.coroutines.CancellationException) throw error
+            AppLogger.wallet.error("Unable to discover interrupted receipts", error)
+            return
+        }
+        // Track every candidate before network recovery of any one account.
+        candidates.forEach { trackReceivedMintLocally(it.mintUrl, it.unit) }
+        for (candidate in candidates) {
+            try { gateway.recoverReceiveAccount(candidate) } catch (error: Exception) {
+                if (error is kotlinx.coroutines.CancellationException) throw error
+                AppLogger.wallet.error("Receipt recovery remains pending", error)
+            }
+        }
+        if (candidates.isNotEmpty()) {
+            refreshBalance()
+            loadTransactions()
+        }
+        // Deliberately no receive confirmation or token redemption here.
     }
 
     private suspend fun ensureMintTracked(url: String): String {

--- a/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/WalletStore.kt
@@ -24,8 +24,26 @@ class WalletStore(
         get() = store.string(StorageKeys.walletActiveMintUrl)
         set(value) = store.putString(StorageKeys.walletActiveMintUrl, value)
 
-    fun loadMints(): List<MintInfo> = loadList(StorageKeys.walletMints, MintInfo.serializer())
+    fun loadMints(): List<MintInfo> {
+        val removed = loadList(StorageKeys.walletRemovedMintUrls, String.serializer())
+        return loadList(StorageKeys.walletMints, MintInfo.serializer()).filterNot { mint ->
+            removed.any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it, mint.url) }
+        }
+    }
     fun saveMints(mints: List<MintInfo>) = saveList(StorageKeys.walletMints, MintInfo.serializer(), mints)
+
+    /** CDK retains proofs after removal; they must not implicitly reconnect a mint. */
+    fun isMintRemoved(url: String): Boolean =
+        loadList(StorageKeys.walletRemovedMintUrls, String.serializer())
+            .any { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it, url) }
+
+    @Synchronized
+    fun setMintRemoved(url: String, removed: Boolean) {
+        val current = loadList(StorageKeys.walletRemovedMintUrls, String.serializer())
+        val updated = current.filterNot { com.cashu.me.Core.CDK.mintRemovalUrlsMatch(it, url) } +
+            if (removed) listOf(url) else emptyList()
+        if (updated != current) saveList(StorageKeys.walletRemovedMintUrls, String.serializer(), updated)
+    }
 
     fun loadBalancesByUnit(): Map<String, Long> =
         loadMap(StorageKeys.walletBalancesByUnit, Long.serializer())

--- a/android/app/src/test/java/com/cashu/me/Core/CDK/ReceiveRecoveryCandidateTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/CDK/ReceiveRecoveryCandidateTest.kt
@@ -1,0 +1,14 @@
+package com.cashu.me.Core.CDK
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class ReceiveRecoveryCandidateTest {
+    @Test fun readsOnlyReceiveSagaAccountIdentity() {
+        assertEquals(ReceiveRecoveryCandidate("https://mint.example", "usd"), receiveRecoveryCandidate(
+            """{"kind":"receive","mint_url":"https://mint.example","unit":"usd","data":{"token":"never copied"}}""",
+        ))
+        assertNull(receiveRecoveryCandidate("""{"kind":"send","mint_url":"https://mint.example","unit":"sat"}"""))
+        assertNull(receiveRecoveryCandidate("not JSON"))
+    }
+}

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -191,6 +191,8 @@
 		36245814414F1DB5CF522A7E /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B376BD104CC679F24FFE37 /* AppLockWindow.swift */; };
 		CCCBC379C1AF8196BDD9CAD9 /* AppLockPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */; };
 		6E771298AB0DD61628FCF572 /* LightningAddressResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */; };
+		94EA670D6C07D36761841BF6 /* ReceiveRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199A5C29E6AB4761101E511B /* ReceiveRecovery.swift */; };
+		996597CC795B00455F4CB48B /* ReceiveRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562DD3E83FDF0A975042E7BF /* ReceiveRecoveryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -393,6 +395,8 @@
 		65B376BD104CC679F24FFE37 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../../App/AppLockWindow.swift; sourceTree = "<group>"; };
 		163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/AppLockPresentationTests.swift; sourceTree = "<group>"; };
 		2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/LightningAddressResolverTests.swift; sourceTree = "<group>"; };
+		199A5C29E6AB4761101E511B /* ReceiveRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveRecovery.swift; sourceTree = "<group>"; };
+		562DD3E83FDF0A975042E7BF /* ReceiveRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/ReceiveRecoveryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -458,6 +462,7 @@
 				9804DC8F57E0384EDE3B390B /* StoredWalletAccountTests.swift */,
 				163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */,
 				2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */,
+				562DD3E83FDF0A975042E7BF /* ReceiveRecoveryTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
 				AA9600000000000000000002 /* NPCServiceTests.swift */,
@@ -769,6 +774,7 @@
 				2100000000000004 /* WalletManager.swift */,
 				5DDA5FB4E01D8EAEC9BB97FA /* StoredWalletAccount.swift */,
 				65B376BD104CC679F24FFE37 /* AppLockWindow.swift */,
+				199A5C29E6AB4761101E511B /* ReceiveRecovery.swift */,
 				D100000000000101 /* WalletManager+Lifecycle.swift */,
 				D100000000000102 /* WalletManager+NPC.swift */,
 				D100000000000103 /* WalletManager+Mints.swift */,
@@ -1066,6 +1072,7 @@
 				881794875F3E0162F335D0D7 /* StoredWalletAccountTests.swift in Sources */,
 				CCCBC379C1AF8196BDD9CAD9 /* AppLockPresentationTests.swift in Sources */,
 				6E771298AB0DD61628FCF572 /* LightningAddressResolverTests.swift in Sources */,
+				996597CC795B00455F4CB48B /* ReceiveRecoveryTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
 				AA9600000000000000000001 /* NPCServiceTests.swift in Sources */,
@@ -1090,6 +1097,7 @@
 				1100000000000004 /* WalletManager.swift in Sources */,
 				F9B9C2789923138C562B8CBF /* StoredWalletAccount.swift in Sources */,
 				36245814414F1DB5CF522A7E /* AppLockWindow.swift in Sources */,
+				94EA670D6C07D36761841BF6 /* ReceiveRecovery.swift in Sources */,
 				D200000000000101 /* WalletManager+Lifecycle.swift in Sources */,
 				D200000000000102 /* WalletManager+NPC.swift in Sources */,
 				D200000000000103 /* WalletManager+Mints.swift in Sources */,

--- a/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
+++ b/ios/CashuWallet/Core/Protocols/StorageProtocol.swift
@@ -87,6 +87,7 @@ enum StorageKeys {
 
     // Wallet
     static let mints = "wallet.mints"
+    static let removedMintUrls = "wallet.removedMintUrls"
     static let activeMintUrl = "wallet.activeMintUrl"
     static let balancesByUnit = "wallet.balancesByUnit"
     static let pendingReceiveTokens = "wallet.pendingReceiveTokens"
@@ -220,6 +221,7 @@ enum StorageKeys {
 
     static let walletDataKeys = [
         mints,
+        removedMintUrls,
         activeMintUrl,
         balancesByUnit,
         pendingReceiveTokens,

--- a/ios/CashuWallet/Core/Services/MintService.swift
+++ b/ios/CashuWallet/Core/Services/MintService.swift
@@ -309,6 +309,25 @@ class MintService: ObservableObject {
         mints.contains { MintRemovalPolicy.matches($0.url, normalizeUrl(url)) }
     }
 
+    /// Persist receipt evidence before metadata lookup or network recovery.
+    func trackReceivedMintLocally(url: String, unit: CurrencyUnit) {
+        let normalized = normalizeUrl(url)
+        if let index = mints.firstIndex(where: { MintRemovalPolicy.matches($0.url, normalized) }) {
+            let unitName = PaymentRequestDecoder.unitDescription(unit)
+            if mints[index].name == "Unknown Mint", !mints[index].units.contains(unitName) {
+                mints[index].units.append(unitName)
+                saveMints()
+                if activeMint?.url == mints[index].url { activeMint = mints[index] }
+            }
+            return
+        }
+        var placeholder = MintInfo(url: normalized, name: "Unknown Mint", isActive: true, balance: 0)
+        placeholder.units = [PaymentRequestDecoder.unitDescription(unit)]
+        mints.append(placeholder)
+        saveMints()
+        if activeMint == nil { activeMint = placeholder }
+    }
+
     /// Ensure a mint discovered via an incoming token or NPC quote is tracked with
     /// full metadata (NUT-04/05 payment methods, on-chain confirmations), not a bare
     /// placeholder. Fetches mint info through the CDK wallet so the send/receive

--- a/ios/CashuWallet/Core/Services/MintService.swift
+++ b/ios/CashuWallet/Core/Services/MintService.swift
@@ -148,6 +148,7 @@ class MintService: ObservableObject {
             fetchedInfo: info
         )
         
+        walletStore.setMintRemoved(url: normalizedUrl, removed: false)
         mints.append(mintInfo)
         saveMints()
         
@@ -187,6 +188,9 @@ class MintService: ObservableObject {
                 )
             },
             commitMetadata: {
+                // Persist the exclusion first so a relaunch cannot rediscover
+                // retained CDK proofs if metadata removal is interrupted.
+                self.walletStore.setMintRemoved(url: mint.url, removed: true)
                 self.mints = MintRemovalPolicy.removingMint(
                     withURL: mint.url,
                     from: self.mints
@@ -312,6 +316,7 @@ class MintService: ObservableObject {
     /// Persist receipt evidence before metadata lookup or network recovery.
     func trackReceivedMintLocally(url: String, unit: CurrencyUnit) {
         let normalized = normalizeUrl(url)
+        guard !walletStore.isMintRemoved(url: normalized) else { return }
         if let index = mints.firstIndex(where: { MintRemovalPolicy.matches($0.url, normalized) }) {
             let unitName = PaymentRequestDecoder.unitDescription(unit)
             if mints[index].name == "Unknown Mint", !mints[index].units.contains(unitName) {
@@ -339,6 +344,7 @@ class MintService: ObservableObject {
     ///   user-selected active mint and the mint's balance are preserved.
     func ensureMintTracked(url: String, name: String? = nil) async {
         let normalizedUrl = normalizeUrl(url)
+        walletStore.setMintRemoved(url: normalizedUrl, removed: false)
         let existingIndex = mints.firstIndex(where: { MintRemovalPolicy.matches($0.url, normalizedUrl) })
 
         // Already tracked with real metadata — nothing to do.

--- a/ios/CashuWallet/Core/Wallet/ReceiveRecovery.swift
+++ b/ios/CashuWallet/Core/Wallet/ReceiveRecovery.swift
@@ -1,0 +1,65 @@
+import Cdk
+import Foundation
+
+/// Durable evidence of a receipt account, without copying bearer tokens out of CDK.
+struct ReceiveRecoveryCandidate: Hashable {
+    let mintURL: String
+    let unit: CurrencyUnit
+
+    static func fromSaga(_ json: String) -> Self? {
+        struct Identity: Decodable {
+            let kind: String
+            let mint_url: String
+            let unit: String
+        }
+        guard let data = json.data(using: .utf8),
+              let identity = try? JSONDecoder().decode(Identity.self, from: data),
+              identity.kind == "receive" else { return nil }
+        return Self(mintURL: identity.mint_url, unit: PaymentRequestDecoder.currencyUnit(from: identity.unit))
+    }
+
+    static func discover(database: WalletSqliteDatabase) async throws -> [Self] {
+        let proofs = try await database.getProofs(mintUrl: nil, unit: nil, state: [.unspent, .reserved, .pending], spendingConditions: nil)
+        let sagas = try await database.getIncompleteSagas()
+        return Array(Set(proofs.map { Self(mintURL: $0.mintUrl.url, unit: $0.unit) } + sagas.compactMap(fromSaga)))
+            .sorted { ($0.mintURL, PaymentRequestDecoder.unitDescription($0.unit)) < ($1.mintURL, PaymentRequestDecoder.unitDescription($1.unit)) }
+    }
+}
+
+extension WalletManager {
+    /// Own the repository lease before calling. CDK remains the recovery journal;
+    /// preview wallets and app-side tokens awaiting approval provide no evidence.
+    @discardableResult
+    func reconcileReceivedAccountsAssumingLease() async -> Bool {
+        guard let db, let walletRepository else { return false }
+        let candidates: [ReceiveRecoveryCandidate]
+        do { candidates = try await ReceiveRecoveryCandidate.discover(database: db) }
+        catch {
+            AppLogger.wallet.error("Unable to discover interrupted receipts")
+            return false
+        }
+        for candidate in candidates {
+            mintService.trackReceivedMintLocally(url: candidate.mintURL, unit: candidate.unit)
+        }
+        for candidate in candidates {
+            guard !Task.isCancelled else { break }
+            do {
+                let wallets = await walletRepository.getWallets()
+                if !wallets.contains(where: { MintRemovalPolicy.matches($0.mintUrl().url, candidate.mintURL) && $0.unit() == candidate.unit }) {
+                    // createWallet builds a local handle; metadata is unnecessary.
+                    try await walletRepository.createWallet(mintUrl: MintUrl(url: candidate.mintURL), unit: candidate.unit, targetProofCount: nil)
+                }
+                let wallet = try await walletRepository.getWallet(mintUrl: MintUrl(url: candidate.mintURL), unit: candidate.unit)
+                _ = try await wallet.recoverIncompleteSagas()
+            } catch {
+                AppLogger.wallet.error("Receipt recovery remains pending")
+            }
+        }
+        if !candidates.isEmpty {
+            await refreshBalanceAssumingWalletOperationLease()
+            await transactionService.loadTransactions(includeRemoteObservations: false)
+        }
+        // No original token redemption or second payment announcement.
+        return !candidates.isEmpty
+    }
+}

--- a/ios/CashuWallet/Core/Wallet/ReceiveRecovery.swift
+++ b/ios/CashuWallet/Core/Wallet/ReceiveRecovery.swift
@@ -33,8 +33,10 @@ extension WalletManager {
     func reconcileReceivedAccountsAssumingLease() async -> Bool {
         guard let db, let walletRepository else { return false }
         let candidates: [ReceiveRecoveryCandidate]
-        do { candidates = try await ReceiveRecoveryCandidate.discover(database: db) }
-        catch {
+        do {
+            candidates = try await ReceiveRecoveryCandidate.discover(database: db)
+                .filter { !walletStore.isMintRemoved(url: $0.mintURL) }
+        } catch {
             AppLogger.wallet.error("Unable to discover interrupted receipts")
             return false
         }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -697,6 +697,7 @@ extension WalletManager {
             protectsBackgroundExecution: true
         ) {
             let mintUrl = MintUrl(url: normalizedUrl)
+            self.walletStore.setMintRemoved(url: normalizedUrl, removed: false)
 
             // Create wallet for this mint
             try await walletRepository.createWallet(mintUrl: mintUrl, unit: .sat, targetProofCount: nil)

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -1442,6 +1442,7 @@ extension WalletManager {
 
     private func performBestEffortWalletStartupMaintenanceAssumingLease() async -> Bool {
         guard walletRepository != nil else { return false }
+        let reconciledReceipts = await reconcileReceivedAccountsAssumingLease()
         let mintUrls = trackedMintUrlsForWalletAccess()
         guard !mintUrls.isEmpty else { return false }
 
@@ -1450,7 +1451,7 @@ extension WalletManager {
         var keysetRefreshTimestamps = storedKeysetRefreshTimestamps
             .filter { mintUrls.contains($0.key) }
         var timestampsChanged = keysetRefreshTimestamps != storedKeysetRefreshTimestamps
-        var recoveredWalletState = false
+        var recoveredWalletState = reconciledReceipts
 
         let wallets = await trackedWalletsAssumingWalletOperationLease()
         for mintUrlString in mintUrls {

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -124,6 +124,11 @@ extension WalletManager {
             defaultFailureOutcome: .ambiguousFailure
         ) {
             do {
+                // This receive has passed approval. Allow its durable receipt
+                // to reconnect a previously removed mint, even after a lost response.
+                if let recoveryContext {
+                    self.walletStore.setMintRemoved(url: recoveryContext.mintURL, removed: false)
+                }
                 // Receive first: tokenService creates the CDK wallet and consumes the
                 // keyset counter. Enriching the mint (createWallet/fetchMintInfo) before
                 // this desyncs the counter and makes the mint reject "duplicate outputs"

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Tokens.swift
@@ -135,9 +135,13 @@ extension WalletManager {
                     .subtracting(beforeIds)
                     .first
 
+                if let recoveryContext {
+                    self.mintService.trackReceivedMintLocally(url: recoveryContext.mintURL, unit: recoveryContext.unit)
+                }
                 try? await self.ensureMintTrackedForToken(tokenString)
                 return (amount, newTransactionID)
             } catch {
+                await self.reconcileReceivedAccountsAssumingLease()
                 await self.captureWalletFailureDiagnostics(kind: .receive)
                 await self.recoverWalletStateAfterFailureAssumingWalletOperationLease(
                     kind: .receive,

--- a/ios/CashuWallet/Core/WalletStore.swift
+++ b/ios/CashuWallet/Core/WalletStore.swift
@@ -13,11 +13,28 @@ final class WalletStore {
     }
 
     func loadMints() -> [MintInfo] {
-        value(forKey: StorageKeys.mints, legacyKeys: [StorageKeys.Legacy.mints]) ?? []
+        let mints: [MintInfo] = value(forKey: StorageKeys.mints, legacyKeys: [StorageKeys.Legacy.mints]) ?? []
+        let removed: [String] = value(forKey: StorageKeys.removedMintUrls) ?? []
+        let removedIdentities = Set(removed.map(MintURLIdentity.normalized))
+        return mints.filter { !removedIdentities.contains(MintURLIdentity.normalized($0.url)) }
     }
 
     func saveMints(_ mints: [MintInfo]) {
         set(mints, forKey: StorageKeys.mints)
+    }
+
+    /// CDK retains proofs after removal; they must not implicitly reconnect a mint.
+    func isMintRemoved(url: String) -> Bool {
+        let removed: [String] = value(forKey: StorageKeys.removedMintUrls) ?? []
+        return removed.contains { MintURLIdentity.normalized($0) == MintURLIdentity.normalized(url) }
+    }
+
+    func setMintRemoved(url: String, removed: Bool) {
+        let current: [String] = value(forKey: StorageKeys.removedMintUrls) ?? []
+        let normalized = MintURLIdentity.normalized(url)
+        var updated = current.filter { MintURLIdentity.normalized($0) != normalized }
+        if removed { updated.append(normalized) }
+        if updated != current { set(updated, forKey: StorageKeys.removedMintUrls) }
     }
 
     func loadBalancesByUnit() -> [String: UInt64] {

--- a/ios/CashuWalletTests/ReceiveRecoveryTests.swift
+++ b/ios/CashuWalletTests/ReceiveRecoveryTests.swift
@@ -1,0 +1,101 @@
+import Cdk
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class ReceiveRecoveryTests: XCTestCase {
+    private let mintURL = "http://localhost:3340"
+
+    func testOnlyReceiveSagasSupplyRecoveryCandidates() {
+        XCTAssertEqual(ReceiveRecoveryCandidate.fromSaga(#"{"kind":"receive","mint_url":"https://mint.example","unit":"usd"}"#)?.unit, .usd)
+        XCTAssertNil(ReceiveRecoveryCandidate.fromSaga(#"{"kind":"send","mint_url":"https://mint.example","unit":"sat"}"#))
+        XCTAssertNil(ReceiveRecoveryCandidate.fromSaga("invalid"))
+    }
+
+    func testOfflinePlaceholderKeepsEveryRecoveredCurrency() {
+        let store = WalletStore(storage: InMemoryStorage())
+        let service = MintService(walletRepository: { nil }, walletStore: store)
+        service.trackReceivedMintLocally(url: "https://mint.example", unit: .sat)
+        service.trackReceivedMintLocally(url: "https://mint.example", unit: .usd)
+        service.trackReceivedMintLocally(url: "https://mint.example", unit: .usd)
+        XCTAssertEqual(store.loadMints().count, 1)
+        XCTAssertEqual(Set(store.loadMints().first?.units ?? []), ["sat", "usd"])
+    }
+
+    func testCompletedReceiptBeforeTrackingSurvivesOfflineRelaunch() async throws {
+        try await exerciseReceipt(interrupt: false)
+    }
+
+    func testAcceptedSwapWithLostResponseRecoversAfterRelaunchExactlyOnce() async throws {
+        try await exerciseReceipt(interrupt: true)
+    }
+
+    private func exerciseReceipt(interrupt: Bool) async throws {
+        try await control("reset")
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let seed = try generateMnemonic()
+        let path = directory.appendingPathComponent("receiver.sqlite").path
+        let senderDB = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("sender.sqlite").path)
+        let sender = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: senderDB))
+        let mint = MintUrl(url: mintURL)
+        try await sender.createWallet(mintUrl: mint, unit: .sat, targetProofCount: nil)
+        let wallet = try await sender.getWallet(mintUrl: mint, unit: .sat)
+        let quote = try await wallet.mintQuote(paymentMethod: .bolt11, amount: Amount(value: 16), description: nil, extra: nil)
+        for _ in 0..<40 {
+            if try await wallet.checkMintQuote(quoteId: quote.id).state == .paid { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        _ = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        let token = try await TokenService(walletRepository: { sender }, getActiveMint: { nil })
+            .sendTokens(amount: 16, mintUrl: mintURL).token
+        do {
+            let db = try LifecycleSafeWalletDatabase(filePath: path)
+            let repo = try WalletRepository(mnemonic: seed, store: customWalletStore(db: db))
+            try await repo.createWallet(mintUrl: mint, unit: .sat, targetProofCount: nil)
+            let previewCandidates = try await ReceiveRecoveryCandidate.discover(database: db)
+            XCTAssertTrue(previewCandidates.isEmpty, "A preview or unapproved token must not track a mint")
+            if interrupt { try await control("interrupt-next-swap") }
+            do {
+                _ = try await TokenService(walletRepository: { repo }, getActiveMint: { nil }).receiveTokens(tokenString: token)
+                XCTAssertFalse(interrupt, "Proxy should interrupt the accepted swap")
+            } catch {
+                if !interrupt { throw error }
+            }
+        }
+        try await control("offline")
+        let db = try LifecycleSafeWalletDatabase(filePath: path)
+        let repo = try WalletRepository(mnemonic: seed, store: customWalletStore(db: db))
+        let candidates = try await ReceiveRecoveryCandidate.discover(database: db)
+        XCTAssertEqual(candidates, [ReceiveRecoveryCandidate(mintURL: mintURL, unit: .sat)])
+        let store = WalletStore(storage: InMemoryStorage())
+        let mints = MintService(walletRepository: { nil }, walletStore: store)
+        for candidate in candidates {
+            mints.trackReceivedMintLocally(url: candidate.mintURL, unit: candidate.unit)
+            mints.trackReceivedMintLocally(url: candidate.mintURL, unit: candidate.unit)
+        }
+        XCTAssertEqual(store.loadMints().count, 1, "Tracking needs no repository or metadata request")
+        if !interrupt {
+            let offlineBalance = try await db.getBalance(mintUrl: mint, unit: .sat, state: [.unspent])
+            XCTAssertEqual(offlineBalance, 16)
+        }
+        try await control("reset")
+        let recovered = try await repo.getWallet(mintUrl: mint, unit: .sat)
+        _ = try await recovered.recoverIncompleteSagas()
+        _ = try await recovered.recoverIncompleteSagas()
+        let balance = try await recovered.totalBalance().value
+        XCTAssertEqual(balance, 16)
+        let history = try await recovered.listTransactions(direction: .incoming)
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history.first?.status, .completed)
+    }
+
+    private func control(_ action: String) async throws {
+        var request = URLRequest(url: URL(string: "\(mintURL)/__receipt_test/\(action)")!)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 5
+        let (_, response) = try await URLSession.shared.data(for: request)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+    }
+}

--- a/ios/CashuWalletTests/ReceiveRecoveryTests.swift
+++ b/ios/CashuWalletTests/ReceiveRecoveryTests.swift
@@ -6,6 +6,52 @@ import XCTest
 final class ReceiveRecoveryTests: XCTestCase {
     private let mintURL = "http://localhost:3340"
 
+    func testRemovalSurvivesReloadWithoutReconnectingRetainedAccounts() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let db = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("wallet.sqlite").path)
+        let repo = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: db))
+        let url = "https://mint.example/Mint"
+        try await repo.createWallet(mintUrl: MintUrl(url: url), unit: .sat, targetProofCount: nil)
+        let storage = InMemoryStorage()
+        let store = WalletStore(storage: storage)
+        let service = MintService(walletRepository: { repo }, walletStore: store)
+        service.trackReceivedMintLocally(url: url, unit: .sat)
+        try await service.removeMint(XCTUnwrap(service.mints.first))
+
+        let reloadedStore = WalletStore(storage: storage)
+        let reloaded = MintService(walletRepository: { nil }, walletStore: reloadedStore)
+        reloaded.loadCachedMints()
+        reloaded.trackReceivedMintLocally(url: "https://MINT.example/Mint/", unit: .sat)
+        reloaded.trackReceivedMintLocally(url: url, unit: .usd)
+        XCTAssertTrue(reloadedStore.isMintRemoved(url: url))
+        XCTAssertTrue(reloaded.mints.isEmpty)
+        XCTAssertNil(reloaded.activeMint)
+
+        // Deliberately reconnecting the mint enables receipt recovery again,
+        // even when metadata cannot be fetched yet.
+        await reloaded.ensureMintTracked(url: url)
+        reloaded.trackReceivedMintLocally(url: url, unit: .usd)
+        XCTAssertFalse(reloadedStore.isMintRemoved(url: url))
+        XCTAssertEqual(reloaded.mints.count, 1)
+        XCTAssertEqual(Set(reloaded.mints[0].units), ["sat", "usd"])
+    }
+
+    func testRemovalBeforeMetadataCommitSurvivesReloadAndClearsWithTheWallet() {
+        let storage = InMemoryStorage()
+        let store = WalletStore(storage: storage)
+        let url = "https://mint.example/Mint"
+        store.saveMints([MintInfo(url: url, name: "Test", isActive: true, balance: 21)])
+        store.setMintRemoved(url: "https://MINT.example/Mint/", removed: true)
+        let reloaded = WalletStore(storage: storage)
+        XCTAssertTrue(reloaded.isMintRemoved(url: url))
+        XCTAssertFalse(reloaded.isMintRemoved(url: "https://mint.example/mint"))
+        XCTAssertTrue(reloaded.loadMints().isEmpty)
+        reloaded.removeAllWalletData()
+        XCTAssertFalse(reloaded.isMintRemoved(url: url))
+    }
+
     func testOnlyReceiveSagasSupplyRecoveryCandidates() {
         XCTAssertEqual(ReceiveRecoveryCandidate.fromSaga(#"{"kind":"receive","mint_url":"https://mint.example","unit":"usd"}"#)?.unit, .usd)
         XCTAssertNil(ReceiveRecoveryCandidate.fromSaga(#"{"kind":"send","mint_url":"https://mint.example","unit":"sat"}"#))


### PR DESCRIPTION
## Changes
Recover receipts that CDK persisted before the app saved their mint. Both apps discover receipt accounts from durable proofs and incomplete receive operations, save missing mints locally before network recovery, and reconcile the affected currency account before normal startup maintenance or after an ambiguous receive failure.

Recovery uses CDK's existing journal, never redeems the original token again, and does not emit another payment announcement. Preview wallets and tokens awaiting unknown-mint approval are excluded. Offline placeholder mints retain every recovered currency until metadata can be refreshed.

Both apps persist explicit mint removals in wallet-scoped storage so retained CDK proofs cannot reconnect a removed mint during recovery or after a restart. Adding, restoring, or accepting another receive from that mint enables recovery again. Removal choices participate in wallet replacement snapshots and are cleared when deleting the wallet.

Android successful receives save the durable placeholder before best-effort metadata enrichment. Enrichment refreshes existing placeholders, preserves balances, recovered currencies, and the active-mint selection, and keeps the successful receipt visible when metadata is offline.

## Validation
- Follow-up fixes in `841a87c1`: Swift syntax parsing and `git diff --check` passed. Regression coverage added for persisted removals, reconnecting, failed removal, wallet boundaries, and Android metadata success/failure. Tests and full builds were not run for this follow-up, as requested.
- Original implementation (`2be8407c`), as previously recorded:
  - Android: 738 unit tests (732 passed, 6 skipped), release lint (0 errors; 36 existing warnings), and release build passed.
  - Android emulator: 3 native regression tests passed, including approval preservation and repeated reconciliation.
  - iOS simulator: 36 receipt-recovery and mint-service tests passed; affected app/test build passed.
  - Both native CDK integrations passed against a local test mint: receipt completed before app tracking with offline database reopen, and a swap accepted by the mint with its response lost, followed by database reopen and repeated recovery. Assertions verify one receipt and the expected balance.
- The loopback-only receipt fault proxy runs with the existing local mint suites in CI.

This branch uses CDK 0.18.0. Broader crash-recovery work remains outside this PR.
