### PR TITLE
Protect presented screens with App Lock on both platforms

### DIFF
--- a/android/app/src/androidTest/java/com/cashu/me/ui/security/AppLockPresentationTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/security/AppLockPresentationTest.kt
@@ -1,0 +1,122 @@
+package com.cashu.me.ui.security
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.Until
+import com.cashu.me.ui.setCashuContent
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalMaterial3Api::class)
+class AppLockPresentationTest {
+    @get:Rule val compose = createComposeRule()
+    private val device get() = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+    @Test fun lockBlocksTouchBackAndAccessibilityAboveExistingAndNewSheets() {
+        var locked by mutableStateOf(false)
+        var nested by mutableStateOf(false)
+        var draft by mutableStateOf("Sensitive payment draft")
+        var paid = 0
+        var dismissed = 0
+        var attempts = 0
+        compose.setCashuContent {
+            Column { Text("Wallet balance"); Text(draft) }
+            ModalBottomSheet(onDismissRequest = { dismissed++ }) {
+                Text(draft)
+                Button(onClick = { paid++ }) { Text("Pay underlying") }
+            }
+            if (nested) {
+                ModalBottomSheet(onDismissRequest = { dismissed++ }) { Text("Sensitive nested settings") }
+            }
+            if (locked) {
+                AppLockDialog {
+                    AppLockGateContent(isAuthenticating = false, onUnlock = {
+                        attempts++
+                        // First attempt models cancelled authentication.
+                        if (attempts > 1) locked = false
+                    })
+                }
+            }
+        }
+        compose.waitForIdle()
+        compose.runOnIdle { locked = true }
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Wallet Locked")), 5_000))
+        assertFalse(device.hasObject(By.text("Sensitive payment draft")))
+        device.pressBack()
+        device.click(device.displayWidth / 2, device.displayHeight / 2)
+        compose.runOnIdle { assertEquals(0, paid); assertEquals(0, dismissed) }
+        // An asynchronous flow may open another native sheet after locking.
+        compose.runOnIdle { nested = true }
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Wallet Locked")), 5_000))
+        assertFalse(device.hasObject(By.text("Sensitive nested settings")))
+        device.findObject(By.text("Unlock")).click()
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Wallet Locked")), 5_000))
+        compose.runOnIdle { draft = "Payment complete" }
+        compose.waitForIdle()
+        device.findObject(By.text("Unlock")).click()
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Sensitive nested settings")), 5_000))
+        compose.runOnIdle { assertEquals(0, dismissed); nested = false }
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Payment complete")), 5_000))
+    }
+
+    @Test fun privacyCoverUsesTheSameModalBoundaryAndRestoresTheScreen() {
+        var covered by mutableStateOf(false)
+        compose.setCashuContent {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) { Text("Full-screen receipt") }
+            if (covered) AppLockDialog { PrivacyCover() }
+        }
+        compose.runOnIdle { covered = true }
+        compose.waitForIdle()
+        assertFalse(device.hasObject(By.text("Full-screen receipt")))
+        device.pressBack()
+        compose.runOnIdle { assertTrue(covered); covered = false }
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Full-screen receipt")), 5_000))
+    }
+    @Test fun cancelledAuthenticationReturnsFocusToTheGate() {
+        var authenticating by mutableStateOf(false)
+        compose.setCashuContent {
+            AppLockDialog(isAuthenticating = authenticating) {
+                AppLockGateContent(isAuthenticating = authenticating, onUnlock = { authenticating = true })
+            }
+            // Model a native authentication window taking focus, without using
+            // a real device credential or biometric prompt in the test runner.
+            if (authenticating) AlertDialog(
+                onDismissRequest = { authenticating = false },
+                title = { Text("Authentication challenge") },
+                confirmButton = { Button(onClick = { authenticating = false }) { Text("Cancel challenge") } },
+            )
+        }
+        compose.waitForIdle()
+        device.findObject(By.text("Unlock")).click()
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Authentication challenge")), 5_000))
+        device.findObject(By.text("Cancel challenge")).click()
+        compose.waitForIdle()
+        assertTrue(device.wait(Until.hasObject(By.text("Wallet Locked")), 5_000))
+        device.pressBack()
+        assertTrue(device.hasObject(By.text("Wallet Locked")))
+    }
+
+}

