### PR TITLE
Expand wallet UI coverage across iOS and Android

### DIFF
--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -106,6 +106,7 @@ jobs:
 
         ./CI/setup-nutshell.sh &
         NUTSHELL_SETUP_PID=$!
+        # The shared multi-unit profile enables the USD UI payment journey.
         ./CI/setup-cdk.sh 3339 android &
         CDK_SETUP_PID=$!
 
@@ -155,7 +156,7 @@ jobs:
     # UI tests are deliberately serial. Two simulator clones on the hosted
     # three-core VM caused accessibility startup timeouts and made the suite
     # slower. A failed test gets one retry in a fresh app process.
-    - name: Run iOS UI smoke tests
+    - name: Run iOS UI journeys
       id: ui_tests
       if: ${{ always() && steps.build.outcome == 'success' && steps.setup_mints.outcome == 'success' && steps.start_mints.outcome == 'success' }}
       continue-on-error: true

--- a/.github/workflows/ios-tests.yml
+++ b/.github/workflows/ios-tests.yml
@@ -155,9 +155,11 @@ jobs:
 
     # UI tests are deliberately serial. Two simulator clones on the hosted
     # three-core VM caused accessibility startup timeouts and made the suite
-    # slower. A failed test gets one retry in a fresh app process.
+    # slower. Run once: Xcode's repetition flags reran the entire bundle,
+    # doubling runtime and obscuring first-attempt interaction failures.
     - name: Run iOS UI journeys
       id: ui_tests
+      timeout-minutes: 30
       if: ${{ always() && steps.build.outcome == 'success' && steps.setup_mints.outcome == 'success' && steps.start_mints.outcome == 'success' }}
       continue-on-error: true
       run: |
@@ -174,9 +176,6 @@ jobs:
           -test-timeouts-enabled YES \
           -default-test-execution-time-allowance 90 \
           -maximum-test-execution-time-allowance 150 \
-          -retry-tests-on-failure \
-          -test-iterations 2 \
-          -test-repetition-relaunch-enabled YES \
           -resultBundlePath "$RUNNER_TEMP/CashuWalletUITests.xcresult" \
           CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="-" \
           | tee ios-ui-test-output.log | xcbeautify
@@ -225,12 +224,12 @@ jobs:
           exit 1
         fi
         if [ "${{ steps.ui_tests.outcome }}" != "success" ]; then
-          echo "UI smoke tests failed after retry"
+          echo "UI journeys failed"
           exit 1
         fi
 
     - name: Upload failed test diagnostics
-      if: failure()
+      if: ${{ always() && (failure() || cancelled() || steps.ui_tests.outcome == 'failure') }}
       uses: actions/upload-artifact@v4
       with:
         name: ios-test-results-${{ github.sha }}

--- a/CI/README.md
+++ b/CI/README.md
@@ -183,19 +183,23 @@ max_delay_time = 0
 
 ## GitHub Actions Workflow
 
-The workflow (`.github/workflows/integration-tests.yml`) runs on every push/PR to main:
+The iOS workflow (`.github/workflows/ios-tests.yml`) runs for relevant pull
+requests and pushes to main/develop. Native UI coverage is described in the
+[wallet UI matrix](../docs/testing/wallet-ui-coverage.md). The workflow uses
+`./CI/setup-cdk.sh 3339 android` to enable the shared SAT/USD profile needed by
+the multi-currency UI journey; the historical profile name is used by both apps.
 
 1. Checks out code
 2. Setups Python 3.11 and Xcode
 3. Restores the Swift package cache
-4. Sets up and starts Nutshell and CDK in parallel
-5. Builds the iOS test products while the simulator boots
-6. Runs unit, protocol, and UI tests in one bounded-parallel Xcode session
-7. Exercises all live protocol scenarios and onboarding against both mints
+4. Builds the iOS test products while the simulator boots
+5. Sets up and starts Nutshell and CDK in parallel
+6. Runs unit/protocol tests, followed by serial native UI journeys
+7. Exercises local-mint payments, restore, onboarding, and settings
 8. Uploads test results and both mint logs on failure
 
-The optimized workflow targets roughly 6–9 minutes instead of the previous
-19–26 minute range; the exact duration depends on hosted-runner load and cache state.
+UI failures get one retry in a fresh app process. The job has a 45-minute bound
+for the expanded suite; duration depends on hosted-runner load and cache state.
 
 ## Manual Testing
 

--- a/CI/README.md
+++ b/CI/README.md
@@ -198,8 +198,9 @@ the multi-currency UI journey; the historical profile name is used by both apps.
 7. Exercises local-mint payments, restore, onboarding, and settings
 8. Uploads test results and both mint logs on failure
 
-UI failures get one retry in a fresh app process. The job has a 45-minute bound
-for the expanded suite; duration depends on hosted-runner load and cache state.
+UI tests run once so first-attempt failures remain visible. The UI step has a
+30-minute bound inside the 45-minute job, leaving time for cleanup and failed
+test diagnostics; duration depends on hosted-runner load and cache state.
 
 ## Manual Testing
 

--- a/CI/payment-tests/README.md
+++ b/CI/payment-tests/README.md
@@ -160,7 +160,7 @@ fake-payment services to a public interface.
 Nutshell 0.20.1 has a fixture timing limitation: it can return async `PENDING`
 before its background task persists the new state, and stock FakeWallet reports
 external payments settled even before they execute. The fast internal-payment
-scenario delays its first status GET by one second; external Nutshell payments are
-also exercised through the real UI. This pacing does not establish correctness of
+scenario and the iOS external-payment UI journey delay their first status GET by
+one second through the session proxy. This pacing does not establish correctness of
 the mint's immediate-status race. The standalone Swift package can also emit
 nonfatal native Tokio runtime-drop warnings from CDK 0.18 during teardown.

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/AppTestFixture.kt
@@ -11,6 +11,15 @@ import com.cashu.me.App.MainActivity
 import com.cashu.me.App.UiRuntimePolicy
 import com.cashu.me.App.UiTestApplication
 import com.cashu.me.Core.CDK.CdkWalletGatewayImpl
+import com.cashu.me.Core.PriceService
+import com.cashu.me.Core.AppLockManager
+import com.cashu.me.Core.NPCClient
+import com.cashu.me.Core.NPCQuote
+import com.cashu.me.Core.NPCService
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.Dispatchers
 import com.cashu.me.Models.TransactionKind
 import com.cashu.me.Models.PaymentMethodKind
 import com.cashu.me.Models.TransactionStatus
