### PR TITLE
Add cross-platform payment safety and live mint UI coverage

### DIFF
--- a/.github/workflows/android-ui-tests.yml
+++ b/.github/workflows/android-ui-tests.yml
@@ -173,6 +173,8 @@ jobs:
         python3 CI/receipt-recovery-proxy.py > "$RUNNER_TEMP/receipt-proxy.log" 2>&1 &
         echo $! > "$RUNNER_TEMP/receipt-proxy.pid"
         ./CI/start-cdk.sh
+        ./CI/start-payment-fixtures.sh
+        CI/.nutshell-venv/bin/python -m unittest discover -s CI/payment-tests -v
 
     - name: Run required Android UI suite
       if: env.UI_TIER != 'full'
@@ -184,6 +186,8 @@ jobs:
           ./gradlew --no-daemon :app:pixel2Api35DebugAndroidTest \
           -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.cashu.me.test.FullOnly \
           -Pandroid.testInstrumentationRunnerArguments.timeout_msec=600000 \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtures=true \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtureUrl=http://10.0.2.2:3341 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.liveUiLocalMintEnabled=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nativeWalletLocalMintIntegration=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338 \
@@ -199,11 +203,18 @@ jobs:
         bash ../CI/retry-android-ui-test.sh \
           ./gradlew --no-daemon :app:modernApi36DebugAndroidTest \
           -Pandroid.testInstrumentationRunnerArguments.timeout_msec=600000 \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtures=true \
+          -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtureUrl=http://10.0.2.2:3341 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.liveUiLocalMintEnabled=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nativeWalletLocalMintIntegration=true \
           -Pandroid.testInstrumentationRunnerArguments.cashu.nutshellMintUrl=http://10.0.2.2:3338 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.receiptRecoveryMintUrl=http://10.0.2.2:3340 \
           -Pandroid.testInstrumentationRunnerArguments.cashu.cdkMintUrl=http://10.0.2.2:3339
+
+    - name: Enforce executed payment coverage
+      if: always()
+      working-directory: .
+      run: python3 CI/payment-tests/check_coverage.py --platform android --tier "$UI_TIER" android/app/build/outputs/androidTest-results/managedDevice
 
     - name: Stop local test mints
       if: always()
@@ -211,6 +222,7 @@ jobs:
       run: |
         chmod +x CI/stop-nutshell.sh CI/stop-cdk.sh
         if [ -f "$RUNNER_TEMP/receipt-proxy.pid" ]; then kill "$(cat "$RUNNER_TEMP/receipt-proxy.pid")" || true; fi
+        ./CI/stop-payment-fixtures.sh
         ./CI/stop-nutshell.sh
         ./CI/stop-cdk.sh
 

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -8,7 +8,15 @@ on:
       - 'ios/**'
       - 'CI/**'
       - '.github/workflows/ios-tests.yml'
+  schedule:
+    - cron: '0 4 * * *'
   workflow_dispatch:
+    inputs:
+      tier:
+        description: Payment test depth
+        type: choice
+        default: pr
+        options: [pr, full]
 
 concurrency:
   group: ios-tests-${{ github.ref }}
@@ -17,12 +25,15 @@ concurrency:
 env:
   NUTSHELL_MINT_URL: http://localhost:3338
   CDK_MINT_URL: http://127.0.0.1:3339
+  PAYMENT_TIER: ${{ (github.event_name == 'schedule' && 'full') || inputs.tier || 'pr' }}
+  TEST_RUNNER_PAYMENT_FIXTURE_URL: http://127.0.0.1:3341
+  TEST_RUNNER_PAYMENT_TEST_TIER: ${{ (github.event_name == 'schedule' && 'full') || inputs.tier || 'pr' }}
 
 jobs:
   ios-tests:
     name: iOS Unit, Mint Integration & UI Tests
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
     - name: Checkout code
@@ -95,7 +106,7 @@ jobs:
 
         ./CI/setup-nutshell.sh &
         NUTSHELL_SETUP_PID=$!
-        ./CI/setup-cdk.sh &
+        ./CI/setup-cdk.sh 3339 android &
         CDK_SETUP_PID=$!
 
         STATUS=0
@@ -119,7 +130,9 @@ jobs:
         STATUS=0
         wait "$NUTSHELL_START_PID" || STATUS=$?
         wait "$CDK_START_PID" || STATUS=$?
-        exit "$STATUS"
+        if [ "$STATUS" != 0 ]; then exit "$STATUS"; fi
+        ./CI/start-payment-fixtures.sh
+        CI/.nutshell-venv/bin/python -m unittest discover -s CI/payment-tests -v
 
     - name: Run unit and mint integration tests
       id: unit_tests
@@ -167,11 +180,18 @@ jobs:
           CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="-" \
           | tee ios-ui-test-output.log | xcbeautify
 
+    - name: Enforce executed payment coverage
+      if: ${{ always() && steps.build.outcome == 'success' }}
+      run: |
+        python3 CI/payment-tests/check_coverage.py --platform ios --tier "$PAYMENT_TIER" \
+          "$RUNNER_TEMP/CashuWalletUnitTests.xcresult" "$RUNNER_TEMP/CashuWalletUITests.xcresult"
+
     - name: Stop local test mints
       if: always()
       run: |
         chmod +x CI/stop-nutshell.sh CI/stop-cdk.sh
         if [ -f "$RUNNER_TEMP/receipt-proxy.pid" ]; then kill "$(cat "$RUNNER_TEMP/receipt-proxy.pid")" || true; fi
+        ./CI/stop-payment-fixtures.sh
         ./CI/stop-nutshell.sh &
         NUTSHELL_STOP_PID=$!
         ./CI/stop-cdk.sh &

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ iOSInjectionProject/
 # Impeccable (design critique tool output / hook cache)
 .impeccable/
 .sentryclirc
+
+# Local payment integration fixtures
+CI/.payment-workdir/
+CI/.nutshell-venv
+CI/payment-tests/__pycache__/

--- a/CI/IntegrationTests/Package.swift
+++ b/CI/IntegrationTests/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
             ],
             sources: [
                 "IntegrationTestBase.swift",
-                "NutshellIntegrationTests.swift"
+                "NutshellIntegrationTests.swift",
+                "PaymentSafetyIntegrationTests.swift"
             ]
         )
     ]

--- a/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
+++ b/CI/IntegrationTests/Tests/NutshellIntegrationTests.swift
@@ -21,11 +21,9 @@ class MintIntegrationTestSuite: IntegrationTestBase {
     }
 
     func runGetMintKeysets() async throws {
-        let keysets = try await wallet.keysets(policy: .refresh).filter { $0.active == true }
-        XCTAssertFalse(keysets.isEmpty, "\(mintName) mint should have at least one active keyset")
-        for keyset in keysets {
-            XCTAssertEqual(keyset.unit, .sat, "Keyset unit should be sat")
-        }
+        let keysets = try await wallet.keysets(policy: .refresh)
+        XCTAssertTrue(keysets.contains { $0.active == true && $0.unit == .sat },
+                      "\(mintName) mint should have an active sat keyset")
     }
 
     // MARK: - Minting
@@ -667,11 +665,18 @@ class MintIntegrationTestSuite: IntegrationTestBase {
 
         XCTAssertEqual(quote.state, .unpaid, "Initial state should be unpaid")
 
-        let proofs = try await mintSats(42)
-        XCTAssertFalse(proofs.isEmpty, "Should have minted proofs")
-
-        let paidQuote = try await wallet.checkMintQuote(quoteId: quote.id)
-        XCTAssertEqual(paidQuote.state, .paid, "Quote should be paid after minting")
+        var paidQuote = try await wallet.checkMintQuote(quoteId: quote.id)
+        for _ in 0..<75 where paidQuote.state != .paid {
+            try await Task.sleep(nanoseconds: 200_000_000)
+            paidQuote = try await wallet.checkMintQuote(quoteId: quote.id)
+        }
+        XCTAssertEqual(paidQuote.state, .paid)
+        let proofs = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        XCTAssertEqual(proofs.reduce(0) { $0 + $1.amount.value }, 42)
+        let issuedQuote = try await wallet.checkMintQuote(quoteId: quote.id)
+        XCTAssertEqual(issuedQuote.state, .issued)
+        let secondSweep = try await wallet.mintUnissuedQuotes()
+        XCTAssertEqual(secondSweep.value, 0)
     }
 }
 

--- a/CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift
+++ b/CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift
@@ -70,6 +70,17 @@ class PaymentFixtureTestCase: XCTestCase {
         return wallet
     }
 
+    func makeWallet(inSameRepositoryAs wallet: Wallet, unit: CurrencyUnit) async throws -> Wallet {
+        let index = try XCTUnwrap(storeByWallet[ObjectIdentifier(wallet)])
+        let repo = stores[index].0
+        let url = wallet.mintUrl()
+        try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
+        let additionalWallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        walletHandles.append(additionalWallet)
+        storeByWallet[ObjectIdentifier(additionalWallet)] = index
+        return additionalWallet
+    }
+
     func reopen(_ wallet: Wallet) async throws -> Wallet {
         let index = try XCTUnwrap(storeByWallet[ObjectIdentifier(wallet)])
         let entry = stores[index]
@@ -422,7 +433,11 @@ final class PaymentExtendedIntegrationTests: PaymentFixtureTestCase {
             let credited = try await receive(receiver, token: token)
             XCTAssertEqual(credited, 21, "A payment request includes the receiver's redemption fee")
             let left = try await balance(payer)
-            XCTAssertLessThanOrEqual(left, 79)
+            if mint == "controlled" {
+                XCTAssertEqual(left, 79, "A zero-fee request must debit exactly the requested amount")
+            } else {
+                XCTAssertLessThanOrEqual(left, 79)
+            }
         }
     }
 