--- a/android/app/src/main/java/com/cashu/me/ui/security/AppLockDialog.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/security/AppLockDialog.kt
@@ -5,17 +5,18 @@ import android.os.Build
 import android.view.KeyEvent
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
-import android.graphics.Color
-import androidx.core.graphics.drawable.toDrawable
 import android.view.Window
 import android.view.WindowManager
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -27,6 +28,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.cashu.me.R
 
 /**
  * A full-screen native modal window. The Activity and its drafts stay mounted;
@@ -44,7 +46,8 @@ internal fun AppLockDialog(isAuthenticating: Boolean = false, content: @Composab
     val authenticating by rememberUpdatedState(isAuthenticating)
     val onFocusChanged = remember { mutableListOf<(Boolean) -> Unit>() }
     val dialog = remember(context, source) {
-        object : Dialog(context) {
+        // The gate must be opaque from its first frame, including after a re-show.
+        object : Dialog(context, R.style.Theme_CashuWallet_AppLock) {
             @Suppress("OVERRIDE_DEPRECATION")
             override fun onWindowFocusChanged(hasFocus: Boolean) {
                 super.onWindowFocusChanged(hasFocus)
@@ -56,10 +59,20 @@ internal fun AppLockDialog(isAuthenticating: Boolean = false, content: @Composab
             setCanceledOnTouchOutside(false)
             setOnKeyListener { _, keyCode, _ -> keyCode == KeyEvent.KEYCODE_BACK }
             window?.apply {
-                setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
                 addFlags(WindowManager.LayoutParams.FLAG_SECURE or WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)
                 clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
-                WindowCompat.setDecorFitsSystemWindows(this, false)
+                // The non-floating theme fills the window; also extend the cover
+                // behind system bars and display cutouts on every supported API.
+                WindowCompat.enableEdgeToEdge(this)
+            }
+        }
+    }
+    val useDarkSystemBarIcons = MaterialTheme.colorScheme.background.luminance() > 0.5f
+    SideEffect {
+        dialog.window?.let { window ->
+            WindowCompat.getInsetsController(window, window.decorView).apply {
+                isAppearanceLightStatusBars = useDarkSystemBarIcons
+                isAppearanceLightNavigationBars = useDarkSystemBarIcons
             }
         }
     }

--- a/android/app/src/main/java/com/cashu/me/ui/security/AppLockDialog.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/security/AppLockDialog.kt
@@ -1,0 +1,116 @@
+package com.cashu.me.ui.security
+
+import android.app.Dialog
+import android.os.Build
+import android.view.KeyEvent
+import android.window.OnBackInvokedCallback
+import android.window.OnBackInvokedDispatcher
+import android.graphics.Color
+import androidx.core.graphics.drawable.toDrawable
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.WindowCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+
+/**
+ * A full-screen native modal window. The Activity and its drafts stay mounted;
+ * a later app sheet yields focus back to this gate, while system authentication
+ * remains free to take focus.
+ */
+@Composable
+internal fun AppLockDialog(isAuthenticating: Boolean = false, content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val source = LocalView.current
+    val parentComposition = rememberCompositionContext()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val savedStateOwner = LocalSavedStateRegistryOwner.current
+    val currentContent by rememberUpdatedState(content)
+    val authenticating by rememberUpdatedState(isAuthenticating)
+    val onFocusChanged = remember { mutableListOf<(Boolean) -> Unit>() }
+    val dialog = remember(context, source) {
+        object : Dialog(context) {
+            @Suppress("OVERRIDE_DEPRECATION")
+            override fun onWindowFocusChanged(hasFocus: Boolean) {
+                super.onWindowFocusChanged(hasFocus)
+                onFocusChanged.forEach { it(hasFocus) }
+            }
+        }.apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setCancelable(false)
+            setCanceledOnTouchOutside(false)
+            setOnKeyListener { _, keyCode, _ -> keyCode == KeyEvent.KEYCODE_BACK }
+            window?.apply {
+                setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+                addFlags(WindowManager.LayoutParams.FLAG_SECURE or WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM)
+                clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+                WindowCompat.setDecorFitsSystemWindows(this, false)
+            }
+        }
+    }
+    DisposableEffect(dialog, lifecycleOwner, savedStateOwner) {
+        val compose = ComposeView(context).apply {
+            setParentCompositionContext(parentComposition)
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycleOwner))
+            setViewTreeLifecycleOwner(lifecycleOwner)
+            setViewTreeSavedStateRegistryOwner(savedStateOwner)
+            setContent { currentContent() }
+        }
+        dialog.setContentView(compose)
+        val blockedBack = if (Build.VERSION.SDK_INT >= 33) OnBackInvokedCallback {} else null
+        fun showGate() {
+            dialog.show()
+            dialog.window?.setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.MATCH_PARENT)
+            if (Build.VERSION.SDK_INT >= 33 && blockedBack != null) {
+                dialog.onBackInvokedDispatcher.registerOnBackInvokedCallback(OnBackInvokedDispatcher.PRIORITY_OVERLAY, blockedBack)
+            }
+        }
+        var active = true
+        val focusListener: (Boolean) -> Unit = { hasFocus ->
+            if (!hasFocus) source.post {
+                if (active && dialog.isShowing && dialog.window?.decorView?.hasWindowFocus() == false && !authenticating &&
+                    lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                    // Re-add this app window above a later sheet. Retain its
+                    // composition so the one-shot authentication effect stays put.
+                    // System authentication is allowed to own focus instead.
+                    dialog.dismiss()
+                    showGate()
+                }
+            }
+        }
+        onFocusChanged.add(focusListener)
+        val resumeObserver = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) focusListener(false)
+        }
+        lifecycleOwner.lifecycle.addObserver(resumeObserver)
+        showGate()
+        onDispose {
+            active = false
+            onFocusChanged.remove(focusListener)
+            lifecycleOwner.lifecycle.removeObserver(resumeObserver)
+            if (Build.VERSION.SDK_INT >= 33 && blockedBack != null) {
+                dialog.onBackInvokedDispatcher.unregisterOnBackInvokedCallback(blockedBack)
+            }
+            dialog.dismiss()
+            compose.disposeComposition()
+        }
+    }
+    LaunchedEffect(isAuthenticating) {
+        if (!isAuthenticating) onFocusChanged.forEach { it(false) }
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/ui/security/AppLockGate.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/security/AppLockGate.kt
@@ -87,6 +87,20 @@ fun AppLockGate(
         }
     }
 
