### PR TITLE
Add opt-in NFC receive on eligible iPhones

### DIFF
--- a/ios/CashuWallet.xcodeproj/project.pbxproj
+++ b/ios/CashuWallet.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		BE86C0C8B9BAF95539080EF9 /* Cdk in Frameworks */ = {isa = PBXBuildFile; productRef = E118F77A2062DDD58C0A6DA3 /* Cdk */; };
 		BF36C01CE0AB810E1B462448 /* IntegrationTestBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CF8C0C2E1379BCD23CF8C6 /* IntegrationTestBase.swift */; };
 		C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */; };
+		AFCE00000000000000000FFF /* NFCReceiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE10000000000000000FFF /* NFCReceiveTests.swift */; };
 		CC00000000000001 /* ThemeSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000000000011 /* ThemeSettingsSection.swift */; };
 		CC00000000000002 /* BackupSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000000000012 /* BackupSettingsSection.swift */; };
 		CC00000000000004 /* P2PKSettingsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000000000014 /* P2PKSettingsSection.swift */; };
@@ -194,6 +195,10 @@
 		6E771298AB0DD61628FCF572 /* LightningAddressResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */; };
 		94EA670D6C07D36761841BF6 /* ReceiveRecovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 199A5C29E6AB4761101E511B /* ReceiveRecovery.swift */; };
 		996597CC795B00455F4CB48B /* ReceiveRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 562DD3E83FDF0A975042E7BF /* ReceiveRecoveryTests.swift */; };
+		AFCE00000000000000000001 /* NFCType4Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE10000000000000000001 /* NFCType4Tag.swift */; };
+		AFCE00000000000000000002 /* NFCReceivePayment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE10000000000000000002 /* NFCReceivePayment.swift */; };
+		AFCE00000000000000000003 /* NFCReceiveCardSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE10000000000000000003 /* NFCReceiveCardSession.swift */; };
+		AFCE00000000000000000004 /* NFCReceiveCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE10000000000000000004 /* NFCReceiveCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -302,6 +307,7 @@
 		BB00000000000013 /* TokenService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenService.swift; sourceTree = "<group>"; };
 		BB00000000000014 /* LightningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LightningService.swift; sourceTree = "<group>"; };
 		C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CashuRequestPaymentObservationTests.swift; path = CashuWalletTests/CashuRequestPaymentObservationTests.swift; sourceTree = "<group>"; };
+		AFCE10000000000000000FFF /* NFCReceiveTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NFCReceiveTests.swift; path = CashuWalletTests/NFCReceiveTests.swift; sourceTree = "<group>"; };
 		CC00000000000011 /* ThemeSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsSection.swift; sourceTree = "<group>"; };
 		CC00000000000012 /* BackupSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupSettingsSection.swift; sourceTree = "<group>"; };
 		CC00000000000014 /* P2PKSettingsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = P2PKSettingsSection.swift; sourceTree = "<group>"; };
@@ -399,6 +405,10 @@
 		2686B0C8F81DE3346F5643EA /* LightningAddressResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/LightningAddressResolverTests.swift; sourceTree = "<group>"; };
 		199A5C29E6AB4761101E511B /* ReceiveRecovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiveRecovery.swift; sourceTree = "<group>"; };
 		562DD3E83FDF0A975042E7BF /* ReceiveRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CashuWalletTests/ReceiveRecoveryTests.swift; sourceTree = "<group>"; };
+		AFCE10000000000000000001 /* NFCType4Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCType4Tag.swift; sourceTree = "<group>"; };
+		AFCE10000000000000000002 /* NFCReceivePayment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReceivePayment.swift; sourceTree = "<group>"; };
+		AFCE10000000000000000003 /* NFCReceiveCardSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReceiveCardSession.swift; sourceTree = "<group>"; };
+		AFCE10000000000000000004 /* NFCReceiveCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReceiveCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -457,6 +467,7 @@
 				T1B0000000000100 /* ConnectMintContextTests.swift */,
 				T1B000000000000D /* CashuRequestRouteExplanationTests.swift */,
 				C0A100000000000000000001 /* CashuRequestPaymentObservationTests.swift */,
+				AFCE10000000000000000FFF /* NFCReceiveTests.swift */,
 				T1B000000000000E /* CrashReportSanitizerTests.swift */,
 				T1B000000000000F /* HistorySearchTests.swift */,
 				AV00000000000012 /* AppVersionTests.swift */,
@@ -760,6 +771,10 @@
 				F200000000000001 /* NDEFTextRecordCoder.swift */,
 				F200000000000002 /* NFCReaderDelegate.swift */,
 				F200000000000003 /* NFCPaymentService.swift */,
+				AFCE10000000000000000004 /* NFCReceiveCoordinator.swift */,
+				AFCE10000000000000000003 /* NFCReceiveCardSession.swift */,
+				AFCE10000000000000000002 /* NFCReceivePayment.swift */,
+				AFCE10000000000000000001 /* NFCType4Tag.swift */,
 				F200000000000004 /* ContactlessPaymentCoordinator.swift */,
 				BB00000000000012 /* TransactionService.swift */,
 				BB00000000000013 /* TokenService.swift */,
@@ -1068,6 +1083,7 @@
 				T2B0000000000100 /* ConnectMintContextTests.swift in Sources */,
 				T2B000000000000D /* CashuRequestRouteExplanationTests.swift in Sources */,
 				C0A100000000000000000002 /* CashuRequestPaymentObservationTests.swift in Sources */,
+				AFCE00000000000000000FFF /* NFCReceiveTests.swift in Sources */,
 				T2B000000000000E /* CrashReportSanitizerTests.swift in Sources */,
 				T2B000000000000F /* HistorySearchTests.swift in Sources */,
 				AV00000000000002 /* AppVersionTests.swift in Sources */,
@@ -1206,6 +1222,10 @@
 				F100000000000001 /* NDEFTextRecordCoder.swift in Sources */,
 				F100000000000002 /* NFCReaderDelegate.swift in Sources */,
 				F100000000000003 /* NFCPaymentService.swift in Sources */,
+				AFCE00000000000000000004 /* NFCReceiveCoordinator.swift in Sources */,
+				AFCE00000000000000000003 /* NFCReceiveCardSession.swift in Sources */,
+				AFCE00000000000000000002 /* NFCReceivePayment.swift in Sources */,
+				AFCE00000000000000000001 /* NFCType4Tag.swift in Sources */,
 				F100000000000004 /* ContactlessPaymentCoordinator.swift in Sources */,
 				F300000000000001 /* CurrencyAmountDisplay.swift in Sources */,
 				F300000000000002 /* NumberPadAmountInput.swift in Sources */,
@@ -1403,6 +1423,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CASHU_HCE_ENABLED = NO;
 				CODE_SIGN_ENTITLEMENTS = CashuWallet/CashuWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1411,7 +1432,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CashuWallet/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Cashu;
-				INFOPLIST_KEY_NFCReaderUsageDescription = "Hold your iPhone near a payment terminal or NFC tag to send Cashu ecash.";
+				INFOPLIST_KEY_NFCReaderUsageDescription = "Hold your iPhone near another device to send or receive Cashu ecash.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera is used to scan QR codes for receiving ecash tokens and Lightning invoices.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Cashu Wallet uses Face ID to unlock the app and protect your funds.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -1442,6 +1463,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CASHU_HCE_ENABLED = NO;
 				CODE_SIGN_ENTITLEMENTS = CashuWallet/CashuWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1450,7 +1472,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = CashuWallet/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Cashu;
-				INFOPLIST_KEY_NFCReaderUsageDescription = "Hold your iPhone near a payment terminal or NFC tag to send Cashu ecash.";
+				INFOPLIST_KEY_NFCReaderUsageDescription = "Hold your iPhone near another device to send or receive Cashu ecash.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Camera is used to scan QR codes for receiving ecash tokens and Lightning invoices.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Cashu Wallet uses Face ID to unlock the app and protect your funds.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/ios/CashuWallet/CashuWalletHCE.entitlements
+++ b/ios/CashuWallet/CashuWalletHCE.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.nfc.hce</key>
+	<true/>
+	<key>com.apple.developer.nfc.hce.iso7816.select-identifier-prefixes</key>
+	<array>
+		<string>D2760000850101</string>
+	</array>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
+	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
+	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+</dict>
+</plist>