@@ -459,17 +474,22 @@ final class PaymentExtendedIntegrationTests: PaymentFixtureTestCase {
 
     func testMultipleMintUnitsDoNotCrossCredit() async throws {
         let sat = try await makeWallet("cdk")
-        let usd = try await makeWallet("cdk", unit: .usd)
+        let usd = try await makeWallet(inSameRepositoryAs: sat, unit: .usd)
         try await fund(sat, amount: 21)
         try await fund(usd, amount: 125)
-        let recipient = try await makeWallet("cdk", unit: .usd)
+        let recipientSat = try await makeWallet("cdk")
+        let recipient = try await makeWallet(inSameRepositoryAs: recipientSat, unit: .usd)
         let token = try await send(usd, amount: 25).confirm(memo: nil)
         let received = try await receive(recipient, token: token)
         XCTAssertEqual(received, 25)
         let sats = try await balance(sat)
         let dollars = try await balance(usd)
+        let recipientSats = try await balance(recipientSat)
+        let recipientDollars = try await balance(recipient)
         XCTAssertEqual(sats, 21)
         XCTAssertEqual(dollars, 100)
+        XCTAssertEqual(recipientSats, 0)
+        XCTAssertEqual(recipientDollars, 25)
     }
 
     func testNwcPaymentLimitReplayAndBalance() async throws {

--- a/CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift
+++ b/CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift
@@ -1,0 +1,506 @@
+import Foundation
+import XCTest
+import Cdk
+
+/// Real native wallets, separate durable stores, and a scenario-scoped fault proxy.
+/// The fixture is required in CI; ordinary unit-only runs can opt out explicitly.
+class PaymentFixtureTestCase: XCTestCase {
+    var fixture: String!
+    var sessionID: String!
+    var stores: [(WalletRepository, String, String)] = []
+    var reopened: [WalletRepository] = []
+    var walletHandles: [Wallet] = []
+    var storeByWallet: [ObjectIdentifier: Int] = [:]
+
+    override func setUp() async throws {
+        try await super.setUp()
+        fixture = ProcessInfo.processInfo.environment["PAYMENT_FIXTURE_URL"]
+        try XCTSkipIf(fixture == nil, "Run with PAYMENT_FIXTURE_URL to enable payment fixtures")
+        sessionID = try await call("/sessions", method: "POST")["id"] as? String
+        XCTAssertNotNil(sessionID)
+    }
+
+    override func tearDown() async throws {
+        if sessionID != nil { _ = try await call("/sessions/\(sessionID!)", method: "DELETE") }
+        // Keep repository handles alive until the synchronous teardown boundary:
+        // dropping the last native Tokio runtime from an async context is unsafe.
+        try await super.tearDown()
+    }
+
+    override func tearDown() {
+        let paths = stores.map { $0.1 }
+        storeByWallet.removeAll()
+        walletHandles.removeAll()
+        reopened.removeAll()
+        stores.removeAll()
+        for path in paths {
+            for suffix in ["", "-wal", "-shm"] { try? FileManager.default.removeItem(atPath: path + suffix) }
+        }
+        super.tearDown()
+    }
+
+    func call(_ path: String, method: String = "GET", body: [String: Any]? = nil) async throws -> [String: Any] {
+        var request = URLRequest(url: URL(string: fixture + path)!)
+        request.httpMethod = method
+        request.timeoutInterval = 15
+        if let body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let response = response as? HTTPURLResponse, (200..<300).contains(response.statusCode) else {
+            throw NSError(domain: "PaymentFixture", code: 1, userInfo: [NSLocalizedDescriptionKey: "Fixture request failed: \(path)"])
+        }
+        return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+    }
+
+    var root: String { "/sessions/\(sessionID!)" }
+    func mintURL(_ mint: String) -> String { fixture + root + "/mint/" + mint }
+
+    func makeWallet(_ mint: String, unit: CurrencyUnit = .sat) async throws -> Wallet {
+        let seed = try generateMnemonic()
+        let path = NSTemporaryDirectory() + "payment-\(UUID().uuidString).sqlite"
+        let repo = try WalletRepository(mnemonic: seed, store: .sqlite(path: path))
+        stores.append((repo, path, seed))
+        let url = MintUrl(url: mintURL(mint))
+        try await repo.createWallet(mintUrl: url, unit: unit, targetProofCount: nil)
+        let wallet = try await repo.getWallet(mintUrl: url, unit: unit)
+        walletHandles.append(wallet)
+        storeByWallet[ObjectIdentifier(wallet)] = stores.count - 1
+        return wallet
+    }
+
+    func reopen(_ wallet: Wallet) async throws -> Wallet {
+        let index = try XCTUnwrap(storeByWallet[ObjectIdentifier(wallet)])
+        let entry = stores[index]
+        let repo = try WalletRepository(mnemonic: entry.2, store: .sqlite(path: entry.1))
+        reopened.append(repo)
+        let recovered = try await repo.getWallet(mintUrl: wallet.mintUrl(), unit: wallet.unit())
+        walletHandles.append(recovered)
+        storeByWallet[ObjectIdentifier(recovered)] = index
+        return recovered
+    }
+
+    func paidQuote(_ wallet: Wallet, amount: UInt64, controlled: String? = nil) async throws -> MintQuote {
+        let quote = try await wallet.mintQuote(paymentMethod: .bolt11, amount: Amount(value: amount), description: nil, extra: nil)
+        if let controlled {
+            _ = try await call(root + "/pay/" + controlled, method: "POST", body: ["invoice": quote.request])
+        }
+        return try await awaitPaid(wallet, id: quote.id)
+    }
+
+    func awaitPaid(_ wallet: Wallet, id: String) async throws -> MintQuote {
+        for _ in 0..<80 {
+            let quote = try await wallet.checkMintQuote(quoteId: id)
+            if quote.state == .paid || quote.state == .issued { return quote }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        throw NSError(domain: "PaymentFixture", code: 2, userInfo: [NSLocalizedDescriptionKey: "Quote did not become paid"])
+    }
+
+    func fund(_ wallet: Wallet, amount: UInt64 = 100, controlled: String? = nil) async throws {
+        let quote = try await paidQuote(wallet, amount: amount, controlled: controlled)
+        let proofs = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        XCTAssertEqual(proofs.reduce(0) { $0 + $1.amount.value }, amount)
+    }
+
+    func invoice(amount: UInt64 = 21, script: [String: Any]? = nil, expired: Bool = false) async throws -> String {
+        var body: [String: Any] = ["amount": amount]
+        if let script { body["description"] = String(data: try JSONSerialization.data(withJSONObject: script), encoding: .utf8)! }
+        if expired { body["expiry"] = 1; body["age"] = 60 }
+        return try await call(root + "/invoice", method: "POST", body: body)["invoice"] as! String
+    }
+
+    func arm(_ path: String, action: String, method: String = "POST", count: Int = 1) async throws {
+        _ = try await call(root + "/faults", method: "POST", body: ["path": path, "method": method, "action": action, "remaining": count])
+    }
+
+    func send(_ wallet: Wallet, amount: UInt64, key: String? = nil, includeFee: Bool = false) async throws -> PreparedSend {
+        try await wallet.prepareSend(amount: Amount(value: amount), options: SendOptions(
+            memo: SendMemo(memo: "Payment test", includeMemo: true),
+            conditions: key.map { .p2pk(pubkey: $0, conditions: nil) }, amountSplitTarget: .none,
+            sendKind: .onlineExact, includeFee: includeFee, useP2bk: false, maxProofs: nil,
+            metadata: [:], p2pkSigningKeys: [], p2pkLockedProofSendMode: .swap))
+    }
+
+    func receive(_ wallet: Wallet, token: Token, keys: [String] = []) async throws -> UInt64 {
+        try await wallet.receive(token: token, options: ReceiveOptions(amountSplitTarget: .none,
+            p2pkSigningKeys: keys.map { SecretKey(hex: $0) }, preimages: [], metadata: [:])).value
+    }
+
+    // Match the app's NUT-05 path, including a pending response followed by wait.
+    func melt(_ wallet: Wallet, quoteID: String) async throws -> FinalizedMelt {
+        switch try await wallet.prepareMelt(quoteId: quoteID).confirmPreferAsync() {
+        case .paid(let finalized): return finalized
+        case .pending(let pending): return try await pending.wait()
+        }
+    }
+
+    func balance(_ wallet: Wallet) async throws -> UInt64 { try await wallet.totalBalance().value }
+
+    /// An assertion failure must never be swallowed by a catch-all error test.
+    func expectError(_ fragments: [String], _ operation: () async throws -> Void) async {
+        do { try await operation(); XCTFail("Expected payment rejection: \(fragments)") }
+        catch {
+            let message = String(describing: error).lowercased()
+            XCTAssertTrue(fragments.contains { message.contains($0.lowercased()) }, "Unexpected rejection: \(error)")
+        }
+    }
+}
+
+final class PaymentSafetyIntegrationTests: PaymentFixtureTestCase {
+    func testControlledQuoteIsUnpaidUntilExplicitPaymentAndIssuesOnlyOnce() async throws {
+        let wallet = try await makeWallet("controlled")
+        let quote = try await wallet.mintQuote(paymentMethod: .bolt11, amount: Amount(value: 21), description: nil, extra: nil)
+        let unpaid = try await wallet.checkMintQuote(quoteId: quote.id)
+        XCTAssertEqual(unpaid.state, .unpaid)
+        let before = try await balance(wallet)
+        XCTAssertEqual(before, 0)
+        await expectError(["not paid", "unpaid", "20001", "Amount undefined"]) {
+            _ = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        }
+        _ = try await wallet.recoverIncompleteSagas()
+        _ = try await call(root + "/pay/controlled", method: "POST", body: ["invoice": quote.request])
+        _ = try await awaitPaid(wallet, id: quote.id)
+        _ = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        let issued = try await wallet.checkMintQuote(quoteId: quote.id)
+        XCTAssertEqual(issued.state, .issued)
+        let sweep = try await wallet.mintUnissuedQuotes()
+        XCTAssertEqual(sweep.value, 0)
+        let after = try await balance(wallet)
+        XCTAssertEqual(after, 21)
+    }
+
+    func testBolt11InternalAndExternalPaymentsConserveBalanceAndPersistReceipt() async throws {
+        // Nutshell's stock FakeWallet reports every external payment settled
+        // before it starts. Use a real internal invoice for this fast native
+        // path; the simulator journey also exercises its external payment path.
+        for mint in ["controlled", "cdk"] {
+            let payer = try await makeWallet(mint)
+            let recipient = try await makeWallet(mint)
+            try await fund(payer, controlled: mint == "controlled" ? mint : nil)
+            let incoming = mint == "controlled"
+                ? try await recipient.mintQuote(paymentMethod: .bolt11, amount: Amount(value: 21), description: nil, extra: nil)
+                : nil
+            let request: String
+            if let incoming { request = incoming.request } else { request = try await invoice() }
+            let quote = try await payer.meltQuote(method: .bolt11, request: request, options: nil, extra: nil)
+            if mint == "controlled" {
+                // Nutshell 0.20.1 sends PENDING before its background task
+                // persists it. Pace the first status read past that fixture race.
+                try await arm("/v1/melt/quote/bolt11/", action: "delay", method: "GET")
+            }
+            let result = try await melt(payer, quoteID: quote.id)
+            XCTAssertEqual(result.state, .paid)
+            XCTAssertEqual(result.amount.value, 21)
+            let after = try await balance(payer)
+            XCTAssertEqual(after, 100 - 21 - result.feePaid.value)
+            let receipts = try await payer.listTransactions(direction: .outgoing).filter { $0.quoteId == quote.id }
+            XCTAssertEqual(receipts.count, 1)
+            XCTAssertEqual(receipts.first?.amount.value, 21)
+            XCTAssertEqual(receipts.first?.fee.value, result.feePaid.value)
+            if let incoming {
+                _ = try await awaitPaid(recipient, id: incoming.id)
+                let received = try await recipient.mint(quoteId: incoming.id, amountSplitTarget: .none, spendingConditions: nil)
+                XCTAssertEqual(received.reduce(0) { $0 + $1.amount.value }, 21)
+            }
+        }
+    }
+
+    func testLostMeltResponseRecoversWithoutSecondDebit() async throws {
+        let payer = try await makeWallet("cdk")
+        try await fund(payer)
+        let quote = try await payer.meltQuote(method: .bolt11, request: invoice(), options: nil, extra: nil)
+        try await arm("/v1/melt/bolt11", action: "lose_response")
+        let prepared = try await payer.prepareMelt(quoteId: quote.id)
+        // CDK can reconcile internally or surface the transport failure. Both
+        // must converge through the same durable saga without a second send.
+        do { _ = try await prepared.confirm() } catch { }
+        _ = try await payer.recoverIncompleteSagas()
+        let status = try await payer.checkMeltQuoteStatus(quoteId: quote.id)
+        XCTAssertEqual(status.state, .paid)
+        let after = try await balance(payer)
+        XCTAssertLessThan(after, 100)
+        let recovered = try await reopen(payer)
+        _ = try await recovered.recoverIncompleteSagas()
+        let reopenedBalance = try await balance(recovered)
+        XCTAssertEqual(reopenedBalance, after)
+        let receipts = try await recovered.listTransactions(direction: .outgoing).filter { $0.quoteId == quote.id }
+        XCTAssertEqual(receipts.count, 1)
+        XCTAssertEqual(after + 21 + (receipts.first?.fee.value ?? 0), 100)
+        let records = try await call(root)["requests"] as! [[String: Any]]
+        XCTAssertTrue(records.contains { $0["fault"] as? String == "lose_response" && $0["forwarded"] as? Bool == true })
+    }
+
+    func testLostMintResponseRecoversPaidQuoteExactlyOnce() async throws {
+        let wallet = try await makeWallet("controlled")
+        let quote = try await paidQuote(wallet, amount: 42, controlled: "controlled")
+        try await arm("/v1/mint/bolt11", action: "lose_response")
+        do { _ = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil) } catch { }
+        let recovered = try await reopen(wallet)
+        _ = try await recovered.recoverIncompleteSagas()
+        _ = try await recovered.mintUnissuedQuotes()
+        let after = try await balance(recovered)
+        XCTAssertEqual(after, 42)
+        let second = try await recovered.mintUnissuedQuotes()
+        XCTAssertEqual(second.value, 0)
+        let receipts = try await recovered.listTransactions(direction: .incoming).filter { $0.quoteId == quote.id }
+        XCTAssertEqual(receipts.count, 1)
+        let records = try await call(root)["requests"] as! [[String: Any]]
+        XCTAssertTrue(records.contains { $0["fault"] as? String == "lose_response" && $0["forwarded"] as? Bool == true })
+    }
+
+    func testInsufficientFundsAndOfflineQuoteDoNotDebit() async throws {
+        let wallet = try await makeWallet("controlled")
+        try await fund(wallet, controlled: "controlled")
+        let quote = try await wallet.meltQuote(method: .bolt11, request: invoice(amount: 101), options: nil, extra: nil)
+        await expectError(["insufficient", "not enough"]) { _ = try await wallet.prepareMelt(quoteId: quote.id) }
+        try await arm("/v1/melt/quote/bolt11", action: "reject")
+        await expectError(["503", "unavailable", "http"]) {
+            _ = try await wallet.meltQuote(method: .bolt11, request: self.invoice(), options: nil, extra: nil)
+        }
+        let after = try await balance(wallet)
+        XCTAssertEqual(after, 100)
+        let recipient = try await makeWallet("controlled")
+        let token = try await send(wallet, amount: 100).confirm(memo: nil)
+        let received = try await receive(recipient, token: token)
+        XCTAssertEqual(received, 100)
+    }
+
+    func testBackendFailureReturnsSpendableFunds() async throws {
+        let payer = try await makeWallet("cdk")
+        try await fund(payer)
+        let request = try await invoice(script: ["pay_invoice_state": "UNPAID", "check_payment_state": "UNPAID", "pay_err": true, "check_err": false])
+        let quote = try await payer.meltQuote(method: .bolt11, request: request, options: nil, extra: nil)
+        do { _ = try await payer.prepareMelt(quoteId: quote.id).confirm() } catch { }
+        _ = try await payer.recoverIncompleteSagas()
+        let amount = try await balance(payer)
+        XCTAssertEqual(amount, 100)
+        let recipient = try await makeWallet("cdk")
+        let token = try await send(payer, amount: 100).confirm(memo: nil)
+        let received = try await receive(recipient, token: token)
+        XCTAssertEqual(received, 100)
+    }
+
+    func testPaidBolt11RecoversAfterDatabaseReopenExactlyOnce() async throws {
+        let wallet = try await makeWallet("controlled")
+        let quote = try await paidQuote(wallet, amount: 42, controlled: "controlled")
+        let recovered = try await reopen(wallet)
+        let first = try await recovered.mintUnissuedQuotes()
+        let second = try await recovered.mintUnissuedQuotes()
+        XCTAssertEqual(first.value, 42)
+        XCTAssertEqual(second.value, 0)
+        let history = try await recovered.listTransactions(direction: .incoming).filter { $0.quoteId == quote.id }
+        XCTAssertEqual(history.count, 1)
+    }
+
+    func testEcashClaimAfterReopenCannotBeRevokedOrReceivedTwice() async throws {
+        let sender = try await makeWallet("controlled")
+        let receiver = try await makeWallet("controlled")
+        try await fund(sender, controlled: "controlled")
+        let prepared = try await send(sender, amount: 21)
+        let id = prepared.operationId()
+        let token = try await prepared.confirm(memo: "Saved token")
+        let reopenedSender = try await reopen(sender)
+        let pending = try await reopenedSender.getPendingSends()
+        XCTAssertTrue(pending.contains(id))
+        let credited = try await receive(receiver, token: token)
+        XCTAssertEqual(credited, 21)
+        let claimed = try await reopenedSender.checkSendStatus(operationId: id)
+        XCTAssertTrue(claimed)
+        await expectError(["spent", "claimed", "not found", "completed", "unknown"]) {
+            _ = try await reopenedSender.revokeSend(operationId: id)
+        }
+        await expectError(["spent", "already", "11001"]) { _ = try await self.receive(receiver, token: token) }
+        let senderBalance = try await balance(reopenedSender)
+        let receiverBalance = try await balance(receiver)
+        XCTAssertEqual(senderBalance, 79)
+        XCTAssertEqual(receiverBalance, 21)
+    }
+
+    func testRevokeUnclaimedTokenRestoresSpendability() async throws {
+        let sender = try await makeWallet("controlled")
+        let receiver = try await makeWallet("controlled")
+        try await fund(sender, controlled: "controlled")
+        let prepared = try await send(sender, amount: 21)
+        let token = try await prepared.confirm(memo: nil)
+        let amount = try await sender.revokeSend(operationId: prepared.operationId())
+        XCTAssertEqual(amount.value, 21)
+        await expectError(["spent", "already", "11001"]) { _ = try await self.receive(receiver, token: token) }
+        let newToken = try await send(sender, amount: 100).confirm(memo: nil)
+        let received = try await receive(receiver, token: newToken)
+        XCTAssertEqual(received, 100)
+    }
+
+    func testFeeChargingMintMaxSendAndReceiveConserveValue() async throws {
+        let sender = try await makeWallet("fees")
+        let receiver = try await makeWallet("fees")
+        try await fund(sender, controlled: "fees")
+        let prepared = try await send(sender, amount: 100)
+        XCTAssertEqual(prepared.fee().value, 0, "Send max transfers existing proofs without a swap")
+        let token = try await prepared.confirm(memo: nil)
+        let proofCount = prepared.proofs().count
+        let received = try await receive(receiver, token: token)
+        XCTAssertGreaterThan(proofCount, 0)
+        XCTAssertEqual(received, 100 - UInt64(proofCount), "1000 ppk charges one unit per input proof")
+        let senderBalance = try await balance(sender)
+        let receiverBalance = try await balance(receiver)
+        XCTAssertEqual(senderBalance, 0)
+        XCTAssertEqual(receiverBalance, received)
+    }
+
+    func testP2PKWrongKeyThenCorrectKeyOnBothMints() async throws {
+        let key = nostrGenerateSecretKey()
+        let publicKey = try "02" + nostrGetPubkey(nostrSecretKey: key)
+        for mint in ["nutshell", "cdk"] {
+            let sender = try await makeWallet(mint)
+            let receiver = try await makeWallet(mint)
+            try await fund(sender)
+            let token = try await send(sender, amount: 21, key: publicKey).confirm(memo: nil)
+            await expectError(["key", "signature", "witness", "sign", "p2pk"]) {
+                _ = try await self.receive(receiver, token: token, keys: [nostrGenerateSecretKey()])
+            }
+            let before = try await balance(receiver)
+            XCTAssertEqual(before, 0)
+            let received = try await receive(receiver, token: token, keys: [key])
+            XCTAssertEqual(received, 21)
+        }
+    }
+
+    func testConcurrentReceiversCannotDoubleCredit() async throws {
+        let sender = try await makeWallet("controlled")
+        let a = try await makeWallet("controlled")
+        let b = try await makeWallet("controlled")
+        try await fund(sender, controlled: "controlled")
+        let token = try await send(sender, amount: 21).confirm(memo: nil)
+        async let first = attemptReceive(a, token: token)
+        async let second = attemptReceive(b, token: token)
+        let results = await [first, second]
+        XCTAssertEqual(results.filter { $0 }.count, 1)
+        let total = try await balance(a) + balance(b)
+        XCTAssertEqual(total, 21)
+    }
+
+    private func attemptReceive(_ wallet: Wallet, token: Token) async -> Bool {
+        do { _ = try await receive(wallet, token: token); return true } catch { return false }
+    }
+}
+
+/// The expanded matrix is selected explicitly by the full/nightly CI tier.
+final class PaymentExtendedIntegrationTests: PaymentFixtureTestCase {
+    override func setUp() async throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["PAYMENT_TEST_TIER"] == "full", "Full payment tier")
+        try await super.setUp()
+    }
+
+    func testCashuRequestFixedAndAmountlessHttpDelivery() async throws {
+        try await assertRequestDelivery(mint: "controlled")
+    }
+
+    // Opt-in reproduction: CDK 0.18 delivers 19 instead of 21 at 1000 ppk.
+    // Keep the intended assertion; do not make underpayment a passing contract.
+    func testCashuRequestReceiverFeeRegression() async throws {
+        try XCTSkipUnless(ProcessInfo.processInfo.environment["PAYMENT_KNOWN_REGRESSIONS"] == "1",
+                          "Known CDK 0.18 receiver-fee regression; see CI/payment-tests/README.md")
+        try await assertRequestDelivery(mint: "fees")
+    }
+
+    private func assertRequestDelivery(mint: String) async throws {
+        for amount: UInt64? in [21, nil] {
+            let payer = try await makeWallet(mint)
+            let receiver = try await makeWallet(mint)
+            try await fund(payer, controlled: mint)
+            var config: [String: Any] = ["target": fixture + root + "/receive", "mints": [mintURL(mint)]]
+            if let amount { config["amount"] = amount }
+            let encoded = try await call(root + "/request", method: "POST", body: config)["request"] as! String
+            let request = try PaymentRequest.fromString(encoded: encoded)
+            let prepared = try await payer.preparePayRequest(paymentRequest: request, customAmount: amount == nil ? Amount(value: 21) : nil)
+            try await prepared.confirm()
+            let delivered = try await call(root + "/received-token")
+            XCTAssertEqual(delivered["id"] as? String, sessionID)
+            let token = try Token.decode(encodedToken: delivered["token"] as! String)
+            let credited = try await receive(receiver, token: token)
+            XCTAssertEqual(credited, 21, "A payment request includes the receiver's redemption fee")
+            let left = try await balance(payer)
+            XCTAssertLessThanOrEqual(left, 79)
+        }
+    }
+
+    func testCashuRequestDeliveryFailureLeavesReclaimableToken() async throws {
+        let payer = try await makeWallet("controlled")
+        try await fund(payer, controlled: "controlled")
+        let encoded = try await call(root + "/request", method: "POST", body: ["target": fixture + root + "/unavailable", "amount": 21])["request"] as! String
+        let request = try PaymentRequest.fromString(encoded: encoded)
+        let prepared = try await payer.preparePayRequest(paymentRequest: request, customAmount: nil)
+        do {
+            try await prepared.confirm()
+            XCTFail("Delivery must fail")
+        } catch FfiError.PaymentRequestDeliveryFailed(let operationId, _) {
+            let recovered = try await payer.revokeSend(operationId: operationId)
+            XCTAssertEqual(recovered.value, 21)
+        }
+        let after = try await balance(payer)
+        XCTAssertEqual(after, 100)
+    }
+
+    func testPreparedSendCancellationAndCompetingSpendPreserveFunds() async throws {
+        let sender = try await makeWallet("controlled")
+        try await fund(sender, controlled: "controlled")
+        let prepared = try await send(sender, amount: 80)
+        await expectError(["insufficient", "not enough"]) { _ = try await self.send(sender, amount: 80) }
+        try await prepared.cancel()
+        let balance = try await balance(sender)
+        XCTAssertEqual(balance, 100)
+        let recipient = try await makeWallet("controlled")
+        let token = try await send(sender, amount: 100).confirm(memo: nil)
+        let received = try await receive(recipient, token: token)
+        XCTAssertEqual(received, 100)
+    }
+
+    func testMultipleMintUnitsDoNotCrossCredit() async throws {
+        let sat = try await makeWallet("cdk")
+        let usd = try await makeWallet("cdk", unit: .usd)
+        try await fund(sat, amount: 21)
+        try await fund(usd, amount: 125)
+        let recipient = try await makeWallet("cdk", unit: .usd)
+        let token = try await send(usd, amount: 25).confirm(memo: nil)
+        let received = try await receive(recipient, token: token)
+        XCTAssertEqual(received, 25)
+        let sats = try await balance(sat)
+        let dollars = try await balance(usd)
+        XCTAssertEqual(sats, 21)
+        XCTAssertEqual(dollars, 100)
+    }
+
+    func testNwcPaymentLimitReplayAndBalance() async throws {
+        let payer = try await makeWallet("cdk")
+        try await fund(payer)
+        let relay = fixture.replacingOccurrences(of: "http://", with: "ws://") + root + "/relay"
+        let service = try NwcService.create(wallet: payer, relays: [relay], serviceSecretKey: nostrGenerateSecretKey(), maxPaymentMsat: 21_000)
+        try await service.start()
+        do {
+            let uri = service.connectionUri()
+            let initial = try await call(root + "/nwc", method: "POST", body: ["uri": uri, "method": "get_balance"])
+            XCTAssertEqual((initial["result"] as? [String: Any])?["balance"] as? Int, 100_000)
+            let rejected = try await call(root + "/nwc", method: "POST", body: ["uri": uri, "method": "pay_invoice", "params": ["invoice": invoice(amount: 22)]])
+            XCTAssertEqual((rejected["error"] as? [String: Any])?["code"] as? String, "QUOTA_EXCEEDED")
+            let untouched = try await balance(payer)
+            XCTAssertEqual(untouched, 100)
+            let paid = try await call(root + "/nwc", method: "POST", body: ["uri": uri, "method": "pay_invoice", "params": ["invoice": invoice()], "duplicate": true])
+            XCTAssertNotNil(paid["result"])
+            XCTAssertNil(paid["timeout"])
+            let receipts = try await payer.listTransactions(direction: .outgoing)
+            XCTAssertEqual(receipts.count, 1)
+            let after = try await balance(payer)
+            XCTAssertEqual(after + 21 + receipts[0].fee.value, 100)
+            let remote = try await call(root + "/nwc", method: "POST", body: ["uri": uri, "method": "get_balance"])
+            XCTAssertEqual((remote["result"] as? [String: Any])?["balance"] as? UInt64, after * 1000)
+            let finalReceipts = try await payer.listTransactions(direction: .outgoing)
+            XCTAssertEqual(finalReceipts.count, 1)
+            try await service.stop()
+        } catch {
+            try? await service.stop()
+            throw error
+        }
+    }
+}