+    AppLockGateContent(
+        isAuthenticating = state.isAuthenticating,
+        onUnlock = { scope.launch { appLockManager.authenticate(activity) } },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+internal fun AppLockGateContent(
+    isAuthenticating: Boolean,
+    onUnlock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -117,17 +131,15 @@ fun AppLockGate(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center,
             )
-            if (state.isAuthenticating) {
+            if (isAuthenticating) {
                 Spacer(Modifier.height(CashuTheme.spacing.snug))
                 LoadingIndicator()
             }
         }
         PrimaryButton(
             text = "Unlock",
-            onClick = {
-                scope.launch { appLockManager.authenticate(activity) }
-            },
-            enabled = !state.isAuthenticating,
+            onClick = onUnlock,
+            enabled = !isAuthenticating,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()

--- a/android/app/src/main/java/com/cashu/me/ui/security/AppLockGate.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/security/AppLockGate.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Lock
@@ -104,7 +105,8 @@ internal fun AppLockGateContent(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
+            .background(MaterialTheme.colorScheme.background)
+            .safeDrawingPadding(),
     ) {
         Column(
             modifier = Modifier

--- a/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/shell/CashuApp.kt
@@ -122,9 +122,16 @@ fun CashuApp(containerFlow: StateFlow<AppContainer?>) {
                 } else {
                     CashuAppContent(container = checkNotNull(container))
                 }
-                ConfirmationToastHost(
-                    controller = confirmationToastController,
-                )
+                val lockState = container?.appLockManager?.state?.collectAsState()?.value
+                if (lockState?.isLocked != true && lockState?.isObscured != true) {
+                    ConfirmationToastHost(controller = confirmationToastController)
+                }
+                if (lockState?.isLocked == true || lockState?.isObscured == true) {
+                    com.cashu.me.ui.security.AppLockDialog(isAuthenticating = lockState.isAuthenticating) {
+                        if (lockState.isLocked) AppLockGate(appLockManager = checkNotNull(container).appLockManager)
+                        else PrivacyCover()
+                    }
+                }
             }
         }
     }
@@ -563,7 +570,7 @@ private fun AuthenticatedShell(container: AppContainer) {
         // OnBackPressedDispatcher and takes precedence over NavHost back handling
         // while an overlay is visible. Receive detail renders above the scanner.
         // Modal sheets live in their own windows and handle back themselves.
-        BackHandler(enabled = !appLockState.isLocked && (receiveTokenDetail != null || activeScannerTarget != null)) {
+        BackHandler(enabled = !appLockState.isLocked && !appLockState.isObscured && (receiveTokenDetail != null || activeScannerTarget != null)) {
             when (shellBackAction(receiveTokenDetail != null, activeScannerTarget != null)) {
                 com.cashu.me.ui.navigation.ShellBackAction.CloseReceiveDetail -> {
                     // Never abandon a redeem in flight.
@@ -572,12 +579,6 @@ private fun AuthenticatedShell(container: AppContainer) {
                 com.cashu.me.ui.navigation.ShellBackAction.CloseScanner -> closeScanner()
                 null -> Unit
             }
-        }
-        if (appLockState.isObscured && !appLockState.isLocked) {
-            PrivacyCover()
-        }
-        if (appLockState.isLocked) {
-            AppLockGate(appLockManager = container.appLockManager)
         }
     }
 

--- a/android/app/src/main/res/values/app_lock_theme.xml
+++ b/android/app/src/main/res/values/app_lock_theme.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Shared by light and dark mode through Theme.CashuWallet and cashu_canvas. -->
+    <style name="Theme.CashuWallet.AppLock" parent="Theme.CashuWallet">
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:windowIsTranslucent">false</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="android:windowBackground">@color/cashu_canvas</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
+</resources>

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -186,6 +186,8 @@
 		T2B0000000000013 /* AsciiFieldErosionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000013 /* AsciiFieldErosionTests.swift */; };
 		T2B0000000000014 /* MintQuoteDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000014 /* MintQuoteDomainTests.swift */; };
 		T2B0000000000100 /* ConnectMintContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T1B0000000000100 /* ConnectMintContextTests.swift */; };
+		36245814414F1DB5CF522A7E /* AppLockWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B376BD104CC679F24FFE37 /* AppLockWindow.swift */; };
+		CCCBC379C1AF8196BDD9CAD9 /* AppLockPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -383,6 +385,8 @@
 		T1B0000000000013 /* AsciiFieldErosionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsciiFieldErosionTests.swift; path = CashuWalletTests/AsciiFieldErosionTests.swift; sourceTree = "<group>"; };
 		T1B0000000000014 /* MintQuoteDomainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MintQuoteDomainTests.swift; path = CashuWalletTests/MintQuoteDomainTests.swift; sourceTree = "<group>"; };
 		T1B0000000000100 /* ConnectMintContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectMintContextTests.swift; path = CashuWalletTests/ConnectMintContextTests.swift; sourceTree = "<group>"; };
+		65B376BD104CC679F24FFE37 /* AppLockWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../../App/AppLockWindow.swift; sourceTree = "<group>"; };
+		163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/AppLockPresentationTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -445,6 +449,7 @@
 				AV00000000000012 /* AppVersionTests.swift */,
 				MW00000000000011 /* MeltSettlementWaitTests.swift */,
 				A09100000000000000000006 /* WalletAuditRegressionTests.swift */,
+				163973969F1D25EA091AC4FF /* AppLockPresentationTests.swift */,
 				TG00000000000012 /* TypographyGuardTests.swift */,
 				WE00000000000012 /* WalletErrorMessageTests.swift */,
 				AA9600000000000000000002 /* NPCServiceTests.swift */,
@@ -754,6 +759,7 @@
 			isa = PBXGroup;
 			children = (
 				2100000000000004 /* WalletManager.swift */,
+				65B376BD104CC679F24FFE37 /* AppLockWindow.swift */,
 				D100000000000101 /* WalletManager+Lifecycle.swift */,
 				D100000000000102 /* WalletManager+NPC.swift */,
 				D100000000000103 /* WalletManager+Mints.swift */,
@@ -1048,6 +1054,7 @@
 				AV00000000000002 /* AppVersionTests.swift in Sources */,
 				MW00000000000001 /* MeltSettlementWaitTests.swift in Sources */,
 				A09100000000000000000005 /* WalletAuditRegressionTests.swift in Sources */,
+				CCCBC379C1AF8196BDD9CAD9 /* AppLockPresentationTests.swift in Sources */,
 				TG00000000000002 /* TypographyGuardTests.swift in Sources */,
 				WE00000000000002 /* WalletErrorMessageTests.swift in Sources */,
 				AA9600000000000000000001 /* NPCServiceTests.swift in Sources */,
@@ -1070,6 +1077,7 @@
 				1100000000000002 /* ContentView.swift in Sources */,
 				6A8EC9362F244C8C0058C21B /* TransactionDetailView.swift in Sources */,
 				1100000000000004 /* WalletManager.swift in Sources */,
+				36245814414F1DB5CF522A7E /* AppLockWindow.swift in Sources */,
 				D200000000000101 /* WalletManager+Lifecycle.swift in Sources */,
 				D200000000000102 /* WalletManager+NPC.swift in Sources */,
 				D200000000000103 /* WalletManager+Mints.swift in Sources */,

--- a/ios/CashuWallet/App/AppLockWindow.swift
+++ b/ios/CashuWallet/App/AppLockWindow.swift
@@ -1,0 +1,103 @@
+import Combine
+import SwiftUI
+import UIKit
+
+/// Anchors protection to this SwiftUI scene, including its presented controllers.
+struct AppLockWindowBridge: UIViewRepresentable {
+    let manager: AppLockManager
+
+    func makeCoordinator() -> AppLockWindowController { AppLockWindowController(manager: manager) }
+    func makeUIView(context: Context) -> AppLockSceneProbe {
+        let view = AppLockSceneProbe()
+        view.onWindow = { [weak coordinator = context.coordinator] in coordinator?.attach(to: $0) }
+        return view
+    }
+    func updateUIView(_ uiView: AppLockSceneProbe, context: Context) {}
+    static func dismantleUIView(_ uiView: AppLockSceneProbe, coordinator: AppLockWindowController) {
+        coordinator.detach()
+    }
+}
+
+final class AppLockSceneProbe: UIView {
+    var onWindow: ((UIWindow) -> Void)?
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if let window { onWindow?(window) }
+    }
+}
+
+@MainActor
+final class AppLockWindowController {
+    private let manager: AppLockManager
+    private weak var sourceWindow: UIWindow?
+    private weak var previousKeyWindow: UIWindow?
+    private var previousAccessibilityHidden = false
+    private var subscriptions = Set<AnyCancellable>()
+    private(set) var protectionWindow: UIWindow?
+
+    init(manager: AppLockManager) { self.manager = manager }
+
+    func attach(to source: UIWindow) {
+        guard sourceWindow !== source, let scene = source.windowScene else { return }
+        detach()
+        sourceWindow = source
+        let window = UIWindow(windowScene: scene)
+        window.windowLevel = .alert + 1
+        window.backgroundColor = .systemBackground
+        let host = UIHostingController(rootView: AppLockWindowContent(manager: manager))
+        host.view.accessibilityViewIsModal = true
+        window.rootViewController = host
+        protectionWindow = window
+        manager.$isLocked.combineLatest(manager.$isObscured)
+            .sink { [weak self] locked, obscured in self?.setCovered(locked || obscured) }
+            .store(in: &subscriptions)
+        // UIKit posts these synchronously before scene snapshots. SwiftUI's
+        // scenePhase remains responsible for service lifecycle, not privacy timing.
+        NotificationCenter.default.publisher(for: UIScene.willDeactivateNotification, object: scene)
+            .sink { [weak self] _ in self?.manager.appResignedActive() }
+            .store(in: &subscriptions)
+        NotificationCenter.default.publisher(for: UIScene.didActivateNotification, object: scene)
+            .sink { [weak self] _ in self?.manager.appBecameActive() }
+            .store(in: &subscriptions)
+    }
+
+    private func setCovered(_ covered: Bool) {
+        guard let window = protectionWindow, let source = sourceWindow else { return }
+        if covered {
+            if window.isHidden {
+                previousKeyWindow = source.windowScene?.windows.first(where: \.isKeyWindow)
+                previousAccessibilityHidden = source.accessibilityElementsHidden
+                source.accessibilityElementsHidden = true
+                window.makeKeyAndVisible()
+                // No fade: the first inactive frame must already be opaque.
+                window.layoutIfNeeded()
+                UIAccessibility.post(notification: .screenChanged, argument: window.rootViewController?.view)
+            }
+        } else if !window.isHidden {
+            window.isHidden = true
+            source.accessibilityElementsHidden = previousAccessibilityHidden
+            (previousKeyWindow ?? source).makeKey()
+            previousKeyWindow = nil
+            UIAccessibility.post(notification: .screenChanged, argument: nil)
+        }
+    }
+
+    func detach() {
+        subscriptions.removeAll()
+        setCovered(false)
+        protectionWindow?.rootViewController = nil
+        protectionWindow = nil
+        sourceWindow = nil
+    }
+}
+
+private struct AppLockWindowContent: View {
+    @ObservedObject var manager: AppLockManager
+    var body: some View {
+        Group {
+            if manager.isLocked { AppLockView().environmentObject(manager) }
+            else { PrivacyCoverView() }
+        }
+        .transaction { $0.disablesAnimations = true }
+    }
+}

--- a/ios/CashuWallet/App/CashuWalletApp.swift
+++ b/ios/CashuWallet/App/CashuWalletApp.swift
@@ -89,20 +89,8 @@ struct CashuWalletApp: App {
                         navigationManager.handleDeepLink(url: url)
                     }
 
-                // App-switcher privacy cover (no lock yet). Sits above sheets so
-                // backgrounding mid-presentation never leaks content.
-                if appLockManager.isObscured && !appLockManager.isLocked {
-                    PrivacyCoverView()
-                }
-
-                // Lock gate. Window-level so it covers ContentView's full-screen
-                // covers and MainTabView's sheets too.
-                if appLockManager.isLocked {
-                    AppLockView()
-                        .environmentObject(appLockManager)
-                }
             }