--- a/ios/CashuWallet/Core/PaymentRequestBuilder.swift
+++ b/ios/CashuWallet/Core/PaymentRequestBuilder.swift
@@ -1,6 +1,20 @@
 import Foundation
 
 enum PaymentRequestBuilder {
+    /// In-band NUT-18 request: omit transports so the payer writes the token
+    /// back to the emulated tag instead of delivering it over Nostr.
+    static func buildNFC(request: CashuRequest) -> String {
+        var fields: [(Nut18Key, Nut18Value)] = [(.text("i"), .text(request.id))]
+        if let amount = request.amount, amount > 0 { fields.append((.text("a"), .uint(amount))) }
+        fields.append((.text("u"), .text(request.unit)))
+        fields.append((.text("s"), .bool(!request.reusable)))
+        if !request.mints.isEmpty {
+            fields.append((.text("m"), .array(request.mints.map { .text($0) })))
+        }
+        if let memo = request.memo, !memo.isEmpty { fields.append((.text("d"), .text(memo))) }
+        return "creqA" + Base64URL.encode(Nut18CBOR.encode(.map(fields)))
+    }
+
     enum BuildError: Error {
         case invalidPubkeyHex
         case nprofileEncodeFailed

--- a/ios/CashuWallet/Core/Services/NFCReceiveCardSession.swift
+++ b/ios/CashuWallet/Core/Services/NFCReceiveCardSession.swift
@@ -1,0 +1,100 @@
+import CoreNFC
+import Foundation
+
+@MainActor
+protocol NFCReceiveTransport: AnyObject {
+    func receive(request: String, accept: (NFCNdefPayload) throws -> NFCReceivePayment) async throws -> NFCReceivePayment?
+    func stop()
+}
+
+/// Uses the same foreground CardSession / presentment-assertion approach as
+/// Macadamia's NFCRequestEmulation. No APDU or bearer-token data is logged.
+@MainActor
+final class NFCReceiveCardSession: NFCReceiveTransport {
+    private var session: CardSession?
+
+    static var isAvailable: Bool {
+        get async {
+            #if targetEnvironment(simulator)
+            return false
+            #else
+            guard Bundle.main.object(forInfoDictionaryKey: "CashuHCEEnabled") as? String == "YES" else { return false }
+            guard CardSession.isSupported else { return false }
+            return await CardSession.isEligible
+            #endif
+        }
+    }
+
+    func stop() {
+        session?.invalidate()
+        session = nil
+    }
+
+    func receive(
+        request: String,
+        accept: (NFCNdefPayload) throws -> NFCReceivePayment
+    ) async throws -> NFCReceivePayment? {
+        guard await Self.isAvailable else {
+            throw NFCReceiveError.message("Contactless receive isn't available on this iPhone or in your region.")
+        }
+        try Task.checkCancellation()
+        var tag = try NFCType4Tag(request: request)
+        // Optional suppression of the default contactless app. A cooldown or
+        // unavailable assertion must not prevent a foreground card session.
+        let assertion = try? await NFCPresentmentIntentAssertion.acquire()
+        defer { withExtendedLifetime(assertion) {} }
+        try Task.checkCancellation()
+        let card = try await CardSession()
+        defer { card.invalidate(); session = nil }
+        try Task.checkCancellation()
+        session = card
+        var accepted: NFCReceivePayment?
+        do {
+            for try await event in card.eventStream {
+                try Task.checkCancellation()
+                switch event {
+                case .sessionStarted:
+                    card.alertMessage = "Hold this iPhone near the payer's device."
+                    try await card.startEmulation()
+                case .readerDetected:
+                    if await !card.isEmulationInProgress {
+                        try Task.checkCancellation()
+                        try await card.startEmulation()
+                    }
+                case .readerDeselected:
+                    tag.reset()
+                case .received(let apdu):
+                    let result = tag.process(apdu.payload)
+                    if let payload = result.payload {
+                        do {
+                            accepted = try accept(payload)
+                        } catch {
+                            // Don't acknowledge a token that we couldn't retain.
+                            try? await apdu.respond(response: Data([0x6A, 0x80]))
+                            throw error
+                        }
+                    }
+                    try await apdu.respond(response: result.response)
+                    if accepted != nil {
+                        card.alertMessage = "Payment data received."
+                        await card.stopEmulation(status: .success)
+                        return accepted
+                    }
+                case .sessionInvalidated(let reason):
+                    switch reason {
+                    case .userInvalidated, .maxSessionDurationReached, .emulationStopped, .invalidated:
+                        return accepted
+                    default: throw reason
+                    }
+                @unknown default: break
+                }
+            }
+        } catch {
+            // Once persisted, finish receiving even if the last response or
+            // native-sheet dismissal failed. Never lose an already accepted token.
+            if let accepted { return accepted }
+            throw error
+        }
+        return accepted
+    }
+}

--- a/ios/CashuWallet/Core/Services/NFCReceiveCoordinator.swift
+++ b/ios/CashuWallet/Core/Services/NFCReceiveCoordinator.swift
@@ -64,7 +64,8 @@ final class NFCReceiveCoordinator {
             } catch {
                 guard generation == current, !Task.isCancelled else { return }
                 phase = .idle
-                message = "Couldn't receive by tap. Keep the phones together and try again."
+                message = (error as? NFCReceiveError)?.errorDescription
+                    ?? "Couldn't receive by tap. Keep the phones together and try again."
             }
             if generation == current {
                 exchangeTask = nil

--- a/ios/CashuWallet/Core/Services/NFCReceiveCoordinator.swift
+++ b/ios/CashuWallet/Core/Services/NFCReceiveCoordinator.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class NFCReceiveCoordinator {
+    enum Phase: Equatable { case idle, presenting, redeeming }
+    private(set) var phase: Phase = .idle
+    private(set) var message: String?
+    private(set) var reviewPayment: PendingReceiveToken?
+    private(set) var receivedAmount: UInt64?
+    private var session: (any NFCReceiveTransport)?
+    private var exchangeTask: Task<Void, Never>?
+    private var generation = UUID()
+    private let makeSession: @MainActor () -> any NFCReceiveTransport
+
+    init(makeSession: @escaping @MainActor () -> any NFCReceiveTransport = { NFCReceiveCardSession() }) {
+        self.makeSession = makeSession
+    }
+
+    var isBusy: Bool { phase != .idle }
+
+    func start(request: CashuRequest, walletManager: WalletManager) {
+        guard walletManager.isRuntimeReady else { return }
+        start(
+            request: request,
+            stage: { try walletManager.stageNFCReceive($0, request: request) },
+            claim: { try await walletManager.claimPendingReceiveToken($0) },
+            refresh: { await walletManager.loadTransactions() }
+        )
+    }
+
+    func start(
+        request: CashuRequest,
+        stage: @escaping (NFCNdefPayload) throws -> NFCReceivePayment,
+        claim: @escaping (PendingReceiveToken) async throws -> UInt64,
+        refresh: @escaping () async -> Void
+    ) {
+        guard !isBusy, NFCReceivePayment.canPresent(request) else { return }
+        stop()
+        message = nil
+        reviewPayment = nil
+        receivedAmount = nil
+        phase = .presenting
+        let current = generation
+        let card = makeSession()
+        session = card
+        exchangeTask = Task {
+            do {
+                let payment = try await card.receive(request: PaymentRequestBuilder.buildNFC(request: request)) {
+                    guard generation == current else { throw CancellationError() }
+                    try Task.checkCancellation()
+                    return try stage($0)
+                }
+                if let payment {
+                    // A new task deliberately survives view disappearance and RF
+                    // cancellation after receipt. Wallet operations protect their
+                    // own background execution and serialize CDK access.
+                    if generation == current { phase = .redeeming }
+                    Task { await finish(payment, claim: claim, refresh: refresh, generation: current) }
+                } else if generation == current {
+                    phase = .idle
+                }
+            } catch {
+                guard generation == current, !Task.isCancelled else { return }
+                phase = .idle
+                message = "Couldn't receive by tap. Keep the phones together and try again."
+            }
+            if generation == current {
+                exchangeTask = nil
+                session = nil
+            }
+        }
+    }
+
+    /// Stop advertising on background, dismissal, or request edits. An accepted
+    /// payment is already persisted; its wallet operation is never cancelled.
+    func stop() {
+        // Keep ownership while the independent wallet operation finishes.
+        if phase == .redeeming { return }
+        generation = UUID()
+        exchangeTask?.cancel()
+        exchangeTask = nil
+        session?.stop()
+        session = nil
+        if phase == .presenting { phase = .idle }
+    }
+
+    func dismissReview() { reviewPayment = nil }
+
+    private func finish(
+        _ payment: NFCReceivePayment,
+        claim: (PendingReceiveToken) async throws -> UInt64,
+        refresh: () async -> Void,
+        generation current: UUID
+    ) async {
+        if payment.needsReview {
+            await refresh()
+            if generation == current {
+                message = payment.validationMessage.map { "\($0) The token is saved in History for review." }
+                // Keep validation failures visible on the request; never cover
+                // the mismatch explanation with an ordinary claim screen.
+                if payment.validationMessage == nil { reviewPayment = payment.pending }
+                phase = .idle
+            }
+            return
+        }
+        do {
+            let amount = try await claim(payment.pending)
+            if generation == current { receivedAmount = amount; phase = .idle }
+        } catch {
+            await refresh()
+            if generation == current {
+                message = "Couldn't claim the payment. The token is saved in History; review it to try again."
+                reviewPayment = payment.pending
+                phase = .idle
+            }
+        }
+    }
+}

--- a/ios/CashuWallet/Core/Services/NFCReceivePayment.swift
+++ b/ios/CashuWallet/Core/Services/NFCReceivePayment.swift
@@ -1,0 +1,77 @@
+import Cdk
+import Foundation
+
+enum NFCReceiveError: LocalizedError {
+    case message(String)
+    var errorDescription: String? {
+        switch self { case .message(let message): return message }
+    }
+}
+
+struct NFCReceivePayment {
+    let pending: PendingReceiveToken
+    let needsReview: Bool
+    let validationMessage: String?
+
+    static func canPresent(_ request: CashuRequest, now: Date = Date()) -> Bool {
+        (request.amount ?? 0) > 0 &&
+            (request.rail == .ecash || request.receivedPayments.isEmpty) &&
+            (request.expiry.map { $0 > now } ?? true)
+    }
+
+    static func validationMessage(request: CashuRequest, amount: UInt64, unit: String, mint: String) -> String? {
+        if !canPresent(request) { return "This request is no longer accepting contactless payments." }
+        guard amount > 0 else { return "The received token has no value." }
+        guard unit.caseInsensitiveCompare(request.unit) == .orderedSame else {
+            return "The received token uses a different currency from this request."
+        }
+        if let required = request.amount, amount < required {
+            return "The received token is less than the requested amount."
+        }
+        if !request.mints.isEmpty,
+           !request.mints.contains(where: { MintURLIdentity.normalized($0) == MintURLIdentity.normalized(mint) }) {
+            return "The received token is from a different mint than this request accepts."
+        }
+        return nil
+    }
+
+    static func decode(_ payload: NFCNdefPayload) throws -> Token {
+        switch payload {
+        case .cashuBinary(let data): return try Token.fromRawBytes(bytes: data)
+        case .text(let text):
+            // Also accept Cashu token links written by Numo-compatible payers.
+            guard let range = text.range(of: "cashuA") ?? text.range(of: "cashuB") else {
+                throw NFCReceiveError.message("No Cashu token was received. Try again.")
+            }
+            let encoded = text[range.lowerBound...].prefix {
+                $0.isASCII && ($0.isLetter || $0.isNumber || "-_=+/".contains($0))
+            }
+            return try Token.decode(encodedToken: String(encoded))
+        }
+    }
+}
+
+extension WalletManager {
+    /// Save before acknowledging the final APDU. Even a disconnect, cancellation,
+    /// unknown mint, or failed redeem must leave the bearer token claimable.
+    func stageNFCReceive(_ payload: NFCNdefPayload, request: CashuRequest) throws -> NFCReceivePayment {
+        let token = try NFCReceivePayment.decode(payload)
+        let encoded = token.encode()
+        let amount = try token.value().value
+        let mint = try token.mintUrl().url
+        let unit = PaymentRequestDecoder.unitDescription(token.unit() ?? .sat)
+        let message = NFCReceivePayment.validationMessage(request: request, amount: amount, unit: unit, mint: mint)
+        let known = mints.contains { MintURLIdentity.normalized($0.url) == MintURLIdentity.normalized(mint) }
+        let pending = pendingReceiveTokens.first { $0.token == encoded } ?? PendingReceiveToken(
+            tokenId: UUID().uuidString, token: encoded, amount: amount, unit: unit,
+            date: Date(), mintUrl: mint,
+            // Mismatched payments stay claimable without fulfilling this request.
+            cashuRequestId: message == nil ? request.id : nil, memo: token.memo()
+        )
+        savePendingReceiveToken(pending)
+        guard walletStore.loadPendingReceiveTokens().contains(where: { $0.token == encoded }) else {
+            throw NFCReceiveError.message("Couldn't save the payment. Try again.")
+        }
+        return NFCReceivePayment(pending: pending, needsReview: !known || message != nil, validationMessage: message)
+    }
+}

--- a/ios/CashuWallet/Core/Services/NFCReceivePayment.swift
+++ b/ios/CashuWallet/Core/Services/NFCReceivePayment.swift
@@ -57,10 +57,16 @@ extension WalletManager {
     func stageNFCReceive(_ payload: NFCNdefPayload, request: CashuRequest) throws -> NFCReceivePayment {
         let token = try NFCReceivePayment.decode(payload)
         let encoded = token.encode()
+        let savedTokens = walletStore.loadSavedTokens()
+        guard !transactions.contains(where: {
+            $0.type == .incoming && $0.status == .completed && savedTokens[$0.id] == encoded
+        }) else {
+            throw NFCReceiveError.message("This token has already been received.")
+        }
         let amount = try token.value().value
         let mint = try token.mintUrl().url
         let unit = PaymentRequestDecoder.unitDescription(token.unit() ?? .sat)
-        let message = NFCReceivePayment.validationMessage(request: request, amount: amount, unit: unit, mint: mint)
+        var message = NFCReceivePayment.validationMessage(request: request, amount: amount, unit: unit, mint: mint)
         let known = mints.contains { MintURLIdentity.normalized($0.url) == MintURLIdentity.normalized(mint) }
         let pending = pendingReceiveTokens.first { $0.token == encoded } ?? PendingReceiveToken(
             tokenId: UUID().uuidString, token: encoded, amount: amount, unit: unit,
@@ -68,6 +74,9 @@ extension WalletManager {
             // Mismatched payments stay claimable without fulfilling this request.
             cashuRequestId: message == nil ? request.id : nil, memo: token.memo()
         )
+        if message == nil, pending.cashuRequestId != request.id {
+            message = "This token was already saved for another receipt."
+        }
         savePendingReceiveToken(pending)
         guard walletStore.loadPendingReceiveTokens().contains(where: { $0.token == encoded }) else {
             throw NFCReceiveError.message("Couldn't save the payment. Try again.")

--- a/ios/CashuWallet/Core/Services/NFCType4Tag.swift
+++ b/ios/CashuWallet/Core/Services/NFCType4Tag.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+enum NFCNdefPayload: Equatable {
+    case text(String)
+    case cashuBinary(Data)
+}
+
+/// NFC Forum Type 4 / Numo wire protocol, shared with Android's NfcType4Tag.
+/// Kept independent of CoreNFC so malformed and interrupted exchanges can be tested.
+struct NFCType4Tag {
+    static let maxMessageSize = 0x70ff
+    static let aid: [UInt8] = [0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01]
+    static let capabilityContainer: [UInt8] = [
+        0x00, 0x0F, 0x20, 0x00, 0x3B, 0x00, 0x34,
+        0x04, 0x06, 0xE1, 0x04, 0x70, 0xFF, 0x00, 0x00
+    ]
+    private enum File { case none, cc, ndef }
+    private var selected: File = .none
+    private var applicationSelected = false
+    private let requestFile: [UInt8]
+    private var incoming = [UInt8](repeating: 0, count: maxMessageSize + 2)
+    private var written = [Bool](repeating: false, count: maxMessageSize + 2)
+
+    init(request: String) throws {
+        requestFile = try NFCNdefCodec.textFile(request)
+    }
+
+    mutating func reset() {
+        applicationSelected = false
+        selected = .none
+        resetIncoming()
+    }
+
+    mutating func process(_ command: Data) -> (response: Data, payload: NFCNdefPayload?) {
+        let bytes = [UInt8](command)
+        guard bytes.count >= 4 else { return reply(0x67, 0x00) }
+        guard bytes[0] == 0 else { return reply(0x6E, 0x00) }
+        if bytes[1] == 0xA4, bytes[2] == 0x04 {
+            reset()
+            guard bytes[3] == 0, bytes.count == 12 || bytes.count == 13,
+                  bytes[4] == 7, Array(bytes[5..<12]) == Self.aid else {
+                return reply(0x6A, 0x82)
+            }
+            applicationSelected = true
+            return reply()
+        }
+        guard applicationSelected else { return reply(0x6A, 0x82) }
+        switch bytes[1] {
+        case 0xA4:
+            selected = .none
+            guard bytes.count == 7 || bytes.count == 8, bytes[2] == 0, bytes[3] == 0x0C,
+                  bytes[4] == 2, bytes[5] == 0xE1 else { return reply(0x67, 0x00) }
+            switch bytes[6] {
+            case 0x03: selected = .cc
+            case 0x04: selected = .ndef
+            default: return reply(0x6A, 0x82)
+            }
+            return reply()
+        case 0xB0:
+            guard bytes.count == 5 else { return reply(0x67, 0x00) }
+            guard selected != .none else { return reply(0x6A, 0x82) }
+            let file = selected == .cc ? Self.capabilityContainer : requestFile
+            let offset = Int(bytes[2]) << 8 | Int(bytes[3])
+            let length = bytes[4] == 0 ? 256 : Int(bytes[4])
+            guard offset <= file.count else { return reply(0x6B, 0x00) }
+            return (Data(file[offset..<min(offset + length, file.count)]) + Data([0x90, 0x00]), nil)
+        case 0xD6:
+            guard selected == .ndef else { return reply(0x6A, 0x82) }
+            guard bytes.count >= 5, bytes[4] > 0,
+                  bytes.count == 5 + Int(bytes[4]) else { return reply(0x67, 0x00) }
+            let offset = Int(bytes[2]) << 8 | Int(bytes[3])
+            let length = Int(bytes[4])
+            guard offset + length <= incoming.count else { return reply(0x6B, 0x00) }
+            // Support both NLEN-first and zero-NLEN/body/final-NLEN writers.
+            if offset == 0, length >= 2, bytes[5] == 0, bytes[6] == 0 {
+                resetIncoming()
+            }
+            incoming.replaceSubrange(offset..<offset + length, with: bytes[5...])
+            for index in offset..<offset + length { written[index] = true }
+            guard written[0], written[1] else { return reply() }
+            let expected = Int(incoming[0]) << 8 | Int(incoming[1])
+            guard expected <= Self.maxMessageSize else {
+                resetIncoming()
+                return reply(0x6B, 0x00)
+            }
+            guard expected > 0, written[0..<expected + 2].allSatisfy({ $0 }) else { return reply() }
+            let payload = NFCNdefCodec.parseFile(Array(incoming[0..<expected + 2]))
+            resetIncoming()
+            guard let payload else { return reply(0x6A, 0x80) }
+            return (Data([0x90, 0x00]), payload)
+        default:
+            return reply(0x6D, 0x00)
+        }
+    }
+
+    private mutating func resetIncoming() {
+        incoming = .init(repeating: 0, count: Self.maxMessageSize + 2)
+        written = .init(repeating: false, count: Self.maxMessageSize + 2)
+    }
+
+    private func reply(_ sw1: UInt8 = 0x90, _ sw2: UInt8 = 0) -> (Data, NFCNdefPayload?) {
+        (Data([sw1, sw2]), nil)
+    }
+}
+
+enum NFCNdefCodec {
+    enum EncodingError: Error { case tooLarge }
+
+    static func textFile(_ text: String) throws -> [UInt8] {
+        let payload = [0x02, 0x65, 0x6E] + Array(text.utf8)
+        guard payload.count + 7 <= NFCType4Tag.maxMessageSize else { throw EncodingError.tooLarge }
+        let short = payload.count <= 255
+        let length = UInt32(payload.count)
+        var record: [UInt8] = short
+            ? [0xD1, 1, UInt8(length), 0x54]
+            : [0xC1, 1, UInt8(length >> 24), UInt8((length >> 16) & 255),
+               UInt8((length >> 8) & 255), UInt8(length & 255), 0x54]
+        record += payload
+        return [UInt8(record.count >> 8), UInt8(record.count & 255)] + record
+    }
+
+    static func parseFile(_ file: [UInt8]) -> NFCNdefPayload? {
+        guard file.count >= 5 else { return nil }
+        let nlen = Int(file[0]) << 8 | Int(file[1])
+        guard nlen > 0, nlen <= NFCType4Tag.maxMessageSize, nlen + 2 == file.count else { return nil }
+        let record = Array(file.dropFirst(2))
+        let header = record[0]
+        // Exactly one complete record; no chunks or IDs.
+        guard header & 0xC0 == 0xC0, header & 0x28 == 0 else { return nil }
+        let typeLength = Int(record[1])
+        let short = header & 0x10 != 0
+        let start = short ? 3 : 6
+        guard record.count >= start, typeLength > 0 else { return nil }
+        let payloadLength = short ? Int(record[2]) : record[2..<6].reduce(0) { ($0 << 8) | Int($1) }
+        guard start + typeLength + payloadLength == record.count else { return nil }
+        let type = Array(record[start..<start + typeLength])
+        let payload = Array(record.dropFirst(start + typeLength))
+        if header & 7 == 2 {
+            guard String(bytes: type, encoding: .ascii)?.lowercased() == "application/octet-stream",
+                  !payload.isEmpty else { return nil }
+            return .cashuBinary(Data(payload))
+        }
+        guard header & 7 == 1, type.count == 1, let status = payload.first else { return nil }
+        switch type[0] {
+        case 0x54:
+            let textStart = 1 + Int(status & 0x3F)
+            guard status & 0xC0 == 0, textStart <= payload.count,
+                  let text = String(bytes: payload.dropFirst(textStart), encoding: .utf8) else { return nil }
+            return .text(text)
+        case 0x55:
+            // Cashu URLs use an uncompressed scheme, or an HTTP(S) token URL.
+            let prefixes: [UInt8: String] = [0: "", 1: "http://www.", 2: "https://www.", 3: "http://", 4: "https://"]
+            guard let prefix = prefixes[status],
+                  let text = String(bytes: payload.dropFirst(), encoding: .utf8) else { return nil }
+            return .text(prefix + text)
+        default: return nil
+        }
+    }
+}

--- a/ios/CashuWallet/Info.plist
+++ b/ios/CashuWallet/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CashuHCEEnabled</key>
+	<string>$(CASHU_HCE_ENABLED)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -26,6 +26,8 @@ struct CashuRequestDetailView: View {
     /// VoiceOver Share action for the QR: ShareLink can't be invoked
     /// imperatively, so the accessibility action presents the share sheet.
     @State private var showShareSheet = false
+    @State private var nfcReceive = NFCReceiveCoordinator()
+    @State private var contactlessAvailable = false
 
     init(request: CashuRequest, onClose: (() -> Void)? = nil, showsNavigationHeader: Bool = true) {
         self._requestId = State(initialValue: request.id)
@@ -125,14 +127,46 @@ struct CashuRequestDetailView: View {
             }
         }
         .onChange(of: request?.receivedPayments) {
+            nfcReceive.stop()
             presentNextPayment()
         }
         .onChange(of: showPaymentSuccess) {
             presentNextPayment()
         }
+        .onChange(of: nfcReceive.receivedAmount) {
+            // CDK may credit the wallet without returning an attributable tx ID.
+            // Still show the actual redeemed amount in that case.
+            if let amount = nfcReceive.receivedAmount, !showPaymentSuccess {
+                receivedAmount = amount
+                showPaymentSuccess = true
+            }
+        }
         .task(id: monitoredQuoteID) {
             guard let quoteID = monitoredQuoteID else { return }
             await walletManager.monitorDisplayedMintQuote(quoteID: quoteID, homeHaptic: false)
+        }
+        .task(id: scenePhase) {
+            if scenePhase == .active {
+                contactlessAvailable = await NFCReceiveCardSession.isAvailable
+            } else if scenePhase == .background {
+                nfcReceive.stop()
+            }
+        }
+        .onChange(of: request) { nfcReceive.stop() }
+        .onDisappear { nfcReceive.stop() }
+        .fullScreenCover(item: Binding(
+            get: { nfcReceive.reviewPayment },
+            set: { if $0 == nil { nfcReceive.dismissReview() } }
+        )) { pending in
+            ReceiveTokenDetailView(
+                tokenString: pending.token,
+                onComplete: { nfcReceive.dismissReview() },
+                claim: { try await walletManager.claimPendingReceiveToken(pending) },
+                secondaryActionTitle: "Review Later",
+                onSecondaryAction: { nfcReceive.dismissReview() }
+            )
+            .environmentObject(walletManager)
+            .canvasSheetBackground()
         }
         .compactBottomSheetSurface()
     }
@@ -213,6 +247,8 @@ struct CashuRequestDetailView: View {
 
                     deliveryStatus(for: request)
 
+                    contactlessReceive(request: request)
+
                     if let regenerationError {
                         InlineNotice(message: regenerationError, severity: .error)
                     }
@@ -283,6 +319,43 @@ struct CashuRequestDetailView: View {
             .multilineTextAlignment(.center)
             .padding(.horizontal)
             .padding(.bottom, 16)
+        }
+    }
+
+    @ViewBuilder
+    private func contactlessReceive(request: CashuRequest) -> some View {
+        if contactlessAvailable && (request.rail == .ecash || request.receivedPayments.isEmpty) {
+            VStack(spacing: 8) {
+                Button {
+                    nfcReceive.start(request: request, walletManager: walletManager)
+                } label: {
+                    if nfcReceive.phase == .redeeming {
+                        HStack {
+                            ProgressView()
+                            Text("Securing ecash…")
+                        }
+                    } else {
+                        Label("Receive by Tap", systemImage: "wave.3.right")
+                    }
+                }
+                .flatSheetSecondaryButton()
+                .disabled(nfcReceive.isBusy || !NFCReceivePayment.canPresent(request) || !walletManager.isRuntimeReady)
+                .accessibilityIdentifier("cashu.receive.contactless")
+                .accessibilityHint("Hold this iPhone near the payer's device to receive ecash")
+                if (request.amount ?? 0) == 0 {
+                    Text("Set an amount to receive by tap.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Hold this iPhone near the payer's device. You'll review payments from new mints before claiming.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+                if let message = nfcReceive.message {
+                    InlineNotice(message: message, severity: .caution)
+                }
+            }
         }
     }
 

--- a/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
+++ b/ios/CashuWallet/Views/Receive/CashuRequestDetailView.swift
@@ -28,6 +28,7 @@ struct CashuRequestDetailView: View {
     @State private var showShareSheet = false
     @State private var nfcReceive = NFCReceiveCoordinator()
     @State private var contactlessAvailable = false
+    @State private var nfcPaymentCountAtStart = 0
 
     init(request: CashuRequest, onClose: (() -> Void)? = nil, showsNavigationHeader: Bool = true) {
         self._requestId = State(initialValue: request.id)
@@ -136,11 +137,13 @@ struct CashuRequestDetailView: View {
         .onChange(of: nfcReceive.receivedAmount) {
             // CDK may credit the wallet without returning an attributable tx ID.
             // Still show the actual redeemed amount in that case.
-            if let amount = nfcReceive.receivedAmount, !showPaymentSuccess {
+            if let amount = nfcReceive.receivedAmount, !showPaymentSuccess,
+               paymentCount == nfcPaymentCountAtStart {
                 receivedAmount = amount
                 showPaymentSuccess = true
             }
         }
+        .onChange(of: nfcReceive.reviewPayment) { presentNextPayment() }
         .task(id: monitoredQuoteID) {
             guard let quoteID = monitoredQuoteID else { return }
             await walletManager.monitorDisplayedMintQuote(quoteID: quoteID, homeHaptic: false)
@@ -174,8 +177,17 @@ struct CashuRequestDetailView: View {
     /// Keep the current receipt stable; payments arriving during it are picked
     /// up after Done without replaying any previously acknowledged payment.
     private func presentNextPayment() {
-        guard !showPaymentSuccess, let request,
-              let payment = paymentObservation.newlyLinkedPayment(in: request.receivedPayments) else { return }
+        guard !showPaymentSuccess, let request else { return }
+        if let reviewed = nfcReceive.reviewPayment {
+            // The review screen owns this payment's success. Keep other
+            // concurrent receipts queued until that screen closes.
+            let saved = walletManager.walletStore.loadSavedTokens()
+            for payment in request.receivedPayments where saved[payment.transactionId] == reviewed.token {
+                paymentObservation.acknowledge(transactionId: payment.transactionId)
+            }
+            return
+        }
+        guard let payment = paymentObservation.newlyLinkedPayment(in: request.receivedPayments) else { return }
         receivedAmount = payment.amount
         // PaymentStatusView owns the success haptic on appear — don't buzz here.
         showPaymentSuccess = true
@@ -327,6 +339,7 @@ struct CashuRequestDetailView: View {
         if contactlessAvailable && (request.rail == .ecash || request.receivedPayments.isEmpty) {
             VStack(spacing: 8) {
                 Button {
+                    nfcPaymentCountAtStart = paymentCount
                     nfcReceive.start(request: request, walletManager: walletManager)
                 } label: {
                     if nfcReceive.phase == .redeeming {
@@ -578,6 +591,10 @@ struct CashuRequestPaymentObservation {
 
     init(existingPayments: [CashuRequestPayment]) {
         observedTransactionIds = Set(existingPayments.map(\.transactionId))
+    }
+
+    mutating func acknowledge(transactionId: String) {
+        observedTransactionIds.insert(transactionId)
     }
 
     mutating func newlyLinkedPayment(

--- a/ios/CashuWalletTests/NFCReceiveTests.swift
+++ b/ios/CashuWalletTests/NFCReceiveTests.swift
@@ -1,0 +1,285 @@
+import Cdk
+import XCTest
+@testable import CashuWallet
+
+final class NFCReceiveTests: XCTestCase {
+    private let selectApplication: [UInt8] = [0, 0xA4, 4, 0, 7] + NFCType4Tag.aid + [0]
+    private let selectNdef: [UInt8] = [0, 0xA4, 0, 0x0C, 2, 0xE1, 4]
+    private let ok = Data([0x90, 0])
+
+    private func selectedTag() throws -> NFCType4Tag {
+        var tag = try NFCType4Tag(request: "creqAtest")
+        XCTAssertEqual(tag.process(Data(selectApplication)).response, ok)
+        XCTAssertEqual(tag.process(Data(selectNdef)).response, ok)
+        return tag
+    }
+
+    private func update(_ offset: Int, _ bytes: [UInt8]) -> Data {
+        Data([0, 0xD6, UInt8(offset >> 8), UInt8(offset & 255), UInt8(bytes.count)] + bytes)
+    }
+
+    func testAndroidCompatibleCapabilityContainerAndRequest() throws {
+        var tag = try selectedTag()
+        XCTAssertEqual(tag.process(Data([0, 0xB0, 0, 0, 0])).response,
+                       Data(try NFCNdefCodec.textFile("creqAtest")) + ok)
+        XCTAssertEqual(tag.process(Data([0, 0xA4, 0, 0x0C, 2, 0xE1, 3])).response, ok)
+        XCTAssertEqual(tag.process(Data([0, 0xB0, 0, 0, 15])).response,
+                       Data(NFCType4Tag.capabilityContainer) + ok)
+        XCTAssertNotEqual(tag.process(update(0, [0, 1, 2])).response, ok)
+    }
+
+    func testShortAndLongUTF8TextRoundTrip() throws {
+        for text in ["cashuBtoken", String(repeating: "é", count: 500)] {
+            XCTAssertEqual(NFCNdefCodec.parseFile(try NFCNdefCodec.textFile(text)), .text(text))
+        }
+        XCTAssertThrowsError(try NFCNdefCodec.textFile(String(repeating: "a", count: 30_000)))
+    }
+
+    func testNlenFirstRequiresEveryByteIncludingHoles() throws {
+        var tag = try selectedTag()
+        let file = try NFCNdefCodec.textFile("cashuBtest")
+        XCTAssertNil(tag.process(update(0, Array(file[0..<2]))).payload)
+        XCTAssertNil(tag.process(update(8, Array(file[8...]))).payload)
+        XCTAssertNil(tag.process(update(2, Array(file[2..<7]))).payload)
+        XCTAssertEqual(tag.process(update(7, [file[7]])).payload, .text("cashuBtest"))
+        XCTAssertNil(tag.process(update(7, [file[7]])).payload)
+    }
+
+    func testNlenLastAndOutOfOrderChunks() throws {
+        var tag = try selectedTag()
+        let file = try NFCNdefCodec.textFile("cashuBtest")
+        XCTAssertNil(tag.process(update(0, [0, 0])).payload)
+        XCTAssertNil(tag.process(update(8, Array(file[8...]))).payload)
+        XCTAssertNil(tag.process(update(2, Array(file[2..<8]))).payload)
+        XCTAssertEqual(tag.process(update(0, Array(file[0..<2]))).payload, .text("cashuBtest"))
+    }
+
+    func testDisconnectAndReselectDiscardPartialWrites() throws {
+        for disconnect in [true, false] {
+            var tag = try selectedTag()
+            let file = try NFCNdefCodec.textFile("cashuBtest")
+            _ = tag.process(update(0, Array(file[0..<8])))
+            if disconnect { tag.reset() }
+            _ = tag.process(Data(selectApplication))
+            _ = tag.process(Data(selectNdef))
+            XCTAssertNil(tag.process(update(8, Array(file[8...]))).payload)
+            XCTAssertNil(tag.process(update(0, Array(file[0..<2]))).payload)
+        }
+    }
+
+    func testZeroNlenDiscardsPreviousBody() throws {
+        var tag = try selectedTag()
+        let file = try NFCNdefCodec.textFile("cashuBtest")
+        _ = tag.process(update(2, Array(file.dropFirst(2))))
+        _ = tag.process(update(0, [0, 0]))
+        XCTAssertNil(tag.process(update(0, Array(file.prefix(2)))).payload)
+    }
+
+    func testMalformedApdusAndBounds() throws {
+        var tag = try selectedTag()
+        for bytes: [UInt8] in [[], [0], [0, 0xB0], [0, 0xB0, 0, 0],
+                               [0, 0xD6, 0, 0, 2, 1], [0, 0xD6, 0xFF, 0xFF, 1, 0],
+                               [0, 0xB0, 0xFF, 0xFF, 1], [0x80, 0xB0, 0, 0, 1]] {
+            XCTAssertNotEqual(tag.process(Data(bytes)).response, ok)
+        }
+        XCTAssertNotEqual(tag.process(update(0, [0xFF, 0xFF])).response, ok)
+    }
+
+    func testApplicationSelectionRequiredAndUnknownFileClearsSelection() throws {
+        var tag = try NFCType4Tag(request: "creqAtest")
+        XCTAssertNotEqual(tag.process(Data(selectNdef)).response, ok)
+        _ = tag.process(Data(selectApplication))
+        _ = tag.process(Data(selectNdef))
+        _ = tag.process(Data([0, 0xA4, 0, 0x0C, 2, 0xE1, 9]))
+        XCTAssertNotEqual(tag.process(update(0, [0, 0])).response, ok)
+    }
+
+    func testRejectsTruncationChunkingIdsAndTrailingBytes() throws {
+        let valid = try NFCNdefCodec.textFile("cashuBtest")
+        for count in 0..<valid.count {
+            XCTAssertNil(NFCNdefCodec.parseFile(Array(valid.prefix(count))))
+        }
+        for header: UInt8 in [0x91, 0x51, 0xF1, 0xD9] {
+            var invalid = valid
+            invalid[2] = header
+            XCTAssertNil(NFCNdefCodec.parseFile(invalid))
+        }
+        XCTAssertNil(NFCNdefCodec.parseFile(valid + [0]))
+        // Huge long-record payload length must not allocate or index out of bounds.
+        XCTAssertNil(NFCNdefCodec.parseFile([0, 7, 0xC1, 1, 0xFF, 0xFF, 0xFF, 0xFF, 0x54]))
+    }
+
+    func testBinaryMimeAndUriRecords() {
+        let mime = Array("application/octet-stream".utf8)
+        let record: [UInt8] = [0xD2, UInt8(mime.count), 3] + mime + [0, 1, 2]
+        XCTAssertEqual(NFCNdefCodec.parseFile([0, UInt8(record.count)] + record), .cashuBinary(Data([0, 1, 2])))
+        let uri: [UInt8] = [0xD1, 1, 7, 0x55, 0] + Array("cashuB".utf8)
+        XCTAssertEqual(NFCNdefCodec.parseFile([0, UInt8(uri.count)] + uri), .text("cashuB"))
+    }
+
+    func testMalformedTextAndUnsupportedUriAreRejected() {
+        for payload: [UInt8] in [[0x80], [0x40], [5, 0x65], [0, 0xFF]] {
+            let record: [UInt8] = [0xD1, 1, UInt8(payload.count), 0x54] + payload
+            XCTAssertNil(NFCNdefCodec.parseFile([0, UInt8(record.count)] + record))
+        }
+        XCTAssertNil(NFCNdefCodec.parseFile([0, 5, 0xD1, 1, 1, 0x55, 0xFF]))
+    }
+
+    func testTransportFreeRequestPreservesTerms() throws {
+        let request = CashuRequest(id: "nfc", encoded: "unused", amount: 21, unit: "usd",
+                                   mints: ["https://mint.example"], memo: "Coffee", reusable: false)
+        let decoded = try decodePaymentRequest(encoded: PaymentRequestBuilder.buildNFC(request: request))
+        XCTAssertEqual(decoded.paymentId(), "nfc")
+        XCTAssertEqual(decoded.amount()?.value, 21)
+        XCTAssertEqual(decoded.unit(), .usd)
+        XCTAssertEqual(decoded.mints(), ["https://mint.example"])
+        XCTAssertTrue(decoded.transports().isEmpty)
+    }
+
+    func testRequestValidationAndAvailability() {
+        let request = CashuRequest(encoded: "unused", amount: 21, mints: ["https://mint.example/"])
+        XCTAssertTrue(NFCReceivePayment.canPresent(request))
+        XCTAssertNil(NFCReceivePayment.validationMessage(request: request, amount: 22, unit: "SAT", mint: "https://MINT.example"))
+        XCTAssertNotNil(NFCReceivePayment.validationMessage(request: request, amount: 20, unit: "sat", mint: "https://mint.example"))
+        XCTAssertNotNil(NFCReceivePayment.validationMessage(request: request, amount: 21, unit: "usd", mint: "https://mint.example"))
+        XCTAssertNotNil(NFCReceivePayment.validationMessage(request: request, amount: 21, unit: "sat", mint: "https://other.example"))
+        XCTAssertFalse(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused")))
+        XCTAssertFalse(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused", amount: 21, expiry: .distantPast)))
+        let paid = [CashuRequestPayment(transactionId: "tx", amount: 21, receivedAt: Date())]
+        XCTAssertFalse(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused", amount: 21, receivedPayments: paid, rail: .bolt11)))
+        XCTAssertTrue(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused", amount: 21, receivedPayments: paid)))
+    }
+}
+
+@MainActor
+final class NFCReceiveLifecycleTests: XCTestCase {
+    private final class Transport: NFCReceiveTransport {
+        var gate: CheckedContinuation<Void, Never>?
+        var stopped = false
+        var payload: NFCNdefPayload? = .text("token")
+
+        func receive(request: String, accept: (NFCNdefPayload) throws -> NFCReceivePayment) async throws -> NFCReceivePayment? {
+            await withCheckedContinuation { gate = $0 }
+            guard let payload else { return nil }
+            return try accept(payload)
+        }
+
+        func stop() { stopped = true }
+        func deliver() { gate?.resume(); gate = nil }
+    }
+
+    private let request = CashuRequest(encoded: "unused", amount: 21)
+    private func payment(review: Bool = false, validation: String? = nil) -> NFCReceivePayment {
+        NFCReceivePayment(pending: PendingReceiveToken(
+            tokenId: "receipt", token: "token", amount: 21, date: Date(), mintUrl: "https://mint.example"
+        ), needsReview: review, validationMessage: validation)
+    }
+
+    private func settle() async {
+        for _ in 0..<20 { await Task.yield() }
+    }
+
+    func testCancelledInitializationCannotAcceptOrClearReplacement() async {
+        let old = Transport(), next = Transport()
+        var transports = [old, next]
+        let coordinator = NFCReceiveCoordinator { transports.removeFirst() }
+        var staged = 0
+        coordinator.start(request: request, stage: { _ in staged += 1; return self.payment() }, claim: { _ in 21 }, refresh: {})
+        await settle()
+        coordinator.stop()
+        coordinator.start(request: request, stage: { _ in staged += 1; return self.payment() }, claim: { _ in 21 }, refresh: {})
+        await settle()
+        old.deliver()
+        await settle()
+        XCTAssertTrue(old.stopped)
+        XCTAssertEqual(staged, 0)
+        XCTAssertEqual(coordinator.phase, .presenting)
+        next.deliver()
+        await settle()
+        XCTAssertEqual(staged, 1)
+        XCTAssertEqual(coordinator.receivedAmount, 21)
+    }
+
+    func testAcceptedClaimSurvivesStopAndBlocksAnotherTap() async {
+        let transport = Transport()
+        let coordinator = NFCReceiveCoordinator { transport }
+        var claimGate: CheckedContinuation<Void, Never>?
+        var claims = 0
+        coordinator.start(request: request, stage: { _ in self.payment() }, claim: { _ in
+            claims += 1
+            await withCheckedContinuation { claimGate = $0 }
+            XCTAssertFalse(Task.isCancelled)
+            return 20
+        }, refresh: {})
+        await settle()
+        transport.deliver()
+        await settle()
+        XCTAssertEqual(coordinator.phase, .redeeming)
+        coordinator.stop()
+        coordinator.start(request: request, stage: { _ in XCTFail("Duplicate tap"); return self.payment() }, claim: { _ in 0 }, refresh: {})
+        claimGate?.resume()
+        await settle()
+        XCTAssertEqual(claims, 1)
+        XCTAssertEqual(coordinator.receivedAmount, 20)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
+    func testUnknownMintRequiresReviewWithoutClaim() async {
+        let transport = Transport()
+        let coordinator = NFCReceiveCoordinator { transport }
+        coordinator.start(request: request, stage: { _ in self.payment(review: true) }, claim: { _ in
+            XCTFail("Unknown mint must be reviewed")
+            return 0
+        }, refresh: {})
+        await settle()
+        transport.deliver()
+        await settle()
+        XCTAssertNotNil(coordinator.reviewPayment)
+        XCTAssertNil(coordinator.receivedAmount)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
+    func testMismatchIsVisibleAndDoesNotShowPaymentSuccess() async {
+        let transport = Transport()
+        let coordinator = NFCReceiveCoordinator { transport }
+        coordinator.start(request: request, stage: { _ in self.payment(review: true, validation: "Wrong amount.") }, claim: { _ in
+            XCTFail("Mismatched payment must not fulfill request")
+            return 0
+        }, refresh: {})
+        await settle()
+        transport.deliver()
+        await settle()
+        XCTAssertNil(coordinator.reviewPayment)
+        XCTAssertNil(coordinator.receivedAmount)
+        XCTAssertTrue(coordinator.message?.contains("Wrong amount.") == true)
+    }
+
+    func testClaimFailureKeepsRecoveryReceipt() async {
+        let transport = Transport()
+        let coordinator = NFCReceiveCoordinator { transport }
+        coordinator.start(request: request, stage: { _ in self.payment() }, claim: { _ in
+            throw NFCReceiveError.message("Offline")
+        }, refresh: {})
+        await settle()
+        transport.deliver()
+        await settle()
+        XCTAssertEqual(coordinator.reviewPayment?.tokenId, "receipt")
+        XCTAssertNil(coordinator.receivedAmount)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+
+    func testPersistenceFailureDoesNotClaim() async {
+        let transport = Transport()
+        let coordinator = NFCReceiveCoordinator { transport }
+        coordinator.start(request: request, stage: { _ in throw NFCReceiveError.message("Storage failed") }, claim: { _ in
+            XCTFail("Unretained payment must not be claimed")
+            return 0
+        }, refresh: {})
+        await settle()
+        transport.deliver()
+        await settle()
+        XCTAssertNil(coordinator.receivedAmount)
+        XCTAssertNotNil(coordinator.message)
+        XCTAssertEqual(coordinator.phase, .idle)
+    }
+}

--- a/ios/CashuWalletTests/NFCReceiveTests.swift
+++ b/ios/CashuWalletTests/NFCReceiveTests.swift
@@ -2,6 +2,69 @@ import Cdk
 import XCTest
 @testable import CashuWallet
 
+/// Uses the same fake-money mint fixture as the existing receipt recovery tests.
+@MainActor
+final class NFCReceiveIntegrationTests: XCTestCase {
+    func testTextAndBinaryTokensSurviveChunkedNfcTransferAndRedeemOnce() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let senderDB = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("sender.sqlite").path)
+        let receiverDB = try LifecycleSafeWalletDatabase(filePath: directory.appendingPathComponent("receiver.sqlite").path)
+        let sender = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: senderDB))
+        let receiver = try WalletRepository(mnemonic: generateMnemonic(), store: customWalletStore(db: receiverDB))
+        let mint = MintUrl(url: "http://localhost:3338")
+        try await sender.createWallet(mintUrl: mint, unit: .sat, targetProofCount: nil)
+        let wallet = try await sender.getWallet(mintUrl: mint, unit: .sat)
+        let quote = try await wallet.mintQuote(paymentMethod: .bolt11, amount: Amount(value: 32), description: nil, extra: nil)
+        for _ in 0..<40 {
+            if try await wallet.checkMintQuote(quoteId: quote.id).state == .paid { break }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        _ = try await wallet.mint(quoteId: quote.id, amountSplitTarget: .none, spendingConditions: nil)
+        let senderService = TokenService(walletRepository: { sender }, getActiveMint: { nil })
+        let receiverService = TokenService(walletRepository: { receiver }, getActiveMint: { nil })
+
+        for binary in [false, true] {
+            let tokenString = try await senderService.sendTokens(amount: 16, mintUrl: mint.url).token
+            let token = try Token.decode(encodedToken: tokenString)
+            let file: [UInt8]
+            if binary {
+                let payload = [UInt8](try token.toRawBytes())
+                let mime = Array("application/octet-stream".utf8)
+                let length = UInt32(payload.count)
+                let record: [UInt8] = [0xC2, UInt8(mime.count), UInt8(length >> 24), UInt8((length >> 16) & 255),
+                                       UInt8((length >> 8) & 255), UInt8(length & 255)] + mime + payload
+                file = [UInt8(record.count >> 8), UInt8(record.count & 255)] + record
+            } else {
+                file = try NFCNdefCodec.textFile("https://wallet.example/#token=\(tokenString)")
+            }
+            var tag = try NFCType4Tag(request: PaymentRequestBuilder.buildNFC(request:
+                CashuRequest(encoded: "unused", amount: 16, mints: [mint.url])))
+            _ = tag.process(Data([0, 0xA4, 4, 0, 7] + NFCType4Tag.aid))
+            _ = tag.process(Data([0, 0xA4, 0, 0x0C, 2, 0xE1, 4]))
+            var received: NFCNdefPayload?
+            for offset in stride(from: 0, to: file.count, by: 52) {
+                let chunk = Array(file[offset..<min(offset + 52, file.count)])
+                let result = tag.process(Data([0, 0xD6, UInt8(offset >> 8), UInt8(offset & 255), UInt8(chunk.count)] + chunk))
+                XCTAssertEqual(result.response, Data([0x90, 0]))
+                received = result.payload ?? received
+            }
+            let decoded = try NFCReceivePayment.decode(XCTUnwrap(received))
+            XCTAssertEqual(try decoded.value().value, 16)
+            let credited = try await receiverService.receiveTokens(tokenString: decoded.encode())
+            XCTAssertEqual(credited, 16)
+            do {
+                _ = try await receiverService.receiveTokens(tokenString: decoded.encode())
+                XCTFail("The same proofs must not credit twice")
+            } catch { }
+        }
+        let receivedWallet = try await receiver.getWallet(mintUrl: mint, unit: .sat)
+        let balance = try await receivedWallet.totalBalance().value
+        XCTAssertEqual(balance, 32)
+    }
+}
+
 final class NFCReceiveTests: XCTestCase {
     private let selectApplication: [UInt8] = [0, 0xA4, 4, 0, 7] + NFCType4Tag.aid + [0]
     private let selectNdef: [UInt8] = [0, 0xA4, 0, 0x0C, 2, 0xE1, 4]
@@ -148,6 +211,15 @@ final class NFCReceiveTests: XCTestCase {
         let paid = [CashuRequestPayment(transactionId: "tx", amount: 21, receivedAt: Date())]
         XCTAssertFalse(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused", amount: 21, receivedPayments: paid, rail: .bolt11)))
         XCTAssertTrue(NFCReceivePayment.canPresent(CashuRequest(encoded: "unused", amount: 21, receivedPayments: paid)))
+    }
+
+    func testReviewedReceiptDoesNotReplaySuccessOrSuppressConcurrentPayment() {
+        let reviewed = CashuRequestPayment(transactionId: "reviewed", amount: 21, receivedAt: Date())
+        let concurrent = CashuRequestPayment(transactionId: "concurrent", amount: 5, receivedAt: Date())
+        var observation = CashuRequestPaymentObservation(existingPayments: [])
+        observation.acknowledge(transactionId: reviewed.transactionId)
+        XCTAssertEqual(observation.newlyLinkedPayment(in: [concurrent, reviewed])?.transactionId, "concurrent")
+        XCTAssertNil(observation.newlyLinkedPayment(in: [concurrent, reviewed]))
     }
 }
 

--- a/ios/HCE.xcconfig
+++ b/ios/HCE.xcconfig
@@ -1,0 +1,4 @@
+// Use only with an Apple-approved HCE provisioning profile for this bundle ID.
+// xcodebuild ... -xcconfig HCE.xcconfig
+CASHU_HCE_ENABLED = YES
+CODE_SIGN_ENTITLEMENTS = CashuWallet/CashuWalletHCE.entitlements

--- a/ios/README.md
+++ b/ios/README.md
@@ -99,7 +99,11 @@ default contactless app or start on field detection/double-click.
 
 `NFCReceiveTests` covers request encoding, APDU selection/read/write, both NLEN
 write orders, missing chunks, reconnect resets, malformed NDEF, binary records,
-and request terms. These tests run in Simulator without HCE approval.
+and request terms. `NFCReceiveLifecycleTests` covers cancellation, stale sessions,
+review, and failed claims. These tests run in Simulator without HCE approval.
+`NFCReceiveIntegrationTests` uses the [CI fake mint](../CI/README.md) to create
+real test tokens, transfer them in text and binary APDUs, redeem them, and verify
+that a duplicate cannot credit twice.
 
 Before shipping an HCE build, use an entitled physical iPhone and an Android or
 Macadamia payer to verify:

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,7 +9,7 @@ Built with SwiftUI, targets iOS 18+, and uses [cdk-swift](https://github.com/asm
 - **Ecash** — mint, send, and redeem Cashu tokens across multiple mints
 - **Lightning** — pay and receive BOLT11 invoices, with Lightning Address support
 - **On-chain** — send to and receive from regular Bitcoin addresses
-- **Contactless (NFC)** — tap-to-pay using NDEF tags
+- **Contactless (NFC)** — tap-to-pay using NDEF tags; receive ecash by tap on eligible iPhones with HCE enabled
 - **Nostr** — NWC (Nostr Wallet Connect), payment requests, and NPC integration
 - **P2PK** locking, multi-mint discovery, and deterministic recovery from seed
 - Backup & restore from BIP-39 seed phrase
@@ -49,3 +49,76 @@ xcodebuild -project CashuWallet.xcodeproj \
 - `CashuWallet/Core` — services (wallet, mints, NFC, Nostr, keychain), navigation, settings
 - `CashuWallet/Views` — SwiftUI views grouped by flow (Send, Receive, Mints, History, Settings)
 - `CashuWallet/Models` — data types and protocols
+
+## Receiving by tap (HCE)
+
+Open **Receive → Ecash**, set an amount, then choose **Receive by Tap** and
+hold the payer's device near the top of the iPhone. The system presents Apple's
+contactless sheet. The same action is available when reopening a request in
+History. It is hidden in Simulator, ordinary builds, and on ineligible devices.
+
+The payer reads a transport-free NUT-18 request and writes the token back using
+the NFC Forum Type 4 / Numo protocol, matching Android. The shared QR retains its
+Nostr transport. NFC accepts text, URI token links, and binary Cashu MIME records.
+Tokens are saved before the final write is acknowledged. Known-mint tokens are
+redeemed through the existing wallet operation coordinator and attributed to the
+request. Unfamiliar mints open the existing token review screen; **Review Later**
+keeps the token in History. Tokens with a wrong amount, unit, or mint are saved
+for review without fulfilling the request. Failed claims remain recoverable there.
+
+Unlike Android, iOS deliberately requires review of unfamiliar mints rather than
+automatically converting their tokens into the default mint. Future automatic
+conversion would need a separate implementation of Android's fee limits and
+settlement recovery. NFC availability also differs because Apple restricts HCE.
+
+### Signing and availability
+
+Apple's [HCE entitlement](https://developer.apple.com/support/hce-transactions-in-apps/)
+requires approval for the app's bundle ID and AID `D2760000850101`. Apple's
+eligibility requirements apply; setting a region or adding an entitlement file
+does not grant access. This app still targets iOS 18+, above CardSession's iOS
+17.4 minimum. HCE cannot be exercised in Simulator.
+
+After Apple approves the entitlement, enable it for the App ID, regenerate the
+development/distribution profiles, and build with the supplied configuration:
+
+```sh
+xcodebuild -project CashuWallet.xcodeproj -scheme CashuWallet \
+  -destination 'generic/platform=iOS' -xcconfig HCE.xcconfig build
+```
+
+For Xcode, set the app target's `CASHU_HCE_ENABLED` to `YES` and
+`CODE_SIGN_ENTITLEMENTS` to `CashuWallet/CashuWalletHCE.entitlements` for the
+approved configuration. Apply the same configuration when archiving. Ordinary
+builds keep their existing entitlements so developers without HCE approval can
+still build and sign. The app also checks `CardSession.isSupported` and
+`CardSession.isEligible` before offering the action. It does not register as the
+default contactless app or start on field detection/double-click.
+
+### Verification
+
+`NFCReceiveTests` covers request encoding, APDU selection/read/write, both NLEN
+write orders, missing chunks, reconnect resets, malformed NDEF, binary records,
+and request terms. These tests run in Simulator without HCE approval.
+
+Before shipping an HCE build, use an entitled physical iPhone and an Android or
+Macadamia payer to verify:
+
+- Fixed-amount receipt at a known mint, with credited amount and linked History.
+- New-mint review, Review Later, app restart, and claim from History.
+- Wrong amount/unit/mint, offline redemption, and duplicate delivery.
+- Both text and binary token writes, including a token larger than one APDU.
+- Separation during a write, retap, native-sheet cancellation/timeout, background,
+  request edits, and a second receipt on a reusable request.
+- No contactless action on an ineligible device; ordinary NFC sending still works.
+
+### Reference implementation
+
+Investigated Macadamia's
+[NFCRequestEmulation.swift](https://github.com/zeugmaster/macadamia/blob/73bf9d378553e8ac37f7137700163606e333b835/macadamia/Wallet/NFCRequestEmulation.swift)
+and its RequestView integration on the `release` branch. It uses a foreground
+`CardSession`, an optional presentment-intent assertion, and Type 4 tag emulation
+to receive an in-band token. This implementation follows that approach while
+implementing the protocol from our Android counterpart, with complete-write
+tracking, binary token support, persistent recovery, and the wallet's own claim
+and mint-review paths.


### PR DESCRIPTION
Adds **Receive by Tap** to iOS Cashu request details using Apple’s native `CardSession` presentment sheet. A compatible payer reads a transport-free NUT-18 request and writes back an ecash token using the same Type 4 / Numo protocol as Android. The existing QR continues to use Nostr.

Received tokens are saved before acknowledging the final NFC write. Known-mint payments use the existing serialized claim and request-history paths. Unfamiliar mints require review in the existing receive screen; Review Later and failed claims retain the token in History. Amount, unit, and mint mismatches cannot fulfill the request. Interrupted writes, stale sessions, duplicate receipts, and cancellation after acceptance are covered.

The implementation follows the foreground HCE approach investigated in [Macadamia’s release source](https://github.com/zeugmaster/macadamia/blob/73bf9d378553e8ac37f7137700163606e333b835/macadamia/Wallet/NFCRequestEmulation.swift), using our Android protocol implementation and iOS wallet services. **Unlike Android, unfamiliar-mint tokens are reviewed rather than automatically converted to the default mint.** Android behavior is unchanged.

HCE is opt-in through `ios/HCE.xcconfig` and `CashuWalletHCE.entitlements`, preserving ordinary signing profiles. Enabling it requires [Apple’s approval](https://developer.apple.com/support/hce-transactions-in-apps/) for this bundle ID and AID `D2760000850101`. The action is hidden unless the build enables HCE and CoreNFC reports support and eligibility. The README documents setup and a device-test checklist.

Validation:
- 58 focused simulator tests pass, covering the NFC codec and APDU protocol, request terms, session lifecycle, mint review, request history, and interrupted-receipt recovery.
- A local fake-mint integration test issues real test tokens, transfers them through text and binary NFC APDUs, redeems them, and rejects duplicate redemption.
- Simulator build and unsigned HCE-enabled physical-iPhone SDK build pass; generated Info.plist flags are NO and YES respectively.
- Actual radio exchange, entitlement signing, and Apple’s native sheet require an approved profile and eligible physical iPhone; these have not been device-tested.