--- a/CI/README.md
+++ b/CI/README.md
@@ -82,6 +82,14 @@ xcodebuild test \
 ./CI/stop-cdk.sh
 ```
 
+## Payment safety pack
+
+The [payment coverage review and runbook](payment-tests/README.md) describes the
+new scenario-isolated fault proxy, controlled fee/no-fee mints, native payment
+suites, live UI journeys, required-test manifest, known regression, and prioritized
+remaining gaps. Both platform workflows run core payment cases on PRs and the
+expanded request/NWC/unit matrix nightly.
+
 ## Test Coverage
 
 The integration tests verify **CDK-Swift ↔ real mint** compatibility:

--- a/CI/cleanup.sh
+++ b/CI/cleanup.sh
@@ -7,7 +7,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "🧹 Cleaning up CI test environment..."
 
-# Stop any running mints
+# Stop any running mints and scenario fixtures
+if [ -f "$SCRIPT_DIR/stop-payment-fixtures.sh" ]; then
+    bash "$SCRIPT_DIR/stop-payment-fixtures.sh" 2>/dev/null || true
+fi
+
 if [ -f "$SCRIPT_DIR/stop-nutshell.sh" ]; then
     bash "$SCRIPT_DIR/stop-nutshell.sh" 2>/dev/null || true
 fi

--- a/CI/payment-tests/README.md
+++ b/CI/payment-tests/README.md
@@ -1,0 +1,166 @@
+# Payment coverage and remaining risks
+
+This pack adds real native-wallet and simulator payment tests to the existing
+Nutshell/CDK pipeline. It focuses first on loss or duplication of funds, then on
+transport delivery and real UI wiring. It does **not** claim every payment feature
+is end-to-end covered.
+
+## What the review found
+
+The existing native matrix already covers basic minting, token round trips,
+insufficient ecash, duplicate redemption, counter restoration, reusable BOLT12
+offer issuance deltas, and on-chain quotes/payments. Android also has dedicated BOLT12 restart and foreign-NFC recovery
+regressions. Most Android UI journeys use `FakeWalletGateway`; the iOS live smoke
+suite primarily covers onboarding and adding a mint. Those are useful tests, but
+they cannot establish payment conservation across a lost HTTP response, a durable
+saga, and a second independent wallet.
+
+The previous Swift quote-transition test paid/minted a *different* quote through
+`mintSats`. It now checks and issues the original quote, then verifies that a second
+unissued-quote sweep credits nothing. Sat keyset checks now allow a mint to advertise
+other units, so both platforms can use the sat+USD CDK fixture profile.
+
+## Added required coverage
+
+`coverage.json` lists individual executable tests, not feature labels. Both
+platforms require 14 cases on PRs (12 native + 2 UI) and 19 on full/nightly runs.
+`check_coverage.py` reads JUnit XML or Xcode test-result trees and fails for any
+missing, skipped, or unsuccessful required case. The existing suites still run.
+
+| Boundary | Assertions | Tier |
+|---|---|---|
+| Unpaid invoice | Zero balance until explicit payment; reject early issuance; issue once | PR |
+| Internal Nutshell and external CDK BOLT11 | Paid state, amount + actual fee + change conservation, one outgoing receipt; internal recipient redeems | PR |
+| Lost melt response after mint commit | Recovery, durable reopen, paid quote, one receipt, no second debit | PR |
+| Lost mint response after issuance | Recover the same paid quote after reopen; one receipt and no second credit | PR |
+| Failed Lightning backend | Balance restored and all funds spendable by another wallet | PR |
+| Insufficient funds / unavailable quote endpoint | Rejection without debit; remaining proofs spendable | PR |
+| Paid but unissued invoice | Reopen SQLite, sweep once, second sweep zero | PR |
+| Ecash claim after sender reopen | Pending operation persists; claimed token cannot be revoked or redeemed twice | PR |
+| Ecash revoke | Original token becomes unspendable; recovered funds transfer successfully | PR |
+| Nonzero input fees | Send-max at 1000 ppk, real redemption fee and net balances | PR |
+| P2PK on both mint implementations | Wrong key cannot credit; correct key subsequently succeeds | PR |
+| Concurrent redemption | Two separate receivers race; exactly one succeeds and total credit equals token value | PR |
+| Real native UI on both mints | Receive 100, pay 21, history survives relaunch (iOS) / activity recreation (Android) | PR |
+| Cashu Request HTTP | Fixed and amountless request, matching request ID, actual recipient redemption | Full |
+| Cashu Request delivery failure | Failed HTTP delivery leaves a reclaimable operation; revoke restores balance | Full |
+| Proof reservation release | Swift competing preparation/cancel; Android repeated real fee-preview/cancel; full balance remains spendable | Full |
+| Currency isolation | Sat and USD payments cannot cross-credit unit balances | Full |
+| NWC over local signed Nostr relay | Balance, payment limit, duplicated request event, one payment and conserved funds | Full |
+
+Repository reopen tests use the same mnemonic and SQLite file; they are not
+OS-process-death tests. iOS UI explicitly terminates and relaunches the app.
+Android UI recreation retains its application container, so it proves activity
+restoration only. FakeWallet settlement is not evidence of routing on a real
+Lightning network or confirmation by a Bitcoin node.
+
+## Fixture design
+
+Start the ordinary mints first, then `CI/start-payment-fixtures.sh`. All listeners
+bind to loopback; Android reaches the host using its emulator alias.
+
+- `3341`: per-test proxy, invoice/request generator, HTTP receiver, Nostr relay.
+- `3342`: real Nutshell ledger with manually paid FakeWallet invoices, zero input fee.
+- `3343`: the same controlled mint at 1000 input-fee ppk.
+
+Every scenario gets a distinct URL namespace, fault list, delivery store and relay
+subscriptions. Wallet seeds and databases are separate. The proxy never fabricates
+proofs or balances. A reject fault does not forward the request; a lost-response
+fault waits for the actual upstream response and then truncates the response body.
+Tests verify that the latter was forwarded. Request records omit proof bodies.
+
+The relay validates canonical event IDs and Schnorr signatures, filters and replays
+subscriptions, and carries actual NIP-47 encrypted requests/responses. It is a small
+local test relay, not a general-purpose Nostr implementation. Fixture behavior and
+the coverage gate have their own Python tests.
+
+The proxy currently forwards mint HTTP endpoints, not NUT-17 mint WebSockets;
+SDK subscriptions therefore fall back to HTTP polling. These tests do not cover
+mint push delivery, reconnect, or missed-update recovery.
+
+The UI live-payment mode enables real payment maintenance while preserving test
+animation settings and disabling unrelated external services. iOS relay traffic is
+redirected to the local session relay. Android's native NWC test uses the relay
+directly; its UI fixture leaves external listeners disabled.
+
+## Run locally
+
+From the repository root, with the platform toolchains installed:
+
+```sh
+./CI/setup-nutshell.sh
+./CI/setup-cdk.sh 3339 android
+./CI/start-nutshell.sh
+./CI/start-cdk.sh
+./CI/start-payment-fixtures.sh
+CI/.nutshell-venv/bin/python -m unittest discover -s CI/payment-tests -v
+
+PAYMENT_FIXTURE_URL=http://127.0.0.1:3341 PAYMENT_TEST_TIER=full \
+  swift test --package-path CI/IntegrationTests \
+  --filter 'Payment(Safety|Extended)IntegrationTests'
+```
+
+For Xcode, use the scheme's regular build/test commands with
+`TEST_RUNNER_PAYMENT_FIXTURE_URL=http://127.0.0.1:3341` and
+`TEST_RUNNER_PAYMENT_TEST_TIER=full`. The `TEST_RUNNER_` prefix passes variables into
+the simulator test runner. Select `PaymentSafetyIntegrationTests`,
+`PaymentExtendedIntegrationTests`, `LiveCdkPaymentUITests` and
+`LiveNutshellPaymentUITests` for only this pack.
+
+For a running Android emulator:
+
+```sh
+cd android
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=com.cashu.me.liveintegration.PaymentSafetyLocalMintTest,com.cashu.me.liveintegration.PaymentExtendedLocalMintTest,com.cashu.me.ui.journeys.LivePaymentJourneyTest \
+  -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtures=true \
+  -Pandroid.testInstrumentationRunnerArguments.cashu.paymentFixtureUrl=http://10.0.2.2:3341
+cd ..
+python3 CI/payment-tests/check_coverage.py --platform android --tier full \
+  android/app/build/outputs/androidTest-results/connected
+```
+
+Stop with `CI/stop-payment-fixtures.sh`, `CI/stop-nutshell.sh`, and
+`CI/stop-cdk.sh`. Fixture state lives under ignored `CI/.payment-workdir/`.
+The scripts manage only their recorded processes. Never expose these unauthenticated
+fake-payment services to a public interface.
+
+## Known regressions and next tests
+
+1. **Cashu Request receiver fees — highest priority.** With CDK 0.18, a funded
+   100-sat wallet paying a 21-sat request at 1000 ppk produces a token redeeming for
+   19 sats. It has been observed with fixed and amountless requests; proof selection can
+   affect the exact shortfall. The test retains the
+   intended `received == 21` assertion; it is excluded from the required manifest
+   and skipped unless explicitly enabled. Reproduce with
+   `PAYMENT_KNOWN_REGRESSIONS=1 PAYMENT_TEST_TIER=full` in Swift, or
+   `-Pandroid.testInstrumentationRunnerArguments.cashu.paymentKnownRegressions=true`
+   on Android, selecting the `ReceiverFeeRegression` case. Fix the SDK fee/proof
+   selection and make this case required when the binding is upgraded. A green CI
+   run currently does **not** mean fee-bearing request underpayment is fixed.
+2. **Actual process death while pending.** Add two-phase drivers that stop the app
+   after proof reservation, mint acceptance, or HTTP delivery and restart it while
+   preserving all stores. Include pending-to-paid, pending-to-failed, prolonged
+   unknown state, repeated recovery, and history/notification deduplication.
+3. **Requests beyond HTTP.** Nostr gift-wrap delivery, listener reconnect/replay,
+   expired/invalid requests, P2PK request locks, multi-mint top-up, underpayment,
+   overpayment, repeated and partial payment. NWC needs unauthorized clients,
+   revoke/restore, concurrent distinct payments, and limit persistence tests.
+4. **Address resolution and remote services.** LNURL callbacks and amount/comment
+   bounds, bad callback invoices, BIP353/DNSSEC resolution, and NPC quote recovery
+   need controlled resolver/service endpoints and native coordinator tests.
+5. **Broader payment-method state transitions.** Extend the existing BOLT12 and
+   on-chain matrix with BOLT12 invoice-request failures, invalid amounts,
+   duplicate/late settlement, expiry, restart between successive offer credits,
+   on-chain fee-option changes and restart during pending settlement.
+6. **Device entry points.** Deep links, clipboard, QR/camera, and NFC cancellation,
+   disconnect/retry and replay need UI/device tests layered on the native payment
+   invariants. Physical NFC and camera behavior need real-device validation.
+
+Nutshell 0.20.1 has a fixture timing limitation: it can return async `PENDING`
+before its background task persists the new state, and stock FakeWallet reports
+external payments settled even before they execute. The fast internal-payment
+scenario delays its first status GET by one second; external Nutshell payments are
+also exercised through the real UI. This pacing does not establish correctness of
+the mint's immediate-status race. The standalone Swift package can also emit
+nonfatal native Tokio runtime-drop warnings from CDK 0.18 during teardown.