@@ -48,6 +57,9 @@ object AppTestFixture {
         deepLink: String? = null,
         supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
         paymentMintUrl: String? = null,
+        authenticate: (suspend (String) -> Boolean)? = null,
+        supportedUnits: List<String> = listOf("sat"),
+        npcQuotes: () -> List<NPCQuote> = { emptyList() },
     ): LaunchedFixture {
         val application = ApplicationProvider.getApplicationContext<UiTestApplication>()
         val usesLiveGateway = mode == FixtureMode.LiveLocalMint ||
@@ -94,6 +106,7 @@ object AppTestFixture {
         } else {
             FakeWalletGateway(
                 supportedMintMethods = supportedMintMethods,
+                supportedUnits = supportedUnits,
                 initialBalances = if (mode == FixtureMode.FundedWithHistory) {
                     mapOf(mintUrl to 500L)
                 } else {
@@ -107,6 +120,31 @@ object AppTestFixture {
                 UiRuntimePolicy.DeterministicTest.copy(runStartupMaintenance = true, pollQuotesInForeground = true)
             } else UiRuntimePolicy.DeterministicTest,
             walletGateway = { fake ?: CdkWalletGatewayImpl() },
+            npcService = { context, settings ->
+                NPCService(
+                    prefs = context.getSharedPreferences("npc_store", Context.MODE_PRIVATE),
+                    settingsState = settings.state,
+                    scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+                    makeClient = { _, _ -> object : NPCClient {
+                        override suspend fun getQuotes() = npcQuotes()
+                        override suspend fun setMintUrl(mintUrl: String) = mintUrl
+                        override fun close() = Unit
+                    } },
+                )
+            },
+            appLockManager = { context, settings ->
+                AppLockManager(context, settings,
+                    authenticationAvailable = if (authenticate != null) ({ true }) else null,
+                    authenticationPrompt = authenticate,
+                )
+            },
+            priceService = { store ->
+                PriceService(
+                    settingsStore = store,
+                    priceFetcher = { currency -> if (currency == "EUR") 80_000.0 else 100_000.0 },
+                    enableAutoRefresh = false,
+                )
+            },
         )
         val container = AppContainer(application, dependencies)
 

--- a/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/test/fixtures/FakeWalletGateway.kt
@@ -37,6 +37,7 @@ class FakeWalletGateway(
     initialBalances: Map<String, Long> = emptyMap(),
     initialTransactions: List<WalletTransaction> = emptyList(),
     private val supportedMintMethods: List<PaymentMethodKind> = listOf(PaymentMethodKind.Bolt11),
+    private val supportedUnits: List<String> = listOf("sat"),
 ) : WalletGateway {
     private val sequence = AtomicInteger(1)
     private val walletUrls = linkedSetOf<String>()
@@ -44,6 +45,13 @@ class FakeWalletGateway(
     private val mintInfo = linkedMapOf<String, MintInfo>()
     private val balances = initialBalances.toMutableMap()
     private val nonSatBalances = mutableMapOf<Pair<String, String>, Long>()
+    var lastSentMint: String? = null
+        private set
+    var lastSentUnit: String? = null
+        private set
+    var lastSentAmount: Long? = null
+        private set
+    var pendingSendClaimed = false
     private val transactions = initialTransactions.toMutableList()
     private val mintQuotes = linkedMapOf<String, MutableStateFlow<MintQuoteInfo>>()
     private val meltQuotes = linkedMapOf<String, MeltQuoteInfo>()
@@ -61,7 +69,8 @@ class FakeWalletGateway(
 
     suspend fun setUnitBalance(mintUrl: String, unit: String, amount: Long) {
         ensureWallet(mintUrl, unit)
-        nonSatBalances[normalize(mintUrl) to unit] = amount
+        if (unit.equals("sat", ignoreCase = true)) setBalance(mintUrl, amount)
+        else nonSatBalances[normalize(mintUrl) to unit] = amount
     }
 
     fun setBalance(mintUrl: String, amount: Long) {
@@ -128,6 +137,7 @@ class FakeWalletGateway(
     }
 
     override suspend fun removeWalletIfSingleUnit(mintUrl: String): Boolean {
+        failIfRequested()
         val normalized = normalize(mintUrl)
         val registeredUnits = walletUnits[normalized].orEmpty().toList()
         if (registeredUnits.size > 1) throw MultiUnitWalletRemovalException(registeredUnits)
@@ -174,7 +184,7 @@ class FakeWalletGateway(
         if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else nonSatBalances[normalize(mintUrl) to unit] ?: 0
 
     override suspend fun unitBalanceIfExists(mintUrl: String, unit: String): Long? =
-        if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else null
+        if (unit.equals("sat", ignoreCase = true)) totalBalance(mintUrl) else nonSatBalances[normalize(mintUrl) to unit]
 
     override suspend fun createMintQuote(
         amount: Long?,
@@ -220,7 +230,7 @@ class FakeWalletGateway(
         check(quote.state == MintQuoteState.Paid) { "Fake quote has not been paid." }
         val credited = (quote.amountPaid.takeIf { it > 0 } ?: quote.amount ?: 0) - quote.amountIssued
         val mintUrl = checkNotNull(quote.mintUrl)
-        balances[mintUrl] = (balances[mintUrl] ?: 0) + credited
+        setUnitBalance(mintUrl, quote.unit, unitBalance(mintUrl, quote.unit) + credited)
         transactions += WalletTransaction(
             id = "mint-payment-${sequence.getAndIncrement()}",
             quoteId = quote.id,
@@ -338,8 +348,11 @@ class FakeWalletGateway(
         failIfRequested()
         val normalized = normalize(mintUrl)
         val fee = 1L
-        check((balances[normalized] ?: 0) >= amount + fee) { "Insufficient balance." }
-        balances[normalized] = checkNotNull(balances[normalized]) - amount - fee
+        check(unitBalance(normalized, unit) >= amount + fee) { "Insufficient balance." }
+        setUnitBalance(normalized, unit, unitBalance(normalized, unit) - amount - fee)
+        lastSentMint = normalized
+        lastSentUnit = unit
+        lastSentAmount = amount
         return SendTokenResult(
             token = DeterministicToken,
             fee = fee,
@@ -393,7 +406,10 @@ class FakeWalletGateway(
 
     override suspend fun estimateCashuPaymentRequestFee(amountSats: Long, mintUrl: String): Long = 0
 
-    override suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean = true
+    // Despite the gateway method's historical name, true means proofs are
+    // spent. App-synthesized send rows use this path rather than a saga check.
+    override suspend fun checkTokenSpendable(token: String, mintUrl: String): Boolean =
+        if (lastSentAmount != null) pendingSendClaimed else true
 
     override suspend fun listTransactions(
         unitsByMint: Map<String, List<String>>,
@@ -401,7 +417,17 @@ class FakeWalletGateway(
 
     override suspend fun listPendingSendOperationIds(mintUrl: String, unit: String): List<String> = emptyList()
 
-    override suspend fun checkPendingSendClaimed(mintUrl: String, operationId: String, unit: String): Boolean = false
+    override suspend fun checkPendingSendClaimed(mintUrl: String, operationId: String, unit: String): Boolean {
+        failIfRequested()
+        if (pendingSendClaimed) {
+            for (index in transactions.indices) {
+                if (transactions[index].sagaId == operationId) {
+                    transactions[index] = transactions[index].copy(status = TransactionStatus.Completed)
+                }
+            }
+        }
+        return pendingSendClaimed
+    }
 
     override suspend fun revokePendingSend(mintUrl: String, operationId: String, unit: String): Long = 0
 
@@ -426,11 +452,16 @@ class FakeWalletGateway(
         seed: ByteArray,
         clientSecretKey: String?,
         maxPaymentMsat: ULong?,
-    ): NwcServiceHandle = FakeNwcServiceHandle
+    ): NwcServiceHandle = FakeNwcServiceHandle(
+        "nostr+walletconnect://" + "01".repeat(32) + "?relay=wss%3A%2F%2Frelay.test&secret=" +
+            (clientSecretKey ?: sequence.getAndIncrement().toString(16).padStart(64, '0')),
+    )
 
     private fun defaultMint(url: String): MintInfo = MintInfo(
         url = url,
         supportedMintMethods = supportedMintMethods,
+        units = supportedUnits,
+        mintUnits = supportedUnits,
         name = if (url == TestMintUrl) "Nutshell UI Test Mint" else "Test Mint",
         description = "Deterministic instrumented-test mint",
         nutSupport = NutSupport(
@@ -455,8 +486,7 @@ class FakeWalletGateway(
     }
 }
 
-private object FakeNwcServiceHandle : NwcServiceHandle {
-    override val connectionUri: String = "nostr+walletconnect://deterministic-ui-test"
+private class FakeNwcServiceHandle(override val connectionUri: String) : NwcServiceHandle {
     private var running = false
 
     override suspend fun start() {

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/AdvancedSettingsJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/AdvancedSettingsJourneyTest.kt
@@ -1,0 +1,105 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.NPCQuote
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.*
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AdvancedSettingsJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+
+    private fun nostr(): LaunchedFixture = AppTestFixture.launch(FixtureMode.SeededWithMint).also {
+        fixture = it
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .scrollToText(UiTestTags.SettingsList, "Nostr").tapText("Nostr")
+    }
+
+    @Test fun walletConnectLimitAndResetHavePersistentEffects() {
+        val app = nostr()
+        compose.onNodeWithText("Wallet Connect").performScrollTo().performClick()
+        compose.onNode(hasText("Enable Wallet Connect") and isToggleable()).performClick()
+        compose.waitUntil { app.container.nwcManager.state.value.isRunning }
+        val original = checkNotNull(app.container.nwcManager.state.value.connectionUri)
+        robot.awaitDescription("Copy connection code")
+        compose.onNodeWithText("Payment limit").performScrollTo().performClick()
+        compose.onNode(hasSetTextAction()).performTextReplacement("250")
+        robot.tapText("Save")
+        compose.waitUntil { app.container.nwcManager.state.value.budgetSats == 250L }
+        app.scenario.recreate()
+        robot.awaitDescription("Copy connection code")
+        assertEquals(250L, app.container.nwcManager.state.value.budgetSats)
+        compose.onNodeWithText("Reset connection").performScrollTo().performClick()
+        robot.awaitText("Reset connection?").tapText("Cancel")
+        assertEquals(original, app.container.nwcManager.state.value.connectionUri)
+        compose.onNodeWithText("Reset connection").performScrollTo().performClick()
+        robot.tapText("Delete")
+        compose.waitUntil { app.container.nwcManager.state.value.connectionUri != original }
+        assertEquals(250L, app.container.nwcManager.state.value.budgetSats)
+        compose.onNode(hasText("Enable Wallet Connect") and isToggleable()).performScrollTo().performClick()
+        compose.waitUntil { !app.container.nwcManager.state.value.isRunning }
+        robot.assertTextDoesNotExist("Copy connection code")
+    }
+
+    @Test fun relayAddDuplicateAndRemovePersist() {
+        val app = nostr()
+        val before = app.container.settingsManager.state.value.nostrRelays
+        val field = compose.onNode(hasSetTextAction())
+        field.performScrollTo().performTextInput("wss://relay.test")
+        robot.tapDescription("Add relay")
+        compose.waitUntil { "wss://relay.test" in app.container.settingsManager.state.value.nostrRelays }
+        field.performTextInput("wss://relay.test")
+        robot.tapDescription("Add relay")
+        assertEquals(1, app.container.settingsManager.state.value.nostrRelays.count { it == "wss://relay.test" })
+        app.scenario.recreate()
+        compose.onNodeWithText("wss://relay.test").performScrollTo().assertIsDisplayed()
+        // The native relay list appends new entries; its unmerged remove icons
+        // have the same label and the merged tree flattens all rows together.
+        compose.onAllNodesWithContentDescription("Remove relay")
+            .assertCountEquals(before.size + 1)[before.size].performClick()
+        compose.waitUntil { app.container.settingsManager.state.value.nostrRelays == before }
+    }
+
+    @Test fun lightningAddressManualCheckClaimsPaymentOnlyOnce() {
+        var quotes = emptyList<NPCQuote>()
+        fixture = AppTestFixture.launch(FixtureMode.SeededWithMint, npcQuotes = { quotes })
+        val app = fixture!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings").tapText("Lightning")
+        compose.onNode(hasText("Enable Lightning Address") and isToggleable()).performClick()
+        compose.waitUntil { app.container.npcService.state.value.isConnected }
+        compose.runOnIdle {
+            quotes = listOf(NPCQuote(id = "address-payment", amount = 21,
+                mintUrl = FakeWalletGateway.TestMintUrl, state = "PAID", locked = false,
+                createdAtEpochSeconds = null, paidAtEpochSeconds = null))
+        }
+        compose.onNodeWithText("Check for payments").performScrollTo().performClick()
+        compose.waitUntil(20_000) { app.container.walletManager.state.value.balance == 21L }
+        compose.onNodeWithText("Check for payments").performScrollTo().performClick()
+        compose.waitUntil { !app.container.npcService.state.value.isCheckingPayments }
+        assertEquals(21L, app.container.walletManager.state.value.balance)
+        compose.onNode(hasText("Enable Lightning Address") and isToggleable()).performScrollTo().performClick()
+        compose.waitUntil { !app.container.npcService.state.value.isEnabled }
+        app.scenario.recreate()
+        compose.onNode(hasText("Enable Lightning Address") and isToggleable()).assertIsOff()
+    }
+
+    @Test fun cancellingNostrIdentityReplacementKeepsIdentity() {
+        val app = nostr()
+        val before = app.container.nostrService.state.value.publicKeyHex
+        // The currently selected signer and the replacement confirmation remain native UI.
+        compose.onNodeWithText("Generate new key").performScrollTo().performClick()
+        robot.awaitText("Generate new key?").tapText("Cancel")
+        assertEquals(before, app.container.nostrService.state.value.publicKeyHex)
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MintSafetyJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MintSafetyJourneyTest.kt
@@ -1,0 +1,86 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.*
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MintSafetyJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+
+    private fun launch(mode: FixtureMode = FixtureMode.SeededWithMint): LaunchedFixture =
+        AppTestFixture.launch(mode).also {
+            fixture = it
+            robot.awaitTag(UiTestTags.WalletScreen).tapText("Mints")
+        }
+
+    @Test fun invalidMintCanBeCorrectedWithoutLeavingSheet() {
+        val app = launch()
+        robot.tapDescription("Add mint").typeIntoTag(UiTestTags.AddMintUrl, "http://unsafe.example")
+            .tapTag(UiTestTags.AddMintSubmit)
+            .awaitText("That doesn't look like a mint address.", substring = true)
+        assertEquals(1, app.container.walletManager.state.value.mints.size)
+        robot.replaceTextInTag(UiTestTags.AddMintUrl, SecondMint).tapTag(UiTestTags.AddMintSubmit)
+            .awaitTag(UiTestTags.mintRow(SecondMint))
+        assertEquals(2, app.container.walletManager.state.value.mints.size)
+    }
+
+    @Test fun duplicateWithTrailingSlashDoesNotCreateAnotherMint() {
+        val app = launch()
+        robot.tapDescription("Add mint").typeIntoTag(UiTestTags.AddMintUrl, FakeWalletGateway.TestMintUrl + "/")
+            .tapTag(UiTestTags.AddMintSubmit).awaitText("Mint already exists.")
+        assertEquals(1, app.container.walletManager.state.value.mints.size)
+        robot.pressSystemBack().awaitTag(UiTestTags.mintRow(FakeWalletGateway.TestMintUrl))
+    }
+
+    @Test fun removingLastMintReturnsToUsableEmptyWalletAfterRecreation() {
+        val app = launch()
+        openRemoval()
+        robot.tapText("Remove").awaitTag(UiTestTags.MintsScreen)
+            .assertTagDoesNotExist(UiTestTags.mintRow(FakeWalletGateway.TestMintUrl))
+        assertTrue(app.container.walletManager.state.value.mints.isEmpty())
+        assertNull(app.container.walletManager.state.value.activeMint)
+        app.scenario.recreate()
+        robot.awaitTag(UiTestTags.MintsScreen).tapText("Wallet").awaitText("Add a mint to get started")
+            .tapTag(UiTestTags.WalletSend).awaitTag(UiTestTags.ConnectMintSheet)
+    }
+
+    @Test fun cancellingFundedMintRemovalPreservesFundsAndDefault() {
+        val app = launch(FixtureMode.FundedWithHistory)
+        openRemoval()
+        robot.tapText("Cancel").awaitTag(UiTestTags.MintDetailScreen)
+        assertEquals(500L, app.container.walletManager.state.value.balance)
+        assertEquals(FakeWalletGateway.TestMintUrl, app.container.walletManager.state.value.activeMint?.url)
+    }
+
+    @Test fun multiUnitRemovalRefusalKeepsMintAndBalance() {
+        val app = launch(FixtureMode.FundedWithHistory)
+        runBlocking { checkNotNull(app.fakeGateway).ensureWallet(FakeWalletGateway.TestMintUrl, "eur") }
+        openRemoval()
+        robot.tapText("Remove").awaitTag(UiTestTags.MintDetailScreen)
+        // Wait for the operation's visible failure before checking retained state.
+        robot.awaitText("multiple currency units", substring = true)
+        assertEquals(500L, app.container.walletManager.state.value.balance)
+        assertEquals(1, app.container.walletManager.state.value.mints.size)
+        robot.tapDescription("Back").awaitTag(UiTestTags.mintRow(FakeWalletGateway.TestMintUrl))
+    }
+
+    private fun openRemoval() {
+        robot.tapTag(UiTestTags.mintRow(FakeWalletGateway.TestMintUrl))
+            .scrollToText(UiTestTags.MintDetailContent, "Remove mint").tapText("Remove mint")
+            .awaitText("Remove mint?")
+    }
+
+    companion object { private const val SecondMint = "https://second.test" }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MultiCurrencyJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/MultiCurrencyJourneyTest.kt
@@ -1,0 +1,66 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.*
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MultiCurrencyJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+
+    @Test fun usdSendUsesCentsAndLeavesSatAccountUnchanged() {
+        val app = AppTestFixture.launch(FixtureMode.FundedWithHistory, supportedUnits = listOf("sat", "usd", "eur"))
+        fixture = app
+        val fake = app.fakeGateway!!
+        runBlocking {
+            fake.ensureWallet(FakeWalletGateway.TestMintUrl, "usd")
+            fake.setUnitBalance(FakeWalletGateway.TestMintUrl, "usd", 1000)
+            app.container.walletManager.refreshBalance()
+        }
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletSend)
+            .tapDescription("Ecash. Create ecash").tapText("SAT").tapText("USD")
+            .tapDescription("2").tapDescription("Decimal point").tapDescription("5").tapDescription("0")
+            // An extra fraction digit must not silently turn $2.50 into $25.09.
+            .tapDescription("9").tapText("USD")
+        compose.onNode(hasText("USD") and hasText("US Dollar")).performClick()
+        robot.tapTag(UiTestTags.SendEcashSubmit).awaitText("Pending Ecash")
+        assertEquals("usd", fake.lastSentUnit)
+        assertEquals(250L, fake.lastSentAmount)
+        assertEquals(749L, runBlocking { fake.unitBalance(FakeWalletGateway.TestMintUrl, "usd") })
+        assertEquals(500L, runBlocking { fake.totalBalance(FakeWalletGateway.TestMintUrl) })
+    }
+
+    @Test fun selectedDefaultMintIsUsedByNextSendAndSurvivesRecreation() {
+        val app = AppTestFixture.launch(FixtureMode.FundedWithHistory)
+        fixture = app
+        val fake = app.fakeGateway!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("Mints").tapDescription("Add mint")
+            .typeIntoTag(UiTestTags.AddMintUrl, SecondMint).tapTag(UiTestTags.AddMintSubmit)
+            .awaitTag(UiTestTags.mintRow(SecondMint))
+        runBlocking { fake.setBalance(SecondMint, 200); app.container.walletManager.refreshBalance() }
+        robot.tapTag(UiTestTags.mintRow(SecondMint)).scrollToText(UiTestTags.MintDetailContent, "Set as Default")
+            .tapText("Set as Default")
+        compose.waitUntil { app.container.walletManager.state.value.activeMint?.url == SecondMint }
+        app.scenario.recreate()
+        robot.awaitTag(UiTestTags.MintDetailScreen).tapDescription("Back").tapText("Wallet")
+            .tapTag(UiTestTags.WalletSend).tapDescription("Ecash. Create ecash")
+            .tapDescription("2").tapDescription("5").tapTag(UiTestTags.SendEcashSubmit).awaitText("Pending Ecash")
+        assertEquals(SecondMint, fake.lastSentMint)
+        assertEquals(174L, runBlocking { fake.totalBalance(SecondMint) })
+        assertEquals(500L, runBlocking { fake.totalBalance(FakeWalletGateway.TestMintUrl) })
+    }
+
+    companion object { private const val SecondMint = "https://second.test" }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/PaymentRecoveryJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/PaymentRecoveryJourneyTest.kt
@@ -1,0 +1,132 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Models.*
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.*
+import com.cashu.me.ui.testing.UiTestTags
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PaymentRecoveryJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+
+    private fun launch(mode: FixtureMode = FixtureMode.FundedWithHistory, token: String? = null): LaunchedFixture =
+        AppTestFixture.launch(mode, deepLink = token?.let { "cashu:$it" }).also { fixture = it }
+
+    @Test fun receiveLaterCanBeClaimedFromHistoryExactlyOnce() {
+        val app = launch(FixtureMode.SeededWithMint, FakeWalletGateway.MemoDeterministicToken)
+        robot.awaitTag(UiTestTags.ReceiveEcashDetail).tapText("Receive later").awaitTag(UiTestTags.WalletScreen)
+        val pending = app.container.walletManager.state.value.pendingReceiveTokens.single()
+        app.scenario.recreate()
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("History")
+            .tapTag(UiTestTags.transactionRow(pending.tokenId)).tapText("Receive")
+            .awaitTag(UiTestTags.ReceiveEcashDetail)
+            .tapTextWithinTag(UiTestTags.ReceiveEcashDetail, "Receive").awaitText("Payment Received!")
+            .tapText("Done").awaitTag(UiTestTags.HistoryScreen)
+        compose.waitUntil { app.container.walletManager.state.value.pendingReceiveTokens.isEmpty() }
+        assertEquals(25L, runBlocking { app.fakeGateway!!.totalBalance(FakeWalletGateway.TestMintUrl) })
+        app.scenario.recreate()
+        robot.awaitTag(UiTestTags.HistoryScreen)
+        assertEquals(25L, app.container.walletManager.state.value.balance)
+        assertTrue(app.container.walletManager.state.value.pendingReceiveTokens.isEmpty())
+    }
+
+    @Test fun editingAndCancellingEcashAmountDoesNotSpendFunds() {
+        val app = launch()
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletSend)
+            .tapDescription("Ecash. Create ecash").awaitTag(UiTestTags.SendEcashScreen)
+            .assertTagIsNotEnabled(UiTestTags.SendEcashSubmit)
+            .tapDescription("2").tapDescription("5").tapDescription("Delete. Long press to clear.")
+        compose.onNodeWithContentDescription("Delete. Long press to clear.", useUnmergedTree = true)
+            .performTouchInput { longClick() }
+        robot.assertTagIsNotEnabled(UiTestTags.SendEcashSubmit).tapDescription("9").tapDescription("9")
+            .tapDescription("9").awaitText("Insufficient balance")
+            .assertTagIsNotEnabled(UiTestTags.SendEcashSubmit).pressSystemBack()
+        assertEquals(500L, app.container.walletManager.state.value.balance)
+        assertEquals(2, app.container.walletManager.state.value.transactions.size)
+    }
+
+    @Test fun historyFilterAndSearchComposeAndCanBeCleared() {
+        launch()
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").tapDescription("Filter")
+            .tapText("Pending").assertTagDoesNotExist(UiTestTags.transactionRow("fixture-incoming"))
+            .tapDescription("Filter").tapText("Completed")
+            .awaitTag(UiTestTags.transactionRow("fixture-incoming"))
+            .tapDescription("Search history").typeIntoTag(UiTestTags.HistorySearch, "deposit")
+            .awaitTag(UiTestTags.transactionRow("fixture-incoming"))
+            .assertTagDoesNotExist(UiTestTags.transactionRow("fixture-outgoing"))
+            .tapDescription("Clear search").awaitTag(UiTestTags.transactionRow("fixture-outgoing"))
+    }
+
+    @Test fun manualSentTokenCheckDistinguishesPendingAndClaimed() {
+        val app = launch()
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .scrollToText(UiTestTags.SettingsList, "Privacy").tapText("Privacy")
+        compose.onNode(hasText("Check sent ecash") and isToggleable()).performClick()
+        robot.tapDescription("Back").tapDescription("Back").tapTag(UiTestTags.WalletSend)
+            .tapDescription("Ecash. Create ecash").tapDescription("2").tapDescription("5")
+            .tapTag(UiTestTags.SendEcashSubmit).awaitText("Pending Ecash")
+            .tapText("Check Status")
+        compose.waitUntil(20_000) {
+            compose.onAllNodesWithText("This token has not been claimed yet.").fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText("This token has not been claimed yet.").performScrollTo().assertIsDisplayed()
+        assertEquals(474L, app.container.walletManager.state.value.balance)
+        compose.runOnIdle { app.fakeGateway!!.pendingSendClaimed = true }
+        robot.tapText("Check Status")
+        // The animated receipt title exposes its full text in the merged tree.
+        compose.waitUntil(20_000) {
+            compose.onAllNodesWithText("Claimed", substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
+        compose.onNodeWithText("Claimed", substring = true).assertIsDisplayed()
+        assertEquals(474L, app.container.walletManager.state.value.balance)
+    }
+
+    @Test fun backgroundDuringReceiveCreditsOnlyOnce() {
+        val app = launch(FixtureMode.SeededWithMint)
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletReceive)
+            .tapDescription("Bitcoin. Receive over Lightning or on-chain")
+            .tapDescription("2").tapText("Create invoice").awaitText("Lightning Invoice")
+        val fake = app.fakeGateway!!
+        compose.waitUntil { fake.latestMintQuoteId != null }
+        app.scenario.moveToState(Lifecycle.State.CREATED)
+        fake.markMintQuotePaid(checkNotNull(fake.latestMintQuoteId))
+        app.scenario.moveToState(Lifecycle.State.RESUMED)
+        robot.awaitText("Payment Received!", timeoutMillis = 20_000).tapText("Done")
+            .awaitTag(UiTestTags.WalletScreen)
+        assertEquals(2L, app.container.walletManager.state.value.balance)
+        app.scenario.recreate()
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").awaitText("Lightning received")
+        assertEquals(2L, app.container.walletManager.state.value.balance)
+        assertEquals(1, app.container.walletManager.state.value.transactions.count { it.type == TransactionType.Incoming })
+    }
+
+    @Test fun onchainReceiveShowsAddressThenSettlesToHistory() {
+        fixture = AppTestFixture.launch(FixtureMode.SeededWithMint,
+            supportedMintMethods = listOf(PaymentMethodKind.Bolt11, PaymentMethodKind.Onchain))
+        val app = fixture!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapTag(UiTestTags.WalletReceive)
+            .tapDescription("Bitcoin. Receive over Lightning or on-chain")
+            .tapDescription("Receive method: Lightning invoice, One-time, instant")
+            .tapText("On-chain address").awaitText("Bitcoin Address")
+        val fake = app.fakeGateway!!
+        compose.waitUntil { fake.latestMintQuoteId != null }
+        val quoteId = checkNotNull(fake.latestMintQuoteId)
+        assertEquals(PaymentMethodKind.Onchain, runBlocking { fake.checkMintQuote(quoteId) }.paymentMethod)
+        compose.runOnIdle { fake.markMintQuotePaid(quoteId, 21) }
+        robot.awaitText("Payment Received!", timeoutMillis = 20_000).tapText("Done")
+        assertEquals(21L, runBlocking { fake.totalBalance(FakeWalletGateway.TestMintUrl) })
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/PaymentRecoveryJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/PaymentRecoveryJourneyTest.kt
@@ -60,9 +60,9 @@ class PaymentRecoveryJourneyTest {
 
     @Test fun historyFilterAndSearchComposeAndCanBeCleared() {
         launch()
-        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").tapDescription("Filter")
+        robot.awaitTag(UiTestTags.WalletScreen).tapText("History").tapDescription("Filter transactions")
             .tapText("Pending").assertTagDoesNotExist(UiTestTags.transactionRow("fixture-incoming"))
-            .tapDescription("Filter").tapText("Completed")
+            .tapDescription("Filter transactions").tapText("Completed")
             .awaitTag(UiTestTags.transactionRow("fixture-incoming"))
             .tapDescription("Search history").typeIntoTag(UiTestTags.HistorySearch, "deposit")
             .awaitTag(UiTestTags.transactionRow("fixture-incoming"))

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/SecurityJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/SecurityJourneyTest.kt
@@ -1,0 +1,124 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.*
+import com.cashu.me.ui.testing.UiTestTags
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Real app security screens with only the OS authentication response replaced. */
+@RunWith(AndroidJUnit4::class)
+class SecurityJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+    private var allowAuthentication = false
+    private val challenges = mutableListOf<String>()
+
+    private fun settings(): LaunchedFixture = AppTestFixture.launch(
+        FixtureMode.SeededWithoutMint,
+        authenticate = { reason -> challenges += reason; allowAuthentication },
+    ).also {
+        fixture = it
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings").awaitTag(UiTestTags.SettingsScreen)
+    }
+
+    @Test fun rejectedAppLockEnablementStaysOffThenSuccessfulRetryPersists() {
+        val app = settings()
+        robot.tapText("App Lock")
+        val toggle = compose.onNode(isToggleable())
+        toggle.performClick()
+        robot.awaitText("Authentication failed. App Lock was not enabled. Try turning it on again.")
+        toggle.assertIsOff()
+        assertFalse(app.container.settingsManager.state.value.appLockEnabled)
+        compose.runOnIdle { allowAuthentication = true }
+        toggle.performClick()
+        compose.waitUntil { app.container.settingsManager.state.value.appLockEnabled }
+        toggle.assertIsOn()
+        app.scenario.recreate()
+        compose.onNode(isToggleable()).assertIsOn()
+        assertTrue(challenges.contains("Confirm to enable App Lock"))
+    }
+
+    @Test fun seedRevealRequiresAuthenticationEvenWithAppLockOff() {
+        val app = settings()
+        assertFalse(app.container.settingsManager.state.value.appLockEnabled)
+        robot.tapText("Backup & Restore").tapText("Backup seed phrase").awaitText("Reveal Recovery Phrase")
+            .tapText("Reveal Recovery Phrase")
+        compose.waitUntil { challenges.isNotEmpty() }
+        robot.assertTextDoesNotExist("Copy Recovery Phrase")
+        compose.runOnIdle { allowAuthentication = true }
+        robot.tapText("Reveal Recovery Phrase").awaitText("Copy Recovery Phrase")
+        assertTrue(challenges.contains("Reveal your seed phrase"))
+        robot.pressSystemBack().tapText("Backup seed phrase").awaitText("Reveal Recovery Phrase")
+        robot.assertTextDoesNotExist("Copy Recovery Phrase")
+    }
+
+    @Test fun cancellingRestorePreservesExistingWalletAndReturnsToSettings() {
+        val app = settings()
+        val original = app.container.walletManager.state.value
+        robot.tapText("Backup & Restore").tapText("Restore").awaitText("Restore Wallet")
+        robot.pressSystemBack().awaitText("Backup seed phrase")
+        assertEquals(original.balance, app.container.walletManager.state.value.balance)
+        assertEquals(original.mints, app.container.walletManager.state.value.mints)
+        robot.tapDescription("Back").awaitTag(UiTestTags.SettingsScreen)
+    }
+
+    @Test fun restoreFromSeedRecoversFundedMintAndCompletes() {
+        fixture = AppTestFixture.launch(FixtureMode.FundedWithHistory)
+        val app = fixture!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .tapText("Backup & Restore").tapText("Restore").awaitText("Restore Wallet")
+        val words = FakeWalletGateway.FixedMnemonic.split(" ")
+        for (word in words) {
+            robot.typeIntoTag(UiTestTags.SeedWordField, word)
+            compose.onNodeWithTag(UiTestTags.SeedWordField).performImeAction()
+        }
+        robot.tapText("Next").awaitText("Add your mints")
+        compose.onNode(hasSetTextAction()).performTextInput(FakeWalletGateway.TestMintUrl)
+        compose.onNode(hasSetTextAction()).performImeAction()
+        robot.pressSystemBack().tapText("Restore from 1 mint").awaitText("Restore complete", timeoutMillis = 30_000)
+            .tapText("Continue").awaitText("Backup seed phrase")
+        assertEquals(500L, app.container.walletManager.state.value.balance)
+        assertEquals(FakeWalletGateway.TestMintUrl, app.container.walletManager.state.value.activeMint?.url)
+    }
+
+    @Test fun encryptedMintBackupCompletesThroughSettings() {
+        fixture = AppTestFixture.launch(FixtureMode.SeededWithMint)
+        val app = fixture!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .tapText("Backup & Restore").tapText("Back up now")
+        compose.waitUntil { app.container.nostrMintBackupService.state.value.lastBackupDateEpochMillis != null }
+        robot.awaitText("Last backup", substring = true)
+    }
+
+    @Test fun quickLockSelectionAndCancellationPreserveEnteredAmount() {
+        fixture = AppTestFixture.launch(FixtureMode.FundedWithHistory)
+        val app = fixture!!
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .scrollToText(UiTestTags.SettingsList, "Locked Ecash").tapText("Locked Ecash")
+        val quickLock = compose.onNode(hasText("Quick lock to my key") and isToggleable())
+        quickLock.performScrollTo().performClick()
+        quickLock.assertIsOn()
+        app.scenario.recreate()
+        compose.onNode(hasText("Quick lock to my key") and isToggleable()).assertIsOn()
+        robot.tapDescription("Back").tapDescription("Back").tapTag(UiTestTags.WalletSend)
+            .tapDescription("Ecash. Create ecash").tapDescription("2").tapDescription("5")
+            .tapDescription("Lock ecash").tapText("Allow Camera").awaitText("Lock to my key")
+            .pressSystemBack().awaitTag(UiTestTags.SendEcashSubmit)
+        compose.onNodeWithTag(UiTestTags.SendEcashSubmit).assertIsEnabled()
+        robot.tapDescription("Lock ecash").tapText("Allow Camera").tapText("Lock to my key")
+            .awaitTag(UiTestTags.SendEcashSubmit)
+        compose.onNodeWithTag(UiTestTags.SendEcashSubmit).assertIsEnabled()
+        robot.pressSystemBack().awaitTag(UiTestTags.WalletScreen)
+        assertEquals(500L, app.container.walletManager.state.value.balance)
+        assertNull(app.fakeGateway!!.lastSentAmount)
+    }
+}

--- a/android/app/src/androidTest/java/com/cashu/me/ui/journeys/WalletPreferencesJourneyTest.kt
+++ b/android/app/src/androidTest/java/com/cashu/me/ui/journeys/WalletPreferencesJourneyTest.kt
@@ -1,0 +1,102 @@
+package com.cashu.me.ui.journeys
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.v2.createEmptyComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.cashu.me.Core.SettingsStore
+import com.cashu.me.test.UiFailureArtifactsRule
+import com.cashu.me.test.WalletJourneyRobot
+import com.cashu.me.test.fixtures.AppTestFixture
+import com.cashu.me.test.fixtures.FixtureMode
+import com.cashu.me.test.fixtures.LaunchedFixture
+import com.cashu.me.ui.testing.UiTestTags
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Production settings journeys; rates are injected at the service boundary. */
+@RunWith(AndroidJUnit4::class)
+class WalletPreferencesJourneyTest {
+    @get:Rule(order = 0) val compose = createEmptyComposeRule()
+    @get:Rule(order = 1) val artifacts = UiFailureArtifactsRule(compose) { fixture?.close() }
+    private val robot by lazy { WalletJourneyRobot(compose) }
+    private var fixture: LaunchedFixture? = null
+
+    private fun settings(): LaunchedFixture = AppTestFixture.launch(FixtureMode.FundedWithHistory).also {
+        fixture = it
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings").awaitTag(UiTestTags.SettingsScreen)
+    }
+
+    @Test fun currencySelectionChangesRateAndPersistsWithoutChangingWalletFunds() {
+        val app = settings()
+        val originalBalance = app.container.walletManager.state.value.balance
+        for ((code, rate) in listOf("EUR" to 80_000.0, "USD" to 100_000.0)) {
+            robot.tapText("Currency").tapText(code).awaitTag(UiTestTags.SettingsScreen)
+            compose.waitUntil { app.container.priceService.state.value.btcPrice == rate }
+            assertEquals(code, app.container.settingsManager.state.value.bitcoinPriceCurrency)
+            assertEquals(originalBalance, app.container.walletManager.state.value.balance)
+            // A new store instance reads the persisted preference, not a ViewModel cache.
+            val stored = SettingsStore(ApplicationProvider.getApplicationContext())
+            assertTrue(stored.showFiatBalance)
+            assertEquals(code, stored.bitcoinPriceCurrency)
+            app.scenario.recreate()
+            robot.awaitTag(UiTestTags.SettingsScreen).awaitText(code)
+        }
+        robot.tapText("Currency").tapText("Off").awaitTag(UiTestTags.SettingsScreen).awaitText("Off")
+        assertFalse(SettingsStore(ApplicationProvider.getApplicationContext()).showFiatBalance)
+        assertEquals(originalBalance, app.container.walletManager.state.value.balance)
+    }
+
+    @Test fun dismissCurrencyPickerPreservesSelection() {
+        val app = settings()
+        val before = app.container.settingsManager.state.value.bitcoinPriceCurrency
+        robot.tapText("Currency").pressSystemBack().awaitTag(UiTestTags.SettingsScreen)
+        assertEquals(before, app.container.settingsManager.state.value.bitcoinPriceCurrency)
+    }
+
+    @Test fun privacyDependenciesAndWebSocketsPersistIndependently() {
+        val app = settings()
+        robot.scrollToText(UiTestTags.SettingsList, "Privacy").tapText("Privacy")
+        setSwitch("Check incoming invoice", false)
+        compose.onNode(hasText("Check all invoices") and isToggleable()).assertIsNotEnabled()
+        setSwitch("Check sent ecash", false)
+        setSwitch("Use WebSockets", true)
+        app.scenario.recreate()
+        compose.onNode(hasText("Check incoming invoice") and isToggleable()).assertIsOff()
+        compose.onNode(hasText("Check sent ecash") and isToggleable()).assertIsOff()
+        compose.onNode(hasText("Use WebSockets") and isToggleable()).assertIsOn().assertIsEnabled()
+        setSwitch("Check incoming invoice", true)
+        compose.onNode(hasText("Check all invoices") and isToggleable()).assertIsEnabled()
+    }
+
+    @Test fun automaticReceiveRequiresListeningAndPreservesItsPreference() {
+        settings()
+        robot.scrollToText(UiTestTags.SettingsList, "Privacy").tapText("Privacy")
+        setSwitch("Listen for payment requests", true)
+        setSwitch("Claim received ecash automatically", true)
+        setSwitch("Listen for payment requests", false)
+        compose.onNode(hasText("Claim received ecash automatically") and isToggleable())
+            .performScrollTo().assertIsNotEnabled().assertIsOn()
+        setSwitch("Listen for payment requests", true)
+        compose.onNode(hasText("Claim received ecash automatically") and isToggleable()).assertIsEnabled().assertIsOn()
+    }
+
+    @Test fun walletConnectWithoutMintExplainsRequirement() {
+        fixture = AppTestFixture.launch(FixtureMode.SeededWithoutMint)
+        robot.awaitTag(UiTestTags.WalletScreen).tapDescription("Settings")
+            .scrollToText(UiTestTags.SettingsList, "Nostr").tapText("Nostr")
+        compose.onNodeWithText("Wallet Connect").performScrollTo().performClick()
+        robot.awaitText("Add a mint first to use Wallet Connect.")
+        compose.onNode(hasText("Enable Wallet Connect") and isToggleable()).assertIsNotEnabled()
+    }
+
+    private fun setSwitch(label: String, on: Boolean) {
+        val node = compose.onNode(hasText(label) and isToggleable())
+        node.performScrollTo()
+        val expected = if (on) isOn() else isOff()
+        if (!expected.matches(node.fetchSemanticsNode())) node.performClick()
+        node.assert(expected)
+    }
+}

--- a/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
+++ b/android/app/src/main/java/com/cashu/me/App/AppContainer.kt
@@ -33,7 +33,7 @@ class AppContainer(
     val cashuRequestStore = CashuRequestStore(walletStore)
     val settingsStore = dependencies.settingsStore(appContext)
     val settingsManager = SettingsManager(settingsStore, secureStorage)
-    val appLockManager = AppLockManager(appContext, settingsManager)
+    val appLockManager = dependencies.appLockManager(appContext, settingsManager)
     val sentryService = SentryService(appContext, settingsStore)
     val nostrService = NostrService(secureStorage, settingsStore)
     val navigationManager = NavigationManager()
@@ -52,7 +52,7 @@ class AppContainer(
         },
         relayProvider = { settingsManager.state.value.nostrRelays },
     )
-    val npcService = NPCService(appContext, settingsManager)
+    val npcService = dependencies.npcService(appContext, settingsManager)
     val nostrMintBackupService = NostrMintBackupService(settingsManager, settingsStore, cdkGateway)
     val walletManager = WalletManager(
         secureStorage = secureStorage,
@@ -71,7 +71,7 @@ class AppContainer(
         externalServicesEnabled = runtimePolicy.startExternalListeners,
         allowCleartextLocalTestMints = runtimePolicy.allowCleartextLocalTestMints,
     )
-    val priceService = PriceService(settingsStore)
+    val priceService = dependencies.priceService(settingsStore)
     val mintDiscoveryManager = MintDiscoveryManager(settingsManager)
     val cashuRequestListener = CashuRequestListener(
         nostrService = nostrService,

--- a/android/app/src/main/java/com/cashu/me/App/AppContainerDependencies.kt
+++ b/android/app/src/main/java/com/cashu/me/App/AppContainerDependencies.kt
@@ -7,6 +7,10 @@ import com.cashu.me.Core.Platform.AndroidSecureStorage
 import com.cashu.me.Core.Protocols.SecureStorage
 import com.cashu.me.Core.SettingsStore
 import com.cashu.me.Core.WalletStore
+import com.cashu.me.Core.PriceService
+import com.cashu.me.Core.AppLockManager
+import com.cashu.me.Core.SettingsManager
+import com.cashu.me.Core.NPCService
 
 /**
  * Runtime switches for work that is unrelated to an explicitly requested UI
@@ -51,4 +55,9 @@ data class AppContainerDependencies(
     val secureStorage: (Context) -> SecureStorage = { AndroidSecureStorage(it) },
     val walletStore: (Context) -> WalletStore = { WalletStore(it) },
     val settingsStore: (Context) -> SettingsStore = { SettingsStore(it) },
+    val priceService: (SettingsStore) -> PriceService = { PriceService(it) },
+    val appLockManager: (Context, SettingsManager) -> AppLockManager = { context, settings ->
+        AppLockManager(context, settings)
+    },
+    val npcService: (Context, SettingsManager) -> NPCService = { context, settings -> NPCService(context, settings) },
 )

--- a/android/app/src/main/java/com/cashu/me/App/MainActivity.kt
+++ b/android/app/src/main/java/com/cashu/me/App/MainActivity.kt
@@ -15,7 +15,10 @@ class MainActivity : FragmentActivity() {
         installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        handleIntent(intent)
+        // A consumed launch link must not navigate again when Android recreates
+        // the activity (rotation, theme change, or process state restoration).
+        // New links delivered to the running activity are handled below.
+        if (savedInstanceState == null) handleIntent(intent)
         setContent {
             CashuApp(containerFlow = (application as CashuWalletApplication).container)
         }

--- a/android/app/src/main/java/com/cashu/me/Core/AppLockManager.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/AppLockManager.kt
@@ -22,6 +22,8 @@ class AppLockManager(
     context: Context,
     private val settingsManager: SettingsManager,
     private val nowMillis: () -> Long = { System.currentTimeMillis() },
+    private val authenticationAvailable: (() -> Boolean)? = null,
+    private val authenticationPrompt: (suspend (String) -> Boolean)? = null,
 ) {
     private val appContext = context.applicationContext
     private val authenticators =
@@ -129,7 +131,7 @@ class AppLockManager(
 
         applyRuntime(AppLockPolicy.authenticating(runtime, isAuthenticating = true))
         return try {
-            val success = prompt(activity, reason)
+            val success = authenticationPrompt?.invoke(reason) ?: prompt(activity, reason)
             if (success) applyRuntime(AppLockPolicy.authenticated(runtime))
             success
         } finally {
@@ -179,7 +181,8 @@ class AppLockManager(
             .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS
 
     private fun canAuthenticate(): Boolean =
-        BiometricManager.from(appContext).canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS
+        authenticationAvailable?.invoke()
+            ?: (BiometricManager.from(appContext).canAuthenticate(authenticators) == BiometricManager.BIOMETRIC_SUCCESS)
 
     private fun applyRuntime(next: AppLockRuntime) {
         runtime = next

--- a/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
+++ b/android/app/src/main/java/com/cashu/me/Core/Wallet/WalletMessages.kt
@@ -43,6 +43,11 @@ object WalletErrorMessages {
         "The wallet couldn't finish that action. Try again in a moment."
 
     fun classify(error: Throwable): WalletMessage {
+        // This is an application safety policy, not a transport failure. Its
+        // guidance contains "connected", which the raw network matcher catches.
+        if (error is com.cashu.me.Core.CDK.MultiUnitWalletRemovalException) {
+            return WalletMessage(checkNotNull(error.message))
+        }
         if (error is com.cashu.me.Core.CDK.MeltPaymentRecoveryException) {
             return WalletMessage(
                 text = checkNotNull(error.message),

--- a/android/app/src/main/java/com/cashu/me/Views/Components/ScannerView.kt
+++ b/android/app/src/main/java/com/cashu/me/Views/Components/ScannerView.kt
@@ -203,15 +203,6 @@ fun ScannerView(
     }
     if (cameraPermissionState != CameraPermissionState.Granted) return
 
-    if (useDeterministicPermission) {
-        CameraPermissionView(
-            title = "Camera Ready",
-            message = "The scanner is ready to read a QR code.",
-            onClose = onClose,
-        )
-        return
-    }
-
     cameraError?.let { message ->
         CameraPermissionView(
             title = "Camera Unavailable",
@@ -228,7 +219,11 @@ fun ScannerView(
             .fillMaxSize()
             .background(Color.Black),
     ) {
-        CameraPreviewScanner(
+        if (useDeterministicPermission) {
+            // Replace only the hardware preview. Keep the production scanner
+            // chrome and key shortcuts available to app UI journeys.
+            Text("Camera Ready", color = Color.White, modifier = Modifier.align(Alignment.Center))
+        } else CameraPreviewScanner(
             onCode = { code ->
                 if (completedScan) return@CameraPreviewScanner
                 val trimmed = code.trim()

--- a/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
+++ b/android/app/src/main/java/com/cashu/me/ui/send/SendEcashScreen.kt
@@ -558,10 +558,13 @@ fun SendEcashScreen(
             units = activeMint?.units ?: listOf("sat"),
             selectedUnit = effectiveUnit,
             onSelect = {
+                val changedUnit = it != effectiveUnit
                 selectedUnit = it
-                amount = ""
-                nonSatBalance = null
-                errorText = null
+                if (changedUnit) {
+                    amount = ""
+                    nonSatBalance = null
+                    errorText = null
+                }
                 unitPickerOpen = false
             },
             onDismiss = { unitPickerOpen = false },

--- a/android/app/src/test/java/com/cashu/me/Core/WalletErrorMessagesTest.kt
+++ b/android/app/src/test/java/com/cashu/me/Core/WalletErrorMessagesTest.kt
@@ -9,6 +9,15 @@ import org.junit.Test
 /** iOS parity: `WalletErrorMessageTests.swift`. */
 class WalletErrorMessagesTest {
 
+    @Test
+    fun multiUnitRemovalPreservesSafetyGuidanceInsteadOfSuggestingNetworkRetry() {
+        val error = com.cashu.me.Core.CDK.MultiUnitWalletRemovalException(listOf("sat", "usd"))
+        assertEquals(
+            "This mint uses multiple currency units and cannot be removed safely yet. Keep it connected and try again after updating the app.",
+            WalletErrorMessages.classify(error).text,
+        )
+    }
+
     private val mintLimitsCopy =
         "This amount is outside the mint's limits. Try a different amount."
 

--- a/docs/android/TESTING.md
+++ b/docs/android/TESTING.md
@@ -23,6 +23,11 @@ UX, and destructive-action confirmation.
 Nutshell. Tests annotated `FullOnly` run only in nightly and release tiers;
 tests annotated `Compatibility` form the small cross-device behavior pack.
 
+The [wallet UI coverage matrix](../testing/wallet-ui-coverage.md) lists the
+priority interactions, including currency units, restore, app lock, advanced
+settings, and recovery. The [bug report](../testing/ui-coverage-report.md) records
+defects found while adding these journeys and their validation results.
+
 ## Deterministic app runtime
 
 `CashuUiTestRunner` launches the debug-only `UiTestApplication`. The application
@@ -51,6 +56,12 @@ The fake has fixed test-only seed, token, invoice, balance, quote, and
 transaction data. Tests explicitly advance quote states such as invoice-paid;
 there are no timer-based transitions. Android Test Orchestrator clears package
 data and creates a fresh instrumentation process for every test.
+
+Price, NPC transport, and authentication responses are injected through app
+dependencies. Currency journeys use fixed exchange rates. The camera fixture
+replaces capture while retaining production scanner controls and key shortcuts.
+These fixtures exercise application behavior, not OS enrollment or real camera
+recognition.
 
 ## Local commands
 

--- a/docs/testing/ui-coverage-report.md
+++ b/docs/testing/ui-coverage-report.md
@@ -1,0 +1,137 @@
+# Wallet UI coverage and bug report
+
+The expansion adds **51 native UI tests**: 28 Android journeys and 23 iOS tests.
+The [coverage matrix](wallet-ui-coverage.md) lists priorities, test owners, and
+remaining device/service boundaries. All new UI cases have passed; detailed run boundaries are recorded below.
+
+## Confirmed application defects
+
+### UI-001 — iOS enables App Lock without available authentication
+
+- Severity: high; iOS.
+- Reproduction: open Settings → App Lock with no device-owner authentication
+  available and enable the setting.
+- Expected: enablement fails and the setting stays off.
+- Actual: the shared runtime unlock fallback returned success when authentication
+  was unavailable, allowing the setting to be enabled without a challenge.
+- Fix: a separate enablement entry point requires authentication; runtime recovery
+  retains its existing behavior when device authentication becomes unavailable.
+- Regression: `SettingsUITests.testUnavailableAuthenticationCannotEnableAppLock`,
+  alongside rejected and successful authentication journeys on both platforms.
+- Validation: the unavailable, rejected, successful-enable/relaunch, rejected seed
+  reveal, and reveal/dismiss/reopen iOS journeys passed. Android rejected enablement
+  and successful retry/recreation also passed. The controlled response replaces
+  OS authentication only; it does not validate biometric enrollment.
+
+### UI-002 — Android replays a consumed payment link on activity recreation
+
+- Severity: medium; Android.
+- Reproduction: launch a token link, choose Receive later, recreate the activity,
+  and attempt to open the pending token from History.
+- Expected: the dismissed link remains dismissed and History stays navigable.
+- Actual: `MainActivity.onCreate` routed the original intent again, interrupting
+  navigation. The receive-later journey reproduced the replay before the fix.
+- Fix: route launch intents only on initial creation; retain `onNewIntent` for
+  new links delivered to the running activity.
+- Regression: `PaymentRecoveryJourneyTest.receiveLaterCanBeClaimedFromHistoryExactlyOnce`.
+- Validation: failed before the fix and passed after it, including one balance
+  credit and the expected final transaction status.
+
+### UI-003 — Android hides the multi-unit removal safety explanation
+
+- Severity: medium; Android, with an explicit mapping regression on iOS too.
+- Reproduction: connect a mint with wallets in more than one currency unit, then
+  confirm removal from its detail screen.
+- Expected: explain that multi-unit removal is not yet safe and retain the mint.
+- Actual: the generic error classifier interpreted “Keep it connected” as a
+  connection failure, telling the user to retry their network instead.
+- Fix: classify the typed app-owned removal error before generic transport text
+  matching. Preserve the same policy explanation explicitly on iOS.
+- Regression: native multi-unit refusal journeys and `WalletErrorMessagesTest` /
+  `WalletErrorMessageTests` check the explanation and retained wallet state.
+- Validation: reproduced in the full Android UI suite; the focused post-fix mint-safety journey and JVM regression passed.
+
+### UI-004 — reselecting the current non-sat currency disables Send
+
+- Severity: medium; iOS and Android.
+- Reproduction: fund a USD wallet, open Send Ecash, then choose USD again from
+  the unit picker and enter a valid amount.
+- Expected: the balance stays available and the payment can be sent.
+- Actual: unit selection cleared the cached balance, while the balance-loading
+  task did not restart because its mint/unit key had not changed. Send remained
+  disabled. Selecting the same unit also discarded the entered amount.
+- Fix: preserve the balance and amount when the effective unit is unchanged;
+  still record the explicit selection and dismiss the picker.
+- Regression: both USD journeys now reselect USD after entering $2.50 and verify
+  that the resulting ecash amount remains 250 cents.
+- Validation: reproduced in the live iOS UI suite; both final USD journeys passed after the fix.
+
+## Test infrastructure defects
+
+### TEST-001 — UI fixtures could use external service transports
+
+Currency selection still used production exchange-rate fetching. Explicit NPC
+and NWC enablement could also start public transport clients despite the quiet
+startup policy. The app fixtures now inject fixed USD/EUR prices and local
+transport doubles. Currency, Lightning Address settings, and Wallet Connect
+limit/reset journeys passed with those boundaries controlled. Android's manual
+Lightning Address check also verifies one credit across repeated checks.
+
+### TEST-002 — camera fixtures prevented native key-shortcut coverage
+
+The Android deterministic scanner returned a replacement permission screen after
+camera authorization, omitting the real scanner controls and quick actions. The
+iOS simulator could not expose these actions after physical-camera startup
+failed. Both integration runtimes now substitute only camera capture and keep
+the production scanner overlay, key shortcuts, and route handling. Release
+camera behavior remains unchanged. Hardware decoding is not claimed as tested.
+
+### TEST-003 — iOS source guards mishandled symlinked checkout paths
+
+The typography guards compared a compiler source path with file-enumerator paths
+without resolving aliases. That could include the excluded design-system folder
+and report existing type definitions as new violations. Both paths are now
+canonicalized before computing the relative source path. The focused typography
+suite passed after this correction; no design-system allowlist was loosened.
+
+## Validation results
+
+- **All 51 new UI tests passed across the final targeted runs.** This means all
+  28 new Android cases and all 23 new iOS cases have successful executed results;
+  it does not describe a single combined 51-case run.
+- **Android JVM:** 738 discovered, 732 passed, six configured skips, zero failures.
+- **Android lint:** zero errors (62 warnings and six hints).
+- **Android full required UI run:** 161 discovered, 155 passed, four configured
+  skips, two failures. Those failures exposed the removal-message bug and the
+  fake spend-state/visibility assertion issue. After corrections, the 28-case
+  expansion run passed 27 cases; the remaining payment case and the changed USD
+  case were included in the final eight-case payment/currency run, which passed
+  all eight. Existing payment journeys were also rerun after the fixture change.
+- **iOS full UI run:** 44 discovered, 40 passed, one configured skip, three
+  failures. The final targeted rerun passed all three: Wallet Connect code
+  persistence/reset, seed restore, and USD send. The first two needed reliable
+  native sheet/word-entry actions; USD exposed UI-004.
+- **iOS unit/integration:** 659 discovered, 657 passed, two configured skips,
+  zero failures in the final full-target run. The typography/error-message
+  suites passed after the source-path correction.
+- Local-mint iOS journeys execute real CDK for receive, send, clipboard token
+  redemption, and seed restoration. Android app fixtures explicitly control
+  backend results; the full suite also exercises its local-mint UI boundary.
+- Full-suite failures and follow-up runs are disclosed separately. No retry is
+  presented as an initially green full-suite run. Four Android optional native/
+  BOLT12 cases, six JVM cases, two iOS unit cases, and one iOS optional live BOLT12 UI case were skipped
+  by their existing configuration gates.
+
+## Deliberate scope boundaries
+
+- Currency pickers have no search feature; tests cover selection, dismissal, off,
+  persistence, conversion settings, and payment-unit behavior.
+- History filters are All/Pending/Completed, not incoming/outgoing.
+- Multi-unit mint removal is deliberately refused by the current product safety
+  policy. Tests check the refusal and retained wallet state; this is not reported
+  as an accidental deletion failure.
+- Android fixture recreation retains the app container; it is not a cold process
+  restart. iOS persistence checks terminate/relaunch without resetting the wallet.
+- Physical camera/NFC, OS biometric enrollment, cloud accounts, and external
+  signer/relay interoperability need their actual environments. The coverage
+  matrix explicitly separates these from application behavior exercised by mocks.

--- a/docs/testing/ui-coverage-report.md
+++ b/docs/testing/ui-coverage-report.md
@@ -2,7 +2,8 @@
 
 The expansion adds **51 native UI tests**: 28 Android journeys and 23 iOS tests.
 The [coverage matrix](wallet-ui-coverage.md) lists priorities, test owners, and
-remaining device/service boundaries. All new UI cases have passed; detailed run boundaries are recorded below.
+remaining device/service boundaries. Local results and the subsequent hosted CI
+failures are recorded separately below.
 
 ## Confirmed application defects
 
@@ -135,3 +136,36 @@ suite passed after this correction; no design-system allowlist was loosened.
 - Physical camera/NFC, OS biometric enrollment, cloud accounts, and external
   signer/relay interoperability need their actual environments. The coverage
   matrix explicitly separates these from application behavior exercised by mocks.
+
+
+## Hosted CI follow-up
+
+The first PR run passed all required Android checks and the iOS unit/integration
+step (659 discovered, zero failures). The iOS UI bundle ran twice: the first
+attempt had five failures, and the second retained one failure out of 44 cases
+(with one configured skip). The job ended cancelled after nearly 55 minutes;
+no diagnostic artifacts were uploaded.
+
+- `testCancellingCurrencyPickerPreservesSelection` failed on both attempts.
+  Its navigation-bar swipe did not establish that the currency sheet had opened
+  or dismissed. The test now waits for the picker and drags the native sheet
+  grabber, then asserts that the picker disappears before checking selection.
+- The onboarding chassis test matched both the app's Continue action and the
+  first-use keyboard tutorial's Continue action. It now selects the existing
+  `onboarding-restore-continue` accessibility identifier.
+- The amount-entry journey lost its initial mint-field focus. The shared helper
+  now checks for the keyboard and refocuses once if the insertion transition
+  consumed the tap; it still requires the keyboard before typing.
+- Last-mint removal and seed restore reported generic tappability failures on
+  the first attempt and passed on the second. Without the missing attachments,
+  their exact failing controls cannot be established from the hosted log.
+- Xcode's repetition configuration ran the complete bundle twice, adding about
+  20 minutes. CI now executes once, bounds the UI step to 30 minutes within the
+  45-minute job, and attempts diagnostic upload on failure or cancellation.
+  First-attempt failures remain failures; no assertions or cases were removed.
+
+All five affected cases passed locally without retries: currency dismissal and
+onboarding together (2/2), then amount entry, last-mint removal, and seed restore
+against the local mints (3/3). Workflow YAML and every embedded shell step parse.
+These focused results do not establish a green hosted suite; the updated PR
+requires a fresh CI run.

--- a/docs/testing/wallet-ui-coverage.md
+++ b/docs/testing/wallet-ui-coverage.md
@@ -1,0 +1,85 @@
+# Wallet UI interaction coverage
+
+The highest-priority checks follow actions through to their effects: balances,
+transaction status, selected mint, saved preferences, and state after returning
+to the app. Merely opening a screen is not a payment test.
+
+## Priority checklist and test owners
+
+| Priority | Interaction and expected outcome | Android journeys | iOS journeys |
+| --- | --- | --- | --- |
+| P0 | Create wallet, acknowledge recovery phrase, skip/add first mint, reopen wallet | MainActivity | WalletIntegration, OnboardingChassis |
+| P0 | Add mint; reject malformed and duplicate URLs; select default; remove/cancel removal; handle last-mint empty state | MintSafety, MultiCurrency, FunctionalWallet | Settings, WalletLifecycle |
+| P0 | Enter, delete, clear, and cancel payment amount; refuse insufficient funds | PaymentRecovery, FunctionalWallet | WalletLifecycle |
+| P0 | Send ecash, show pending receipt, debit once, preserve history | FunctionalWallet, PaymentRecovery | WalletLifecycle |
+| P0 | Receive ecash via routed input; inspect unknown mint; receive later and claim from history | FunctionalWallet, PaymentRecovery | WalletLifecycle (clipboard round trip) |
+| P0 | Receive Lightning payment and preserve balance/history across lifecycle transitions | FunctionalWallet, PaymentRecovery | WalletLifecycle |
+| P0 | Restore seed/mints/funds; cancel before replacement; delete wallet confirmation/cancellation | Security, FunctionalWallet | WalletLifecycle, Settings |
+| P0 | Require successful authentication to enable lock; reject denied seed reveal; reveal again only after authentication | Security | Settings |
+| P1 | Select display currency, dismiss/off, persist preference; never change underlying funds | WalletPreferences | Settings |
+| P1 | Select mint currency unit; keep cents distinct from sats; reject excess decimal digits | MultiCurrency, ActivityDetail | WalletLifecycle, MainTab |
+| P1 | Combine history status filter and search; inspect receipt and return | PaymentRecovery, FunctionalWallet | WalletLifecycle |
+| P1 | Check pending sent ecash manually; distinguish pending from claimed without another debit | PaymentRecovery | WalletLifecycle (pending check and live round trip) |
+| P1 | Edit reusable request currency/mint/description, create a new request, retain prior receipts | ActivityDetail, ReusableReceive, HistoryDescription | MainTab, Receive |
+| P1 | Enable quick lock, return from key scanner, preserve amount, remove lock | Security | WalletLifecycle |
+| P1 | Toggle polling/listening dependencies independently and persist settings | WalletPreferences | Settings |
+| P1 | Lightning Address enable/disable and auto-claim; manually check without duplicate credit | AdvancedSettings | Settings (connection/preferences) |
+| P1 | Wallet Connect no-mint explanation, enable/disable, spending limit, reset/cancel | WalletPreferences, AdvancedSettings | Settings |
+| P1 | Relay add/duplicate/remove or reset; cancel identity replacement | AdvancedSettings | Settings |
+| P1 | Invoice payment, on-chain receive, reusable BOLT12 payments | FunctionalWallet, PaymentRecovery, ReusableReceive | Existing service/integration tests and Receive BOLT12 UI |
+| P2 | Camera permission denial/retry, back navigation, empty clipboard, large text, accessibility | MainActivity, ActivityDetail and component suites | MainTab, OnboardingChassis and component suites |
+
+Class names in the table omit `JourneyTest` / `UITests` suffixes where appropriate.
+Both suites drive production native UI. Android fixtures replace wallet and
+external-service boundaries; iOS live wallet journeys execute real CDK against
+local FakeWallet mints. Android activity recreation is not a cold process restart;
+iOS relaunch tests terminate the app and remove all reset/seed launch flags.
+
+## Running and maintaining the checks
+
+The normal Android PR instrumentation suite automatically discovers the new
+journey classes. See [Android testing](../android/TESTING.md) for managed-device,
+local-mint, and compatibility commands. For an already running emulator:
+
+```sh
+cd android
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.notAnnotation=com.cashu.me.test.FullOnly
+```
+
+The iOS project registers `WalletLifecycleUITests` in the shared UI test target.
+The iOS workflow runs all UI tests serially and provisions both local mints. Use
+the CDK multi-unit profile for the USD case:
+
+```sh
+./CI/setup-cdk.sh 3339 android
+./CI/start-cdk.sh
+./CI/setup-nutshell.sh
+./CI/start-nutshell.sh 3338
+xcodebuild test -project ios/CashuWallet.xcodeproj -scheme CashuWallet \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -parallel-testing-enabled NO -only-testing:CashuWalletUITests
+```
+
+Settings tests use fixed exchange rates and no remote NPC/NWC transport.
+Authentication outcomes are injected at the operating-system boundary. iOS
+transport doubles and authentication overrides are compiled only in DEBUG and
+activated only in the integration runtime. Production authentication and native
+screen/navigation code still execute outside that boundary.
+
+## Explicit limits and follow-up priorities
+
+This is not a claim of exhaustive feature or protocol coverage. Remaining UI
+parity work includes iOS receive-later/error/retry scenarios, manual NPC payment
+claiming and claimed-token status transitions, on-chain receipt settlement, and full
+locked-token/key-management operations. Android cold-process restoration also
+needs a separate process-launch fixture. Existing lower-level tests cover parts
+of these behaviors; they do not substitute for the missing UI journeys.
+
+Physical camera/NFC interaction, actual OS biometric enrollment, real iCloud
+accounts, and external signer/relay interoperability require their respective
+device or service environments. Deterministic mocks do not validate those
+systems. Currency search is absent from the current product; history filters are
+All/Pending/Completed, not incoming/outgoing.
+
+See [the bug report](ui-coverage-report.md) for defects found and executed results.

--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		E20100000000000000000001 /* PaymentSafetyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E20100000000000000000002; };
+		A0C011000000000000000005 /* UITestNWCService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C011000000000000000006 /* UITestNWCService.swift */; };
+		A0C011000000000000000003 /* UITestNPCClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C011000000000000000004 /* UITestNPCClient.swift */; };
+		A0C011000000000000000001 /* WalletLifecycleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C011000000000000000002 /* WalletLifecycleUITests.swift */; };
 		AA9600000000000000000001 /* NPCServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA9600000000000000000002 /* NPCServiceTests.swift */; };
 		BD0100000000000000000002 /* ReceivedBalanceFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */; };
 		BD0100000000000000000004 /* ReceivedBalanceFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */; };
@@ -215,6 +218,9 @@
 
 /* Begin PBXFileReference section */
 		E20100000000000000000002 /* PaymentSafetyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PaymentSafetyIntegrationTests.swift; path = ../CI/IntegrationTests/Tests/PaymentSafetyIntegrationTests.swift; sourceTree = "<group>"; };
+		A0C011000000000000000006 /* UITestNWCService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UITestNWCService.swift; path = CashuWallet/Core/UITestNWCService.swift; sourceTree = "<group>"; };
+		A0C011000000000000000004 /* UITestNPCClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = UITestNPCClient.swift; path = CashuWallet/Core/UITestNPCClient.swift; sourceTree = "<group>"; };
+		A0C011000000000000000002 /* WalletLifecycleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = WalletLifecycleUITests.swift; path = CashuWalletUITests/WalletLifecycleUITests.swift; sourceTree = "<group>"; };
 		AA9600000000000000000002 /* NPCServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/NPCServiceTests.swift; sourceTree = "<group>"; };
 		BD0100000000000000000001 /* ReceivedBalanceFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedBalanceFeedback.swift; sourceTree = "<group>"; };
 		BD0100000000000000000003 /* ReceivedBalanceFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ReceivedBalanceFeedbackTests.swift; path = CashuWalletTests/ReceivedBalanceFeedbackTests.swift; sourceTree = "<group>"; };
@@ -489,6 +495,8 @@
 				172BA94269E4241413C46309 /* CashuWalletTests */,
 				46FCF584756C5A2EEED0B106 /* CashuWalletUITests */,
 				FB989C698CCB0CCD5FA8788D /* IntegrationTestConfig.swift */,
+				A0C011000000000000000004 /* UITestNPCClient.swift */,
+				A0C011000000000000000006 /* UITestNWCService.swift */,
 			);
 			sourceTree = "<group>";
 		};
@@ -715,6 +723,7 @@
 				T1A0000000000001 /* MainTabUITests.swift */,
 				T1A0000000000002 /* ReceiveUITests.swift */,
 				T1A0000000000003 /* SettingsUITests.swift */,
+				A0C011000000000000000002 /* WalletLifecycleUITests.swift */,
 				T1A0000000000004 /* UITestBase.swift */,
 			);
 			name = CashuWalletUITests;
@@ -1161,6 +1170,8 @@
 				6A8EC9482F2580000058C21B /* TransactionIcon.swift in Sources */,
 				6A8EC94A2F2590000058C21B /* PriceService.swift in Sources */,
 				6A8EC94C2F25A0000058C21B /* NostrService.swift in Sources */,
+				A0C011000000000000000003 /* UITestNPCClient.swift in Sources */,
+				A0C011000000000000000005 /* UITestNWCService.swift in Sources */,
 				6A8EC94E2F25A0000058C21B /* NPCService.swift in Sources */,
 				CC000000000000A1 /* NWCManager.swift in Sources */,
 				AB00000000000002 /* CashuRequestStore.swift in Sources */,
@@ -1238,6 +1249,7 @@
 				T2A0000000000001 /* MainTabUITests.swift in Sources */,
 				T2A0000000000002 /* ReceiveUITests.swift in Sources */,
 				T2A0000000000003 /* SettingsUITests.swift in Sources */,
+				A0C011000000000000000001 /* WalletLifecycleUITests.swift in Sources */,
 				T2A0000000000004 /* UITestBase.swift in Sources */,
 				T2A0000000000009 /* OnboardingChassisUITests.swift in Sources */,
 			);

--- a/ios/CashuWallet/App/ContentView.swift
+++ b/ios/CashuWallet/App/ContentView.swift
@@ -241,6 +241,11 @@ final class AppLockManager: ObservableObject {
     /// Whether `deviceOwnerAuthentication` (biometrics OR passcode) is available.
     /// False only when no device passcode is set at all.
     static func canEvaluate() -> Bool {
+        #if DEBUG
+        if let outcome = authenticationFixture {
+            return outcome != "unavailable"
+        }
+        #endif
         var error: NSError?
         let ok = LAContext().canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
         if !ok {
@@ -252,6 +257,23 @@ final class AppLockManager: ObservableObject {
     /// Runs one biometric/passcode evaluation. Returns `true` on success.
     @discardableResult
     func authenticate(reason: String = "Unlock your wallet") async -> Bool {
+        await authenticate(reason: reason, succeedWhenUnavailable: true)
+    }
+
+    /// Enabling a lock must require a successful device-owner challenge.
+    /// Runtime unlocking may still recover when device authentication disappears.
+    func authenticateForAppLockEnablement() async -> Bool {
+        await authenticate(reason: "Confirm to enable App Lock", succeedWhenUnavailable: false)
+    }
+
+    #if DEBUG
+    private static var authenticationFixture: String? {
+        guard IntegrationTestConfig.shouldUseDeterministicUIRuntime else { return nil }
+        return ProcessInfo.processInfo.environment["UITEST_AUTHENTICATION"]
+    }
+    #endif
+
+    private func authenticate(reason: String, succeedWhenUnavailable: Bool) async -> Bool {
         guard !isAuthenticating else { return false }
         isAuthenticating = true
         defer { isAuthenticating = false }
@@ -262,6 +284,14 @@ final class AppLockManager: ObservableObject {
             return success
         }
 
+        #if DEBUG
+        if let outcome = Self.authenticationFixture {
+            let success = outcome == "allow" || (outcome == "unavailable" && succeedWhenUnavailable)
+            if success { unlock() }
+            return success
+        }
+        #endif
+
         // A fresh context per evaluation is mandatory: reusing one short-circuits
         // auth and caches stale enrollment / biometryType.
         let context = LAContext()
@@ -269,10 +299,11 @@ final class AppLockManager: ObservableObject {
 
         var policyError: NSError?
         guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &policyError) else {
-            // Capability gap (no passcode) → fail open so funds are never bricked.
-            AppLogger.security.warning("Auth unavailable, unlocking: \(policyError?.localizedDescription ?? "unknown")")
-            unlock()
-            return true
+            // Runtime recovery can allow access without a passcode, but a new
+            // App Lock must never be enabled without a successful challenge.
+            AppLogger.security.warning("Device-owner authentication unavailable: \(policyError?.localizedDescription ?? "unknown")")
+            if succeedWhenUnavailable { unlock() }
+            return succeedWhenUnavailable
         }
 
         do {

--- a/ios/CashuWallet/Core/NPCService.swift
+++ b/ios/CashuWallet/Core/NPCService.swift
@@ -6,7 +6,14 @@ import Cdk
 /// Provides Lightning address functionality via Nostr identity
 @MainActor
 class NPCService: ObservableObject {
-    static let shared = NPCService()
+    static let shared: NPCService = {
+        #if DEBUG
+        if IntegrationTestConfig.shouldUseDeterministicUIRuntime {
+            return NPCService(makeClient: { _, _ in UITestNPCClient() })
+        }
+        #endif
+        return NPCService()
+    }()
     
     // MARK: - Settings (persisted)
     

--- a/ios/CashuWallet/Core/NWCManager.swift
+++ b/ios/CashuWallet/Core/NWCManager.swift
@@ -74,7 +74,7 @@ final class NWCManager: ObservableObject {
 
     // MARK: - Private
 
-    private var service: NwcService?
+    private var service: (any NwcServiceProtocol)?
     private let settingsStore: SettingsStore
     private var lifecycleTask: Task<Void, Never>?
     private var lifecycleRevision: UInt64 = 0
@@ -162,30 +162,8 @@ final class NWCManager: ObservableObject {
         guard isEnabled, revision == lifecycleRevision else { return }
 
         do {
-            let serviceSecretKey = try nwcDeriveServiceSecretKeyFromSeed(seed: seed)
-            let wallet = try await resolveWallet(mintUrl: mintUrl)
+            let svc = try await makeService(mintUrl: mintUrl, seed: seed)
             guard isEnabled, revision == lifecycleRevision else { return }
-            let budgetMsat = try Self.paymentLimitMsat(budgetSats)
-
-            let svc: NwcService
-            if let uri = connectionUri,
-               let clientSecret = Self.clientSecret(fromConnectionUri: uri) {
-                // Reuse the existing connection so the previously shared URI keeps working.
-                svc = try NwcService.restore(
-                    wallet: wallet,
-                    relays: relays,
-                    serviceSecretKey: serviceSecretKey,
-                    clientSecretKey: clientSecret,
-                    maxPaymentMsat: budgetMsat
-                )
-            } else {
-                svc = try NwcService.create(
-                    wallet: wallet,
-                    relays: relays,
-                    serviceSecretKey: serviceSecretKey,
-                    maxPaymentMsat: budgetMsat
-                )
-            }
 
             do {
                 try await svc.start()
@@ -247,6 +225,25 @@ final class NWCManager: ObservableObject {
     }
 
     // MARK: - Helpers
+
+    private func makeService(mintUrl: String, seed: Data) async throws -> any NwcServiceProtocol {
+        let clientSecret = connectionUri.flatMap(Self.clientSecret(fromConnectionUri:))
+        let budgetMsat = try Self.paymentLimitMsat(budgetSats)
+        #if DEBUG
+        if IntegrationTestConfig.shouldUseDeterministicUIRuntime {
+            return UITestNWCService(clientSecret: clientSecret)
+        }
+        #endif
+        let serviceSecretKey = try nwcDeriveServiceSecretKeyFromSeed(seed: seed)
+        let wallet = try await resolveWallet(mintUrl: mintUrl)
+        if let clientSecret {
+            return try NwcService.restore(wallet: wallet, relays: relays,
+                serviceSecretKey: serviceSecretKey, clientSecretKey: clientSecret,
+                maxPaymentMsat: budgetMsat)
+        }
+        return try NwcService.create(wallet: wallet, relays: relays,
+            serviceSecretKey: serviceSecretKey, maxPaymentMsat: budgetMsat)
+    }
 
     private func restartService() async {
         await start()

--- a/ios/CashuWallet/Core/PriceService.swift
+++ b/ios/CashuWallet/Core/PriceService.swift
@@ -4,7 +4,17 @@ import SwiftUI
 /// Service for fetching Bitcoin price from Coinbase API
 @MainActor
 class PriceService: ObservableObject {
-    static let shared = PriceService()
+    static let shared: PriceService = {
+        #if DEBUG
+        if IntegrationTestConfig.shouldUseDeterministicUIRuntime {
+            return PriceService(
+                priceFetcher: { $0 == "EUR" ? 80_000 : 100_000 },
+                enableAutoRefresh: false
+            )
+        }
+        #endif
+        return PriceService()
+    }()
     
     // MARK: - Published Properties
     

--- a/ios/CashuWallet/Core/UITestNPCClient.swift
+++ b/ios/CashuWallet/Core/UITestNPCClient.swift
@@ -1,0 +1,24 @@
+#if DEBUG
+import Foundation
+import Cdk
+
+/// Replaces only the external address-service transport in UI integration mode.
+/// Production connection, settings, and lifecycle code still execute normally.
+@MainActor
+final class UITestNPCClient: NpubCashClientProtocol {
+    private var mintURL: String?
+
+    func getQuotes(since: UInt64?) async throws -> [NpubCashQuote] { [] }
+    func getMissingQuotes(quoteIds: [String]) async throws -> [NpubCashQuote] { [] }
+    func getUserInfo() async throws -> NpubCashUserResponse {
+        NpubCashUserResponse(error: false, pubkey: "", mintUrl: mintURL, lockQuote: false)
+    }
+    func setMintUrl(mintUrl: String) async throws -> NpubCashUserResponse {
+        mintURL = mintUrl
+        return try await getUserInfo()
+    }
+    func setQuoteLocking(lockQuotes: Bool) async throws -> NpubCashUserResponse {
+        NpubCashUserResponse(error: false, pubkey: "", mintUrl: mintURL, lockQuote: lockQuotes)
+    }
+}
+#endif

--- a/ios/CashuWallet/Core/UITestNWCService.swift
+++ b/ios/CashuWallet/Core/UITestNWCService.swift
@@ -1,0 +1,26 @@
+#if DEBUG
+import Foundation
+import Cdk
+
+/// UI transport double. It never opens relay connections or moves funds.
+/// The lock protects the synchronous state required by CDK's Sendable protocol.
+final class UITestNWCService: NwcServiceProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var running = false
+    private let uri: String
+
+    init(clientSecret: String?) {
+        let secret = clientSecret ?? UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+            + UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+        uri = "nostr+walletconnect://" + String(repeating: "01", count: 32)
+            + "?relay=wss%3A%2F%2Frelay.test&secret=" + secret
+    }
+
+    func clientPubkey() -> String { String(repeating: "02", count: 32) }
+    func servicePubkey() -> String { String(repeating: "01", count: 32) }
+    func connectionUri() -> String { uri }
+    func isRunning() -> Bool { lock.withLock { running } }
+    func start() async throws { lock.withLock { running = true } }
+    func stop() async throws { lock.withLock { running = false } }
+}
+#endif

--- a/ios/CashuWallet/Core/Wallet/WalletErrors.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletErrors.swift
@@ -31,6 +31,10 @@ struct WalletMessage {
 enum WalletErrorMessage {
     /// Resolve an error to its user-facing message **and** severity.
     static func classified(for error: Error) -> WalletMessage {
+        if let removalError = error as? MintRemovalPolicyError {
+            // Preserve app-owned safety guidance before generic CDK matching.
+            return .error(removalError.localizedDescription)
+        }
         if let meltRecoveryError = error as? MeltPaymentRecoveryError {
             switch meltRecoveryError {
             case .compensated:

--- a/ios/CashuWallet/Core/Wallet/WalletErrors.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletErrors.swift
@@ -31,6 +31,9 @@ struct WalletMessage {
 enum WalletErrorMessage {
     /// Resolve an error to its user-facing message **and** severity.
     static func classified(for error: Error) -> WalletMessage {
+        if let checkpointError = error as? WalletCheckpointError {
+            return .error(checkpointError.localizedDescription)
+        }
         if let removalError = error as? MintRemovalPolicyError {
             // Preserve app-owned safety guidance before generic CDK matching.
             return .error(removalError.localizedDescription)
@@ -456,6 +459,14 @@ extension Error {
 
     var meltRetryRequiresFreshQuote: Bool {
         (self as? MeltPaymentRecoveryError)?.retryRequiresFreshQuote == true
+    }
+}
+
+enum WalletCheckpointError: LocalizedError, Equatable {
+    case busy
+
+    var errorDescription: String? {
+        "Wallet database is still busy. Try again in a moment."
     }
 }
 

--- a/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
+++ b/ios/CashuWallet/Core/Wallet/WalletManager+Lifecycle.swift
@@ -895,7 +895,7 @@ extension WalletManager {
         resetRuntimeState()
         do {
             try await Task.detached(priority: .userInitiated) {
-                try WalletReplacementCheckpoint.flushDatabases(in: replacementURLs)
+                try await WalletReplacementCheckpoint.flushDatabases(in: replacementURLs)
                 try DurableWalletReplacement(storage: KeychainService(), urls: replacementURLs).begin(state: snapshotData)
             }.value
             removeWalletBoundaryDefaults(defaultsSnapshot)
@@ -1611,7 +1611,7 @@ struct DurableWalletReplacement {
 /// Native FFI handles can be released asynchronously. A successful checkpoint
 /// establishes a stable database image before the replacement journal copies it.
 enum WalletReplacementCheckpoint {
-    static func flushDatabases(in urls: [URL]) throws {
+    static func flushDatabases(in urls: [URL], retryTimeout: Duration = .seconds(1)) async throws {
         for url in urls {
             var directory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &directory) else { continue }
@@ -1619,25 +1619,56 @@ enum WalletReplacementCheckpoint {
                 ? try FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil)
                 : [url]
             for database in candidates where database.pathExtension == "db" || database.pathExtension == "sqlite" {
-                try flush(database)
+                try await flush(database, retryTimeout: retryTimeout)
             }
         }
     }
 
-    private static func flush(_ url: URL) throws {
+    private static func flush(_ url: URL, retryTimeout: Duration) async throws {
         var connection: OpaquePointer?
         guard sqlite3_open_v2(url.path, &connection, SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX, nil) == SQLITE_OK else {
             if let connection { sqlite3_close(connection) }
             throw CocoaError(.fileReadUnknown)
         }
         defer { sqlite3_close(connection) }
+
+        // CDK's final native reference is released asynchronously. Retry both
+        // schema locks during prepare and busy checkpoint results while that
+        // teardown finishes. A competing checkpoint bypasses SQLite's busy
+        // handler, so a busy timeout alone cannot cover every transient lock.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: retryTimeout)
+        while true {
+            try Task.checkCancellation()
+            do {
+                try checkpoint(connection)
+                return
+            } catch WalletCheckpointError.busy {
+                guard clock.now < deadline else { throw WalletCheckpointError.busy }
+                try await clock.sleep(until: min(deadline, clock.now.advanced(by: .milliseconds(20))))
+            }
+        }
+    }
+
+    private static func checkpoint(_ connection: OpaquePointer?) throws {
         var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(connection, "PRAGMA wal_checkpoint(TRUNCATE)", -1, &statement, nil) == SQLITE_OK else {
+        let prepared = sqlite3_prepare_v2(connection, "PRAGMA wal_checkpoint(TRUNCATE)", -1, &statement, nil)
+        defer { sqlite3_finalize(statement) }
+        guard prepared == SQLITE_OK else {
+            if isBusy(prepared) { throw WalletCheckpointError.busy }
             throw CocoaError(.fileWriteUnknown)
         }
-        defer { sqlite3_finalize(statement) }
-        guard sqlite3_step(statement) == SQLITE_ROW, sqlite3_column_int(statement, 0) == 0 else {
-            throw WalletError.networkError("Wallet database is still busy. Try again in a moment.")
+        let result = sqlite3_step(statement)
+        if isBusy(result) || (result == SQLITE_ROW && sqlite3_column_int(statement, 0) != 0) {
+            throw WalletCheckpointError.busy
         }
+        guard result == SQLITE_ROW else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+
+    private static func isBusy(_ result: Int32) -> Bool {
+        let primaryCode = result & 0xff
+        return primaryCode == SQLITE_BUSY || primaryCode == SQLITE_LOCKED
     }
 }

--- a/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
+++ b/ios/CashuWallet/Views/Components/ScannerWrapperView.swift
@@ -153,6 +153,14 @@ struct ScannerWrapperView: View {
     @State private var resolvedQuickFills: [ScannerQuickFill] = []
     @State private var cameraAuthorizationState: CameraAuthorizationState = .checking
     @State private var cameraFailureMessage: String?
+
+    private var usesTestCamera: Bool {
+        #if DEBUG
+        IntegrationTestConfig.shouldUseDeterministicUIRuntime
+        #else
+        false
+        #endif
+    }
     
     var body: some View {
         NavigationStack {
@@ -174,6 +182,10 @@ struct ScannerWrapperView: View {
                             actionTitle: "Try Again",
                             action: retryCamera
                         )
+                    } else if usesTestCamera {
+                        // Keep native scanner controls and routing; substitute
+                        // only hardware capture in simulator UI journeys.
+                        Text("Camera Ready").foregroundStyle(.white)
                     } else {
                         LegacyQRScannerView(
                             onResult: { code in
@@ -313,6 +325,10 @@ struct ScannerWrapperView: View {
     }
 
     private func refreshCameraAuthorization() {
+        if usesTestCamera {
+            cameraAuthorizationState = .authorized
+            return
+        }
         switch AVCaptureDevice.authorizationStatus(for: .video) {
         case .authorized:
             cameraAuthorizationState = .authorized

--- a/ios/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/ReceiveTokenDetailView.swift
@@ -259,6 +259,7 @@ struct ReceiveTokenDetailView: View {
                 Button(action: receiveToken) {
                     Text(reviewPresentation.claimActionTitle)
                 }
+                .accessibilityIdentifier("receive-token-confirm")
                 .glassButton()
                 .disabled(!isValidToken || !tokenLockedToKnownKey || isLoadingFee || receiveFee == nil)
 

--- a/ios/CashuWallet/Views/Send/SendView.swift
+++ b/ios/CashuWallet/Views/Send/SendView.swift
@@ -287,6 +287,7 @@ struct SendView: View {
             .flatSheetSecondaryButton()
             .disabled(!canSend || isGenerating)
             .accessibilityLabel("Send")
+            .accessibilityIdentifier("cashu.send.ecash.submit")
             .accessibilityValue(isGenerating ? "In progress" : "")
             .padding(.horizontal)
             .padding(.top, 16)
@@ -414,7 +415,11 @@ struct SendView: View {
     private var unitBalanceKey: String { "\(displaySendMint?.url ?? "")|\(effectiveSendUnit)" }
 
     private func selectSendUnit(_ unit: String) {
+        let previousUnit = effectiveSendUnit
         selectedSendUnit = unit
+        // Selecting the current unit does not restart the balance task. Keep
+        // its loaded balance and amount instead of leaving Send disabled.
+        guard unit != previousUnit else { return }
         // The typed amount's meaning changes with the unit — clear it and its
         // now-stale balance rather than reinterpret the digits.
         amountString = ""

--- a/ios/CashuWallet/Views/Settings/SettingsView.swift
+++ b/ios/CashuWallet/Views/Settings/SettingsView.swift
@@ -463,7 +463,7 @@ struct SecuritySettingsSection: View {
                     return
                 }
                 Task {
-                    let ok = await AppLockManager.shared.authenticate(reason: "Confirm to enable App Lock")
+                    let ok = await AppLockManager.shared.authenticateForAppLockEnablement()
                     settings.appLockEnabled = ok
                     if !ok {
                         authError = "Authentication failed. App Lock was not enabled. Try turning it on again."

--- a/ios/CashuWalletTests/TypographyGuardTests.swift
+++ b/ios/CashuWalletTests/TypographyGuardTests.swift
@@ -29,6 +29,7 @@ final class TypographyGuardTests: XCTestCase {
             .deletingLastPathComponent()   // CashuWalletTests
             .deletingLastPathComponent()   // ios
             .appendingPathComponent("CashuWallet")
+            .resolvingSymlinksInPath()
 
         try XCTSkipUnless(
             FileManager.default.fileExists(atPath: root.path),
@@ -41,7 +42,7 @@ final class TypographyGuardTests: XCTestCase {
 
         return walker.compactMap { entry in
             guard let url = entry as? URL, url.pathExtension == "swift" else { return nil }
-            let path = url.path.replacingOccurrences(of: root.path + "/", with: "")
+            let path = url.resolvingSymlinksInPath().path.replacingOccurrences(of: root.path + "/", with: "")
             guard !path.hasPrefix("DesignSystem/") else { return nil }
             guard let text = try? String(contentsOf: url, encoding: .utf8) else { return nil }
             return (path, text)

--- a/ios/CashuWalletTests/WalletAuditRegressionTests.swift
+++ b/ios/CashuWalletTests/WalletAuditRegressionTests.swift
@@ -7,7 +7,7 @@ import SQLite3
 final class WalletAuditRegressionTests: XCTestCase {
     private enum Failure: Error { case offline }
 
-    func testReplacementCheckpointPreservesSqliteWalContents() throws {
+    func testReplacementCheckpointPreservesSqliteWalContents() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -16,7 +16,7 @@ final class WalletAuditRegressionTests: XCTestCase {
         XCTAssertEqual(sqlite3_open(database.path, &connection), SQLITE_OK)
         defer { sqlite3_close(connection) }
         XCTAssertEqual(sqlite3_exec(connection, "PRAGMA journal_mode=WAL; CREATE TABLE recovery_test(value TEXT); INSERT INTO recovery_test VALUES ('proofs before replacement');", nil, nil, nil), SQLITE_OK)
-        try WalletReplacementCheckpoint.flushDatabases(in: [directory])
+        try await WalletReplacementCheckpoint.flushDatabases(in: [directory])
         let copy = directory.appendingPathComponent("snapshot.db")
         try FileManager.default.copyItem(at: database, to: copy)
         var reopened: OpaquePointer?
@@ -27,6 +27,100 @@ final class WalletAuditRegressionTests: XCTestCase {
         defer { sqlite3_finalize(statement) }
         XCTAssertEqual(sqlite3_step(statement), SQLITE_ROW)
         XCTAssertEqual(String(cString: sqlite3_column_text(statement, 0)), "proofs before replacement")
+    }
+
+    func testReplacementCheckpointWaitsForTransientWriterAndSchemaLocks() async throws {
+        // WAL blocks the checkpoint; DELETE's exclusive lock blocks statement
+        // preparation. Both can occur while the native database is closing.
+        for journalMode in ["WAL", "DELETE"] {
+            let (directory, writer) = try makeCheckpointDatabase(journalMode: journalMode)
+            defer {
+                sqlite3_close(writer)
+                try? FileManager.default.removeItem(at: directory)
+            }
+            XCTAssertEqual(sqlite3_exec(writer, "BEGIN EXCLUSIVE; INSERT INTO recovery_test VALUES(2)", nil, nil, nil), SQLITE_OK)
+            let started = expectation(description: "Checkpoint started for \(journalMode)")
+            let checkpoint = Task.detached(priority: .userInitiated) {
+                started.fulfill()
+                try await WalletReplacementCheckpoint.flushDatabases(in: [directory])
+            }
+            await fulfillment(of: [started], timeout: 5)
+            try await Task.sleep(for: .milliseconds(100))
+            XCTAssertEqual(sqlite3_exec(writer, "COMMIT", nil, nil, nil), SQLITE_OK)
+            try await checkpoint.value
+
+            // The replacement copies the main file, so the committed value
+            // must survive without depending on the original WAL sidecar.
+            let snapshot = directory.appendingPathComponent("snapshot.db")
+            try FileManager.default.copyItem(at: directory.appendingPathComponent("wallet.db"), to: snapshot)
+            XCTAssertEqual(try checkpointValues(at: snapshot), [1, 2])
+        }
+    }
+
+    func testReplacementCheckpointRejectsPersistentLockWithoutLosingData() async throws {
+        let (directory, writer) = try makeCheckpointDatabase(journalMode: "WAL")
+        defer {
+            sqlite3_close(writer)
+            try? FileManager.default.removeItem(at: directory)
+        }
+        XCTAssertEqual(sqlite3_exec(writer, "BEGIN IMMEDIATE; INSERT INTO recovery_test VALUES(2)", nil, nil, nil), SQLITE_OK)
+        let clock = ContinuousClock()
+        let started = clock.now
+        do {
+            try await WalletReplacementCheckpoint.flushDatabases(in: [directory], retryTimeout: .milliseconds(80))
+            XCTFail("A writer that stays active must prevent replacement")
+        } catch {
+            XCTAssertEqual(error as? WalletCheckpointError, .busy)
+        }
+        XCTAssertGreaterThanOrEqual(started.duration(to: clock.now), .milliseconds(80))
+        XCTAssertLessThan(started.duration(to: clock.now), .seconds(5))
+
+        XCTAssertEqual(sqlite3_exec(writer, "ROLLBACK", nil, nil, nil), SQLITE_OK)
+        try await WalletReplacementCheckpoint.flushDatabases(in: [directory])
+        XCTAssertEqual(try checkpointValues(at: directory.appendingPathComponent("wallet.db")), [1])
+    }
+
+    func testReplacementCheckpointWaitsForNativeDatabaseTeardown() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        for index in 0..<10 {
+            let databaseURL = directory.appendingPathComponent("wallet-\(index).db")
+            try autoreleasepool {
+                let database = try LifecycleSafeWalletDatabase(filePath: databaseURL.path)
+                let repository = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: database))
+                withExtendedLifetime(repository) {}
+            }
+            try await WalletReplacementCheckpoint.flushDatabases(in: [databaseURL])
+        }
+    }
+
+    private func makeCheckpointDatabase(journalMode: String) throws -> (URL, OpaquePointer) {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        var connection: OpaquePointer?
+        let url = directory.appendingPathComponent("wallet.db")
+        XCTAssertEqual(sqlite3_open(url.path, &connection), SQLITE_OK)
+        let database = try XCTUnwrap(connection)
+        XCTAssertEqual(sqlite3_exec(database, "PRAGMA journal_mode=\(journalMode); CREATE TABLE recovery_test(value INTEGER); INSERT INTO recovery_test VALUES(1)", nil, nil, nil), SQLITE_OK)
+        return (directory, database)
+    }
+
+    private func checkpointValues(at url: URL) throws -> [Int32] {
+        var connection: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(url.path, &connection), SQLITE_OK)
+        defer { sqlite3_close(connection) }
+        var statement: OpaquePointer?
+        XCTAssertEqual(sqlite3_prepare_v2(connection, "SELECT value FROM recovery_test ORDER BY value", -1, &statement, nil), SQLITE_OK)
+        defer { sqlite3_finalize(statement) }
+        var values: [Int32] = []
+        var result = sqlite3_step(statement)
+        while result == SQLITE_ROW {
+            values.append(sqlite3_column_int(statement, 0))
+            result = sqlite3_step(statement)
+        }
+        XCTAssertEqual(result, SQLITE_DONE)
+        return values
     }
 
     func testReplacementRelaunchRestoresSeedDefaultsAndDatabase() throws {

--- a/ios/CashuWalletTests/WalletErrorMessageTests.swift
+++ b/ios/CashuWalletTests/WalletErrorMessageTests.swift
@@ -18,6 +18,13 @@ final class WalletErrorMessageTests: XCTestCase {
         )
     }
 
+    func testCheckpointBusyPreservesRetryGuidance() {
+        let message = WalletCheckpointError.busy.walletMessage
+        XCTAssertEqual(message.text, "Wallet database is still busy. Try again in a moment.")
+        XCTAssertEqual(message.severity, .error)
+        XCTAssertEqual(message.recoverability, .retryable)
+    }
+
     /// A NUT-04/05 amount rejection must never reach the UI as CDK's own text.
     /// The mint returns code 11006 with the real bounds in `detail`, but decoding
     /// that response back into an Error rebuilds the variant with three

--- a/ios/CashuWalletTests/WalletErrorMessageTests.swift
+++ b/ios/CashuWalletTests/WalletErrorMessageTests.swift
@@ -11,6 +11,13 @@ private struct RawMintError: Error, CustomStringConvertible {
 
 final class WalletErrorMessageTests: XCTestCase {
 
+    func testMultiUnitRemovalPreservesSafetyGuidance() {
+        XCTAssertEqual(
+            MintRemovalPolicyError.multipleUnits.userFacingWalletMessage,
+            "This mint uses multiple currency units and cannot be removed safely yet. Keep it connected and try again after updating the app."
+        )
+    }
+
     /// A NUT-04/05 amount rejection must never reach the UI as CDK's own text.
     /// The mint returns code 11006 with the real bounds in `detail`, but decoding
     /// that response back into an Error rebuilds the variant with three

--- a/ios/CashuWalletUITests/OnboardingChassisUITests.swift
+++ b/ios/CashuWalletUITests/OnboardingChassisUITests.swift
@@ -71,7 +71,7 @@ final class OnboardingChassisUITests: UITestBase {
             app.keyboards.element.waitForExistence(timeout: 10),
             "restoreInput should focus the seed field on arrival"
         )
-        assertBottomAnchored(app.buttons["Continue"], "restoreInput")
+        assertBottomAnchored(app.buttons["onboarding-restore-continue"], "restoreInput")
         // Paste is a chip in the stage now (directly under the word card), not
         // a chassis action — assert it offers itself while nothing is entered.
         XCTAssertTrue(

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -110,6 +110,289 @@ final class SettingsUITests: UITestBase {
         XCTAssertTrue(mintRow.waitForExistence(timeout: 5))
     }
 
+    func testDisplayCurrencyPersistsAcrossRelaunchAndCanBeDisabled() {
+        navigateToSettings()
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch)
+        tapWhenReady(app.buttons["EUR"])
+        XCTAssertTrue(screen("settings-screen").waitForExistence(timeout: 5))
+        relaunchPreservingWallet()
+        navigateToSettings()
+        let currency = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch
+        XCTAssertTrue(currency.label.contains("EUR"), "Currency preference must survive a fresh process")
+        tapWhenReady(currency)
+        tapWhenReady(app.buttons["USD"])
+        tapWhenReady(currency)
+        tapWhenReady(app.buttons["Off, sats only"])
+        relaunchPreservingWallet()
+        navigateToSettings()
+        XCTAssertTrue(currency.label.contains("Off"))
+    }
+
+    func testCancellingCurrencyPickerPreservesSelection() {
+        navigateToSettings()
+        let currency = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch
+        let original = currency.label
+        tapWhenReady(currency)
+        app.navigationBars["Currency"].swipeDown()
+        XCTAssertTrue(currency.waitUntilEnabledAndHittable(timeout: 5))
+        XCTAssertEqual(currency.label, original)
+    }
+
+    func testPrivacyDependenciesAndPreferencesSurviveRelaunch() {
+        navigateToSettings()
+        scrollToSettingsRow("Privacy")
+        tapWhenReady(app.buttons["Privacy"].firstMatch)
+        let incoming = privacySwitch("Check incoming invoice")
+        setSwitch(incoming, toOn: false)
+        XCTAssertFalse(privacySwitch("Repeat checks on a timer").isEnabled)
+        setSwitch(privacySwitch("Check sent ecash"), toOn: false)
+        setSwitch(privacySwitch("Use WebSockets"), toOn: true)
+        relaunchPreservingWallet()
+        navigateToSettings()
+        scrollToSettingsRow("Privacy")
+        tapWhenReady(app.buttons["Privacy"].firstMatch)
+        XCTAssertEqual(incoming.value as? String, "0")
+        XCTAssertEqual(privacySwitch("Check sent ecash").value as? String, "0")
+        XCTAssertEqual(privacySwitch("Use WebSockets").value as? String, "1")
+        XCTAssertTrue(privacySwitch("Use WebSockets").isEnabled)
+        setSwitch(incoming, toOn: true)
+        XCTAssertTrue(privacySwitch("Repeat checks on a timer").isEnabled)
+    }
+
+    func testDeleteConfirmationRemovesWalletAcrossRelaunch() {
+        navigateToSettings()
+        scrollToSettingsRow("Delete Wallet")
+        tapWhenReady(app.buttons["Delete Wallet"])
+        tapWhenReady(app.buttons["Delete"])
+        XCTAssertTrue(app.buttons["onboarding-create-wallet"].waitForExistence(timeout: 15))
+        app.terminate()
+        for key in ["RESET_WALLET", "UITEST_SEED_WALLET", "UITEST_SEED_MINT"] {
+            app.launchEnvironment.removeValue(forKey: key)
+        }
+        app.launch()
+        XCTAssertTrue(app.buttons["onboarding-create-wallet"].waitForExistence(timeout: 15))
+        XCTAssertFalse(app.buttons["wallet-settings-button"].exists)
+    }
+
+    func testSecurityAndBackupScreensReturnToSettings() {
+        navigateToSettings()
+        for title in ["App Lock", "Backup & Restore", "Locked Ecash", "Nostr"] {
+            scrollToSettingsRow(title)
+            tapWhenReady(app.buttons[title].firstMatch)
+            XCTAssertTrue(app.navigationBars[title].waitForExistence(timeout: 5))
+            tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+            XCTAssertTrue(screen("settings-screen").waitForExistence(timeout: 5))
+        }
+    }
+
+    func testUnavailableAuthenticationCannotEnableAppLock() {
+        launchWithAuthentication("unavailable")
+        navigateToSettings()
+        tapWhenReady(app.buttons["App Lock"])
+        let toggle = app.switches.firstMatch
+        setSwitch(toggle, toOn: false)
+        tapSwitchControl(toggle)
+        XCTAssertTrue(app.staticTexts["Authentication failed. App Lock was not enabled. Try turning it on again."]
+            .waitForExistence(timeout: 5))
+        XCTAssertEqual(toggle.value as? String, "0")
+    }
+
+    func testRejectedAuthenticationCannotEnableAppLock() {
+        launchWithAuthentication("deny")
+        navigateToSettings()
+        tapWhenReady(app.buttons["App Lock"])
+        let toggle = app.switches.firstMatch
+        setSwitch(toggle, toOn: false)
+        tapSwitchControl(toggle)
+        XCTAssertTrue(app.staticTexts["Authentication failed. App Lock was not enabled. Try turning it on again."]
+            .waitForExistence(timeout: 5))
+        XCTAssertEqual(toggle.value as? String, "0")
+    }
+
+    func testSuccessfulAppLockEnablementPersistsAfterRelaunch() {
+        launchWithAuthentication("allow")
+        navigateToSettings()
+        tapWhenReady(app.buttons["App Lock"])
+        let toggle = app.switches.firstMatch
+        setSwitch(toggle, toOn: true)
+        let enabled = XCTNSPredicateExpectation(predicate: NSPredicate(format: "value == '1'"), object: toggle)
+        XCTAssertEqual(XCTWaiter.wait(for: [enabled], timeout: 5), .completed)
+        relaunchPreservingWallet()
+        navigateToSettings()
+        tapWhenReady(app.buttons["App Lock"])
+        XCTAssertEqual(toggle.value as? String, "1")
+    }
+
+    func testRejectedSeedRevealKeepsWordsHiddenWithAppLockOff() {
+        launchWithAuthentication("deny")
+        navigateToSettings()
+        tapWhenReady(app.buttons["Backup & Restore"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Backup seed phrase")).firstMatch)
+        tapWhenReady(app.buttons["Reveal Recovery Phrase"])
+        XCTAssertTrue(app.buttons["Reveal Recovery Phrase"].exists)
+        XCTAssertFalse(app.buttons["Copy Recovery Phrase"].exists)
+    }
+
+    func testSuccessfulSeedRevealCanBeDismissedWithoutPersistingReveal() {
+        launchWithAuthentication("allow")
+        navigateToSettings()
+        tapWhenReady(app.buttons["Backup & Restore"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Backup seed phrase")).firstMatch)
+        tapWhenReady(app.buttons["Reveal Recovery Phrase"])
+        XCTAssertTrue(app.buttons["Copy Recovery Phrase"].waitForExistence(timeout: 5))
+        relaunchPreservingWallet()
+        navigateToSettings()
+        tapWhenReady(app.buttons["Backup & Restore"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Backup seed phrase")).firstMatch)
+        XCTAssertTrue(app.buttons["Reveal Recovery Phrase"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Copy Recovery Phrase"].exists)
+    }
+
+    func testNostrRelayAdditionAndResetPersist() {
+        navigateToSettings()
+        scrollToSettingsRow("Nostr")
+        tapWhenReady(app.buttons["Nostr"])
+        let field = app.textFields["wss://relay.example.com"]
+        for _ in 0..<6 {
+            if field.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(field)
+        field.typeText("wss://relay.test")
+        tapWhenReady(app.buttons["Add relay"])
+        XCTAssertTrue(app.staticTexts["wss://relay.test"].waitForExistence(timeout: 5))
+        relaunchPreservingWallet()
+        navigateToSettings()
+        scrollToSettingsRow("Nostr")
+        tapWhenReady(app.buttons["Nostr"])
+        let reset = app.buttons["Reset to default relays"]
+        for _ in 0..<8 {
+            if reset.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(reset)
+        XCTAssertTrue(app.staticTexts["Reset to default relays?"].waitForExistence(timeout: 5))
+        tapWhenReady(app.buttons["Cancel"])
+        XCTAssertTrue(app.staticTexts["wss://relay.test"].exists)
+        tapWhenReady(reset)
+        tapWhenReady(app.buttons["Reset"])
+        XCTAssertTrue(app.staticTexts["wss://relay.test"].waitForNonExistence(timeout: 5))
+    }
+
+    func testNostrIdentityReplacementCanBeCancelled() {
+        navigateToSettings()
+        scrollToSettingsRow("Nostr")
+        tapWhenReady(app.buttons["Nostr"])
+        let generate = app.buttons["Generate new key"]
+        for _ in 0..<5 {
+            if generate.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(generate)
+        XCTAssertTrue(app.staticTexts["Generate new key?"].waitForExistence(timeout: 5))
+        tapWhenReady(app.buttons["Cancel"])
+        XCTAssertTrue(generate.waitUntilEnabledAndHittable(timeout: 5))
+        XCTAssertFalse(app.buttons["Reset to wallet seed"].exists)
+    }
+
+    func testLightningAddressEnableAutoClaimAndDisablePersist() {
+        navigateToSettings()
+        tapWhenReady(app.buttons["Lightning"])
+        let enabled = app.switches["Enable Lightning Address"]
+        setSwitch(enabled, toOn: true)
+        let automatic = app.switches["Auto-claim payments"]
+        XCTAssertTrue(automatic.waitForExistence(timeout: 10))
+        setSwitch(automatic, toOn: false)
+        relaunchPreservingWallet()
+        navigateToSettings()
+        tapWhenReady(app.buttons["Lightning"])
+        XCTAssertEqual(enabled.value as? String, "1")
+        XCTAssertEqual(automatic.value as? String, "0")
+        setSwitch(enabled, toOn: false)
+        XCTAssertTrue(automatic.waitForNonExistence(timeout: 5))
+    }
+
+    func testWalletConnectLimitAndResetPersist() {
+        app.terminate()
+        app.launchEnvironment["UITEST_SEED_MINT"] = "1"
+        app.launchEnvironment["UITEST_SEED_MINT_URL"] = "https://mint.test"
+        app.launch()
+        navigateToSettings()
+        scrollToSettingsRow("Nostr")
+        tapWhenReady(app.buttons["Nostr"])
+        let connect = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Wallet Connect")).firstMatch
+        for _ in 0..<8 {
+            if connect.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(connect)
+        setSwitch(privacySwitch("Enable Wallet Connect"), toOn: true)
+        let originalCode = walletConnectCode()
+        let limit = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Payment limit")).firstMatch
+        tapWhenReady(limit)
+        let field = app.textFields["No limit"]
+        tapWhenReady(field)
+        field.typeText("250")
+        tapWhenReady(app.buttons["Save"])
+        XCTAssertTrue(limit.waitForExistence(timeout: 5))
+        XCTAssertTrue(limit.label.contains("250"))
+        relaunchPreservingWallet()
+        navigateToSettings()
+        scrollToSettingsRow("Nostr")
+        tapWhenReady(app.buttons["Nostr"])
+        for _ in 0..<8 {
+            if connect.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(connect)
+        XCTAssertEqual(privacySwitch("Enable Wallet Connect").value as? String, "1")
+        XCTAssertTrue(limit.label.contains("250"))
+        XCTAssertEqual(walletConnectCode(), originalCode)
+        let reset = app.buttons["Reset connection"]
+        tapWhenReady(reset)
+        tapWhenReady(app.buttons["Cancel"])
+        XCTAssertTrue(limit.label.contains("250"))
+        XCTAssertEqual(walletConnectCode(), originalCode)
+        tapWhenReady(reset)
+        tapWhenReady(app.buttons["Reset"])
+        XCTAssertTrue(limit.waitUntilEnabledAndHittable(timeout: 5))
+        XCTAssertTrue(limit.label.contains("250"))
+        XCTAssertNotEqual(walletConnectCode(), originalCode)
+        setSwitch(privacySwitch("Enable Wallet Connect"), toOn: false)
+        XCTAssertTrue(limit.waitForNonExistence(timeout: 5))
+    }
+
+    private func launchWithAuthentication(_ outcome: String) {
+        app.terminate()
+        app.launchEnvironment["UITEST_AUTHENTICATION"] = outcome
+        app.launch()
+        waitForMainTab()
+    }
+
+    private func walletConnectCode() -> String {
+        let connection = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Connection code.")).firstMatch
+        tapWhenReady(connection, timeout: 10)
+        let code = app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH %@", "nostr+walletconnect://")).firstMatch
+        XCTAssertTrue(code.waitForExistence(timeout: 5))
+        let value = code.label
+        // The connection row also contains this text behind the QR sheet.
+        // The sheet-only Copy action is the unambiguous dismissal boundary.
+        let copy = app.buttons["Copy"]
+        app.buttons["Sheet Grabber"].coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 0.1, thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.95)))
+        XCTAssertTrue(copy.waitForNonExistence(timeout: 5))
+        return value
+    }
+
+    private func scrollToSettingsRow(_ title: String) {
+        let row = app.buttons[title].firstMatch
+        for _ in 0..<8 {
+            if row.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTAssertTrue(row.isHittable, "Settings row must be reachable: \(title)")
+    }
+
     private func privacySwitch(_ labelPrefix: String) -> XCUIElement {
         app.switches
             .matching(NSPredicate(format: "label BEGINSWITH %@", labelPrefix))

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -133,7 +133,13 @@ final class SettingsUITests: UITestBase {
         let currency = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch
         let original = currency.label
         tapWhenReady(currency)
-        app.navigationBars["Currency"].swipeDown()
+        let picker = app.navigationBars["Currency"]
+        XCTAssertTrue(picker.waitForExistence(timeout: 10))
+        let grabber = app.buttons["Sheet Grabber"]
+        XCTAssertTrue(grabber.waitUntilEnabledAndHittable(timeout: 10))
+        grabber.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+            .press(forDuration: 0.1, thenDragTo: app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.95)))
+        XCTAssertTrue(picker.waitForNonExistence(timeout: 10), "Dragging the sheet grabber should dismiss the picker")
         XCTAssertTrue(currency.waitUntilEnabledAndHittable(timeout: 5))
         XCTAssertEqual(currency.label, original)
     }

--- a/ios/CashuWalletUITests/SettingsUITests.swift
+++ b/ios/CashuWalletUITests/SettingsUITests.swift
@@ -88,10 +88,7 @@ final class SettingsUITests: UITestBase {
         let mintRow = app.buttons.matching(NSPredicate(format: "label CONTAINS %@", "Cashu mint")).firstMatch
         tapWhenReady(mintRow)
         let removeRow = app.buttons["Remove mint"]
-        for _ in 0..<6 {
-            if removeRow.isHittable { break }
-            app.scrollViews.firstMatch.swipeUp()
-        }
+        scrollToButton(removeRow)
         tapWhenReady(removeRow)
         XCTAssertTrue(app.staticTexts["Remove mint?"].waitForExistence(timeout: 5))
         XCTAssertEqual(app.alerts.count, 0)
@@ -113,14 +110,14 @@ final class SettingsUITests: UITestBase {
     func testDisplayCurrencyPersistsAcrossRelaunchAndCanBeDisabled() {
         navigateToSettings()
         tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch)
-        tapWhenReady(app.buttons["EUR"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "EUR, ")).firstMatch)
         XCTAssertTrue(screen("settings-screen").waitForExistence(timeout: 5))
         relaunchPreservingWallet()
         navigateToSettings()
         let currency = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Currency")).firstMatch
         XCTAssertTrue(currency.label.contains("EUR"), "Currency preference must survive a fresh process")
         tapWhenReady(currency)
-        tapWhenReady(app.buttons["USD"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "USD, ")).firstMatch)
         tapWhenReady(currency)
         tapWhenReady(app.buttons["Off, sats only"])
         relaunchPreservingWallet()

--- a/ios/CashuWalletUITests/UITestBase.swift
+++ b/ios/CashuWalletUITests/UITestBase.swift
@@ -222,6 +222,25 @@ class UITestBase: XCTestCase {
         app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
+    func scrollToButton(
+        _ button: XCUIElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let scrollView = app.scrollViews.firstMatch
+        XCTAssertTrue(scrollView.waitForExistence(timeout: 5), file: file, line: line)
+        for attempt in 0...10 {
+            // XCTest can report a SwiftUI button as hittable below the viewport.
+            // Require its whole frame to be visible before trusting a tap.
+            let viewport = scrollView.frame.intersection(app.frame)
+            if button.exists && viewport.contains(button.frame) && button.isHittable {
+                return
+            }
+            if attempt < 10 { scrollView.swipeUp() }
+        }
+        XCTFail("Button must be visible inside the scroll view: \(button.label)", file: file, line: line)
+    }
+
     func tapWhenReady(
         _ element: XCUIElement,
         timeout: TimeInterval = 5,

--- a/ios/CashuWalletUITests/UITestBase.swift
+++ b/ios/CashuWalletUITests/UITestBase.swift
@@ -62,6 +62,17 @@ class UITestBase: XCTestCase {
 
     // MARK: - Onboarding helpers
 
+    /// Relaunch the existing wallet. Setup flags must never erase or reseed
+    /// state when a test is checking persistence or interrupted operations.
+    func relaunchPreservingWallet() {
+        app.terminate()
+        for key in ["RESET_WALLET", "UITEST_SEED_WALLET", "UITEST_SEED_MINT"] {
+            app.launchEnvironment.removeValue(forKey: key)
+        }
+        app.launch()
+        waitForMainTab()
+    }
+
     /// Walk through: welcome → create wallet → acknowledge seed → saved seed.
     /// Leaves the app on the "Pick your first mint" screen.
     func createWalletThroughSeed() {
@@ -213,8 +224,17 @@ class UITestBase: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        let ready = element.waitUntilEnabledAndHittable(timeout: timeout)
+        if !ready {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+            let hierarchy = XCTAttachment(string: app.debugDescription)
+            hierarchy.lifetime = .keepAlways
+            add(hierarchy)
+        }
         XCTAssertTrue(
-            element.waitUntilEnabledAndHittable(timeout: timeout),
+            ready,
             message,
             file: file,
             line: line

--- a/ios/CashuWalletUITests/UITestBase.swift
+++ b/ios/CashuWalletUITests/UITestBase.swift
@@ -111,6 +111,11 @@ class UITestBase: XCTestCase {
         // element nor any descendant has keyboard focus" — hittable is not the
         // same claim as focused. The keyboard is the observable proof that
         // focus actually arrived.
+        if !app.keyboards.element.waitForExistence(timeout: 2) {
+            // The first tap can arrive during the row's insertion transition.
+            // Refocus the field rather than typing into an unfocused control.
+            tapWhenReady(field)
+        }
         XCTAssertTrue(
             app.keyboards.element.waitForExistence(timeout: 10),
             "Tapping the mint field should raise the keyboard"

--- a/ios/CashuWalletUITests/WalletIntegrationTests.swift
+++ b/ios/CashuWalletUITests/WalletIntegrationTests.swift
@@ -107,6 +107,15 @@ class LivePaymentUITestBase: UITestBase {
         tapWhenReady(field)
         field.typeText(invoice)
         let pay = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Pay 21")).firstMatch
+        if backend == "nutshell" {
+            // Nutshell 0.20.1 returns PENDING before its background melt task
+            // persists that state. Match the native integration fixture's
+            // pacing so the first status read cannot race that backend write.
+            _ = try fixtureCall("/sessions/" + fixtureSession + "/faults", method: "POST", body: [
+                "method": "GET", "path": "/v1/melt/quote/bolt11/",
+                "action": "delay", "seconds": 1, "remaining": 1,
+            ])
+        }
         tapWhenReady(pay, timeout: 20)
         XCTAssertTrue(app.staticTexts["Payment Sent!"].waitForExistence(timeout: 30))
         tapWhenReady(app.buttons["Done"])

--- a/ios/CashuWalletUITests/WalletLifecycleUITests.swift
+++ b/ios/CashuWalletUITests/WalletLifecycleUITests.swift
@@ -1,0 +1,298 @@
+import XCTest
+
+/// Full app journeys against the local FakeWallet mint started by CI.
+/// Setup itself follows onboarding; all money-moving operations use real CDK.
+final class WalletLifecycleUITests: UITestBase {
+    func testAddDuplicateSwitchAndRefuseMultiUnitRemovalPersists() {
+        createWalletWithMint()
+        tapTab("Mints")
+        addMint(url: mintURL + "/")
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS[c] %@", "already")).firstMatch
+            .waitForExistence(timeout: 10))
+        tapWhenReady(app.buttons["mints-add-clear-button"])
+        app.textFields["mints-add-url-field"].typeText(cdkMintURL)
+        tapWhenReady(app.buttons["mints-add-submit-button"])
+        let second = mintRow(url: cdkMintURL)
+        tapWhenReady(second, timeout: 30)
+        scrollTo("Set as Default")
+        tapWhenReady(app.buttons["Set as Default"])
+        tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+        XCTAssertEqual(second.value as? String, "Default mint")
+        relaunchPreservingWallet()
+        tapTab("Mints")
+        XCTAssertEqual(second.value as? String, "Default mint")
+        tapWhenReady(second)
+        scrollTo("Remove mint")
+        tapWhenReady(app.buttons["Remove mint"])
+        tapWhenReady(app.buttons["Cancel"])
+        XCTAssertTrue(app.buttons["Remove mint"].exists)
+        tapWhenReady(app.buttons["Remove mint"])
+        tapWhenReady(app.buttons["Remove"])
+        XCTAssertTrue(app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "multiple currency units")).firstMatch
+            .waitForExistence(timeout: 15))
+        relaunchPreservingWallet()
+        tapTab("Mints")
+        XCTAssertTrue(second.waitForExistence(timeout: 10))
+        XCTAssertEqual(second.value as? String, "Default mint")
+        XCTAssertTrue(mintRow(url: mintURL).waitForExistence(timeout: 10))
+    }
+
+    func testRemovingLastMintReturnsToEmptyWalletAfterRelaunch() {
+        createWalletWithMint()
+        tapTab("Mints")
+        tapWhenReady(mintRow(url: mintURL))
+        scrollTo("Remove mint")
+        tapWhenReady(app.buttons["Remove mint"])
+        tapWhenReady(app.buttons["Remove"])
+        XCTAssertTrue(mintRow(url: mintURL).waitForNonExistence(timeout: 15))
+        relaunchPreservingWallet()
+        XCTAssertTrue(app.staticTexts["Add a mint to get started"].waitForExistence(timeout: 10))
+        tapWhenReady(app.buttons["wallet-action-send"])
+        XCTAssertTrue(app.staticTexts["Add a mint first"].waitForExistence(timeout: 5))
+    }
+
+    func testReceiveLightningPersistsBalanceAndHistory() {
+        createWalletWithMint()
+        receive(sats: "100")
+        assertBalance("100")
+        relaunchPreservingWallet()
+        assertBalance("100")
+        tapTab("History")
+        let payment = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Lightning received")).firstMatch
+        tapWhenReady(payment)
+        XCTAssertTrue(app.staticTexts["Lightning received"].waitForExistence(timeout: 10))
+    }
+
+    func testSendEcashUpdatesBalanceAndPendingReceipt() {
+        createWalletWithMint()
+        receive(sats: "100")
+        openSendEcash()
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["5"])
+        tapWhenReady(app.buttons["cashu.send.ecash.submit"])
+        XCTAssertTrue(app.staticTexts["Pending Ecash"].waitForExistence(timeout: 30))
+        XCTAssertTrue(app.buttons["Copy"].exists)
+        tapWhenReady(app.buttons["Close"])
+        assertBalance("75")
+        relaunchPreservingWallet()
+        assertBalance("75")
+        tapTab("History")
+        let outgoing = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Ecash sent")).firstMatch
+        let incoming = app.buttons.matching(NSPredicate(format: "label CONTAINS[c] %@", "Lightning received")).firstMatch
+        XCTAssertTrue(outgoing.waitForExistence(timeout: 10))
+        tapWhenReady(app.buttons["Filter transactions"])
+        tapWhenReady(app.buttons["Pending only"])
+        XCTAssertTrue(outgoing.exists)
+        XCTAssertFalse(incoming.exists)
+        tapWhenReady(app.buttons["Filter transactions"])
+        tapWhenReady(app.buttons["Completed only"])
+        XCTAssertTrue(incoming.exists)
+        XCTAssertFalse(outgoing.exists)
+        tapWhenReady(app.buttons["Search history"])
+        app.searchFields.firstMatch.typeText("no matching payment")
+        XCTAssertTrue(app.staticTexts["No Results"].waitForExistence(timeout: 5))
+    }
+
+    func testAmountClearAndInsufficientBalanceCannotSpend() {
+        createWalletWithMint()
+        receive(sats: "100")
+        openSendEcash()
+        XCTAssertFalse(app.buttons["cashu.send.ecash.submit"].isEnabled)
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["5"])
+        tapWhenReady(app.buttons["Delete"])
+        XCTAssertTrue(app.buttons["cashu.send.ecash.submit"].isEnabled)
+        app.buttons["Delete"].press(forDuration: 0.6)
+        XCTAssertFalse(app.buttons["cashu.send.ecash.submit"].isEnabled)
+        for _ in 0..<3 { tapWhenReady(app.buttons["9"]) }
+        XCTAssertTrue(app.staticTexts["Insufficient balance"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["cashu.send.ecash.submit"].isEnabled)
+        tapWhenReady(app.buttons["Close"])
+        assertBalance("100")
+    }
+
+    func testEcashRoundTripThroughClipboardRestoresBalance() {
+        createWalletWithMint()
+        receive(sats: "100")
+        tapWhenReady(app.buttons["wallet-settings-button"])
+        let privacy = app.buttons["Privacy"]
+        for _ in 0..<8 {
+            if privacy.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(privacy)
+        let polling = app.switches.matching(NSPredicate(format: "label BEGINSWITH %@", "Check sent ecash")).firstMatch
+        if (polling.value as? String) != "0" {
+            polling.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+        }
+        tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+        tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+        openSendEcash()
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["5"])
+        tapWhenReady(app.buttons["cashu.send.ecash.submit"])
+        XCTAssertTrue(app.staticTexts["Pending Ecash"].waitForExistence(timeout: 30))
+        tapWhenReady(app.buttons["cashu.send.ecash.check-status"])
+        XCTAssertTrue(app.staticTexts["This token has not been claimed yet."].waitForExistence(timeout: 15))
+        tapWhenReady(app.buttons["Copy"])
+        tapWhenReady(app.buttons["Close"])
+        assertBalance("75")
+        tapWhenReady(app.buttons["wallet-action-receive"])
+        tapWhenReady(app.buttons["Paste from clipboard"])
+        let receive = app.buttons["receive-token-confirm"]
+        tapWhenReady(receive)
+        XCTAssertTrue(app.staticTexts["Payment Received!"].waitForExistence(timeout: 30))
+        tapWhenReady(app.buttons["Done"])
+        assertBalance("100")
+    }
+
+    func testQuickLockCanBeSelectedAndRemovedWithoutLosingAmount() {
+        createWalletWithMint()
+        receive(sats: "100")
+        tapWhenReady(app.buttons["wallet-settings-button"])
+        let row = app.buttons["Locked Ecash"]
+        for _ in 0..<8 {
+            if row.isHittable { break }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        tapWhenReady(row)
+        let quickLock = app.switches.matching(NSPredicate(format: "label BEGINSWITH %@", "Quick lock to my key")).firstMatch
+        if (quickLock.value as? String) != "1" {
+            quickLock.coordinate(withNormalizedOffset: CGVector(dx: 0.95, dy: 0.5)).tap()
+        }
+        relaunchPreservingWallet()
+        openSendEcash()
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["5"])
+        tapWhenReady(app.buttons["Lock ecash"])
+        tapWhenReady(app.buttons["Lock to my key"])
+        XCTAssertTrue(app.buttons["Locked to public key"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["cashu.send.ecash.submit"].isEnabled)
+        tapWhenReady(app.buttons["Remove lock"])
+        XCTAssertFalse(app.buttons["Locked to public key"].exists)
+        tapWhenReady(app.buttons["cashu.send.ecash.submit"])
+        XCTAssertTrue(app.staticTexts["Pending Ecash"].waitForExistence(timeout: 30))
+        tapWhenReady(app.buttons["Close"])
+        assertBalance("75")
+    }
+
+    func testRestoreFromRevealedTestSeedRecoversFunds() {
+        app.terminate()
+        app.launchEnvironment["UITEST_AUTHENTICATION"] = "allow"
+        app.launch()
+        createWalletWithMint()
+        receive(sats: "100")
+        tapWhenReady(app.buttons["wallet-settings-button"])
+        tapWhenReady(app.buttons["Backup & Restore"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Backup seed phrase")).firstMatch)
+        tapWhenReady(app.buttons["Reveal Recovery Phrase"])
+        XCTAssertTrue(app.buttons["Copy Recovery Phrase"].waitForExistence(timeout: 5))
+        // Read only this newly created synthetic wallet's words through the UI.
+        // Do not log or attach the phrase to assertion messages.
+        let words = (1...12).map { index in
+            app.descendants(matching: .any).matching(
+                NSPredicate(format: "label BEGINSWITH %@", "Word \(index), ")
+            ).firstMatch.label.components(separatedBy: ", ").last!
+        }
+        app.staticTexts["Backup Wallet"].swipeDown()
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Restore,")).firstMatch)
+        let field = app.textFields.firstMatch
+        tapWhenReady(field)
+        for (index, word) in words.enumerated() {
+            field.typeText(word)
+            tapWhenReady(app.buttons[word].firstMatch)
+            if index < 11 {
+                XCTAssertTrue(app.textFields["word \(index + 2)"].waitForExistence(timeout: 5))
+            }
+        }
+        tapWhenReady(app.buttons["Next"])
+        let mintField = app.textFields["mint.example.com"]
+        tapWhenReady(mintField)
+        mintField.typeText(mintURL)
+        tapWhenReady(app.buttons["Add"])
+        tapWhenReady(app.buttons["Restore from 1 mint"])
+        XCTAssertTrue(app.staticTexts["Restore Complete"].waitForExistence(timeout: 60))
+        XCTAssertTrue(app.staticTexts["Recovered: 100 sats"].exists)
+        tapWhenReady(app.buttons["Continue"])
+        tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+        tapWhenReady(app.navigationBars.buttons.element(boundBy: 0))
+        assertBalance("100")
+        relaunchPreservingWallet()
+        assertBalance("100")
+    }
+
+    func testUsdAmountEntryAndSendUseCents() {
+        createWalletWithMint(at: cdkMintURL)
+        tapWhenReady(app.buttons["wallet-action-receive"])
+        tapWhenReady(app.buttons["wallet-flow-receiveLightning"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Unit:")).firstMatch)
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "USD")).firstMatch)
+        tapWhenReady(app.buttons["1"])
+        tapWhenReady(app.buttons["0"])
+        tapWhenReady(app.buttons["receive-lightning-create-request"])
+        XCTAssertTrue(app.staticTexts["Payment Received!"].waitForExistence(timeout: 45))
+        tapWhenReady(app.buttons["Done"])
+        openSendEcash()
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Unit:")).firstMatch)
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "USD")).firstMatch)
+        tapWhenReady(app.buttons["2"])
+        tapWhenReady(app.buttons["Decimal point"])
+        tapWhenReady(app.buttons["5"])
+        tapWhenReady(app.buttons["0"])
+        tapWhenReady(app.buttons["9"])
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "Unit:")).firstMatch)
+        tapWhenReady(app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "USD")).firstMatch)
+        tapWhenReady(app.buttons["cashu.send.ecash.submit"])
+        XCTAssertTrue(app.staticTexts["Pending Ecash"].waitForExistence(timeout: 30))
+        XCTAssertTrue(app.staticTexts["$2.50"].exists)
+        XCTAssertTrue(app.staticTexts["USD"].exists)
+        tapWhenReady(app.buttons["Close"])
+        relaunchPreservingWallet()
+        tapTab("History")
+        XCTAssertTrue(app.buttons.matching(NSPredicate(format: "label CONTAINS %@ AND label CONTAINS %@", "Ecash sent", "$2.50")).firstMatch
+            .waitForExistence(timeout: 10))
+    }
+
+    private func receive(sats: String) {
+        tapWhenReady(app.buttons["wallet-action-receive"])
+        tapWhenReady(app.buttons["wallet-flow-receiveLightning"])
+        for digit in sats { tapWhenReady(app.buttons[String(digit)]) }
+        tapWhenReady(app.buttons["receive-lightning-create-request"])
+        XCTAssertTrue(app.staticTexts["Payment Received!"].waitForExistence(timeout: 45))
+        tapWhenReady(app.buttons["Done"])
+        waitForMainTab()
+    }
+
+    private func openSendEcash() {
+        tapWhenReady(app.buttons["wallet-action-send"])
+        tapWhenReady(app.buttons["Ecash. Create ecash"])
+        XCTAssertTrue(app.buttons["cashu.send.ecash.submit"].waitForExistence(timeout: 10))
+    }
+
+    private func assertBalance(_ amount: String) {
+        let balance = app.descendants(matching: .any).matching(
+            NSPredicate(format: "label MATCHES %@", "Balance: .*\\b" + amount + "\\b.*")
+        ).firstMatch
+        XCTAssertTrue(balance.waitForExistence(timeout: 15), "Wallet must display the settled balance")
+    }
+
+    private func mintRow(url: String) -> XCUIElement {
+        app.buttons.matching(NSPredicate(format: "label CONTAINS %@", url)).firstMatch
+    }
+
+    private func addMint(url: String) {
+        tapWhenReady(app.buttons["mints-add-button"])
+        let field = app.textFields["mints-add-url-field"]
+        tapWhenReady(field)
+        field.typeText(url)
+        tapWhenReady(app.buttons["mints-add-submit-button"])
+    }
+
+    private func scrollTo(_ title: String) {
+        for _ in 0..<10 {
+            if app.buttons[title].isHittable { return }
+            app.scrollViews.firstMatch.swipeUp()
+        }
+        XCTFail("Mint action must be reachable: \(title)")
+    }
+}

--- a/ios/CashuWalletUITests/WalletLifecycleUITests.swift
+++ b/ios/CashuWalletUITests/WalletLifecycleUITests.swift
@@ -43,6 +43,7 @@ final class WalletLifecycleUITests: UITestBase {
         tapWhenReady(mintRow(url: mintURL))
         scrollTo("Remove mint")
         tapWhenReady(app.buttons["Remove mint"])
+        XCTAssertTrue(app.staticTexts["Remove mint?"].waitForExistence(timeout: 5))
         tapWhenReady(app.buttons["Remove"])
         XCTAssertTrue(mintRow(url: mintURL).waitForNonExistence(timeout: 15))
         relaunchPreservingWallet()
@@ -289,10 +290,6 @@ final class WalletLifecycleUITests: UITestBase {
     }
 
     private func scrollTo(_ title: String) {
-        for _ in 0..<10 {
-            if app.buttons[title].isHittable { return }
-            app.scrollViews.firstMatch.swipeUp()
-        }
-        XCTFail("Mint action must be reachable: \(title)")
+        scrollToButton(app.buttons[title])
     }
 }


### PR DESCRIPTION
Adds 51 native UI tests (28 Android, 23 iOS) for mint management, currency selection and units, amount editing, payment/history recovery, restore, security, locked-ecash controls, Lightning Address, Wallet Connect, and relay settings. The tests drive production screens and check resulting balances, status, preferences, and lifecycle persistence.

Fixes four bugs discovered during this work:
- Android replayed consumed payment links on activity recreation.
- iOS could enable App Lock when device-owner authentication was unavailable.
- Android replaced the multi-unit mint-removal safety explanation with a misleading network error.
- Reselecting the current non-sat currency cleared its balance cache and disabled Send on both platforms.

External price/NPC/NWC transports and OS authentication are controlled at their boundaries. Scanner fixtures retain native controls while replacing hardware capture. The iOS workflow now uses the shared SAT/USD local-mint profile and allows time for the expanded suite.

See `docs/testing/wallet-ui-coverage.md` for the prioritized coverage matrix and explicit remaining device/service boundaries, and `docs/testing/ui-coverage-report.md` for reproductions and validation details.

Validation:
- All 51 new UI cases passed across final targeted runs.
- Android: 732 JVM tests passed, six configured skips; lint has zero errors.
- Full UI runs exercised 161 Android and 44 iOS cases. Failures found during those runs were corrected and verified in focused reruns; exact counts and configured skips are in the report.
- iOS: 657 unit/integration tests passed, two configured skips.