-            .animation(.easeInOut(duration: 0.2), value: appLockManager.isLocked)
+            .background { AppLockWindowBridge(manager: appLockManager).frame(width: 0, height: 0) }
             .transaction { transaction in
                 if IntegrationTestConfig.shouldDisableAnimations {
                     transaction.disablesAnimations = true

--- a/ios/CashuWallet/App/ContentView.swift
+++ b/ios/CashuWallet/App/ContentView.swift
@@ -219,13 +219,23 @@ final class AppLockManager: ObservableObject {
     /// Quick app-switches shorter than this don't re-lock.
     private let gracePeriod: TimeInterval = 30
 
-    private var isEnabled: Bool { SettingsManager.shared.appLockEnabled }
+    private let enabled: @MainActor () -> Bool
+    private let available: @MainActor () -> Bool
+    private let now: () -> Date
+    private let evaluation: ((String) async -> Bool)?
+    private var isEnabled: Bool { enabled() }
 
-    private init() {
-        // Cold launch: start locked only if enabled AND we can actually
-        // authenticate. Fail open — never strand the user behind a gate we
-        // can't open.
-        isLocked = SettingsManager.shared.appLockEnabled && Self.canEvaluate()
+    init(
+        enabled: @escaping @MainActor () -> Bool = { SettingsManager.shared.appLockEnabled },
+        available: @escaping @MainActor () -> Bool = { AppLockManager.canEvaluate() },
+        now: @escaping () -> Date = Date.init,
+        evaluation: ((String) async -> Bool)? = nil
+    ) {
+        self.enabled = enabled
+        self.available = available
+        self.now = now
+        self.evaluation = evaluation
+        isLocked = enabled() && available()
     }
 
     /// Whether `deviceOwnerAuthentication` (biometrics OR passcode) is available.
@@ -245,6 +255,12 @@ final class AppLockManager: ObservableObject {
         guard !isAuthenticating else { return false }
         isAuthenticating = true
         defer { isAuthenticating = false }
+
+        if let evaluation {
+            let success = await evaluation(reason)
+            if success { unlock() }
+            return success
+        }
 
         // A fresh context per evaluation is mandatory: reusing one short-circuits
         // auth and caches stale enrollment / biometryType.
@@ -282,7 +298,7 @@ final class AppLockManager: ObservableObject {
     /// the grace clock. Ignored while we're driving our own auth sheet.
     func appResignedActive() {
         guard isEnabled, !isAuthenticating else { return }
-        if backgroundedAt == nil { backgroundedAt = Date() }
+        if backgroundedAt == nil { backgroundedAt = now() }
         isObscured = true
     }
 
@@ -292,7 +308,7 @@ final class AppLockManager: ObservableObject {
         guard isEnabled, !isAuthenticating else { return }
         if isLocked { isObscured = true; return }
 
-        if let backgroundedAt, Date().timeIntervalSince(backgroundedAt) >= gracePeriod {
+        if let backgroundedAt, now().timeIntervalSince(backgroundedAt) >= gracePeriod {
             isLocked = true
             isObscured = true
         } else {
@@ -374,7 +390,7 @@ struct PrivacyCoverView: View {
                 .font(.system(size: 40, weight: .regular))
                 .foregroundStyle(.tertiary)
         }
-        .allowsHitTesting(false)
+        .accessibilityLabel("Wallet hidden")
     }
 }
 

--- a/ios/CashuWalletTests/AppLockPresentationTests.swift
+++ b/ios/CashuWalletTests/AppLockPresentationTests.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import CashuWallet
+
+@MainActor
+final class AppLockPresentationTests: XCTestCase {
+    func testLockProtectsPaymentAndNestedSettingsPresentationsWithoutLosingDraft() async throws {
+        try await exercisePresentation(style: .pageSheet, nested: true)
+    }
+
+    func testLockProtectsFullScreenPaymentAndShowsItsSettledStateOnResume() async throws {
+        try await exercisePresentation(style: .fullScreen, nested: false)
+    }
+
+    private func exercisePresentation(style: UIModalPresentationStyle, nested: Bool) async throws {
+        let scene = try XCTUnwrap(UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first)
+        let originalKeyWindow = scene.windows.first(where: \.isKeyWindow)
+        let window = UIWindow(windowScene: scene)
+        let root = UIViewController()
+        window.rootViewController = root
+        window.makeKeyAndVisible()
+        var enabled = false
+        var time = Date(timeIntervalSince1970: 100)
+        var authSucceeds = false
+        let manager = AppLockManager(enabled: { enabled }, available: { true }, now: { time }, evaluation: { _ in authSucceeds })
+        let protector = AppLockWindowController(manager: manager)
+        protector.attach(to: window)
+        defer {
+            protector.detach()
+            window.isHidden = true
+            originalKeyWindow?.makeKey()
+        }
+        let payment = UIViewController()
+        payment.modalPresentationStyle = style
+        let draft = UITextField(frame: CGRect(x: 20, y: 80, width: 220, height: 44))
+        draft.text = "Draft payment 21"
+        payment.view.addSubview(draft)
+        await present(payment, from: root)
+        if nested {
+            let settings = UIViewController()
+            settings.modalPresentationStyle = .pageSheet
+            await present(settings, from: payment)
+        }
+        enabled = true
+        // UIKit's synchronous notification must cover the app-switcher frame.
+        NotificationCenter.default.post(name: UIScene.willDeactivateNotification, object: scene)
+        let protection = try XCTUnwrap(protector.protectionWindow)
+        XCTAssertFalse(protection.isHidden)
+        XCTAssertTrue(protection.windowLevel > window.windowLevel)
+        XCTAssertTrue(window.accessibilityElementsHidden)
+        XCTAssertFalse(manager.isLocked, "Short switches retain the existing grace period")
+        time += 31
+        manager.appBecameActive()
+        XCTAssertTrue(manager.isLocked)
+        // Let the initial automatic attempt finish, then explicitly retry/cancel.
+        try await Task.sleep(for: .milliseconds(100))
+        let cancelled = await manager.authenticate()
+        XCTAssertFalse(cancelled)
+        XCTAssertFalse(protection.isHidden)
+        manager.appResignedActive()
+        time += 31
+        manager.appBecameActive()
+        XCTAssertTrue(protector.protectionWindow === protection)
+        XCTAssertTrue(root.presentedViewController === payment)
+        XCTAssertEqual(draft.text, "Draft payment 21")
+        if nested { XCTAssertNotNil(payment.presentedViewController) }
+        // Wallet work can settle under the gate without replacing the screen.
+        draft.text = "Payment complete"
+        authSucceeds = true
+        let unlocked = await manager.authenticate()
+        XCTAssertTrue(unlocked)
+        XCTAssertTrue(protection.isHidden)
+        XCTAssertFalse(window.accessibilityElementsHidden)
+        XCTAssertTrue(root.presentedViewController === payment)
+        XCTAssertEqual(draft.text, "Payment complete")
+    }
+
+    func testRepeatedBackgroundNotificationsDoNotExtendTheGracePeriod() {
+        var time = Date(timeIntervalSince1970: 100)
+        var enabled = false
+        let manager = AppLockManager(enabled: { enabled }, available: { true }, now: { time }, evaluation: { _ in false })
+        enabled = true
+        manager.appResignedActive()
+        time += 20
+        manager.appResignedActive()
+        time += 11
+        manager.appBecameActive()
+        XCTAssertTrue(manager.isLocked)
+    }
+
+    private func present(_ controller: UIViewController, from presenter: UIViewController) async {
+        await withCheckedContinuation { continuation in
+            presenter.present(controller, animated: false) { continuation.resume() }
+        }
+    }
+}


### PR DESCRIPTION
## Changes
App Lock covers presented payment and settings screens in both native apps while keeping the underlying screen, draft, and payment state mounted. A payment already in progress can settle under the gate; unlocking reveals its current state.

On iOS, a scene-owned window above app presentations displays an opaque privacy cover synchronously on scene deactivation and hosts authentication when locked.

On Android, a full-screen non-dismissible native dialog blocks underlying touch, back navigation, and accessibility. Its dedicated theme disables native window animations and provides an opaque background, so showing or restoring the gate cannot fade or slide through wallet content. The cover extends behind system bars and display cutouts; the Unlock button respects safe drawing insets and system-bar icons follow the light or dark theme. The dialog restores its position if another app sheet opens while locked and yields focus to authentication. Existing grace-period and authentication behavior are preserved.

## Validation
Latest Android follow-up: debug build and release lint passed (0 errors; 36 existing warnings and 6 hints). No tests were run for this follow-up.

The original implementation at `58a30f2e` had the following validation:

- Android: 737 unit tests (731 passed, 6 skipped), release lint (0 errors; 36 existing warnings), and release build passed.
- Android emulator: 3 native presentation regressions passed, covering existing and newly opened sheets, blocked underlying actions and back navigation, accessibility isolation, cancelled authentication, privacy cover removal, and preserved draft/payment state.
- iOS simulator: 3 native presentation/grace-period regressions passed; affected app/test build passed. Coverage includes nested payment/settings sheets, full-screen presentations, synchronous scene privacy, repeated backgrounding, cancelled authentication, and successful resume.
- Live biometric/passcode interaction and Android hardware/OEM behavior remain unverified. Authentication outcomes are injected in the native regression tests.

Independent fix for release-review finding 1, based on main with CDK 0.18.0. Findings 3 and the broader crash-recovery work in finding 4 are outside this PR.