--- a/CI/payment-tests/README.md
+++ b/CI/payment-tests/README.md
@@ -42,10 +42,10 @@ missing, skipped, or unsuccessful required case. The existing suites still run.
 | P2PK on both mint implementations | Wrong key cannot credit; correct key subsequently succeeds | PR |
 | Concurrent redemption | Two separate receivers race; exactly one succeeds and total credit equals token value | PR |
 | Real native UI on both mints | Receive 100, pay 21, history survives relaunch (iOS) / activity recreation (Android) | PR |
-| Cashu Request HTTP | Fixed and amountless request, matching request ID, actual recipient redemption | Full |
+| Cashu Request HTTP | Fixed and amountless request, matching request ID, actual recipient redemption, exact sender debit on the zero-fee mint | Full |
 | Cashu Request delivery failure | Failed HTTP delivery leaves a reclaimable operation; revoke restores balance | Full |
 | Proof reservation release | Swift competing preparation/cancel; Android repeated real fee-preview/cancel; full balance remains spendable | Full |
-| Currency isolation | Sat and USD payments cannot cross-credit unit balances | Full |
+| Currency isolation | Sat and USD share one repository/database per wallet owner; USD payments preserve both sender and recipient sat balances | Full |
 | NWC over local signed Nostr relay | Balance, payment limit, duplicated request event, one payment and conserved funds | Full |
 
 Repository reopen tests use the same mnemonic and SQLite file; they are not

--- a/CI/payment-tests/check_coverage.py
+++ b/CI/payment-tests/check_coverage.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Fail if a required payment test is absent, skipped, or unsuccessful."""
+import argparse
+import json
+from pathlib import Path
+import subprocess
+import xml.etree.ElementTree as ET
+
+
+def android_results(directory):
+    results = {}
+    for path in Path(directory).rglob('TEST-*.xml'):
+        for case in ET.parse(path).iter('testcase'):
+            key = case.get('classname', '').rsplit('.', 1)[-1] + '/' + case.get('name', '').removesuffix('()')
+            passed = not any(case.find(tag) is not None for tag in ('failure', 'error', 'skipped'))
+            results.setdefault(key, []).append(passed)
+    return results
+
+
+def ios_results(bundles):
+    results = {}
+    def walk(node):
+        if node.get('nodeType') == 'Test Case':
+            key = node['nodeIdentifier'].removesuffix('()')
+            results.setdefault(key, []).append(node.get('result') == 'Passed')
+        for child in node.get('children', []):
+            walk(child)
+    for bundle in bundles:
+        data = json.loads(subprocess.check_output([
+            'xcrun', 'xcresulttool', 'get', 'test-results', 'tests', '--path', bundle, '--format', 'json']))
+        for node in data['testNodes']:
+            walk(node)
+    return results
+
+
+def missing_tests(manifest, platform, tier, results):
+    required = manifest[platform]['pr'] + (manifest[platform]['full'] if tier == 'full' else [])
+    return [name for name in required if not results.get(name) or not all(results[name])]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--platform', choices=['ios', 'android'], required=True)
+    parser.add_argument('--tier', choices=['pr', 'full'], default='pr')
+    parser.add_argument('results', nargs='+')
+    args = parser.parse_args()
+    manifest = json.loads(Path(__file__).with_name('coverage.json').read_text())
+    results = ios_results(args.results) if args.platform == 'ios' else android_results(args.results[0])
+    missing = missing_tests(manifest, args.platform, args.tier, results)
+    if missing:
+        parser.exit(1, 'Required payment tests missing, skipped, or failed:\n' + '\n'.join(missing) + '\n')
+    count = len(manifest[args.platform]['pr']) + (len(manifest[args.platform]['full']) if args.tier == 'full' else 0)
+    print(f'Payment coverage: {count} required tests passed ({args.platform}/{args.tier}).')
+
+
+if __name__ == '__main__':
+    main()

--- a/CI/payment-tests/controlled_mint.py
+++ b/CI/payment-tests/controlled_mint.py
@@ -1,0 +1,42 @@
+"""Nutshell with explicit incoming payments, using its real ledger and proofs.
+
+Only the Lightning backend is controlled. No auto-credit occurs: tests must pay
+an invoice through /test/pay or melt it through this backend.
+"""
+from bolt11 import decode
+from cashu.lightning.base import PaymentResult
+from cashu.lightning.fake import FakeWallet
+import cashu.lightning
+
+
+class ControlledFakeWallet(FakeWallet):
+    async def mark_invoice_paid(self, invoice, delay=True):
+        # get_invoice_status may call this again; the ledger event is idempotent.
+        if invoice in self.paid_invoices_incoming:
+            return
+        self.paid_invoices_incoming.append(invoice)
+        await self.paid_invoices_queue.put(invoice)
+        self.update_balance(invoice, incoming=True)
+
+    async def pay_invoice(self, quote, fee_limit):
+        result = await super().pay_invoice(quote, fee_limit)
+        if result.result == PaymentResult.SETTLED:
+            await self.mark_invoice_paid(decode(quote.request))
+        return result
+
+
+cashu.lightning.ControlledFakeWallet = ControlledFakeWallet
+from cashu.mint.app import app
+from cashu.mint.startup import backends
+from cashu.core.base import Method, Unit
+from fastapi import HTTPException, Request
+
+
+@app.post("/test/pay")
+async def pay(request: Request):
+    payment = decode((await request.json())["invoice"])
+    backend = backends[Method.bolt11][Unit.sat]
+    if not any(i.payment_hash == payment.payment_hash for i in backend.created_invoices):
+        raise HTTPException(404, "Invoice does not belong to the controlled mint")
+    await backend.mark_invoice_paid(payment)
+    return {"paid": True}

--- a/CI/payment-tests/coverage.json
+++ b/CI/payment-tests/coverage.json
@@ -1,0 +1,52 @@
+{
+  "ios": {
+    "pr": [
+      "PaymentSafetyIntegrationTests/testControlledQuoteIsUnpaidUntilExplicitPaymentAndIssuesOnlyOnce",
+      "PaymentSafetyIntegrationTests/testBolt11InternalAndExternalPaymentsConserveBalanceAndPersistReceipt",
+      "PaymentSafetyIntegrationTests/testLostMeltResponseRecoversWithoutSecondDebit",
+      "PaymentSafetyIntegrationTests/testLostMintResponseRecoversPaidQuoteExactlyOnce",
+      "PaymentSafetyIntegrationTests/testInsufficientFundsAndOfflineQuoteDoNotDebit",
+      "PaymentSafetyIntegrationTests/testBackendFailureReturnsSpendableFunds",
+      "PaymentSafetyIntegrationTests/testPaidBolt11RecoversAfterDatabaseReopenExactlyOnce",
+      "PaymentSafetyIntegrationTests/testEcashClaimAfterReopenCannotBeRevokedOrReceivedTwice",
+      "PaymentSafetyIntegrationTests/testRevokeUnclaimedTokenRestoresSpendability",
+      "PaymentSafetyIntegrationTests/testFeeChargingMintMaxSendAndReceiveConserveValue",
+      "PaymentSafetyIntegrationTests/testP2PKWrongKeyThenCorrectKeyOnBothMints",
+      "PaymentSafetyIntegrationTests/testConcurrentReceiversCannotDoubleCredit",
+      "LiveCdkPaymentUITests/testReceivePayAndRelaunch",
+      "LiveNutshellPaymentUITests/testReceivePayAndRelaunch"
+    ],
+    "full": [
+      "PaymentExtendedIntegrationTests/testCashuRequestFixedAndAmountlessHttpDelivery",
+      "PaymentExtendedIntegrationTests/testCashuRequestDeliveryFailureLeavesReclaimableToken",
+      "PaymentExtendedIntegrationTests/testPreparedSendCancellationAndCompetingSpendPreserveFunds",
+      "PaymentExtendedIntegrationTests/testMultipleMintUnitsDoNotCrossCredit",
+      "PaymentExtendedIntegrationTests/testNwcPaymentLimitReplayAndBalance"
+    ]
+  },
+  "android": {
+    "pr": [
+      "PaymentSafetyLocalMintTest/controlledQuoteRequiresPaymentAndIssuesOnlyOnce",
+      "PaymentSafetyLocalMintTest/bolt11InternalAndExternalPaymentsConserveBalanceAndPersistReceipt",
+      "PaymentSafetyLocalMintTest/lostMeltResponseRecoversWithoutSecondDebit",
+      "PaymentSafetyLocalMintTest/lostMintResponseRecoversPaidQuoteExactlyOnce",
+      "PaymentSafetyLocalMintTest/insufficientFundsAndOfflineQuoteDoNotDebit",
+      "PaymentSafetyLocalMintTest/backendFailureReturnsSpendableFunds",
+      "PaymentSafetyLocalMintTest/paidBolt11RecoversAfterDatabaseReopenExactlyOnce",
+      "PaymentSafetyLocalMintTest/ecashClaimAfterReopenCannotBeRevokedOrReceivedTwice",
+      "PaymentSafetyLocalMintTest/revokeUnclaimedTokenRestoresSpendability",
+      "PaymentSafetyLocalMintTest/feeChargingMintMaxSendAndReceiveConserveValue",
+      "PaymentSafetyLocalMintTest/p2pkWrongKeyThenCorrectKeyOnBothMints",
+      "PaymentSafetyLocalMintTest/concurrentReceiversCannotDoubleCredit",
+      "LivePaymentJourneyTest/cdkReceivePayAndReopenHistory",
+      "LivePaymentJourneyTest/nutshellReceivePayAndReopenHistory"
+    ],
+    "full": [
+      "PaymentExtendedLocalMintTest/cashuRequestFixedAndAmountlessHttpDelivery",
+      "PaymentExtendedLocalMintTest/cashuRequestDeliveryFailureLeavesReclaimableToken",
+      "PaymentExtendedLocalMintTest/repeatedFeePreviewReleasesReservedProofs",
+      "PaymentExtendedLocalMintTest/multipleMintUnitsDoNotCrossCredit",
+      "PaymentExtendedLocalMintTest/nwcPaymentLimitReplayAndBalance"
+    ]
+  }
+}

--- a/CI/payment-tests/nostr_client.py
+++ b/CI/payment-tests/nostr_client.py
@@ -1,0 +1,65 @@
+"""A small signed NIP-47 client for testing the native wallet service locally."""
+import asyncio
+import base64
+import hashlib
+import json
+import secrets
+import time
+from urllib.parse import parse_qs, urlparse
+
+from coincurve import PrivateKey, PublicKey
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+import websockets
+
+
+def encode_event(secret, kind, tags, content):
+    key = PrivateKey(bytes.fromhex(secret))
+    event = dict(pubkey=key.public_key.format()[1:].hex(), created_at=int(time.time()),
+                 kind=kind, tags=tags, content=content)
+    canonical = [0, event['pubkey'], event['created_at'], kind, tags, content]
+    digest = hashlib.sha256(json.dumps(canonical, separators=(',', ':'), ensure_ascii=False).encode()).digest()
+    event.update(id=digest.hex(), sig=key.sign_schnorr(digest).hex())
+    return event
+
+
+def shared_key(secret, pubkey):
+    return PublicKey(bytes.fromhex('02' + pubkey)).multiply(bytes.fromhex(secret)).format(compressed=False)[1:33]
+
+
+def encrypt(secret, pubkey, value):
+    iv = secrets.token_bytes(16)
+    padder = padding.PKCS7(128).padder()
+    data = padder.update(json.dumps(value).encode()) + padder.finalize()
+    cipher = Cipher(algorithms.AES(shared_key(secret, pubkey)), modes.CBC(iv)).encryptor()
+    return base64.b64encode(cipher.update(data) + cipher.finalize()).decode() + '?iv=' + base64.b64encode(iv).decode()
+
+
+def decrypt(secret, pubkey, value):
+    ciphertext, iv = value.split('?iv=')
+    cipher = Cipher(algorithms.AES(shared_key(secret, pubkey)), modes.CBC(base64.b64decode(iv))).decryptor()
+    data = cipher.update(base64.b64decode(ciphertext)) + cipher.finalize()
+    unpadder = padding.PKCS7(128).unpadder()
+    return json.loads(unpadder.update(data) + unpadder.finalize())
+
+
+async def nwc_request(relay, uri, method, params=None, duplicate=False):
+    parsed = urlparse(uri)
+    secret = parse_qs(parsed.query)['secret'][0]
+    pubkey = parsed.netloc
+    request = {'method': method, 'params': params or {}}
+    event = encode_event(secret, 23194, [['p', pubkey]], encrypt(secret, pubkey, request))
+    async with websockets.connect(relay) as ws:
+        await ws.send(json.dumps(['REQ', 'response', {'kinds': [23195], '#e': [event['id']]}]))
+        # Wait for subscription readiness so a fast service cannot beat REQ.
+        while json.loads(await asyncio.wait_for(ws.recv(), 10))[0] != 'EOSE':
+            pass
+        await ws.send(json.dumps(['EVENT', event]))
+        if duplicate:
+            await ws.send(json.dumps(['EVENT', event]))
+        async def response():
+            while True:
+                message = json.loads(await ws.recv())
+                if message[0] == 'EVENT' and message[2]['pubkey'] == pubkey:
+                    return decrypt(secret, pubkey, message[2]['content'])
+        return await asyncio.wait_for(response(), 12)

--- a/CI/payment-tests/server.py
+++ b/CI/payment-tests/server.py
@@ -1,0 +1,245 @@
+"""Local payment test services. Never expose this unauthenticated fixture publicly.
+
+Each session has independent faults, request counters and relay storage. Proxies
+forward real mint requests; faults never synthesize signatures or wallet balances.
+"""
+import asyncio
+import base64
+import cbor2
+import hashlib
+import json
+import os
+import secrets
+import time
+from contextlib import asynccontextmanager
+
+import httpx
+from bolt11 import Bolt11, MilliSatoshi, Tag, TagChar, Tags, encode, Feature, Features, FeatureState
+from coincurve import PublicKeyXOnly
+from fastapi import FastAPI, HTTPException, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+UPSTREAMS = {
+    "nutshell": os.environ.get("NUTSHELL_MINT_URL", "http://127.0.0.1:3338"),
+    "cdk": os.environ.get("CDK_MINT_URL", "http://127.0.0.1:3339"),
+    "controlled": os.environ.get("CONTROLLED_MINT_URL", "http://127.0.0.1:3342"),
+    "fees": os.environ.get("FEE_MINT_URL", "http://127.0.0.1:3343"),
+}
+sessions = {}
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with httpx.AsyncClient(timeout=30, trust_env=False) as client:
+        app.state.client = client
+        yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+def session(key):
+    if key not in sessions:
+        raise HTTPException(404, "Unknown scenario")
+    return sessions[key]
+
+
+def invoice(amount=21, description="Payment integration test", expiry=3600, age=0):
+    tags = Tags([
+        Tag(TagChar.payment_hash, secrets.token_hex(32)),
+        Tag(TagChar.payment_secret, secrets.token_hex(32)),
+        Tag(TagChar.features, Features.from_feature_list({Feature.payment_secret: FeatureState.supported, Feature.var_onion_optin: FeatureState.supported})),
+        Tag(TagChar.description, description),
+        Tag(TagChar.expire_time, expiry),
+    ])
+    value = Bolt11(currency="bc", date=int(time.time()) - age, tags=tags,
+                   amount_msat=None if amount is None else MilliSatoshi(amount * 1000))
+    return encode(value, private_key="0" * 63 + "1")
+
+
+@app.get("/health")
+async def health():
+    return {"ready": True, "version": 1}
+
+
+@app.post("/sessions")
+async def create_session():
+    key = secrets.token_hex(12)
+    sessions[key] = {"faults": [], "requests": [], "deliveries": [], "events": {}, "sockets": {}}
+    return {"id": key}
+
+
+@app.delete("/sessions/{key}")
+async def delete_session(key: str):
+    state = session(key)
+    for socket in list(state["sockets"]):
+        await socket.close()
+    sessions.pop(key, None)
+    return {"deleted": True}
+
+
+@app.get("/sessions/{key}")
+async def inspect_session(key: str):
+    state = session(key)
+    return {name: state[name] for name in ("faults", "requests", "deliveries")}
+
+
+@app.post("/sessions/{key}/faults")
+async def add_fault(key: str, request: Request):
+    fault = await request.json()
+    if fault.get("action") not in ("reject", "lose_response", "delay"):
+        raise HTTPException(400, "Unknown fault action")
+    if fault.get("method") not in ("GET", "POST") or not fault.get("path", "").startswith("/v1/"):
+        raise HTTPException(400, "Fault must identify a mint request")
+    fault.setdefault("remaining", 1)
+    session(key)["faults"].append(fault)
+    return {"armed": True}
+
+
+@app.post("/sessions/{key}/invoice")
+async def create_invoice(key: str, request: Request):
+    session(key)
+    config = await request.json()
+    return {"invoice": invoice(**config)}
+
+
+@app.post("/sessions/{key}/pay/{mint}")
+async def pay_controlled(key: str, mint: str, request: Request):
+    session(key)
+    if mint not in ("controlled", "fees"):
+        raise HTTPException(400, "Not a controlled mint")
+    response = await app.state.client.post(UPSTREAMS[mint] + "/test/pay", json=await request.json())
+    return Response(response.content, status_code=response.status_code, media_type="application/json")
+
+
+@app.post("/sessions/{key}/request")
+async def cashu_request(key: str, request: Request):
+    session(key)
+    config = await request.json()
+    payload = {"i": key, "u": config.get("unit", "sat"), "d": "Payment fixture",
+               "t": [{"t": "post", "a": config["target"], "g": []}]}
+    if config.get("amount") is not None:
+        payload["a"] = config["amount"]
+    if config.get("mints"):
+        payload["m"] = config["mints"]
+    return {"request": "creqA" + base64.urlsafe_b64encode(cbor2.dumps(payload)).decode().rstrip("=")}
+
+
+@app.get("/sessions/{key}/received-token")
+async def received_token(key: str):
+    deliveries = session(key)["deliveries"]
+    if not deliveries:
+        raise HTTPException(404, "No payment delivered")
+    payment = deliveries[-1]
+    token = {"token": [{"mint": payment["mint"], "proofs": payment["proofs"]}], "unit": payment.get("unit", "sat")}
+    return {"token": "cashuA" + base64.urlsafe_b64encode(json.dumps(token).encode()).decode().rstrip("="),
+            "id": payment.get("id"), "count": len(deliveries)}
+
+
+@app.post("/sessions/{key}/nwc")
+async def nwc(key: str, request: Request):
+    session(key)
+    from nostr_client import nwc_request
+    config = await request.json()
+    try:
+        return await nwc_request("ws://127.0.0.1:3341/sessions/" + key + "/relay", **config)
+    except asyncio.TimeoutError:
+        return JSONResponse({"timeout": True}, status_code=200)
+
+
+@app.post("/sessions/{key}/receive")
+async def receive_request(key: str, request: Request):
+    payload = await request.json()
+    session(key)["deliveries"].append(payload)
+    return {}
+
+
+@app.api_route("/sessions/{key}/mint/{mint}/{path:path}", methods=["GET", "POST"])
+async def proxy(key: str, mint: str, path: str, request: Request):
+    state = session(key)
+    if mint not in UPSTREAMS or not path.startswith("v1/"):
+        raise HTTPException(404)
+    route = "/" + path
+    fault = next((f for f in state["faults"] if f["remaining"] != 0
+                  and f["method"] == request.method and route.startswith(f["path"])), None)
+    if fault:
+        fault["remaining"] -= 1
+    record = {"method": request.method, "path": route, "forwarded": False,
+              "fault": fault["action"] if fault else None}
+    state["requests"].append(record)
+    if fault and fault["action"] == "reject":
+        return JSONResponse({"detail": "Scenario endpoint unavailable"}, status_code=503)
+    if fault and fault["action"] == "delay":
+        await asyncio.sleep(fault.get("seconds", 1))
+    headers = {name: request.headers[name] for name in ("content-type", "prefer") if name in request.headers}
+    upstream = await app.state.client.request(request.method, UPSTREAMS[mint] + route,
+                                             params=request.query_params,
+                                             content=await request.body(), headers=headers)
+    record.update(forwarded=True, status=upstream.status_code)
+    if fault and fault["action"] == "lose_response":
+        # Upstream has completed. Break the response body, producing a transport
+        # error instead of lying about the mint's committed state.
+        async def broken_body():
+            yield b""
+            raise ConnectionResetError("Intentional lost payment response")
+        return StreamingResponse(broken_body(), status_code=upstream.status_code,
+                                 headers={"content-length": str(max(1, len(upstream.content)))})
+    return Response(upstream.content, status_code=upstream.status_code,
+                    media_type=upstream.headers.get("content-type", "application/json"))
+
+
+def matches(event, filters):
+    def one(f):
+        return all((
+            "kinds" not in f or event["kind"] in f["kinds"],
+            "authors" not in f or event["pubkey"] in f["authors"],
+            "ids" not in f or event["id"] in f["ids"],
+            event["created_at"] >= f.get("since", 0),
+            event["created_at"] <= f.get("until", float("inf")),
+            all(any(t[0] == k[1:] and t[1] in values for t in event.get("tags", []) if len(t) >= 2)
+                for k, values in f.items() if k.startswith("#")),
+        ))
+    return any(one(f) for f in filters)
+
+
+@app.websocket("/sessions/{key}/relay")
+async def relay(key: str, socket: WebSocket):
+    state = session(key)
+    await socket.accept()
+    state["sockets"][socket] = {}
+    try:
+        while True:
+            message = await socket.receive_json()
+            if message[0] == "REQ":
+                sub, filters = message[1], message[2:]
+                state["sockets"][socket][sub] = filters
+                for event in list(state["events"].values()):
+                    if matches(event, filters):
+                        await socket.send_json(["EVENT", sub, event])
+                await socket.send_json(["EOSE", sub])
+            elif message[0] == "CLOSE":
+                state["sockets"][socket].pop(message[1], None)
+            elif message[0] == "EVENT":
+                event = message[1]
+                # Validate both canonical content and Schnorr signature so
+                # relay tests cannot succeed with unsigned synthetic events.
+                canonical = [0, event["pubkey"], event["created_at"], event["kind"], event["tags"], event["content"]]
+                digest = hashlib.sha256(json.dumps(canonical, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+                try:
+                    valid = digest == event["id"] and PublicKeyXOnly(bytes.fromhex(event["pubkey"])).verify(
+                        bytes.fromhex(event["sig"]), bytes.fromhex(digest))
+                except (ValueError, KeyError):
+                    valid = False
+                if not valid:
+                    await socket.send_json(["OK", event["id"], False, "invalid: event signature or id"])
+                    continue
+                state["events"][event["id"]] = event
+                await socket.send_json(["OK", event["id"], True, ""])
+                for peer, subscriptions in list(state["sockets"].items()):
+                    for sub, filters in list(subscriptions.items()):
+                        if matches(event, filters):
+                            await peer.send_json(["EVENT", sub, event])
+    except WebSocketDisconnect:
+        pass
+    finally:
+        state["sockets"].pop(socket, None)

--- a/CI/payment-tests/test_coverage.py
+++ b/CI/payment-tests/test_coverage.py
@@ -1,0 +1,24 @@
+import tempfile
+import unittest
+from pathlib import Path
+from check_coverage import android_results, missing_tests
+
+
+class CoverageGateTests(unittest.TestCase):
+    def test_missing_skipped_and_failed_are_not_coverage(self):
+        manifest = {'android': {'pr': ['Payments/a', 'Payments/b'], 'full': ['Payments/c']}}
+        self.assertEqual(missing_tests(manifest, 'android', 'pr', {}), ['Payments/a', 'Payments/b'])
+        self.assertEqual(missing_tests(manifest, 'android', 'pr', {'Payments/a': [True], 'Payments/b': [False]}), ['Payments/b'])
+        self.assertEqual(missing_tests(manifest, 'android', 'full', {'Payments/a': [True], 'Payments/b': [True]}), ['Payments/c'])
+        self.assertEqual(missing_tests(manifest, 'android', 'pr', {'Payments/a': [True], 'Payments/b': [True]}), [])
+
+    def test_junit_skip_failure_and_mixed_retry(self):
+        with tempfile.TemporaryDirectory() as directory:
+            Path(directory, 'TEST-payments.xml').write_text('''<testsuite>
+              <testcase classname="app.Payments" name="paid"/>
+              <testcase classname="app.Payments" name="skipped"><skipped/></testcase>
+              <testcase classname="app.Payments" name="retry"><failure/></testcase>
+              <testcase classname="app.Payments" name="retry"/>
+            </testsuite>''')
+            self.assertEqual(android_results(directory), {
+                'Payments/paid': [True], 'Payments/skipped': [False], 'Payments/retry': [False, True]})

--- a/CI/payment-tests/test_server.py
+++ b/CI/payment-tests/test_server.py
@@ -1,0 +1,79 @@
+import json
+import unittest
+
+import httpx
+from bolt11 import decode
+from fastapi.testclient import TestClient
+import server
+from nostr_client import encode_event
+
+
+class PaymentFixtureTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(server.app)
+        self.client.__enter__()
+        self.key = self.client.post('/sessions').json()['id']
+        self.root = '/sessions/' + self.key
+        self.forwarded = []
+
+        async def upstream(request):
+            self.forwarded.append(request)
+            return httpx.Response(200, json={'state': 'PAID'})
+        self.upstream = httpx.AsyncClient(transport=httpx.MockTransport(upstream))
+        server.app.state.client = self.upstream
+
+    def tearDown(self):
+        self.client.delete(self.root)
+        self.client.__exit__(None, None, None)
+
+    def test_reject_does_not_forward_then_expires(self):
+        self.client.post(self.root + '/faults', json={'action': 'reject', 'method': 'POST', 'path': '/v1/melt/bolt11'})
+        url = self.root + '/mint/cdk/v1/melt/bolt11'
+        self.assertEqual(self.client.post(url, json={}).status_code, 503)
+        self.assertEqual(len(self.forwarded), 0)
+        self.assertEqual(self.client.post(url, json={}).status_code, 200)
+        self.assertEqual(len(self.forwarded), 1)
+
+    def test_lost_response_occurs_after_upstream_commit(self):
+        self.client.post(self.root + '/faults', json={'action': 'lose_response', 'method': 'POST', 'path': '/v1/melt/bolt11'})
+        with self.assertRaises(Exception):
+            self.client.post(self.root + '/mint/cdk/v1/melt/bolt11', json={})
+        self.assertEqual(len(self.forwarded), 1)
+        record = self.client.get(self.root).json()['requests'][0]
+        self.assertTrue(record['forwarded'])
+        self.assertEqual(record['status'], 200)
+
+    def test_faults_are_isolated_and_match_method(self):
+        other = self.client.post('/sessions').json()['id']
+        try:
+            self.client.post(self.root + '/faults', json={'action': 'reject', 'method': 'POST', 'path': '/v1/melt'})
+            self.assertEqual(self.client.get(self.root + '/mint/cdk/v1/melt/quote/bolt11/one').status_code, 200)
+            self.assertEqual(self.client.post('/sessions/' + other + '/mint/cdk/v1/melt/bolt11', json={}).status_code, 200)
+        finally:
+            self.client.delete('/sessions/' + other)
+
+    def test_invoice_amount_expiry_and_script_are_encoded(self):
+        script = json.dumps({'pay_invoice_state': 'PAID', 'check_payment_state': 'PAID', 'pay_err': True, 'check_err': False})
+        value = self.client.post(self.root + '/invoice', json={'amount': 21, 'description': script, 'expiry': 1, 'age': 60}).json()['invoice']
+        decoded = decode(value)
+        self.assertEqual(decoded.amount_msat, 21000)
+        self.assertEqual(decoded.description, script)
+        self.assertTrue(decoded.has_expired())
+
+    def test_relay_replays_only_matching_session_events(self):
+        event = encode_event('0' * 63 + '1', 1059, [['p', 'recipient']], 'ciphertext')
+        with self.client.websocket_connect(self.root + '/relay') as ws:
+            invalid = dict(event, sig='0' * 128)
+            ws.send_json(['EVENT', invalid])
+            self.assertFalse(ws.receive_json()[2])
+            ws.send_json(['EVENT', event])
+            self.assertEqual(ws.receive_json(), ['OK', event['id'], True, ''])
+            ws.send_json(['REQ', 'matching', {'kinds': [1059], '#p': ['recipient']}])
+            self.assertEqual(ws.receive_json(), ['EVENT', 'matching', event])
+            self.assertEqual(ws.receive_json(), ['EOSE', 'matching'])
+            ws.send_json(['REQ', 'other', {'#p': ['other']}])
+            self.assertEqual(ws.receive_json(), ['EOSE', 'other'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/CI/start-payment-fixtures.sh
+++ b/CI/start-payment-fixtures.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${PAYMENT_TEST_PYTHON:-${SCRIPT_DIR}/.nutshell-venv/bin/python}"
+WORK_DIR="${SCRIPT_DIR}/.payment-workdir"
+mkdir -p "$WORK_DIR"
+if [ -e "$WORK_DIR/pids" ]; then
+    echo 'Payment fixtures already have a PID ledger; stop them before starting again.' >&2
+    exit 1
+fi
+: > "$WORK_DIR/pids"
+trap '"${SCRIPT_DIR}/stop-payment-fixtures.sh"' ERR
+for profile in controlled fees; do
+    port=3342
+    input_fee=0
+    if [ "$profile" = fees ]; then port=3343; input_fee=1000; fi
+    mkdir -p "$WORK_DIR/$profile"
+    # Empty local dotenv and CASHU_DIR prevent inherited personal mint settings.
+    : > "$WORK_DIR/$profile/.env"
+    (
+        cd "$WORK_DIR/$profile"
+        exec nohup env PYTHONPATH="${SCRIPT_DIR}/payment-tests" \
+            CASHU_DIR="$WORK_DIR/$profile" MINT_DATABASE="$WORK_DIR/$profile" \
+            MINT_URL="http://127.0.0.1:$port" MINT_LISTEN_HOST=127.0.0.1 MINT_LISTEN_PORT="$port" \
+            MINT_BACKEND_BOLT11_SAT=ControlledFakeWallet \
+            MINT_PRIVATE_KEY="PAYMENT_TEST_${profile}_DO_NOT_USE" \
+            MINT_INPUT_FEE_PPK="$input_fee" FAKEWALLET_BRR=false \
+            MINT_QUOTE_BACKEND_CHECK_RATE_LIMIT=0 MINT_RATE_LIMIT=false \
+            "$PYTHON_BIN" -m uvicorn controlled_mint:app --host 127.0.0.1 --port "$port" --log-level warning
+    ) > "$WORK_DIR/$profile.log" 2>&1 < /dev/null &
+    echo "$!" >> "$WORK_DIR/pids"
+done
+nohup env PYTHONPATH="${SCRIPT_DIR}/payment-tests" "$PYTHON_BIN" -m uvicorn server:app \
+    --host 127.0.0.1 --port 3341 --log-level warning \
+    > "$WORK_DIR/server.log" 2>&1 < /dev/null &
+echo "$!" >> "$WORK_DIR/pids"
+for endpoint in '3341/health' '3342/v1/info' '3343/v1/info'; do
+    ready=false
+    for _ in {1..100}; do
+        if curl -fsS "http://127.0.0.1:$endpoint" > /dev/null 2>&1; then ready=true; break; fi
+        sleep 0.2
+    done
+    if [ "$ready" != true ]; then echo "Payment fixture failed readiness: $endpoint" >&2; exit 1; fi
+done
+trap - ERR
+echo 'Payment fixtures ready.'

--- a/CI/stop-payment-fixtures.sh
+++ b/CI/stop-payment-fixtures.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PID_FILE="${SCRIPT_DIR}/.payment-workdir/pids"
+if [ -f "$PID_FILE" ]; then
+    while read -r pid; do
+        kill "$pid" 2>/dev/null || true
+    done < "$PID_FILE"
+    rm -f "$PID_FILE"
+fi

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentExtendedLocalMintTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentExtendedLocalMintTest.kt
@@ -37,7 +37,11 @@ class PaymentExtendedLocalMintTest : PaymentFixtureTest() {
             assertEquals(id, delivered.getValue("id").jsonPrimitive.content)
             assertEquals("Payment request must include the receiver's redemption fee", 21,
                 receiver.receive(delivered.getValue("token").jsonPrimitive.content))
-            assertTrue(payer.balance() <= 79)
+            if (mint == "controlled") {
+                assertEquals("A zero-fee request must debit exactly the requested amount", 79, payer.balance())
+            } else {
+                assertTrue(payer.balance() <= 79)
+            }
         }
     }
 

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentExtendedLocalMintTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentExtendedLocalMintTest.kt
@@ -1,0 +1,113 @@
+package com.cashu.me.liveintegration
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.cashu.me.Models.PaymentMethodKind
+import com.cashu.me.test.FullOnly
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+@FullOnly
+class PaymentExtendedLocalMintTest : PaymentFixtureTest() {
+    @Test fun cashuRequestFixedAndAmountlessHttpDelivery() = runBlocking {
+        assertRequestDelivery("controlled")
+    }
+
+    // Runnable reproduction, excluded from the required manifest until CDK is fixed.
+    @Test fun cashuRequestReceiverFeeRegression() = runBlocking {
+        assumeTrue("Known CDK 0.18 receiver-fee regression; see CI/payment-tests/README.md",
+            InstrumentationRegistry.getArguments().getString("cashu.paymentKnownRegressions") == "true")
+        assertRequestDelivery("fees")
+    }
+
+    private suspend fun assertRequestDelivery(mint: String) {
+        for (amount in listOf(21L, null)) {
+            val payer = wallet(mint)
+            val receiver = wallet(mint)
+            payer.fund()
+            val encoded = call("$root/request", "POST", buildJsonObject {
+                put("target", "$fixture$root/receive")
+                putJsonArray("mints") { add(payer.url) }
+                if (amount != null) put("amount", amount)
+            }).getValue("request").jsonPrimitive.content
+            payer.gateway.payCashuPaymentRequest(encoded, if (amount == null) 21 else null, payer.url)
+            val delivered = call("$root/received-token")
+            assertEquals(id, delivered.getValue("id").jsonPrimitive.content)
+            assertEquals("Payment request must include the receiver's redemption fee", 21,
+                receiver.receive(delivered.getValue("token").jsonPrimitive.content))
+            assertTrue(payer.balance() <= 79)
+        }
+    }
+
+    @Test fun cashuRequestDeliveryFailureLeavesReclaimableToken() = runBlocking {
+        val payer = wallet("controlled")
+        payer.fund()
+        val encoded = call("$root/request", "POST", buildJsonObject {
+            put("target", "$fixture$root/unavailable"); put("amount", 21)
+        }).getValue("request").jsonPrimitive.content
+        expectError("deliver") { payer.gateway.payCashuPaymentRequest(encoded, null, payer.url) }
+        val operation = payer.gateway.listPendingSendOperationIds(payer.url).single()
+        assertEquals(21, payer.gateway.revokePendingSend(payer.url, operation))
+        assertEquals(100, payer.balance())
+    }
+
+    @Test fun repeatedFeePreviewReleasesReservedProofs() = runBlocking {
+        val sender = wallet("controlled")
+        sender.fund()
+        repeat(3) { assertEquals(0, sender.gateway.estimateCashuPaymentRequestFee(80, sender.url)) }
+        assertEquals(100, sender.balance())
+        val recipient = wallet("controlled")
+        assertEquals(100, recipient.receive(sender.send(100).token))
+    }
+
+    @Test fun multipleMintUnitsDoNotCrossCredit() = runBlocking {
+        val payer = wallet("cdk")
+        payer.fund(21)
+        payer.gateway.ensureWallet(payer.url, "usd")
+        val quote = payer.gateway.createMintQuote(125, PaymentMethodKind.Bolt11, payer.url, "usd")
+        payer.awaitPaid(quote)
+        assertEquals(125, payer.gateway.mintTokens(quote.id))
+        val recipient = wallet("cdk")
+        recipient.gateway.ensureWallet(recipient.url, "usd")
+        val token = payer.gateway.sendEcashToken(25, null, null, payer.url, "usd")
+        assertEquals(25, recipient.receive(token.token))
+        assertEquals(21, payer.balance())
+        assertEquals(100, payer.gateway.unitBalance(payer.url, "usd"))
+        assertEquals(25, recipient.gateway.unitBalance(recipient.url, "usd"))
+        assertEquals(0, recipient.balance())
+    }
+
+    @Test fun nwcPaymentLimitReplayAndBalance() = runBlocking {
+        val payer = wallet("cdk")
+        payer.fund()
+        val relay = fixture.replace("http://", "ws://") + root + "/relay"
+        val service = payer.gateway.createOrRestoreNwcService(payer.url, listOf(relay), ByteArray(64) { 1 }, null, 21_000u)
+        service.start()
+        try {
+            fun request(method: String, invoice: String? = null, duplicate: Boolean = false) =
+                call("$root/nwc", "POST", buildJsonObject {
+                    put("uri", service.connectionUri); put("method", method); put("duplicate", duplicate)
+                    if (invoice != null) putJsonObject("params") { put("invoice", invoice) }
+                })
+            assertEquals(100_000, request("get_balance").getValue("result").jsonObject.getValue("balance").jsonPrimitive.long)
+            val rejected = request("pay_invoice", invoice(22))
+            assertEquals("QUOTA_EXCEEDED", rejected.getValue("error").jsonObject.getValue("code").jsonPrimitive.content)
+            assertEquals(100, payer.balance())
+            val paid = request("pay_invoice", invoice(), true)
+            assertNotNull(paid["result"])
+            assertNull(paid["timeout"])
+            val receipts = payer.gateway.listTransactions(mapOf(payer.url to listOf("sat"))).filter { it.type == com.cashu.me.Models.TransactionType.Outgoing }
+            assertEquals(1, receipts.size)
+            assertEquals(100, payer.balance() + 21 + receipts.single().fee)
+            assertEquals(payer.balance() * 1000, request("get_balance").getValue("result").jsonObject.getValue("balance").jsonPrimitive.long)
+            assertEquals(1, payer.gateway.listTransactions(mapOf(payer.url to listOf("sat"))).count {
+                it.type == com.cashu.me.Models.TransactionType.Outgoing
+            })
+        } finally {
+            service.stop()
+            service.close()
+        }
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentSafetyLocalMintTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/liveintegration/PaymentSafetyLocalMintTest.kt
@@ -1,0 +1,307 @@
+package com.cashu.me.liveintegration
+
+import androidx.test.platform.app.InstrumentationRegistry
+import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
+import com.cashu.me.Core.NostrService
+import com.cashu.me.Models.MeltQuoteState
+import com.cashu.me.Models.MeltSettlement
+import com.cashu.me.Models.MintQuoteInfo
+import com.cashu.me.Models.MintQuoteState
+import com.cashu.me.Models.PaymentMethodKind
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.UUID
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.*
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/** Production native gateway, real SQLite and mint proofs; only transport is controlled. */
+open class PaymentFixtureTest {
+    private val args = InstrumentationRegistry.getArguments()
+    lateinit var fixture: String
+    lateinit var id: String
+    private val wallets = mutableListOf<TestWallet>()
+    private val directory = File(InstrumentationRegistry.getInstrumentation().targetContext.filesDir, "payments-${UUID.randomUUID()}")
+    val root get() = "/sessions/$id"
+
+    @Before fun setupFixture() {
+        assumeTrue("Enable the local payment suite", args.getString("cashu.paymentFixtures") == "true")
+        fixture = requireNotNull(args.getString("cashu.paymentFixtureUrl")) { "Payment fixture URL is required" }
+        id = call("/sessions", "POST").getValue("id").jsonPrimitive.content
+        directory.mkdirs()
+    }
+
+    @After fun closeFixture() = runBlocking {
+        wallets.forEach { it.gateway.closeWalletRepository() }
+        if (::id.isInitialized) call(root, "DELETE")
+        directory.deleteRecursively()
+        Unit
+    }
+
+    fun call(path: String, method: String = "GET", body: JsonObject? = null): JsonObject {
+        val connection = (URL(fixture + path).openConnection() as HttpURLConnection).apply {
+            requestMethod = method
+            connectTimeout = 10_000
+            readTimeout = 15_000
+            if (body != null) {
+                doOutput = true
+                setRequestProperty("Content-Type", "application/json")
+            }
+        }
+        try {
+            if (body != null) connection.outputStream.use { it.write(body.toString().toByteArray()) }
+            check(connection.responseCode in 200..299) { "Fixture request failed: $path (${connection.responseCode})" }
+            return Json.parseToJsonElement(connection.inputStream.bufferedReader().use { it.readText() }).jsonObject
+        } finally { connection.disconnect() }
+    }
+
+    fun mintUrl(mint: String) = "$fixture$root/mint/$mint"
+    suspend fun wallet(mint: String): TestWallet = TestWallet(mint).also { it.open(); wallets += it }
+
+    inner class TestWallet(val mint: String) {
+        var gateway = CdkWalletGatewayImpl()
+        val url = mintUrl(mint)
+        private val path = File(directory, "${UUID.randomUUID()}.db").absolutePath
+        private lateinit var seed: String
+        suspend fun open() {
+            gateway.initializeLogging("warn")
+            if (!::seed.isInitialized) seed = gateway.generateMnemonic()
+            gateway.openWalletRepository(seed, path)
+            gateway.ensureWallet(url)
+        }
+        suspend fun reopen() {
+            gateway.closeWalletRepository()
+            gateway = CdkWalletGatewayImpl()
+            open()
+        }
+        suspend fun balance() = gateway.totalBalance(url)
+        suspend fun quote(amount: Long) = gateway.createMintQuote(amount, PaymentMethodKind.Bolt11, url, "sat")
+        suspend fun pay(quote: MintQuoteInfo): MintQuoteInfo {
+            if (mint in listOf("controlled", "fees")) {
+                call("$root/pay/$mint", "POST", buildJsonObject { put("invoice", quote.request) })
+            }
+            return awaitPaid(quote)
+        }
+        suspend fun awaitPaid(quote: MintQuoteInfo): MintQuoteInfo {
+            repeat(80) {
+                val current = gateway.checkMintQuote(quote.id)
+                if (current.state == MintQuoteState.Paid || current.state == MintQuoteState.Issued) return current
+                delay(100)
+            }
+            error("Mint quote did not become paid")
+        }
+        suspend fun fund(amount: Long = 100) { assertEquals(amount, gateway.mintTokens(pay(quote(amount)).id)) }
+        suspend fun send(amount: Long, key: String? = null) = gateway.sendEcashToken(amount, "Payment test", key, url)
+        suspend fun receive(token: String, keys: List<String> = emptyList()) = gateway.receiveEcashToken(token, keys)
+    }
+
+    fun invoice(amount: Long = 21, script: JsonObject? = null): String = call("$root/invoice", "POST", buildJsonObject {
+        put("amount", amount)
+        if (script != null) put("description", script.toString())
+    }).getValue("invoice").jsonPrimitive.content
+
+    fun arm(path: String, action: String, method: String = "POST", count: Int = 1) {
+        call("$root/faults", "POST", buildJsonObject {
+            put("path", path); put("action", action); put("method", method); put("remaining", count)
+        })
+    }
+
+    suspend fun expectError(vararg fragments: String, operation: suspend () -> Unit) {
+        val failure = runCatching { operation() }.exceptionOrNull()
+        assertNotNull("Expected payment rejection", failure)
+        val message = failure.toString().lowercase()
+        assertTrue("Unexpected rejection: $failure", fragments.any { message.contains(it.lowercase()) })
+    }
+}
+
+class PaymentSafetyLocalMintTest : PaymentFixtureTest() {
+    @Test fun controlledQuoteRequiresPaymentAndIssuesOnlyOnce() = runBlocking {
+        val wallet = wallet("controlled")
+        val quote = wallet.quote(21)
+        assertEquals(MintQuoteState.Unpaid, wallet.gateway.checkMintQuote(quote.id).state)
+        assertEquals(0, wallet.balance())
+        expectError("not paid", "unpaid", "20001", "Amount undefined") { wallet.gateway.mintTokens(quote.id) }
+        wallet.gateway.recoverIncompleteSagas(wallet.url)
+        wallet.pay(quote)
+        assertEquals(21, wallet.gateway.mintTokens(quote.id))
+        assertEquals(MintQuoteState.Issued, wallet.gateway.checkMintQuote(quote.id).state)
+        assertEquals(0, wallet.gateway.mintUnissuedQuotes(wallet.url, "sat"))
+        assertEquals(21, wallet.balance())
+    }
+
+    @Test fun bolt11InternalAndExternalPaymentsConserveBalanceAndPersistReceipt() = runBlocking {
+        for (mint in listOf("controlled", "cdk")) {
+            val payer = wallet(mint)
+            val recipient = wallet(mint)
+            payer.fund()
+            val incoming = if (mint == "controlled") recipient.quote(21) else null
+            val quote = payer.gateway.createMeltQuote(incoming?.request ?: invoice(), null, payer.url)
+            // Nutshell 0.20.1 returns PENDING before persisting its async task.
+            if (mint == "controlled") arm("/v1/melt/quote/bolt11/", "delay", "GET")
+            val result = payer.gateway.meltTokens(quote.id, payer.url).result
+            assertEquals(MeltSettlement.Settled, result.settlement)
+            assertEquals(21, result.amount)
+            assertEquals(100 - 21 - result.feePaid, payer.balance())
+            payer.reopen()
+            val history = payer.gateway.listTransactions(mapOf(payer.url to listOf("sat"))).filter { it.quoteId == quote.id }
+            assertEquals(1, history.size)
+            assertEquals(21, history.single().amount)
+            assertEquals(result.feePaid, history.single().fee)
+            if (incoming != null) {
+                recipient.awaitPaid(incoming)
+                assertEquals(21, recipient.gateway.mintTokens(incoming.id))
+            }
+        }
+    }
+
+    @Test fun lostMeltResponseRecoversWithoutSecondDebit() = runBlocking {
+        val payer = wallet("cdk")
+        payer.fund()
+        val quote = payer.gateway.createMeltQuote(invoice(), null, payer.url)
+        arm("/v1/melt/bolt11", "lose_response")
+        runCatching { payer.gateway.meltTokens(quote.id, payer.url) }
+        payer.gateway.recoverIncompleteSagas(payer.url)
+        assertEquals(MeltQuoteState.Paid, payer.gateway.checkMeltQuoteStatus(quote.id, payer.url).state)
+        val after = payer.balance()
+        assertTrue(after < 100)
+        payer.reopen()
+        payer.gateway.recoverIncompleteSagas(payer.url)
+        assertEquals(after, payer.balance())
+        val receipts = payer.gateway.listTransactions(mapOf(payer.url to listOf("sat"))).filter { it.quoteId == quote.id }
+        assertEquals(1, receipts.size)
+        assertEquals(100, after + 21 + receipts.single().fee)
+        val records = call(root).getValue("requests").jsonArray
+        assertTrue(records.any { it.jsonObject["fault"]?.jsonPrimitive?.contentOrNull == "lose_response" && it.jsonObject["forwarded"]?.jsonPrimitive?.boolean == true })
+    }
+
+    @Test fun lostMintResponseRecoversPaidQuoteExactlyOnce() = runBlocking {
+        val wallet = wallet("controlled")
+        val quote = wallet.pay(wallet.quote(42))
+        arm("/v1/mint/bolt11", "lose_response")
+        runCatching { wallet.gateway.mintTokens(quote.id) }
+        wallet.reopen()
+        wallet.gateway.recoverIncompleteSagas(wallet.url)
+        wallet.gateway.mintUnissuedQuotes(wallet.url, "sat")
+        assertEquals(42, wallet.balance())
+        assertEquals(0, wallet.gateway.mintUnissuedQuotes(wallet.url, "sat"))
+        assertEquals(1, wallet.gateway.listTransactions(mapOf(wallet.url to listOf("sat"))).count { it.quoteId == quote.id })
+        assertTrue(call(root).getValue("requests").jsonArray.any {
+            it.jsonObject["fault"]?.jsonPrimitive?.contentOrNull == "lose_response" &&
+                it.jsonObject["forwarded"]?.jsonPrimitive?.boolean == true
+        })
+    }
+
+    @Test fun insufficientFundsAndOfflineQuoteDoNotDebit() = runBlocking {
+        val wallet = wallet("controlled")
+        wallet.fund()
+        val quote = wallet.gateway.createMeltQuote(invoice(101), null, wallet.url)
+        expectError("insufficient", "not enough", "Payment status is unknown") { wallet.gateway.meltTokens(quote.id, wallet.url) }
+        arm("/v1/melt/quote/bolt11", "reject")
+        expectError("503", "unavailable", "http") { wallet.gateway.createMeltQuote(invoice(), null, wallet.url) }
+        assertEquals(100, wallet.balance())
+        val recipient = wallet("controlled")
+        assertEquals(100, recipient.receive(wallet.send(100).token))
+    }
+
+    @Test fun backendFailureReturnsSpendableFunds() = runBlocking {
+        val payer = wallet("cdk")
+        payer.fund()
+        val request = invoice(script = buildJsonObject {
+            put("pay_invoice_state", "UNPAID"); put("check_payment_state", "UNPAID")
+            put("pay_err", true); put("check_err", false)
+        })
+        val quote = payer.gateway.createMeltQuote(request, null, payer.url)
+        runCatching { payer.gateway.meltTokens(quote.id, payer.url) }
+        payer.gateway.recoverIncompleteSagas(payer.url)
+        assertEquals(100, payer.balance())
+        val receiver = wallet("cdk")
+        assertEquals(100, receiver.receive(payer.send(100).token))
+    }
+
+    @Test fun paidBolt11RecoversAfterDatabaseReopenExactlyOnce() = runBlocking {
+        val wallet = wallet("controlled")
+        val quote = wallet.pay(wallet.quote(42))
+        wallet.reopen()
+        assertEquals(42, wallet.gateway.mintUnissuedQuotes(wallet.url, "sat"))
+        assertEquals(0, wallet.gateway.mintUnissuedQuotes(wallet.url, "sat"))
+        assertEquals(1, wallet.gateway.listTransactions(mapOf(wallet.url to listOf("sat"))).count { it.quoteId == quote.id })
+    }
+
+    @Test fun ecashClaimAfterReopenCannotBeRevokedOrReceivedTwice() = runBlocking {
+        val sender = wallet("controlled")
+        val receiver = wallet("controlled")
+        sender.fund()
+        val token = sender.send(21).token
+        val operation = sender.gateway.listPendingSendOperationIds(sender.url).single()
+        sender.reopen()
+        assertTrue(sender.gateway.listPendingSendOperationIds(sender.url).contains(operation))
+        assertEquals(21, receiver.receive(token))
+        assertTrue(sender.gateway.checkPendingSendClaimed(sender.url, operation))
+        expectError("spent", "claimed", "not found", "completed", "unknown") { sender.gateway.revokePendingSend(sender.url, operation) }
+        expectError("spent", "already", "11001") { receiver.receive(token) }
+        assertEquals(79, sender.balance())
+        assertEquals(21, receiver.balance())
+    }
+
+    @Test fun revokeUnclaimedTokenRestoresSpendability() = runBlocking {
+        val sender = wallet("controlled")
+        val receiver = wallet("controlled")
+        sender.fund()
+        val token = sender.send(21).token
+        val operation = sender.gateway.listPendingSendOperationIds(sender.url).single()
+        assertEquals(21, sender.gateway.revokePendingSend(sender.url, operation))
+        expectError("spent", "already", "11001") { receiver.receive(token) }
+        assertEquals(100, receiver.receive(sender.send(100).token))
+    }
+
+    @Test fun feeChargingMintMaxSendAndReceiveConserveValue() = runBlocking {
+        val sender = wallet("fees")
+        val receiver = wallet("fees")
+        sender.fund()
+        val sent = sender.send(100)
+        assertEquals(0, sent.fee)
+        val fee = receiver.gateway.calculateReceiveFee(sent.token)
+        assertTrue(fee > 0)
+        val received = receiver.receive(sent.token)
+        assertEquals(100 - fee, received)
+        assertEquals(0, sender.balance())
+        assertEquals(received, receiver.balance())
+    }
+
+    @Test fun p2pkWrongKeyThenCorrectKeyOnBothMints() = runBlocking {
+        val privateKey = "0".repeat(63) + "1"
+        val publicKey = "02" + NostrService.publicKeyHex(privateKey)
+        for (mint in listOf("nutshell", "cdk")) {
+            val sender = wallet(mint)
+            val receiver = wallet(mint)
+            sender.fund()
+            val token = sender.send(21, publicKey).token
+            expectError("key", "signature", "witness", "sign", "p2pk") { receiver.receive(token, listOf("0".repeat(63) + "2")) }
+            assertEquals(0, receiver.balance())
+            assertEquals(21, receiver.receive(token, listOf(privateKey)))
+        }
+    }
+
+    @Test fun concurrentReceiversCannotDoubleCredit() = runBlocking {
+        val sender = wallet("controlled")
+        val a = wallet("controlled")
+        val b = wallet("controlled")
+        sender.fund()
+        val token = sender.send(21).token
+        val results = coroutineScope {
+            val first = async { runCatching { a.receive(token) }.isSuccess }
+            val second = async { runCatching { b.receive(token) }.isSuccess }
+            listOf(first.await(), second.await())
+        }
+        assertEquals(1, results.count { it })
+        assertEquals(21, a.balance() + b.balance())
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
@@ -25,6 +25,7 @@ enum class FixtureMode {
     FundedWithHistory,
     LiveSeededWithoutMint,
     LiveLocalMint,
+    LivePayments,
 }
 
 data class LaunchedFixture(
@@ -46,11 +47,14 @@ object AppTestFixture {
         mode: FixtureMode,
         deepLink: String? = null,
         supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
+        paymentMintUrl: String? = null,
     ): LaunchedFixture {
         val application = ApplicationProvider.getApplicationContext<UiTestApplication>()
         val usesLiveGateway = mode == FixtureMode.LiveLocalMint ||
-            mode == FixtureMode.LiveSeededWithoutMint
-        val mintUrl = if (usesLiveGateway) {
+            mode == FixtureMode.LiveSeededWithoutMint || mode == FixtureMode.LivePayments
+        val mintUrl = if (mode == FixtureMode.LivePayments) {
+            requireNotNull(paymentMintUrl) { "Live payments require an isolated local mint" }
+        } else if (usesLiveGateway) {
             InstrumentationRegistry.getArguments()
                 .getString("cashu.nutshellMintUrl")
                 ?.trim()
@@ -99,7 +103,9 @@ object AppTestFixture {
             )
         }
         val dependencies = AppContainerDependencies(
-            runtimePolicy = UiRuntimePolicy.DeterministicTest,
+            runtimePolicy = if (mode == FixtureMode.LivePayments) {
+                UiRuntimePolicy.DeterministicTest.copy(runStartupMaintenance = true, pollQuotesInForeground = true)
+            } else UiRuntimePolicy.DeterministicTest,
             walletGateway = { fake ?: CdkWalletGatewayImpl() },
         )
         val container = AppContainer(application, dependencies)
@@ -107,11 +113,14 @@ object AppTestFixture {
         runBlocking {
             container.walletManager.initialize()
             if (mode != FixtureMode.EmptyWallet) {
-                container.walletManager.createNewWalletFromMnemonic(FakeWalletGateway.FixedMnemonic)
+                val mnemonic = if (mode == FixtureMode.LivePayments) {
+                    CdkWalletGatewayImpl().generateMnemonic()
+                } else FakeWalletGateway.FixedMnemonic
+                container.walletManager.createNewWalletFromMnemonic(mnemonic)
             }
             if (mode == FixtureMode.SeededWithMint ||
                 mode == FixtureMode.FundedWithHistory ||
-                mode == FixtureMode.LiveLocalMint
+                mode == FixtureMode.LiveLocalMint || mode == FixtureMode.LivePayments
             ) {
                 container.walletManager.addMint(mintUrl)
                 container.walletManager.refreshBalance()

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LivePaymentJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/LivePaymentJourneyTest.kt
@@ -1,0 +1,58 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import com.cashu.me.liveintegration.PaymentFixtureTest
+import com.cashu.me.Models.TransactionKind
+import com.cashu.me.Models.TransactionStatus
+import com.cashu.me.Models.TransactionType
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+
+class LivePaymentJourneyTest : PaymentFixtureTest() {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { launched?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var launched: LaunchedFixture? = null
+
+    @Test fun cdkReceivePayAndReopenHistory() = receivePayAndReopen("cdk")
+    @Test fun nutshellReceivePayAndReopenHistory() = receivePayAndReopen("nutshell")
+
+    private fun receivePayAndReopen(mint: String) {
+        val fixture = AppTestFixture.launch(FixtureMode.LivePayments, paymentMintUrl = mintUrl(mint))
+        launched = fixture
+        robot.awaitTag(UiTestTags.WalletScreen)
+            .tapTag(UiTestTags.WalletReceive)
+            .tapDescription("Bitcoin. Receive over Lightning or on-chain")
+            .awaitTag(UiTestTags.ReceiveLightningScreen)
+            .tapDescription("1").tapDescription("0").tapDescription("0")
+            .tapTextWithinTag(UiTestTags.ReceiveLightningScreen, "Create invoice")
+            .awaitText("Payment Received!", timeoutMillis = 30_000)
+            .tapText("Done")
+            .awaitTag(UiTestTags.WalletScreen)
+        val manager = fixture.container.walletManager
+        assertEquals(100L, manager.state.value.balance)
+        robot.tapTag(UiTestTags.WalletSend)
+            .awaitTag(UiTestTags.SendSheet)
+            .typeIntoTag(UiTestTags.SendDestination, invoice())
+            .awaitTag(UiTestTags.SendPaymentSubmit)
+            .tapTag(UiTestTags.SendPaymentSubmit)
+            .awaitText("Payment sent", timeoutMillis = 30_000)
+        val payment = manager.state.value.transactions.single {
+            it.type == TransactionType.Outgoing && it.kind == TransactionKind.Lightning
+        }
+        assertEquals(TransactionStatus.Completed, payment.status)
+        assertEquals(21L, payment.amount)
+        assertEquals(100L - 21 - payment.fee, manager.state.value.balance)
+        robot.tapText("Done").awaitTag(UiTestTags.WalletScreen).tapText("History")
+            .awaitTag(UiTestTags.transactionRow(payment.id))
+        fixture.scenario.recreate()
+        robot.awaitTag(UiTestTags.HistoryScreen).awaitTag(UiTestTags.transactionRow(payment.id))
+    }
+}

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E20100000000000000000001 /* PaymentSafetyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20100000000000000000002; };
 		AA9600000000000000000001 /* NPCServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9600000000000000000002 /* NPCServiceTests.swift */; };
 		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
 		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
@@ -213,6 +214,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E20100000000000000000002 /* PaymentSafetyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentSafetyIntegrationTests.swift; path = ../CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift; sourceTree = "<group>"; };
 		AA9600000000000000000002 /* NPCServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/NPCServiceTests.swift; sourceTree = "<group>"; };
 		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
 		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 			children = (
 				323A00000000000000000002 /* PriceServiceTests.swift */,
 				F1CF8C0C2E1379BCD23CF8C6 /* IntegrationTestBase.swift */,
+				E20100000000000000000002 /* PaymentSafetyIntegrationTests.swift */,
 				72DD529F60A8D9D1A81E3FBB /* NutshellIntegrationTests.swift */,
 				T1B0000000000001 /* InMemoryStorage.swift */,
 				T1B0000000000002 /* WalletStoreTests.swift */,
@@ -1045,6 +1048,7 @@
 			files = (
 				323A00000000000000000001 /* PriceServiceTests.swift in Sources */,
 				BF36C01CE0AB810E1B462448 /* IntegrationTestBase.swift in Sources */,
+				E20100000000000000000001 /* PaymentSafetyIntegrationTests.swift in Sources */,
 				349E3802577110813AC1A9E3 /* NutshellIntegrationTests.swift in Sources */,
 				T2B0000000000001 /* InMemoryStorage.swift in Sources */,
 				T2B0000000000002 /* WalletStoreTests.swift in Sources */,

--- a/ios/CashuWallet/App/CashuWalletApp.swift
+++ b/ios/CashuWallet/App/CashuWalletApp.swift
@@ -78,7 +78,7 @@ struct CashuWalletApp: App {
                             SentryService.initialize()
                         }
                         await walletManager.initialize()
-                        guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
+                        guard IntegrationTestConfig.shouldRunPaymentServices else { return }
                         CashuRequestListener.shared.attach(walletManager: walletManager)
                         CashuRequestListener.shared.requestStart()
                         if SettingsManager.shared.checkSentTokens {
@@ -97,7 +97,7 @@ struct CashuWalletApp: App {
                 }
             }
             .onChange(of: scenePhase) { _, newPhase in
-                guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
+                guard IntegrationTestConfig.shouldRunPaymentServices else { return }
                 switch newPhase {
                 case .active:
                     appLockManager.appBecameActive()
@@ -109,8 +109,10 @@ struct CashuWalletApp: App {
                     Task { await walletManager.syncPendingMeltQuotes() }
                     Task { await NWCManager.shared.startIfEnabled() }
                     // Recover enabled services and re-arm polling after backgrounding.
-                    Task { await NPCService.shared.initializeIfEnabled() }
-                    if PriceService.shared.isEnabled {
+                    if !IntegrationTestConfig.isEnabled {
+                        Task { await NPCService.shared.initializeIfEnabled() }
+                    }
+                    if !IntegrationTestConfig.isEnabled && PriceService.shared.isEnabled {
                         PriceService.shared.startAutoRefresh()
                     }
                     walletManager.startPendingQuoteForegroundPolling()

--- a/ios/CashuWallet/Core/IntegrationTestConfig.swift
+++ b/ios/CashuWallet/Core/IntegrationTestConfig.swift
@@ -42,6 +42,28 @@ struct IntegrationTestConfig {
         isEnabled
     }
 
+    /// Explicit live-payment tests retain real recovery and local relay listeners.
+    /// This is independent of visual determinism and telemetry suppression.
+    static var shouldRunPaymentServices: Bool {
+        #if DEBUG
+        return !isEnabled || ProcessInfo.processInfo.environment["UITEST_LIVE_PAYMENTS"] == "1"
+        #else
+        return !isEnabled
+        #endif
+    }
+
+    static var localPaymentTestRelay: String? {
+        #if DEBUG
+        guard isEnabled, shouldRunPaymentServices,
+              let value = ProcessInfo.processInfo.environment["UITEST_PAYMENT_RELAY"],
+              let url = URL(string: value), url.scheme == "ws",
+              ["localhost", "127.0.0.1"].contains(url.host ?? "") else { return nil }
+        return value
+        #else
+        return nil
+        #endif
+    }
+
     static var shouldDisableAnimations: Bool {
         ProcessInfo.processInfo.environment["UITEST_DISABLE_ANIMATIONS"] == "1"
     }

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -482,6 +482,9 @@ extension WalletManager {
             SettingsManager.shared.resetWalletScopedData()
         }
 
+        if let relay = IntegrationTestConfig.localPaymentTestRelay {
+            SettingsManager.shared.nostrRelays = [relay]
+        }
         if IntegrationTestConfig.shouldSeedWallet {
             do {
                 try await installSeededUITestWallet()
@@ -752,7 +755,7 @@ extension WalletManager {
             }
         }
         needsOnboarding = false
-        guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
+        guard IntegrationTestConfig.shouldRunPaymentServices else { return }
         startDeferredStartupMaintenance()
         CashuRequestListener.shared.attach(walletManager: self)
         CashuRequestListener.shared.requestStart()
@@ -943,7 +946,7 @@ extension WalletManager {
     private func resumeCashuRequestListener() {
         guard walletRepository != nil else { return }
         CashuRequestListener.shared.attach(walletManager: self)
-        guard !IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return }
+        guard IntegrationTestConfig.shouldRunPaymentServices else { return }
         CashuRequestListener.shared.requestStart()
     }
 

--- a/ios/CashuWalletUITests/UITestBase.swift
+++ b/ios/CashuWalletUITests/UITestBase.swift
@@ -37,7 +37,7 @@ class UITestBase: XCTestCase {
         app = nil
     }
 
-    private func launchEnvironment(for mode: LaunchMode) -> [String: String] {
+    func launchEnvironment(for mode: LaunchMode) -> [String: String] {
         var environment = [
             "CI_INTEGRATION_TEST": "1",
             "RESET_WALLET": "1",

--- a/ios/CashuWalletUITests/WalletIntegrationTests.swift
+++ b/ios/CashuWalletUITests/WalletIntegrationTests.swift
@@ -36,3 +36,97 @@ final class WalletIntegrationTests: UITestBase {
         XCTAssertTrue(mintRow.waitForExistence(timeout: 10), "Added mint should appear in the Mints list")
     }
 }
+
+/// Real UI receive/send flow. Fixture endpoints generate invoices, never balances.
+class LivePaymentUITestBase: UITestBase {
+    var fixtureURL: String!
+    var fixtureSession: String!
+    var backend: String { "cdk" }
+    override var mintURL: String { fixtureURL + "/sessions/" + fixtureSession + "/mint/" + backend }
+
+    override func setUpWithError() throws {
+        fixtureURL = ProcessInfo.processInfo.environment["PAYMENT_FIXTURE_URL"]
+        try XCTSkipIf(fixtureURL == nil, "Local payment fixtures are required")
+        fixtureSession = try fixtureCall("/sessions", method: "POST")["id"] as? String
+        try super.setUpWithError()
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        if fixtureSession != nil { _ = try fixtureCall("/sessions/" + fixtureSession, method: "DELETE") }
+    }
+
+    override func launchEnvironment(for mode: LaunchMode) -> [String: String] {
+        var environment = super.launchEnvironment(for: mode)
+        environment["UITEST_LIVE_PAYMENTS"] = "1"
+        environment["UITEST_PAYMENT_RELAY"] = fixtureURL.replacingOccurrences(of: "http://", with: "ws://") + "/sessions/" + fixtureSession + "/relay"
+        return environment
+    }
+
+    func fixtureCall(_ path: String, method: String = "GET", body: [String: Any]? = nil) throws -> [String: Any] {
+        var request = URLRequest(url: URL(string: fixtureURL + path)!)
+        request.httpMethod = method
+        request.timeoutInterval = 15
+        if let body {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let done = expectation(description: "Payment fixture response")
+        var result: Result<[String: Any], Error>!
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            defer { done.fulfill() }
+            result = Result {
+                if let error { throw error }
+                guard let response = response as? HTTPURLResponse, (200..<300).contains(response.statusCode), let data else {
+                    throw NSError(domain: "PaymentFixture", code: 1)
+                }
+                return try JSONSerialization.jsonObject(with: data) as! [String: Any]
+            }
+        }.resume()
+        wait(for: [done], timeout: 20)
+        return try XCTUnwrap(result, "Fixture returned no response").get()
+    }
+
+    func receiveThroughUI() {
+        tapWhenReady(app.buttons["wallet-action-receive"])
+        tapWhenReady(app.buttons["wallet-flow-receiveLightning"])
+        XCTAssertTrue(screen("receive-lightning-screen").waitForExistence(timeout: 15))
+        for digit in ["1", "0", "0"] { tapWhenReady(app.buttons[digit]) }
+        tapWhenReady(app.buttons["receive-lightning-create-request"])
+        XCTAssertTrue(app.staticTexts["Payment Received!"].waitForExistence(timeout: 30))
+        tapWhenReady(app.buttons["Done"])
+        waitForMainTab()
+    }
+
+    func receiveThenPayAndReopenHistory() throws {
+        createWalletWithMint()
+        receiveThroughUI()
+        let invoice = try fixtureCall("/sessions/" + fixtureSession + "/invoice", method: "POST", body: ["amount": 21])["invoice"] as! String
+        tapWhenReady(app.buttons["wallet-action-send"])
+        let field = app.descendants(matching: .any).matching(identifier: "Address, invoice, or Cashu Request").firstMatch
+        tapWhenReady(field)
+        field.typeText(invoice)
+        let pay = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Pay 21")).firstMatch
+        tapWhenReady(pay, timeout: 20)
+        XCTAssertTrue(app.staticTexts["Payment Sent!"].waitForExistence(timeout: 30))
+        tapWhenReady(app.buttons["Done"])
+        tapTab("History")
+        XCTAssertTrue(app.staticTexts["Lightning paid"].firstMatch.waitForExistence(timeout: 10))
+        app.terminate()
+        app.launchEnvironment["RESET_WALLET"] = "0"
+        app.launch()
+        waitForMainTab(timeout: 30)
+        tapTab("History")
+        XCTAssertTrue(app.staticTexts["Lightning paid"].firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Lightning received"].firstMatch.exists)
+    }
+}
+
+final class LiveCdkPaymentUITests: LivePaymentUITestBase {
+    func testReceivePayAndRelaunch() throws { try receiveThenPayAndReopenHistory() }
+}
+
+final class LiveNutshellPaymentUITests: LivePaymentUITestBase {
+    override var backend: String { "nutshell" }
+    func testReceivePayAndRelaunch() throws { try receiveThenPayAndReopenHistory() }
+}


### PR DESCRIPTION
Payment failures can cross the HTTP, native saga, database, and UI boundaries without being detected by the existing happy-path mint tests or fake-gateway UI journeys. This adds paired iOS/Android coverage using real CDK wallets and Nutshell/CDK ledgers, plus live receive/pay/history journeys on both mint implementations.

- Add scenario-isolated fault injection, explicitly paid invoices, a fee-charging Nutshell profile, HTTP Cashu Request delivery, and a signed local Nostr/NWC fixture.
- Test lost mint/melt responses, recovery and database reopen, proof spendability after failures, revoke/claim races, duplicate redemption, P2PK, fees, requests, unit isolation, and NWC limits/replay.
- Require 14 payment cases per platform on PRs and 19 on nightly/full runs. Validate individual executed results so missing or skipped required tests fail CI.
- Correct the Swift quote-transition test to issue the original quote and document existing coverage, fixture limitations, and prioritized remaining gaps in `CI/payment-tests/README.md`.

Validation: the full Swift package passed (46 passed, one known-regression skip); all 19 required payment cases passed on each platform, including both live UI journeys; both executed-coverage gates passed; seven Python fixture/coverage tests passed. Workflow YAML parsing and diff checks also passed. The opt-in fee regression was separately reproduced on both platforms.

Known regression: CDK 0.18 delivers 19 sats for a 21-sat fee-bearing Cashu Request in this fixture. Runnable reproductions retain the correct 21-sat assertion and are explicitly opt-in/excluded from required coverage; this PR does not fix that SDK defect. Database reopen is distinct from process death, Android UI recreation retains its app container, and mint WebSocket delivery is not covered by the HTTP proxy.
